### PR TITLE
fix: run k6 tests directly on self-hosted runner

### DIFF
--- a/.github/workflows/k6-integration.yml
+++ b/.github/workflows/k6-integration.yml
@@ -1,4 +1,4 @@
-# Run integration.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run integration.spec.ts.
 # Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: integration.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/integration.spec.ts
+        run: k6 run k6/integration.spec.ts

--- a/.github/workflows/k6-integration.yml
+++ b/.github/workflows/k6-integration.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-integration:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k6-lit-action-get-public-key.yml
+++ b/.github/workflows/k6-lit-action-get-public-key.yml
@@ -1,4 +1,4 @@
-# Run lit-action-get-public-key.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run lit-action-get-public-key.spec.ts.
 # Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: lit-action-get-public-key.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/lit-action-get-public-key.spec.ts
+        run: k6 run k6/lit-action-get-public-key.spec.ts

--- a/.github/workflows/k6-lit-action-get-public-key.yml
+++ b/.github/workflows/k6-lit-action-get-public-key.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-lit-action-get-public-key:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k6-lit-action-sign-as-action.yml
+++ b/.github/workflows/k6-lit-action-sign-as-action.yml
@@ -1,4 +1,4 @@
-# Run lit-action-sign-as-action.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run lit-action-sign-as-action.spec.ts.
 # Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: lit-action-sign-as-action.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/lit-action-sign-as-action.spec.ts
+        run: k6 run k6/lit-action-sign-as-action.spec.ts

--- a/.github/workflows/k6-lit-action-sign-as-action.yml
+++ b/.github/workflows/k6-lit-action-sign-as-action.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-lit-action-sign-as-action:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k6-lit-action-verify-action-signature.yml
+++ b/.github/workflows/k6-lit-action-verify-action-signature.yml
@@ -1,4 +1,4 @@
-# Run lit-action-verify-action-signature.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run lit-action-verify-action-signature.spec.ts.
 # Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: lit-action-verify-action-signature.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/lit-action-verify-action-signature.spec.ts
+        run: k6 run k6/lit-action-verify-action-signature.spec.ts

--- a/.github/workflows/k6-lit-action-verify-action-signature.yml
+++ b/.github/workflows/k6-lit-action-verify-action-signature.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-lit-action-verify-action-signature:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k6-new-account.yml
+++ b/.github/workflows/k6-new-account.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-new-account:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k6-new-account.yml
+++ b/.github/workflows/k6-new-account.yml
@@ -1,4 +1,4 @@
-# Run new-account.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run new-account.spec.ts.
 # Called from Deploy to Phala CVM after k6-integration, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: new-account.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/new-account.spec.ts
+        run: k6 run k6/new-account.spec.ts

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -1,4 +1,4 @@
-# Run smoke.spec.ts in smoke mode (2 VUs, 2 iterations).
+# Run smoke.spec.ts.
 # Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
 #
 # Required vars: BASE_URL (for workflow_dispatch when base_url not passed)
@@ -31,4 +31,4 @@ jobs:
       - name: smoke.spec.ts
         env:
           BASE_URL: ${{ inputs.base_url || vars.BASE_URL }}
-        run: k6 run --vus 2 --iterations 2 k6/smoke.spec.ts
+        run: k6 run k6/smoke.spec.ts

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -20,23 +20,8 @@ on:
         type: string
 
 jobs:
-  determine-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      runner: ${{ steps.set-runner.outputs.use-runner }}
-    steps:
-      - name: Determine runner (self-hosted or fallback)
-        id: set-runner
-        uses: mikehardy/runner-fallback-action@v1
-        with:
-          primary-runner: "self-hosted"
-          fallback-runner: "ubuntu-slim"
-          github-token: ${{ secrets.GH_RUNNER_CHECK_TOKEN }}
-          fallback-on-error: true
-
   k6-smoke:
-    needs: determine-runner
-    runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Removes the `determine-runner` job from all 6 k6 workflow files
- Replaces `runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}` with `runs-on: self-hosted` directly

## Test plan

- [ ] Verify k6 workflow jobs pick up on self-hosted runner as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)