### PR TITLE
fix: prevent concurrent nonce collisions with shared NonceManagerMiddleware

### DIFF
--- a/lit-api-server/src/accounts/signable_contract.rs
+++ b/lit-api-server/src/accounts/signable_contract.rs
@@ -2,6 +2,7 @@ pub use crate::abstractions::transfer::chain_info::Chain;
 pub use crate::accounts::contracts::account_config::AccountConfig;
 use crate::config::GLOBAL_NODE_CONFIG;
 pub use anyhow::Result;
+use ethers::middleware::NonceManagerMiddleware;
 pub use ethers::middleware::SignerMiddleware;
 pub use ethers::providers::Http;
 pub use ethers::providers::Provider;
@@ -10,23 +11,57 @@ use ethers::signers::Signer;
 pub use ethers::types::H160;
 pub use lit_core::utils::binary::hex_to_bytes;
 pub use std::sync::Arc;
+use std::sync::OnceLock;
 
-pub(crate) async fn get_signable_account_config_contract()
--> Result<AccountConfig<SignerMiddleware<Provider<Http>, LocalWallet>>, anyhow::Error> {
-    // let chain = Chain::Yellowstone;
-    // let chain = Chain::Anvil;
+/// The shared signing client. A single instance is held for the lifetime of
+/// the process so that `NonceManagerMiddleware` can manage nonces atomically
+/// across concurrent requests. Without this, every request would create a
+/// fresh `SignerMiddleware`, each fetching the same pending nonce from the
+/// chain and causing "nonce too low" / "replacement transaction underpriced"
+/// errors under concurrency.
+pub(crate) type SigningClient =
+    NonceManagerMiddleware<SignerMiddleware<Provider<Http>, LocalWallet>>;
+
+static GLOBAL_SIGNING_CLIENT: OnceLock<Arc<SigningClient>> = OnceLock::new();
+
+/// Initialise the global signing client. Must be called once at startup,
+/// after `init_config()`, before any transactions are sent.
+pub(crate) fn init_signing_client() -> Result<()> {
     let node_config = GLOBAL_NODE_CONFIG
         .get()
-        .ok_or(anyhow::anyhow!("Node configuration not found"))?;
+        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))?;
     let chain_info = node_config.chain.info();
     let secret = hex_to_bytes(&node_config.secret)?;
 
     let wallet = LocalWallet::from_bytes(&secret)?.with_chain_id(chain_info.chain_id);
-
+    let address = wallet.address();
     let provider = Provider::<Http>::try_from(chain_info.rpc_url)?;
-    let signing_provider = SignerMiddleware::new(provider.clone(), wallet);
+    let signer = SignerMiddleware::new(provider, wallet);
 
-    let client = Arc::new(signing_provider);
+    // NonceManagerMiddleware wraps the signer and tracks the nonce in an
+    // AtomicU64. On the first transaction it fetches the current on-chain
+    // nonce; every subsequent call increments it atomically, so concurrent
+    // callers always receive distinct nonces.
+    let nonce_manager = NonceManagerMiddleware::new(signer, address);
+
+    GLOBAL_SIGNING_CLIENT.get_or_init(|| Arc::new(nonce_manager));
+    Ok(())
+}
+
+pub(crate) async fn get_signable_account_config_contract()
+-> Result<AccountConfig<SigningClient>, anyhow::Error> {
+    let client = GLOBAL_SIGNING_CLIENT
+        .get()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Signing client not initialised — call init_signing_client() at startup"
+            )
+        })?
+        .clone();
+
+    let node_config = GLOBAL_NODE_CONFIG
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))?;
     let account_config_address = hex_to_bytes(&node_config.contract_address)?;
     let account_config_address = H160::from_slice(&account_config_address);
     let contract = AccountConfig::new(account_config_address, client);

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -30,6 +30,11 @@ async fn main() -> Result<(), rocket::Error> {
         std::process::exit(1);
     }
 
+    if let Err(e) = accounts::signable_contract::init_signing_client() {
+        eprintln!("Failed to initialize signing client: {:?}. Exiting.", e);
+        std::process::exit(1);
+    }
+
     let allowed_methods = HashSet::from([
         Method::from_str("Get").expect("Invalid method: Get"),
         Method::from_str("Options").expect("Invalid method: Options"),


### PR DESCRIPTION
## Problem

Every call to `get_signable_account_config_contract()` created a brand-new `SignerMiddleware<Provider<Http>, LocalWallet>`. Each fresh instance calls `eth_getTransactionCount` on the RPC to determine the current nonce. Under concurrent load:

1. Request A arrives → creates `SignerMiddleware` → fetches nonce **N** from chain
2. Request B arrives → creates `SignerMiddleware` → fetches nonce **N** from chain (same)
3. Both broadcast a transaction with nonce **N**
4. One succeeds; the other fails with **"nonce too low"** or **"replacement transaction underpriced"**

This is exactly the error pattern seen in the k6 integration tests when `newAccount` (or any write endpoint) is hit by more than one VU at a time.

## Root cause

ethers-rs's `SignerMiddleware` manages nonce state **per-instance**. Creating a new instance per request gives each request an independent view of the chain with no coordination.

## Fix

Replace the per-request signer construction with a **single, process-wide `NonceManagerMiddleware`** stored in a `OnceLock`:

```rust
// signable_contract.rs
static GLOBAL_SIGNING_CLIENT: OnceLock<Arc<SigningClient>> = OnceLock::new();

pub(crate) fn init_signing_client() -> Result<()> {
    // build wallet + provider + SignerMiddleware once
    let nonce_manager = NonceManagerMiddleware::new(signer, address);
    GLOBAL_SIGNING_CLIENT.get_or_init(|| Arc::new(nonce_manager));
    Ok(())
}
```

`NonceManagerMiddleware` (from `ethers::middleware`) stores the nonce in an `AtomicU64`:
- On the **first** `send_transaction` it fetches the on-chain pending nonce exactly once.
- Every subsequent call **atomically increments** the counter before broadcasting.
- Concurrent callers always receive **distinct, sequential nonces** with no RPC round-trip.

`get_signable_account_config_contract()` now clones the `Arc` to the shared client rather than building a new signer stack, so all 15+ write endpoints benefit automatically.

`init_signing_client()` is called from `main()` immediately after `init_config()`, failing fast at startup if the config is missing.

## Files changed

| File | Change |
|---|---|
| `lit-api-server/src/accounts/signable_contract.rs` | Replace per-request signer with global `NonceManagerMiddleware`; add `init_signing_client()` |
| `lit-api-server/src/main.rs` | Call `init_signing_client()` at startup |

## Testing

The fix can be verified by running the k6 integration suite with `--vus 2` against a live deployment and observing that write endpoints no longer return nonce errors:

```bash
LIT_API_KEY=your-key k6 run --vus 2 --iterations 2 k6/integration.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)