### PR TITLE
feat(ci): verify remote attestation after deploy

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -165,6 +165,13 @@ jobs:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
       runner: ${{ needs.determine-runner.outputs.runner }}
 
+  verify-attestation:
+    needs: [wait-for-api-available, determine-runner, determine-target]
+    uses: ./.github/workflows/verify-attestation.yml
+    with:
+      attestation_url: ${{ needs.determine-target.outputs.base_url }}
+      runner: ${{ needs.determine-runner.outputs.runner }}
+
   openapi-spec-check:
     needs: [wait-for-api-available, determine-runner]
     uses: ./.github/workflows/openapi-spec-check.yml

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -36,36 +36,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ── 1. Build the dstack simulator and verifier (cached by upstream SHA) ─
-      # The cache key is the dstack HEAD SHA — obtained without cloning via
-      # git ls-remote. On cache hit the clone and both cargo/build.sh builds
-      # are skipped entirely; the binaries and runtime data files are restored
-      # directly and used as-is. Cache is scoped by branch (base branch for PRs).
+      # ── 1. Build the dstack simulator and verifier (cached separately) ────
+      # Each artifact has its own cache keyed by the dstack HEAD SHA (obtained
+      # without cloning via git ls-remote). The verifier cache is shared with
+      # the verify-attestation workflow so a warm hit there avoids rebuilding
+      # here. On full cache hit the clone and all builds are skipped entirely.
       - name: Get dstack HEAD SHA
         id: dstack-sha
         run: |
           SHA=$(git ls-remote https://github.com/Dstack-TEE/dstack.git HEAD | head -1 | cut -f1 | tr -d '[:space:]')
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "Cache key: dstack-${SHA}-${{ runner.os }}"
 
-      - name: Restore dstack cache
-        id: dstack-cache
+      - name: Restore simulator cache
+        id: sim-cache
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/dstack-cache
-          key: dstack-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+          path: ${{ github.workspace }}/dstack-cache/simulator
+          key: dstack-simulator-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
-      - name: Cache status
-        run: echo "cache-hit=${{ steps.dstack-cache.outputs.cache-hit }}"
+      - name: Restore verifier cache
+        id: verifier-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/dstack-cache/verifier
+          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
       - name: Fix dstack cache permissions
-        if: steps.dstack-cache.outputs.cache-hit == 'true'
+        if: steps.sim-cache.outputs.cache-hit == 'true' || steps.verifier-cache.outputs.cache-hit == 'true'
         run: |
           CACHE_DIR="${{ github.workspace }}/dstack-cache"
           [ -d "$CACHE_DIR" ] && chmod -R u+rwX "$CACHE_DIR" || true
 
       - name: Clone dstack repository
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
         run: |
           DSTACK_BUILD=$(mktemp -d)
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
@@ -73,34 +76,36 @@ jobs:
 
       # Use stable Rust for the dstack build (it may require features newer than 1.91).
       - name: Install Rust (stable, for dstack)
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build dstack simulator
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.sim-cache.outputs.cache-hit != 'true'
         run: cd "$DSTACK_BUILD/sdk/simulator" && bash build.sh
 
-      - name: Build dstack-verifier
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
-
-      - name: Populate dstack cache
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+      - name: Populate simulator cache
+        if: steps.sim-cache.outputs.cache-hit != 'true'
         run: |
-          CACHE_DIR="${{ github.workspace }}/dstack-cache"
-          mkdir -p "$CACHE_DIR/simulator" "$CACHE_DIR/verifier"
-          # Simulator: binary + data files read via relative paths at runtime
+          mkdir -p "${{ github.workspace }}/dstack-cache/simulator"
           cp "$DSTACK_BUILD/sdk/simulator/dstack-simulator" \
              "$DSTACK_BUILD/sdk/simulator/appkeys.json" \
              "$DSTACK_BUILD/sdk/simulator/app-compose.json" \
              "$DSTACK_BUILD/sdk/simulator/sys-config.json" \
              "$DSTACK_BUILD/sdk/simulator/attestation.bin" \
              "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
-             "$CACHE_DIR/simulator/"
-          # Verifier: binary + config
+             "${{ github.workspace }}/dstack-cache/simulator/"
+
+      - name: Build dstack-verifier
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
+        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
+
+      - name: Populate verifier cache
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
           cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
              "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
-             "$CACHE_DIR/verifier/"
+             "${{ github.workspace }}/dstack-cache/verifier/"
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -1,0 +1,143 @@
+# Verify attestation from a deployed Phala CVM
+#
+# Fetches /attestation from the live API, builds the dstack-verifier,
+# and asserts is_valid=true.  Unlike the simulator CI job (which can only
+# check quote_verified), a real TDX deployment must produce a fully valid
+# attestation.
+#
+# Called from Deploy to Phala CVM after the API is available, or manually
+# via workflow_dispatch.
+
+name: Verify Remote Attestation
+
+on:
+  workflow_call:
+    inputs:
+      attestation_url:
+        description: "Base URL of the deployed CVM (e.g. https://host — /attestation is appended)"
+        required: true
+        type: string
+      runner:
+        description: 'Runner as JSON array (e.g. ["self-hosted"])'
+        required: false
+        type: string
+        default: '["self-hosted"]'
+  workflow_dispatch:
+    inputs:
+      attestation_url:
+        description: "Base URL of the deployed CVM (e.g. https://host)"
+        required: true
+        type: string
+      runner:
+        description: "Runner as JSON array"
+        required: false
+        type: string
+        default: '["self-hosted"]'
+
+jobs:
+  verify:
+    name: dstack-verifier (remote)
+    runs-on: ${{ fromJson(inputs.runner) }}
+    steps:
+      # ── 1. Build dstack-verifier (cached by upstream SHA) ────────────
+      - name: Get dstack HEAD SHA
+        id: dstack-sha
+        run: |
+          SHA=$(git ls-remote https://github.com/Dstack-TEE/dstack.git HEAD | head -1 | cut -f1 | tr -d '[:space:]')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Restore dstack cache
+        id: dstack-cache
+        uses: actions/cache@v4
+        with:
+          path: dstack-cache
+          key: dstack-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+
+      - name: Fix dstack cache permissions
+        if: steps.dstack-cache.outputs.cache-hit == 'true'
+        run: chmod -R u+rwX dstack-cache 2>/dev/null || true
+
+      - name: Clone dstack repository
+        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        run: |
+          DSTACK_BUILD=$(mktemp -d)
+          echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
+          git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
+
+      - name: Install Rust (stable, for dstack)
+        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build dstack simulator (verifier dependency)
+        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        run: cd "$DSTACK_BUILD/sdk/simulator" && bash build.sh
+
+      - name: Build dstack-verifier
+        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
+
+      - name: Populate dstack cache
+        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p dstack-cache/simulator dstack-cache/verifier
+          cp "$DSTACK_BUILD/sdk/simulator/dstack-simulator" \
+             "$DSTACK_BUILD/sdk/simulator/appkeys.json" \
+             "$DSTACK_BUILD/sdk/simulator/app-compose.json" \
+             "$DSTACK_BUILD/sdk/simulator/sys-config.json" \
+             "$DSTACK_BUILD/sdk/simulator/attestation.bin" \
+             "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
+             dstack-cache/simulator/
+          cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
+             "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
+             dstack-cache/verifier/
+
+      - name: Remove dstack build directory
+        if: always() && env.DSTACK_BUILD != ''
+        run: rm -rf "$DSTACK_BUILD"
+
+      # ── 2. Fetch attestation from deployed CVM, verify with dstack-verifier ─
+      - name: Verify remote attestation
+        run: |
+          set -eu
+          ATTESTATION_URL="${{ inputs.attestation_url }}"
+          VERIFIER_BIN="$(pwd)/dstack-cache/verifier/dstack-verifier"
+          VERIFIER_CFG="$(pwd)/dstack-cache/verifier/dstack-verifier.toml"
+          TMP_DIR=$(mktemp -d /tmp/verify-remote-XXXXXX)
+
+          echo "Fetching attestation from $ATTESTATION_URL/attestation..."
+          QUOTE_RESP=$(curl -sf "$ATTESTATION_URL/attestation") || {
+            echo "::error::Failed to fetch $ATTESTATION_URL/attestation"
+            rm -rf "$TMP_DIR"
+            exit 1
+          }
+
+          # Build verifier request: strip 0x prefix from quote, set attestation=null.
+          VERIFY_FILE="$TMP_DIR/verify-request.json"
+          printf '%s' "$QUOTE_RESP" | python3 -c \
+            'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
+            > "$VERIFY_FILE"
+
+          # Use a writable image cache dir (avoids /tmp permission issues on self-hosted).
+          VERIFIER_CFG_OVERRIDE="$TMP_DIR/verifier.toml"
+          CACHE_DIR="$(pwd)/dstack-cache/verifier-image-cache"
+          mkdir -p "$CACHE_DIR"
+          sed "s|image_cache_dir = .*|image_cache_dir = \"$CACHE_DIR\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
+
+          echo "Running dstack-verifier (oneshot)..."
+          "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true
+
+          RESULT_FILE="${VERIFY_FILE}.verification.json"
+          echo "--- Verifier output ---"
+          cat "$RESULT_FILE"
+          echo "--- end ---"
+
+          IS_VALID=$(python3 -c \
+            'import sys,json; v=json.load(open(sys.argv[1])); print("true" if v.get("is_valid") else "false")' \
+            "$RESULT_FILE")
+          rm -rf "$TMP_DIR"
+
+          if [ "$IS_VALID" != "true" ]; then
+            echo "::error::is_valid=false — remote attestation from $ATTESTATION_URL is not valid"
+            exit 1
+          fi
+          echo "Remote attestation verified: is_valid=true."

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -46,39 +46,41 @@ jobs:
           SHA=$(git ls-remote https://github.com/Dstack-TEE/dstack.git HEAD | head -1 | cut -f1 | tr -d '[:space:]')
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Restore dstack cache
-        id: dstack-cache
+      # Shared with phala-simulator.yml — same key and path so either
+      # workflow can warm the cache for the other.
+      - name: Restore verifier cache
+        id: verifier-cache
         uses: actions/cache@v4
         with:
-          path: dstack-cache
+          path: ${{ github.workspace }}/dstack-cache/verifier
           key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
       - name: Fix dstack cache permissions
-        if: steps.dstack-cache.outputs.cache-hit == 'true'
-        run: chmod -R u+rwX dstack-cache 2>/dev/null || true
+        if: steps.verifier-cache.outputs.cache-hit == 'true'
+        run: chmod -R u+rwX "${{ github.workspace }}/dstack-cache" 2>/dev/null || true
 
       - name: Clone dstack repository
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
         run: |
           DSTACK_BUILD=$(mktemp -d)
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
           git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
 
       - name: Install Rust (stable, for dstack)
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build dstack-verifier
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
         run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
 
-      - name: Populate dstack cache
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
+      - name: Populate verifier cache
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p dstack-cache/verifier
+          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
           cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
              "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
-             dstack-cache/verifier/
+             "${{ github.workspace }}/dstack-cache/verifier/"
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''
@@ -89,8 +91,9 @@ jobs:
         run: |
           set -eu
           ATTESTATION_URL="${{ inputs.attestation_url }}"
-          VERIFIER_BIN="$(pwd)/dstack-cache/verifier/dstack-verifier"
-          VERIFIER_CFG="$(pwd)/dstack-cache/verifier/dstack-verifier.toml"
+          CACHE_DIR="${{ github.workspace }}/dstack-cache"
+          VERIFIER_BIN="$CACHE_DIR/verifier/dstack-verifier"
+          VERIFIER_CFG="$CACHE_DIR/verifier/dstack-verifier.toml"
           TMP_DIR=$(mktemp -d /tmp/verify-remote-XXXXXX)
 
           echo "Fetching attestation from $ATTESTATION_URL/attestation..."
@@ -108,9 +111,9 @@ jobs:
 
           # Use a writable image cache dir (avoids /tmp permission issues on self-hosted).
           VERIFIER_CFG_OVERRIDE="$TMP_DIR/verifier.toml"
-          CACHE_DIR="$(pwd)/dstack-cache/verifier-image-cache"
-          mkdir -p "$CACHE_DIR"
-          sed "s|image_cache_dir = .*|image_cache_dir = \"$CACHE_DIR\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
+          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
+          mkdir -p "$IMAGE_CACHE"
+          sed "s|image_cache_dir = .*|image_cache_dir = \"$IMAGE_CACHE\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
 
           echo "Running dstack-verifier (oneshot)..."
           "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dstack-cache
-          key: dstack-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
       - name: Fix dstack cache permissions
         if: steps.dstack-cache.outputs.cache-hit == 'true'
@@ -68,10 +68,6 @@ jobs:
         if: steps.dstack-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build dstack simulator (verifier dependency)
-        if: steps.dstack-cache.outputs.cache-hit != 'true'
-        run: cd "$DSTACK_BUILD/sdk/simulator" && bash build.sh
-
       - name: Build dstack-verifier
         if: steps.dstack-cache.outputs.cache-hit != 'true'
         run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
@@ -79,14 +75,7 @@ jobs:
       - name: Populate dstack cache
         if: steps.dstack-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p dstack-cache/simulator dstack-cache/verifier
-          cp "$DSTACK_BUILD/sdk/simulator/dstack-simulator" \
-             "$DSTACK_BUILD/sdk/simulator/appkeys.json" \
-             "$DSTACK_BUILD/sdk/simulator/app-compose.json" \
-             "$DSTACK_BUILD/sdk/simulator/sys-config.json" \
-             "$DSTACK_BUILD/sdk/simulator/attestation.bin" \
-             "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
-             dstack-cache/simulator/
+          mkdir -p dstack-cache/verifier
           cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
              "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
              dstack-cache/verifier/


### PR DESCRIPTION
## Summary
- Adds a new reusable workflow (`verify-attestation.yml`) that fetches `/attestation` from the deployed CVM, runs `dstack-verifier`, and **fails if `is_valid` is not `true`**
- Wired into `deploy-phala.yml` to run in parallel with `openapi-spec-check` after the API is available
- Unlike the simulator CI job (which can only assert `quote_verified=true` due to synthetic attestation), this validates the full attestation from real TDX hardware

## Test plan
- [ ] Merge to `next` and confirm the `verify-attestation` job appears in the deploy workflow graph
- [ ] Verify the job passes against the deployed `next` CVM (is_valid=true)
- [ ] Confirm failure mode by temporarily pointing `attestation_url` at an invalid endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)