### PR TITLE
fix(dstack): hex-decode report_data before passing to dstack SDK

### DIFF
--- a/lit-api-server/src/dstack/v1/dstack.rs
+++ b/lit-api-server/src/dstack/v1/dstack.rs
@@ -36,7 +36,6 @@ fn resolve_socket_path() -> String {
 }
 
 /// Get the socket path from the environment or default to `/var/run/dstack.sock`.
-
 fn get_socket_path() -> Result<String, String> {
     let socket_path = resolve_socket_path();
     if !Path::new(&socket_path).exists() {

--- a/lit-api-server/src/dstack/v1/dstack.rs
+++ b/lit-api-server/src/dstack/v1/dstack.rs
@@ -83,8 +83,7 @@ pub async fn get_quote(
         None | Some("0x") | Some("") => vec![0u8; 64],
         Some(s) => {
             let hex_str = s.strip_prefix("0x").unwrap_or(s);
-            hex::decode(hex_str)
-                .map_err(|e| format!("invalid hex in report_data '{s}': {e}"))?
+            hex::decode(hex_str).map_err(|e| format!("invalid hex in report_data '{s}': {e}"))?
         }
     };
     let quote = client

--- a/lit-api-server/src/dstack/v1/dstack.rs
+++ b/lit-api-server/src/dstack/v1/dstack.rs
@@ -76,9 +76,19 @@ pub async fn get_quote(
     let socket_path = get_socket_path()?;
     let endpoint = Some(socket_path.as_str());
     let client = dstack_client::DstackClient::new(endpoint);
-    let report_data = report_data.unwrap_or("0x");
+    // The dstack SDK takes raw bytes and hex-encodes them internally before sending
+    // to the dstack socket. Callers pass a hex string (e.g. "0xdeadbeef"), so
+    // decode it to actual bytes first. None/empty means all-zero report_data.
+    let report_data_bytes: Vec<u8> = match report_data {
+        None | Some("0x") | Some("") => vec![0u8; 64],
+        Some(s) => {
+            let hex_str = s.strip_prefix("0x").unwrap_or(s);
+            hex::decode(hex_str)
+                .map_err(|e| format!("invalid hex in report_data '{s}': {e}"))?
+        }
+    };
     let quote = client
-        .get_quote(report_data.as_bytes().to_vec())
+        .get_quote(report_data_bytes)
         .await
         .map_err(|e| format!("failed to get quote: {e}"))?;
     Ok(quote)
@@ -209,7 +219,7 @@ mod tests {
     }
 
     /// Fails if the socket is available but the returned quote is invalid.
-    // #[tokio::test]
+    #[tokio::test]
     async fn fails_when_quote_invalid() {
         let path = resolve_socket_path();
         assert!(


### PR DESCRIPTION
## Summary

- Fixes a type mismatch in `get_quote()`: the dstack SDK accepts `Vec<u8>` raw bytes and hex-encodes them internally, but the previous call passed `report_data.as_bytes()` which converts the hex *string* `"0xdeadbeef"` to its ASCII bytes `[0x30, 0x78, 0x64, 0x65, ...]` — so the simulator embedded those ASCII bytes instead of `[0xde, 0xad, 0xbe, 0xef]` in the quote's `report_data` field.
- Fix: strip the `0x` prefix and `hex::decode()` to raw bytes before calling the SDK. `None`/`"0x"`/`""` maps to `vec![0u8; 64]` (all-zero report_data, matching original behaviour).
- Re-enables `fails_when_quote_invalid` which validates the full report_data round-trip.

## Root cause detail

The original hand-rolled HTTP implementation sent `{"report_data": "0xdeadbeef"}` as a JSON string and the dstack server decoded the hex. The replacement `dstack_sdk` client takes raw bytes and does the encoding itself — so the caller must pre-decode. `report_data.as_bytes()` passed the ASCII *representation* of the hex string, not the decoded bytes.

## Test plan

- [ ] `Phala Simulator Validation` CI job runs `fails_when_quote_invalid` against the simulator and passes
- [ ] `Rust CI` (fmt/clippy/build) passes for `lit-api-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)