### PR TITLE
deployed base contracts

### DIFF
--- a/lit-api-server/NodeConfig.demo.sepolia.toml
+++ b/lit-api-server/NodeConfig.demo.sepolia.toml
@@ -1,0 +1,4 @@
+[chain]
+name = "basesepolia"
+contract_address = "0xefbf8042ef4ff8cbb4fa7e4bf06598a19cdb9e21"
+secret = "0xd9884c772d9e85843d36fc4b18972068efc02ec6f50924725d2cc39ecefcd8ef"

--- a/lit-api-server/NodeConfig.demo.toml
+++ b/lit-api-server/NodeConfig.demo.toml
@@ -1,4 +1,4 @@
 [chain]
 name = "base"
 contract_address = "0x97ccfb3a7402a8e62404fa9bb8212f495aea2483"
-secret = "0xf2360ce22ff07cde0dd847d7fa25ef0b2d76cc663fe70f249a53b395a872d853" # Lit Chain Mainnet Shared Funds on Bitwarden
+secret = "0xf2360ce22ff07cde0dd847d7fa25ef0b2d76cc663fe70f249a53b395a872d853"

--- a/lit-api-server/NodeConfig.demo.toml
+++ b/lit-api-server/NodeConfig.demo.toml
@@ -1,4 +1,4 @@
 [chain]
-name = "basesepolia"
-contract_address = "0xefbf8042ef4ff8cbb4fa7e4bf06598a19cdb9e21"
-secret = "0xd9884c772d9e85843d36fc4b18972068efc02ec6f50924725d2cc39ecefcd8ef"
+name = "base"
+contract_address = "0x97ccfb3a7402a8e62404fa9bb8212f495aea2483"
+secret = "0xf2360ce22ff07cde0dd847d7fa25ef0b2d76cc663fe70f249a53b395a872d853" # Lit Chain Mainnet Shared Funds on Bitwarden

--- a/lit-api-server/README.md
+++ b/lit-api-server/README.md
@@ -91,7 +91,7 @@ cargo run --release --bin contract_generator -- <input_folder> <output_folder>
 cargo run --release --bin contract_deployer -- <network> <abis_folder> [secret]
 ```
 
-- **`<network>`** — `0` = Anvil, `1` = Yellowstone, `2` = Base Sepolia.
+- **`<network>`** — `0` = Anvil, `1` = Yellowstone, `2` = Base Sepolia, `3` = Base.
 - **`<abis_folder>`** — Folder of contract **artifact** JSONs (`abi` + `bytecode` or `evm.bytecode.object`).
 - **`[secret]`** — Optional. Deployer private key (hex). If omitted or blank, uses the default Anvil dev secret.
 
@@ -113,7 +113,7 @@ cargo run --release --bin contract_deployer -- 0 ./artifacts 0xYourPrivateKeyHex
 
 - Uses the given secret or the default Anvil account #0 key; suitable for local/testnet.
 - Skips artifacts with no bytecode (e.g. interfaces).
-- RPC URLs: Anvil `http://127.0.0.1:8545`, Yellowstone `https://yellowstone-rpc.litprotocol.com`, Base Sepolia `https://sepolia.base.org`.
+- RPC URLs: Anvil `http://127.0.0.1:8545`, Yellowstone `https://yellowstone-rpc.litprotocol.com`, Base Sepolia `https://sepolia.base.org`, Base `https://mainnet.base.org`.
 
 ---
 

--- a/lit-api-server/blockchain/lit_node_express/Makefile
+++ b/lit-api-server/blockchain/lit_node_express/Makefile
@@ -5,6 +5,7 @@ RUST_PROJECT := ../rust_generator_and_deployer
 GENERATOR_BIN := $(RUST_PROJECT)/target/debug/contract_generator
 DEPLOYER_BIN := $(RUST_PROJECT)/target/debug/contract_deployer
 DEPLOYER_SECRET := 0xd9884c772d9e85843d36fc4b18972068efc02ec6f50924725d2cc39ecefcd8ef
+BASE_DEPLOYER_SECRET := 0xf2360ce22ff07cde0dd847d7fa25ef0b2d76cc663fe70f249a53b395a872d853
 ANVIL_SECRET := 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # 1. Compile Solidity contracts with Hardhat
@@ -16,12 +17,17 @@ generate: compile
 	cd $(RUST_PROJECT) && cargo build --bin contract_generator
 	$(GENERATOR_BIN) artifacts/contracts ../../src/accounts/contracts/
 
-# 3. Deploy contracts. Args: network (1 = Yellowstone, 2 = Base Sepolia), abis_folder
-deploy: generate
+# 3. Deploy contracts to Base mainnet. Args: network (3 = Base), abis_folder
+deploy_base: generate
+	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
+	$(DEPLOYER_BIN) 3 artifacts/contracts $(BASE_DEPLOYER_SECRET)
+
+# 4. Deploy contracts to Base Sepolia. Args: network (2 = Base Sepolia), abis_folder
+deploy_sepolia: generate
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) 2 artifacts/contracts $(DEPLOYER_SECRET)
 
-# 4. Deploy contracts. Args: network (0 = Anvil), abis_folder
+# 5. Deploy contracts to Anvil. Args: network (0 = Anvil), abis_folder
 deploy_anvil: generate
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) 0 artifacts/contracts $(ANVIL_SECRET)

--- a/lit-api-server/blockchain/rust_generator_and_deployer/README.md
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/README.md
@@ -1,6 +1,6 @@
 # rust_generator_and_deployer
 
-Rust CLI tools for the Lit blockchain stack: generate Rust contract bindings from ABI files, and deploy contract artifacts to a chain (Anvil, Yellowstone, or Lit Mainnet).
+Rust CLI tools for the Lit blockchain stack: generate Rust contract bindings from ABI files, and deploy contract artifacts to a chain (Anvil, Yellowstone, Base Sepolia, or Base).
 
 ## Build
 
@@ -71,7 +71,7 @@ cargo run --release --bin contract_deployer -- <network> <abis_folder>
 
 | Argument | Description |
 |----------|-------------|
-| `network` | `0` = Anvil (local), `1` = Yellowstone, `2` = Lit Mainnet. |
+| `network` | `0` = Anvil (local), `1` = Yellowstone, `2` = Base Sepolia, `3` = Base. |
 | `abis_folder` | Folder containing contract artifact JSON files. Subdirectories are scanned. Each artifact must have `abi` and either top-level `bytecode` or `evm.bytecode.object`. |
 
 ### Networks
@@ -80,7 +80,8 @@ cargo run --release --bin contract_deployer -- <network> <abis_folder>
 |------|---------|-----|
 | `0` | Anvil | `http://127.0.0.1:8545` (chain id 31337) |
 | `1` | Yellowstone | `https://yellowstone-rpc.litprotocol.com` (chain id 175188) |
-| `2` | Lit Mainnet | Same as Yellowstone |
+| `2` | Base Sepolia | `https://sepolia.base.org` (chain id 84532) |
+| `3` | Base | `https://mainnet.base.org` (chain id 8453) |
 
 ### Examples
 

--- a/lit-api-server/blockchain/rust_generator_and_deployer/src/bin/contract_deployer.rs
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/src/bin/contract_deployer.rs
@@ -2,7 +2,7 @@
 //!
 //! Usage: deploy <network> <abis_folder> [secret]
 //!
-//! network: 0 = Anvil, 1 = Yellowstone, 2 = LitMainnet
+//! network: 0 = Anvil, 1 = Yellowstone, 2 = Base Sepolia, 3 = Base
 //! secret: optional; if blank or omitted, uses the default Anvil dev secret.
 
 use ethers::contract::ContractFactory;
@@ -20,6 +20,8 @@ const YELLOWSTONE_RPC: &str = "https://yellowstone-rpc.litprotocol.com";
 const YELLOWSTONE_CHAIN_ID: u64 = 175188;
 const BASE_SEPOLIA_RPC: &str = "https://sepolia.base.org";
 const BASE_SEPOLIA_CHAIN_ID: u64 = 84532;
+const BASE_RPC: &str = "https://base-mainnet.g.alchemy.com/v2/PjXc5vEM-AbNrsGKNyK99";
+const BASE_CHAIN_ID: u64 = 8453;
 /// Default Anvil account #0 private key (well-known for local dev)
 const DEFAULT_SECRET: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
@@ -31,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "Usage: {} <network> <abis_folder> [secret]",
             args.first().unwrap_or(&"deploy".into())
         );
-        eprintln!("  network   - 0 = Anvil, 1 = Yellowstone, 2 = Base Sepolia");
+        eprintln!("  network   - 0 = Anvil, 1 = Yellowstone, 2 = Base Sepolia, 3 = Base");
         eprintln!(
             "  abis_folder - folder containing contract artifact JSON files (abi + bytecode)"
         );
@@ -43,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let network: u16 = match args[1].parse() {
         Ok(n) => n,
         Err(_) => {
-            eprintln!("network must be 0, 1, or 2 (got: {:?})", args[1]);
+            eprintln!("network must be 0, 1, 2, or 3 (got: {:?})", args[1]);
             std::process::exit(1);
         }
     };
@@ -51,8 +53,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         0 => (ANVIL_RPC, ANVIL_CHAIN_ID),
         1 => (YELLOWSTONE_RPC, YELLOWSTONE_CHAIN_ID),
         2 => (BASE_SEPOLIA_RPC, BASE_SEPOLIA_CHAIN_ID),
+        3 => (BASE_RPC, BASE_CHAIN_ID),
         _ => {
-            eprintln!("network must be 0 (Anvil), 1 (Yellowstone), or 2 (Base Sepolia)");
+            eprintln!("network must be 0 (Anvil), 1 (Yellowstone), 2 (Base Sepolia), or 3 (Base)");
             std::process::exit(1);
         }
     };


### PR DESCRIPTION
### TL;DR

Added support for Base mainnet deployment alongside the existing Base Sepolia testnet configuration.

### What changed?

- Added Base mainnet as network option `3` in the contract deployer with RPC URL `https://base-mainnet.g.alchemy.com/v2/PjXc5vEM-AbNrsGKNyK99` and chain ID `8453`
- Created new `NodeConfig.demo.sepolia.toml` configuration file for Base Sepolia testnet
- Updated existing `NodeConfig.demo.toml` to use Base mainnet configuration with new contract address and secret
- Added `deploy_base` and `deploy_sepolia` targets in Makefile to deploy to respective networks
- Updated documentation to reflect the new network options and RPC endpoints

### How to test?

1. Use `make deploy_base` to deploy contracts to Base mainnet
2. Use `make deploy_sepolia` to deploy contracts to Base Sepolia testnet  
3. Run the contract deployer directly with network option `3` for Base mainnet or `2` for Base Sepolia
4. Verify the appropriate configuration files are used for each network

### Why make this change?

This change enables deployment to Base mainnet for production use while maintaining the existing Base Sepolia testnet configuration for development and testing purposes.