### PR TITLE
feat(ci): sign container images with Sigstore keyless signing (DR-1b)

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -4,6 +4,17 @@
 #   push to main  → lit-api-server,      base_url https://api.dev.litprotocol.com
 #   push to next  → lit-api-server-next, base_url https://...-8000.dstack-pha-prod5.phala.network
 #
+# Image provenance (DR-1b): Each image is signed with Sigstore (cosign keyless) immediately
+# after push. Signatures are recorded in the public Rekor transparency log, binding the image
+# digest to the GitHub Actions OIDC identity that built it. This allows anyone to verify that
+# a given image digest was built from a specific commit in this repository.
+#
+# To verify an image:
+#   cosign verify \
+#     --certificate-identity-regexp "https://github.com/LIT-Protocol/lit-node-express/.*" \
+#     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+#     <image>@<digest>
+#
 # Required secrets:
 #   DOCKERHUB_TOKEN - Docker Hub PAT (Account Settings > Security > Access Tokens)
 #   PHALA_CLOUD_API_KEY - From Phala Cloud Dashboard > API Tokens
@@ -72,6 +83,9 @@ jobs:
   build:
     needs: [determine-runner, determine-target]
     runs-on: ${{ fromJson(needs.determine-runner.outputs.runner) }}
+    permissions:
+      id-token: write  # required for Sigstore keyless signing (OIDC token)
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +98,9 @@ jobs:
             dockerfile: Dockerfile.lit-static
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Log in to Docker Registry
         uses: docker/login-action@v3
@@ -101,6 +118,11 @@ jobs:
           push: true
           tags: ${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}:${{ github.sha }}
           build-args: ${{ matrix.service == 'lit-static' && format('BASE_URL={0}', needs.determine-target.outputs.base_url) || '' }}
+
+      - name: Sign image with Sigstore (keyless)
+        run: |
+          cosign sign --yes \
+            "${{ vars.DOCKER_IMAGE }}-${{ matrix.service }}@${{ steps.push.outputs.digest }}"
 
       - name: Save image digest
         run: echo "${{ steps.push.outputs.digest }}" > digest-${{ matrix.service }}.txt


### PR DESCRIPTION
## Summary

- Adds `sigstore/cosign-installer@v3` to the `build` job in `deploy-phala.yml`
- Signs each image digest with `cosign sign --yes` immediately after push, using GitHub Actions OIDC (keyless — no secrets required)
- Adds `id-token: write` permission to the `build` job (required for OIDC token issuance)
- Documents the `cosign verify` command in the workflow header for anyone auditing image provenance

## How it works

Cosign requests a short-lived certificate from Sigstore's Fulcio CA, authenticated via the GitHub Actions OIDC token. The signature and certificate are stored in the registry as OCI artifacts alongside the image, and the signing event is recorded in the public Rekor transparency log. This links the image digest to the specific commit and GitHub Actions workflow that produced it.

Signatures can be verified by anyone:
```sh
cosign verify \
  --certificate-identity-regexp "https://github.com/LIT-Protocol/lit-node-express/.*" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  <image>@<digest>
```

## Test plan

- [ ] Merge into `feat/derot-deployment` and trigger a deploy run; confirm all three `build` matrix jobs include a `Sign image with Sigstore (keyless)` step that exits 0
- [ ] Run `cosign verify` against a pushed image digest to confirm the signature is present and valid in Rekor

🤖 Generated with [Claude Code](https://claude.com/claude-code)