### PR TITLE
phase 1 workflow B: pin Docker images by @sha256: digest (DR-1)

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -110,9 +110,6 @@ jobs:
           file: ./${{ matrix.dockerfile }}
           platforms: linux/amd64
           push: true
-          # A tag is required by the registry to accept the push; the digest
-          # (not this tag) is what the deploy step uses. :latest is intentionally
-          # omitted — mutable tags must not exist for images deployed to the CVM.
           tags: ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
 
       - name: Save image digest

--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -110,9 +110,10 @@ jobs:
           file: ./${{ matrix.dockerfile }}
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
-            ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:latest
+          # A tag is required by the registry to accept the push; the digest
+          # (not this tag) is what the deploy step uses. :latest is intentionally
+          # omitted — mutable tags must not exist for images deployed to the CVM.
+          tags: ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
 
       - name: Save image digest
         run: echo "${{ steps.push.outputs.digest }}" > digest-${{ matrix.service }}.txt

--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -103,6 +103,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.service }}
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -113,19 +114,36 @@ jobs:
             ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
             ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:latest
 
+      - name: Save image digest
+        run: echo "${{ steps.push.outputs.digest }}" > digest-${{ matrix.service }}.txt
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.service }}
+          path: digest-${{ matrix.service }}.txt
+
   deploy:
     needs: [determine-runner, determine-target, build]
     runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Prepare docker-compose for deployment
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Prepare docker-compose for deployment (digest-pinned)
         run: |
-          TAG="${{ github.sha }}"
+          DIGEST_LIT_ACTIONS=$(cat digest-lit-actions.txt)
+          DIGEST_LIT_API_SERVER=$(cat digest-lit-api-server.txt)
+          DIGEST_LIT_STATIC=$(cat digest-lit-static.txt)
           sed \
-            -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|${{ vars.DOCKER_IMAGE }}-lit-actions:${TAG}|g" \
-            -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server:${TAG}|g" \
-            -e "s|\${DOCKER_IMAGE_LIT_STATIC}|${{ vars.DOCKER_IMAGE }}-lit-static:${TAG}|g" \
+            -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|${{ vars.DOCKER_IMAGE }}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+            -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
+            -e "s|\${DOCKER_IMAGE_LIT_STATIC}|${{ vars.DOCKER_IMAGE }}-lit-static@${DIGEST_LIT_STATIC}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
           cat docker-compose.deploy.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 .cursor
 docker-compose.deploy.yml
+.digest-*.txt

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -2,6 +2,11 @@
 # lit-actions and lit-api-server share gRPC Unix socket at /tmp/lit_actions.sock.
 # lit-static serves SDKs, docs, dapps on port 8001.
 # Uses tdx.large instance type via phala deploy --instance-type tdx.large
+#
+# Image placeholders (DOCKER_IMAGE_*) are substituted with @sha256: digests by
+# the deploy workflow (DR-1.1, DR-1.2) to ensure verifiable, immutable image
+# references for CVM verification. Mutable tags (:latest, :sha) are never used
+# in the deployed compose file.
 
 services:
   lit-actions:

--- a/justfile
+++ b/justfile
@@ -1,7 +1,9 @@
 # Conventions: https://github.com/casey/just
 
 image_base := env('DOCKER_IMAGE', 'litptcl/lit-node-express')
-# Unique UUID tag per deploy (override with DOCKER_TAG to pin a specific build)
+# Tag used only to satisfy the registry push requirement; the deploy step uses
+# the @sha256: digest captured after push, never this tag. Override with
+# DOCKER_TAG to reuse a previously-pushed image (digest files must then exist).
 image_tag := env('DOCKER_TAG', `uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '\n'`)
 image_lit_actions    := image_base + '-lit-actions:'    + image_tag
 image_lit_api_server := image_base + '-lit-api-server:' + image_tag
@@ -38,7 +40,9 @@ setup:
     npm install -g phala
     phala --version
 
-# Build and push all three Docker images in parallel (release mode, linux/amd64 for Phala CVM)
+# Build and push all three Docker images (release mode, linux/amd64 for Phala CVM).
+# After each push the registry-assigned @sha256: digest is written to
+# .digest-{service}.txt — these are read by `deploy` for DR-1.1 compliance.
 [group: 'deploy']
 docker-build: _check_docker
     #!/usr/bin/env sh
@@ -51,24 +55,42 @@ docker-build: _check_docker
     docker push {{image_lit_api_server}} &
     docker push {{image_lit_static}}     &
     wait
+    # Capture the immutable registry digest for each image.
+    # docker inspect .RepoDigests is populated by `docker push` with the
+    # registry-assigned content hash; we strip the repo prefix to get sha256:...
+    docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_actions}}    | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-actions.txt
+    docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_api_server}} | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-api-server.txt
+    docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_static}}     | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-static.txt
+    for f in .digest-lit-actions.txt .digest-lit-api-server.txt .digest-lit-static.txt; do
+        [ -s "$f" ] || { echo "error: digest capture failed for $f"; exit 1; }
+        printf "captured %s: %s\n" "$f" "$(cat $f)"
+    done
 
 [group: 'deploy']
 docker-push: docker-build
 
 
-# Deploy to Phala Cloud (requires: docker login, phala login)
-# Builds with unique UUID tag, pushes to registry, deploys that tagged image.
-# Override DOCKER_IMAGE (repo path) or DOCKER_TAG (to pin a specific build).
+# Deploy to Phala Cloud (requires: docker login, phala login).
+# Builds, pushes, captures @sha256: digests, then substitutes them into the
+# compose file (DR-1.1, DR-1.2). Override DOCKER_IMAGE (repo path) or
+# DOCKER_TAG (to skip the build and reuse a prior push; digest files must exist).
 # Use deploy to upgrade existing CVM; use deploy-new for first-time provisioning.
 [group: 'deploy']
 deploy: docker-push _check_phala
     #!/usr/bin/env sh
     set -eu
+    DIGEST_LIT_ACTIONS=$(cat .digest-lit-actions.txt)
+    DIGEST_LIT_API_SERVER=$(cat .digest-lit-api-server.txt)
+    DIGEST_LIT_STATIC=$(cat .digest-lit-static.txt)
+    [ -n "$DIGEST_LIT_ACTIONS" ]    || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_API_SERVER" ] || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_STATIC" ]     || { echo "error: lit-static digest missing; run: just docker-build"; exit 1; }
     sed \
-        -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_lit_actions}}|g" \
-        -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_lit_api_server}}|g" \
-        -e "s|\${DOCKER_IMAGE_LIT_STATIC}|{{image_lit_static}}|g" \
+        -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+        -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
+        -e "s|\${DOCKER_IMAGE_LIT_STATIC}|{{image_base}}-lit-static@${DIGEST_LIT_STATIC}|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
+    cat docker-compose.deploy.yml
     phala deploy -c docker-compose.deploy.yml --cvm-id {{app_name}} --instance-type {{instance_type}}
 
 # Run locally with Docker Compose (no Phala Cloud)

--- a/justfile
+++ b/justfile
@@ -40,9 +40,7 @@ setup:
     npm install -g phala
     phala --version
 
-# Build and push all three Docker images (release mode, linux/amd64 for Phala CVM).
-# After each push the registry-assigned @sha256: digest is written to
-# .digest-{service}.txt — these are read by `deploy` for DR-1.1 compliance.
+# Build all three Docker images in parallel (release mode, linux/amd64 for Phala CVM)
 [group: 'deploy']
 docker-build: _check_docker
     #!/usr/bin/env sh
@@ -51,13 +49,19 @@ docker-build: _check_docker
     docker build --platform linux/amd64 -f Dockerfile.lit-api-server -t {{image_lit_api_server}} . &
     docker build --platform linux/amd64 -f Dockerfile.lit-static     -t {{image_lit_static}}     . &
     wait
+
+# Push all three images in parallel and capture each registry-assigned @sha256: digest.
+# Digests are written to .digest-{service}.txt and read by `deploy` (DR-1.1, DR-1.2).
+# docker inspect .RepoDigests is populated by `docker push` with the registry-assigned
+# content hash; we strip the repo prefix to get sha256:...
+[group: 'deploy']
+docker-push: docker-build
+    #!/usr/bin/env sh
+    set -eu
     docker push {{image_lit_actions}}    &
     docker push {{image_lit_api_server}} &
     docker push {{image_lit_static}}     &
     wait
-    # Capture the immutable registry digest for each image.
-    # docker inspect .RepoDigests is populated by `docker push` with the
-    # registry-assigned content hash; we strip the repo prefix to get sha256:...
     docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_actions}}    | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-actions.txt
     docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_api_server}} | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-api-server.txt
     docker inspect --format='{{{{json .RepoDigests}}}}' {{image_lit_static}}     | tr -d '[]" ' | cut -d',' -f1 | sed 's/.*@//' > .digest-lit-static.txt
@@ -65,9 +69,6 @@ docker-build: _check_docker
         [ -s "$f" ] || { echo "error: digest capture failed for $f"; exit 1; }
         printf "captured %s: %s\n" "$f" "$(cat $f)"
     done
-
-[group: 'deploy']
-docker-push: docker-build
 
 
 # Deploy to Phala Cloud (requires: docker login, phala login).


### PR DESCRIPTION
## Summary

- **Captures the SHA256 digest** from each `docker/build-push-action` run (via the `push` step's `digest` output) and uploads it as a per-service artifact
- **Deploy job downloads digests** and substitutes `image@sha256:DIGEST` (instead of `:sha-tag`) when rendering `docker-compose.deploy.yml`
- **Adds a comment** to `docker-compose.phala.yml` documenting that the `${DOCKER_IMAGE_*}` placeholders resolve to immutable digests

Satisfies **DR-1.1** and **DR-1.2** from the Phase 1 Workflow B requirements, enabling **VR-1.3** (verifier can confirm all images use SHA256 digests).

## Verification

The `cat docker-compose.deploy.yml` step (already present) will log the deployed compose file, showing lines like:

```
image: docker.io/org/lit-node-express-lit-actions@sha256:abc123...
```

## Test plan

- [ ] Trigger a deploy workflow run; confirm the logged `docker-compose.deploy.yml` shows `@sha256:` digests for all three services
- [ ] Confirm deploy succeeds and CVM boots normally

## References

- Requirements: `docs/deployment/planning/requirements.md` — DR-1.1, DR-1.2, VR-1.3
- Plan: `docs/deployment/planning/PLAN-phase-1.md` — Workflow B

🤖 Generated with [Claude Code](https://claude.com/claude-code)