### PR TITLE
feat(deploy): switch to Onchain KMS on Base (DeRoT)

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -1,22 +1,28 @@
 # Deploy lit-api-server + lit-actions + lit-static to Phala CVM (tdx.large instance)
+# Uses Onchain KMS on Base (DeRoT) for key management — no Phala Cloud KMS.
 #
 # Branch-based deployment:
-#   push to main  → lit-api-server,      base_url https://api.dev.litprotocol.com
-#   push to next  → lit-api-server-next, base_url https://...-8000.dstack-pha-prod5.phala.network
+#   push to main  → lit-api-server,      api_url https://api.dev.litprotocol.com
+#   push to next  → lit-api-server-next, api_url https://...-8000.dstack-pha-prod5.phala.network
 #
 # Required secrets:
-#   DOCKERHUB_TOKEN - Docker Hub PAT (Account Settings > Security > Access Tokens)
-#   PHALA_CLOUD_API_KEY - From Phala Cloud Dashboard > API Tokens
+#   DOCKERHUB_TOKEN      - Docker Hub PAT (Account Settings > Security > Access Tokens)
+#   PHALA_CLOUD_API_KEY  - From Phala Cloud Dashboard > API Tokens (CVM management)
+#   DEROT_PRIVATE_KEY    - Private key of the DstackApp owner wallet on Base
+#                          Used to whitelist the new compose-hash in the DstackApp contract
+#                          before the CVM boots. This key controls governance.
 #
 # Required vars:
-#   DOCKER_IMAGE - Base image path, e.g. docker.io/username/lit-node-express
-#                  Three images are pushed:
-#                    ${DOCKER_IMAGE}-lit-actions
-#                    ${DOCKER_IMAGE}-lit-api-server
-#                    ${DOCKER_IMAGE}-lit-static
-#   DOCKERHUB_USERNAME - Docker Hub username
+#   DOCKER_IMAGE         - Base image path, e.g. docker.io/username/lit-node-express
+#                          Three images are pushed:
+#                            ${DOCKER_IMAGE}-lit-actions
+#                            ${DOCKER_IMAGE}-lit-api-server
+#                            ${DOCKER_IMAGE}-lit-static
+#   DOCKERHUB_USERNAME   - Docker Hub username
+#   PHALA_APP_NAME       - CVM name, e.g. lit-api-server
+#   BASE_RPC_URL         - Base mainnet RPC URL, e.g. https://mainnet.base.org
 
-name: Deploy to Phala CVM
+name: Deploy to Phala CVM (DeRoT)
 
 # Only one deploy job per-branch: abort any running job on same branch when a new commit is pushed.
 concurrency:
@@ -32,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       phala_app_name: ${{ steps.set.outputs.phala_app_name }}
-      base_url: ${{ steps.set.outputs.base_url }}
+      server_root_url: ${{ steps.set.outputs.server_root_url }}
       api_root_url: ${{ steps.set.outputs.api_root_url }}
     steps:
       - name: Set deployment target
@@ -40,16 +46,16 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "phala_app_name=lit-api-server" >> "$GITHUB_OUTPUT"
-            BASE_URL="https://api.dev.litprotocol.com"
+            SERVER_ROOT_URL="https://api.dev.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
             echo "phala_app_name=lit-api-server-next" >> "$GITHUB_OUTPUT"
-            BASE_URL="https://e364da71b0c9af3b9068daa6321edd6ee932aa89-8000.dstack-pha-prod5.phala.network"
+            SERVER_ROOT_URL="https://e364da71b0c9af3b9068daa6321edd6ee932aa89-8000.dstack-pha-prod5.phala.network"
           else
             echo "Unsupported branch for deployment"
             exit 1
           fi
-          echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
-          echo "api_root_url=${BASE_URL}/core/v1" >> "$GITHUB_OUTPUT"
+          echo "server_root_url=$SERVER_ROOT_URL" >> "$GITHUB_OUTPUT"
+          echo "api_root_url=${SERVER_ROOT_URL}/core/v1" >> "$GITHUB_OUTPUT"
 
   determine-runner:
     runs-on: ubuntu-latest
@@ -96,7 +102,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
-          build-args: ${{ matrix.service == 'lit-static' && format('BASE_URL={0}', needs.determine-target.outputs.base_url) || '' }}
+          build-args: ${{ matrix.service == 'lit-static' && format('BASE_URL={0}', needs.determine-target.outputs.server_root_url) || '' }}
 
       - name: Save image digest
         run: echo "${{ steps.push.outputs.digest }}" > digest-${{ matrix.service }}.txt
@@ -139,14 +145,17 @@ jobs:
       - name: Install Phala CLI
         run: npm install -g phala
 
-      - name: Deploy to Phala Cloud (tdx.large CVM)
+      - name: Deploy to Phala CVM with Onchain KMS (DeRoT on Base)
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
         run: |
           phala deploy \
             -c docker-compose.deploy.yml \
-            --cvm-id ${{ needs.determine-target.outputs.phala_app_name }} \
-            --instance-type tdx.large
+            --cvm-id ${{ vars.PHALA_APP_NAME }} \
+            --instance-type tdx.large \
+            --kms base \
+            --private-key ${{ secrets.DEROT_PRIVATE_KEY }} \
+            --rpc-url ${{ vars.BASE_RPC_URL }}
 
   # Give the Phala CLI time to trigger the CVM restart and begin rebooting.
   # Without this, the old instance may still be serving the API when wait-for-api-available
@@ -169,7 +178,7 @@ jobs:
     needs: [wait-for-api-available, determine-runner, determine-target]
     uses: ./.github/workflows/verify-attestation.yml
     with:
-      attestation_url: ${{ needs.determine-target.outputs.base_url }}
+      attestation_url: ${{ needs.determine-target.outputs.server_root_url }}
       runner: ${{ needs.determine-runner.outputs.runner }}
 
   openapi-spec-check:

--- a/justfile
+++ b/justfile
@@ -11,6 +11,8 @@ image_lit_static     := image_base + '-lit-static:'     + image_tag
 # main → lit-api-server; any other branch → lit-api-server-next (override with PHALA_APP_NAME)
 app_name := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo lit-api-server || echo lit-api-server-next'`
 instance_type := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo tdx.large || echo tdx.small'`
+base_rpc_url := env('BASE_RPC_URL', 'https://mainnet.base.org')
+derot_private_key := env('DEROT_PRIVATE_KEY', '')
 
 # List available recipes (default when invoked with no args)
 default:
@@ -79,13 +81,14 @@ docker-push: docker-build
     done
 
 
-# Deploy to Phala Cloud (requires: docker login, phala login).
-# Builds, pushes, captures @sha256: digests, then substitutes them into the
-# compose file (DR-1.1, DR-1.2). Override DOCKER_IMAGE (repo path) or
-# DOCKER_TAG (to skip the build and reuse a prior push; digest files must exist).
-# Use deploy to upgrade existing CVM; use deploy-new for first-time provisioning.
+# Deploy to Phala CVM with Onchain KMS on Base (DeRoT).
+# Requires: docker login, phala login, DEROT_PRIVATE_KEY env var set.
+# DEROT_PRIVATE_KEY is the private key of the DstackApp owner wallet on Base —
+# the phala CLI uses it to whitelist the new compose-hash before the CVM boots.
+# Builds with unique UUID tag, pushes to registry, deploys that tagged image.
+# Override DOCKER_IMAGE (repo path) or DOCKER_TAG (to pin a specific build).
 [group: 'deploy']
-deploy: docker-push _check_phala
+deploy: docker-push _check_phala _check_derot
     #!/usr/bin/env sh
     set -eu
     DIGEST_LIT_ACTIONS=$(cat .digest-lit-actions.txt)
@@ -99,8 +102,13 @@ deploy: docker-push _check_phala
         -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
         -e "s|\${DOCKER_IMAGE_LIT_STATIC}|{{image_base}}-lit-static@${DIGEST_LIT_STATIC}|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
-    cat docker-compose.deploy.yml
-    phala deploy -c docker-compose.deploy.yml --cvm-id {{app_name}} --instance-type {{instance_type}}
+    phala deploy \
+        -c docker-compose.deploy.yml \
+        --cvm-id {{app_name}} \
+        --instance-type {{instance_type}} \
+        --kms base \
+        --private-key {{derot_private_key}} \
+        --rpc-url {{base_rpc_url}}
 
 # Run locally with Docker Compose (no Phala Cloud)
 [group: 'deploy']
@@ -121,6 +129,12 @@ _check_phala:
     #!/usr/bin/env sh
     set -eu
     command -v phala >/dev/null 2>&1 || { echo "error: phala not found. Run: just setup"; exit 1; }
+
+[private]
+_check_derot:
+    #!/usr/bin/env sh
+    set -eu
+    [ -n "{{derot_private_key}}" ] || { echo "error: DEROT_PRIVATE_KEY is not set. Export the DstackApp owner private key."; exit 1; }
 
 [group: 'debug']
 ssh:


### PR DESCRIPTION
### TL;DR

Migrated Phala CVM deployment from Phala Cloud KMS to Onchain KMS using DeRoT (Decentralized Root of Trust) on Base mainnet for enhanced security and decentralization.

### What changed?

- **Key Management Migration**: Switched from Phala Cloud KMS to Onchain KMS using DeRoT on Base mainnet
- **New Configuration Requirements**: Added `DEROT_PRIVATE_KEY` secret for DstackApp owner wallet and `BASE_RPC_URL` + `PHALA_APP_NAME` variables
- **Updated Deployment Commands**: Modified `phala deploy` commands to include `--kms base`, `--private-key`, and `--rpc-url` flags
- **Variable Renaming**: Changed `base_url` references to `server_root_url` for clarity
- **Enhanced Documentation**: Updated comments to explain the DeRoT integration and governance model

### How to test?

1. Set the required environment variables:
   - `DEROT_PRIVATE_KEY`: Private key of the DstackApp owner wallet on Base
   - `BASE_RPC_URL`: Base mainnet RPC endpoint
   - `PHALA_APP_NAME`: CVM application name
2. Run `just deploy` to test the new deployment flow with Onchain KMS
3. Verify the CVM boots successfully and the compose-hash is whitelisted in the DstackApp contract
4. Confirm the API endpoints remain accessible after deployment

### Why make this change?

This migration enhances security by removing dependency on centralized Phala Cloud KMS and instead leverages blockchain-based key management through DeRoT on Base. The DstackApp owner wallet now controls governance and whitelisting of compose-hashes, providing a more decentralized and trustless deployment model for the Lit Protocol infrastructure.