### PR TITLE
fix(Dockerfile.lit-actions): add protobuf-compiler

### DIFF
--- a/Dockerfile.lit-actions
+++ b/Dockerfile.lit-actions
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     clang \
     libsqlite3-dev \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 COPY lit-core ./lit-core/


### PR DESCRIPTION
`lit-actions/grpc` has a build script that compiles a `.proto` file with `protoc`. Missing from the original split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)