### PR TITLE
Migrate pkp_id = pubkey to pkp_id = wallet_address

### DIFF
--- a/lit-actions/ext/bindings.rs
+++ b/lit-actions/ext/bindings.rs
@@ -91,13 +91,13 @@ async fn op_increment_fetch_count(state: Rc<RefCell<OpState>>) -> Result<u32, Js
 async fn op_sign(
     state: Rc<RefCell<OpState>>,
     #[buffer(copy)] to_sign: Vec<u8>,
-    #[string] public_key: String,
+    #[string] pkp_id: String,
     #[string] sig_name: String,
     #[string] signing_scheme: String,
     #[string] _key_set_id: String,
 ) -> Result<String, JsErrorBox> {
     ensure_not_empty!(to_sign, "toSign");
-    ensure_not_blank!(public_key, "publicKey");
+    ensure_not_blank!(pkp_id, "pkpId");
     ensure_not_blank!(sig_name, "sigName");
     ensure_not_blank!(signing_scheme, "signingScheme");
 
@@ -105,7 +105,7 @@ async fn op_sign(
         state,
         SignRequest {
             to_sign,
-            public_key,
+            pkp_id,
             sig_name,
             signing_scheme,
         },
@@ -189,15 +189,15 @@ async fn op_verify_action_signature(
 #[string]
 async fn op_aes_encrypt(
     state: Rc<RefCell<OpState>>,
-    #[string] public_key: String,
+    #[string] pkp_id: String,
     #[string] message: String,
 ) -> Result<String, JsErrorBox> {
-    ensure_not_blank!(public_key, "publicKey");
+    ensure_not_blank!(pkp_id, "pkpId");
     ensure_not_blank!(message, "message");
 
     remote_op_async!(op_aes_encrypt,
         state,
-        AesEncryptRequest { public_key, message },
+        AesEncryptRequest { pkp_id, message },
         UnionRequest::AesEncrypt(resp) => Ok(resp.ciphertext)
     )
 }
@@ -207,15 +207,15 @@ async fn op_aes_encrypt(
 #[string]
 async fn op_aes_decrypt(
     state: Rc<RefCell<OpState>>,
-    #[string] public_key: String,
+    #[string] pkp_id: String,
     #[string] ciphertext: String,
 ) -> Result<String, JsErrorBox> {
-    ensure_not_blank!(public_key, "publicKey");
+    ensure_not_blank!(pkp_id, "pkpId");
     ensure_not_empty!(ciphertext);
 
     remote_op_async!(op_aes_decrypt,
         state,
-        AesDecryptRequest { public_key, ciphertext },
+        AesDecryptRequest { pkp_id, ciphertext },
         UnionRequest::AesDecrypt(resp) => Ok(resp.plaintext)
     )
 }

--- a/lit-actions/ext/js/02_litActionsSDK.js
+++ b/lit-actions/ext/js/02_litActionsSDK.js
@@ -19,17 +19,17 @@ function getLatestNonce({ address, chain }) {
  * @function signEcdsa
  * @param {Object} params
  * @param {Uint8Array} params.toSign The message to sign
- * @param {string} params.publicKey The public key of the PKP
+ * @param {string} params.pkpId The ID of the PKP
  * @param {string} params.sigName The name of the signature
  * @returns {Promise<Uint8Array>} The resulting signature
  */
-function signEcdsa({ toSign, publicKey, sigName}) {
-  return sign({ toSign, publicKey, sigName, signingScheme: "EcdsaK256Sha256" });
+function signEcdsa({ toSign, pkpId, sigName}) {
+  return sign({ toSign, pkpId, sigName, signingScheme: "EcdsaK256Sha256" });
 }
 
 /**
  * @param {Uint8array} toSign the message to sign
- * @param {string} publicKey the public key of the PKP
+ * @param {string} pkpId the ID of the PKP
  * @param {string} sigName the name of the signature
  * @param {string} signingScheme the name of the signing scheme
  *   one of the following
@@ -51,10 +51,10 @@ function signEcdsa({ toSign, publicKey, sigName}) {
  * @function sign
  * @returns {Uint8Array} The resulting signature 
  */
-function sign({ toSign, publicKey, sigName, signingScheme }) {
+function sign({ toSign, pkpId, sigName, signingScheme }) {
   return ops.op_sign(
     new Uint8Array(toSign),
-    publicKey,
+    pkpId,
     sigName,
     signingScheme,
   );
@@ -208,12 +208,12 @@ function uint8arrayFromString(...args) {
  * @name Lit.Actions.Decrypt
  * @function Decrypt
  * @param {Object} params
- * @param {string} params.publicKey The public key of the PKP
+ * @param {string} params.pkpId The ID of the PKP
  * @param {string} params.ciphertext The ciphertext to decrypt
  * @returns {Promise<string>} The decrypted plaintext
  */
-function Decrypt({ publicKey, ciphertext }) {
-  return ops.op_aes_decrypt(publicKey, ciphertext);
+function Decrypt({ pkpId, ciphertext }) {
+  return ops.op_aes_decrypt(pkpId, ciphertext);
 }
 
 /**
@@ -248,16 +248,16 @@ function encrypt_bls({
  * @name Lit.Actions.Encrypt
  * @function Encrypt
  * @param {Object} params
- * @param {string} params.publicKey The public key of the PKP
+ * @param {string} params.pkpId The ID of the PKP
  * @param {string} params.message The message to encrypt
  * @returns {Promise<string>} The ciphertext
  */
 
 function Encrypt({
-  publicKey,
+  pkpId,
   message,
 }) {
-  return ops.op_aes_encrypt(publicKey, message);
+  return ops.op_aes_encrypt(pkpId, message);
 }
 
 globalThis.LitActions = {

--- a/lit-actions/ext/js/06_litActionsSDK_viem.js
+++ b/lit-actions/ext/js/06_litActionsSDK_viem.js
@@ -1,6 +1,6 @@
 /**
  * Lit.Actions.Viem - custom account compatible with viem's toAccount interface.
- * Initialized by wallet address and PKP public key; signing uses Lit.Actions.sign from
+ * Initialized by wallet address and PKP ID; signing uses Lit.Actions.sign from
  * 02_litActionsSDK.js with EcdsaK256Sha256. Exposed as Lit.Actions.Viem.toAccount().
  */
 import { utils } from 'ext:lit_actions/00_ethers.js';
@@ -16,15 +16,15 @@ function nextSigName() {
  * Sign raw digest bytes via Lit.Actions.sign (op_sign); signature shares are combined
  * by the Lit JS SDK client. Returns the op result (e.g. "success").
  * @param {Uint8Array|string} toSign - digest to sign (bytes or hex)
- * @param {string} publicKey - PKP public key (hex)
+ * @param {string} pkpId - PKP ID
  * @returns {Promise<string>} result from Lit.Actions.sign
  */
-async function signDigest(toSign, publicKey) {
+async function signDigest(toSign, pkpId) {
   const bytes = typeof toSign === 'string' ? utils.arrayify(toSign) : new Uint8Array(toSign);
   const sigName = nextSigName();
   return globalThis.LitActions.sign({
     toSign: bytes,
-    publicKey,
+    pkpId,
     sigName,
     signingScheme: SIGNING_SCHEME,
   });
@@ -40,10 +40,10 @@ async function signDigest(toSign, publicKey) {
  * @function toAccount
  * @param {Object} params
  * @param {string} params.address - EVM address of the account (0x...)
- * @param {string} params.publicKey - PKP public key (hex) used by the sign op
+ * @param {string} params.pkpId - PKP ID used by the sign op
  * @returns {{ address: string, signMessage: Function, signTransaction: Function, signTypedData: Function }}
  */
-function toAccount({ address, publicKey }) {
+function toAccount({ address, pkpId }) {
   const addr = typeof address === 'string' && address.startsWith('0x') ? address : '0x' + address;
 
   return {
@@ -52,21 +52,21 @@ function toAccount({ address, publicKey }) {
     async signMessage({ message }) {
       const hash = utils.hashMessage(message);
       const digestBytes = utils.arrayify(hash);
-      return signDigest(digestBytes, publicKey);
+      return signDigest(digestBytes, pkpId);
     },
 
     async signTransaction(transaction, _opts = {}) {
       const payload = utils.serializeTransaction(transaction);
       const digest = utils.keccak256(payload);
       const digestBytes = utils.arrayify(digest);
-      return signDigest(digestBytes, publicKey);
+      return signDigest(digestBytes, pkpId);
     },
 
     async signTypedData(typedData) {
       const { domain, types, message } = typedData;
       const hash = utils._TypedDataEncoder.hash(domain, types, message);
       const digestBytes = utils.arrayify(hash);
-      return signDigest(digestBytes, publicKey);
+      return signDigest(digestBytes, pkpId);
     },
   };
 }

--- a/lit-actions/grpc/schema/lit_actions.proto
+++ b/lit-actions/grpc/schema/lit_actions.proto
@@ -141,18 +141,18 @@ message ExecuteJsResponse {
 
   message SignRequest {
     bytes to_sign = 1;
-    string public_key = 2;
+    string pkp_id = 2;
     string sig_name = 3;
     string signing_scheme = 4;
   }
 
   message AesEncryptRequest {
-    string public_key = 1;
+    string pkp_id = 1;
     string message = 2;    
   }
 
   message AesDecryptRequest {
-    string public_key = 1;
+    string pkp_id = 1;
     string ciphertext = 2;
   }
 

--- a/lit-actions/tests/it.rs
+++ b/lit-actions/tests/it.rs
@@ -402,7 +402,7 @@ async fn aes_decrypt(mut client: TestClient) {
     assert_eq!(
         client.received::<AesDecryptRequest>(),
         AesDecryptRequest {
-            public_key: "ignored".to_string(),
+            pkp_id: "ignored".to_string(),
             ciphertext: "456".to_string(),
         }
     );

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -24,16 +24,6 @@ pub fn derivation_path(wallet_address: H160) -> U256 {
     U256::from_big_endian(&keccak256(wallet_address.as_bytes()))
 }
 
-pub fn address_from_pubkey(pubkey: &str) -> Result<H160> {
-    let pubkey_bytes = hex_to_bytes(pubkey)?;
-    address_from_pubkey_bytes(&pubkey_bytes)
-}
-
-pub fn address_from_pubkey_bytes(pubkey_bytes: &[u8]) -> Result<H160> {
-    let address = H160::from_slice(&keccak256(pubkey_bytes)[12..]);
-    Ok(address)
-}
-
 /// Create a new account. `initial_balance` is stored on the account's apiKey (AccountConfig.accountApiKey.balance).
 pub async fn new_account(
     api_key: &str,
@@ -347,11 +337,6 @@ pub async fn register_wallet_derivation(
         Ok(_) => Ok(true),
         Err(e) => Err(e.into()),
     }
-}
-
-pub async fn get_wallet_derivation_from_pubkey(api_key: &str, pubkey: &str) -> Result<U256> {
-    let wallet_address = address_from_pubkey(pubkey)?;
-    get_wallet_derivation(api_key, wallet_address).await
 }
 
 /// Get the derivation path for a wallet address under an account (read-only).

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -9,7 +9,6 @@ use crate::accounts::signable_contract::{
 };
 use ethers::types::{H160, U256};
 use ethers::utils::keccak256;
-use lit_core::utils::binary::hex_to_bytes;
 
 pub fn api_key_hash(api_key_base_64: &str) -> U256 {
     U256::from_big_endian(&keccak256(api_key_base_64.as_bytes()))
@@ -17,10 +16,6 @@ pub fn api_key_hash(api_key_base_64: &str) -> U256 {
 
 /// keccak256 of wallet address bytes (hex string with or without 0x) as U256.
 pub fn wallet_address_hash(wallet_address: H160) -> U256 {
-    U256::from_big_endian(&keccak256(wallet_address.as_bytes()))
-}
-
-pub fn derivation_path(wallet_address: H160) -> U256 {
     U256::from_big_endian(&keccak256(wallet_address.as_bytes()))
 }
 

--- a/lit-api-server/src/actions/client/handle_ops.rs
+++ b/lit-api-server/src/actions/client/handle_ops.rs
@@ -50,13 +50,10 @@ impl Client {
                 }
                 .into()
             }
-            UnionResponse::AesEncrypt(AesEncryptRequest {
-                public_key,
-                message,
-            }) => {
+            UnionResponse::AesEncrypt(AesEncryptRequest { pkp_id, message }) => {
                 let encrypted = op_code_helpers::encryption::aes_encrypt_with_pkp(
                     &self.api_key,
-                    &public_key,
+                    &pkp_id,
                     &message,
                 )
                 .await?;
@@ -65,13 +62,10 @@ impl Client {
                 }
                 .into()
             }
-            UnionResponse::AesDecrypt(AesDecryptRequest {
-                public_key,
-                ciphertext,
-            }) => {
+            UnionResponse::AesDecrypt(AesDecryptRequest { pkp_id, ciphertext }) => {
                 let decrypted = op_code_helpers::encryption::aes_decrypt_with_pkp(
                     &self.api_key,
-                    &public_key,
+                    &pkp_id,
                     &ciphertext,
                 )
                 .await?;
@@ -85,13 +79,13 @@ impl Client {
             }
             UnionResponse::Sign(SignRequest {
                 to_sign,
-                public_key,
+                pkp_id,
                 sig_name,
                 signing_scheme,
             }) => {
                 let (sig_name, signed_data) = match op_code_helpers::signing::sign_with_pkp(
                     &self.api_key,
-                    &public_key,
+                    &pkp_id,
                     &to_sign,
                     &sig_name,
                     &signing_scheme,

--- a/lit-api-server/src/actions/client/models.rs
+++ b/lit-api-server/src/actions/client/models.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct SignedData {
     pub signing_scheme: String,
     pub digest: String,
-    pub public_key: String,
+    pub pkp_id: String,
     pub signature: String,
 }
 

--- a/lit-api-server/src/actions/client/op_code_helpers/encryption.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/encryption.rs
@@ -1,43 +1,30 @@
+use super::utils::pkp_id_to_derviation_path;
 use crate::actions::aes::{aes_decrypt, aes_encrypt};
+use crate::dstack::v1::get_client_key;
 use anyhow::{Result, anyhow};
 
-pub async fn aes_encrypt_with_pkp(
-    api_key: &str,
-    public_key: &str,
-    plaintext: &str,
-) -> Result<String> {
-    let secret_u256 =
-        match crate::accounts::get_wallet_derivation_from_pubkey(api_key, public_key).await {
-            Ok(secret_u256) => secret_u256,
-            Err(e) => return Err(anyhow!("Error getting wallet derivation: {:?}", e)),
-        };
-
-    if secret_u256 == ethers::types::U256::zero() {
-        return Err(anyhow!("Wallet not found"));
-    }
-    let mut symmetric_key = [0; 32];
-    secret_u256.to_big_endian(&mut symmetric_key);
-
-    let encrypted = aes_encrypt(&symmetric_key, plaintext.to_string()).await?;
+pub async fn aes_encrypt_with_pkp(api_key: &str, pkp_id: &str, plaintext: &str) -> Result<String> {
+    let derivation_path = pkp_id_to_derviation_path(api_key, pkp_id)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    let symmetric_key = get_client_key(&derivation_path)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    let encrypted = aes_encrypt(&symmetric_key, plaintext.to_string())
+        .await
+        .map_err(|e| anyhow!(e))?;
     Ok(encrypted)
 }
 
-pub async fn aes_decrypt_with_pkp(
-    api_key: &str,
-    public_key: &str,
-    ciphertext: &str,
-) -> Result<String> {
-    let secret_u256 =
-        match crate::accounts::get_wallet_derivation_from_pubkey(api_key, public_key).await {
-            Ok(secret_u256) => secret_u256,
-            Err(e) => return Err(anyhow!("Error getting wallet derivation: {:?}", e)),
-        };
-    if secret_u256 == ethers::types::U256::zero() {
-        return Err(anyhow!("Wallet not found"));
-    }
-    let mut symmetric_key = [0; 32];
-    secret_u256.to_big_endian(&mut symmetric_key);
-
-    let decrypted = aes_decrypt(&symmetric_key, ciphertext).await?;
+pub async fn aes_decrypt_with_pkp(api_key: &str, pkp_id: &str, ciphertext: &str) -> Result<String> {
+    let derivation_path = pkp_id_to_derviation_path(api_key, pkp_id)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    let symmetric_key = get_client_key(&derivation_path)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    let decrypted = aes_decrypt(&symmetric_key, ciphertext)
+        .await
+        .map_err(|e| anyhow!(e))?;
     Ok(decrypted)
 }

--- a/lit-api-server/src/actions/client/op_code_helpers/mod.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/mod.rs
@@ -1,2 +1,3 @@
 pub mod encryption;
 pub mod signing;
+pub mod utils;

--- a/lit-api-server/src/actions/client/op_code_helpers/signing.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/signing.rs
@@ -1,27 +1,18 @@
-use crate::actions::client::models::SignedData;
+use super::utils::pkp_id_to_derviation_path;
+use crate::{actions::client::models::SignedData, dstack::v1::get_client_key};
 use anyhow::Result;
 use k256::ecdsa::SigningKey;
 use lit_core::utils::binary::bytes_to_hex;
 
 pub async fn sign_with_pkp(
     api_key: &str,
-    public_key: &str,
+    pkp_id: &str,
     to_sign: &[u8],
     sig_name: &str,
     signing_scheme: &str,
 ) -> Result<(String, SignedData), String> {
-    let secret_u256 =
-        match crate::accounts::get_wallet_derivation_from_pubkey(api_key, public_key).await {
-            Ok(secret_u256) => secret_u256,
-            Err(e) => return Err(format!("Error getting wallet derivation: {:?}", e)),
-        };
-
-    if secret_u256 == ethers::types::U256::zero() {
-        return Err("Wallet not found".to_string());
-    }
-
-    let mut secret_bytes = [0; 32];
-    secret_u256.to_big_endian(&mut secret_bytes);
+    let derivation_path = pkp_id_to_derviation_path(api_key, pkp_id).await?;
+    let secret_bytes = get_client_key(&derivation_path).await?;
 
     let signing_key = match SigningKey::from_slice(&secret_bytes) {
         Ok(signing_key) => signing_key,
@@ -39,7 +30,7 @@ pub async fn sign_with_pkp(
         SignedData {
             signing_scheme: signing_scheme.to_string(),
             digest: bytes_to_hex(to_sign),
-            public_key: public_key.to_string(),
+            pkp_id: pkp_id.to_string(),
             signature: hex_signature.clone(),
         },
     ))

--- a/lit-api-server/src/actions/client/op_code_helpers/utils.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/utils.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use ethers::types::H160;
+use lit_core::utils::binary::{bytes_to_hex, hex_to_bytes};
+
+pub async fn pkp_id_to_derviation_path(api_key: &str, pkp_id: &str) -> Result<String, String> {
+    let src =
+        &hex_to_bytes(pkp_id).map_err(|e| format!("Error converting PKP ID to bytes: {:?}", e))?;
+    if src.len() != 20 {
+        return Err(format!("Invalid PKP ID length: {} (expected 20): Ppk Id {}", src.len(), pkp_id));
+    }
+    let wallet_address = H160::from_slice(src);
+    let derivation_u256 =
+        match crate::accounts::get_wallet_derivation(api_key, wallet_address).await {
+            Ok(secret_u256) => secret_u256,
+            Err(e) => return Err(format!("Error getting wallet derivation: {:?}", e)),
+        };
+
+    if derivation_u256 == ethers::types::U256::zero() {
+        return Err("Wallet not found".to_string());
+    }
+
+    if derivation_u256 == ethers::types::U256::zero() {
+        return Err("Wallet not found".to_string());
+    }
+
+    let mut derivation_bytes = [0; 32];
+    derivation_u256.to_big_endian(&mut derivation_bytes);
+
+    let derivation_path = bytes_to_hex(derivation_bytes);
+    Ok(derivation_path)
+}

--- a/lit-api-server/src/actions/client/op_code_helpers/utils.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/utils.rs
@@ -6,7 +6,11 @@ pub async fn pkp_id_to_derviation_path(api_key: &str, pkp_id: &str) -> Result<St
     let src =
         &hex_to_bytes(pkp_id).map_err(|e| format!("Error converting PKP ID to bytes: {:?}", e))?;
     if src.len() != 20 {
-        return Err(format!("Invalid PKP ID length: {} (expected 20): Ppk Id {}", src.len(), pkp_id));
+        return Err(format!(
+            "Invalid PKP ID length: {} (expected 20): Ppk Id {}",
+            src.len(),
+            pkp_id
+        ));
     }
     let wallet_address = H160::from_slice(src);
     let derivation_u256 =

--- a/lit-api-server/src/actions/client/op_code_helpers/utils.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/utils.rs
@@ -19,10 +19,6 @@ pub async fn pkp_id_to_derviation_path(api_key: &str, pkp_id: &str) -> Result<St
         return Err("Wallet not found".to_string());
     }
 
-    if derivation_u256 == ethers::types::U256::zero() {
-        return Err("Wallet not found".to_string());
-    }
-
     let mut derivation_bytes = [0; 32];
     derivation_u256.to_big_endian(&mut derivation_bytes);
 

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -11,7 +11,7 @@ use crate::core::v1::models::response::{
     AccountOpResponse, AddUsageApiKeyResponse, ApiKeyItem, CreateWalletResponse, ListMetadataItem,
     NewAccountResponse, NodeChainConfigResponse, WalletItem,
 };
-use crate::dstack::v1::get_key;
+use crate::dstack::v1::get_client_key;
 use elliptic_curve::group::GroupEncoding;
 use ethers::types::{H160, U256};
 use ethers::utils::keccak256;
@@ -48,37 +48,37 @@ fn parse_u256_hex_list(strings: &[String]) -> Result<Vec<U256>, ApiStatus> {
 
 fn get_random_secret() -> [u8; 32] {
     let mut secret: [u8; 32] = [0; 32];
-
     // Get a thread-local random number generator and fill the array.
     rand::thread_rng().fill(&mut secret);
     secret
 }
 
+// Generate a unique derivation path for a new wallet.
+fn generate_unique_derivation_path() -> Result<String, ApiStatus> {
+    let seed_bytes = get_random_secret();
+    let seed_address = H160::from_slice(&keccak256(&seed_bytes)[12..]);
+    let derivation_path = accounts::derivation_path(seed_address);
+    let mut derivation_bytes = [0; 32];
+    derivation_path.to_big_endian(&mut derivation_bytes);
+    let derivation_path = bytes_to_hex(derivation_bytes);
+    Ok(derivation_path)
+}
+
+// Create a new wallet and return the public key, wallet address, and secret.
 async fn create_new_wallet() -> Result<(String, H160, [u8; 32]), ApiStatus> {
-    let wallet_seed_id = bytes_to_hex(get_random_secret());
 
-    let path = format!("clients/{}", wallet_seed_id);
-    let purpose = "client";
-    let key_response = get_key(path.as_str(), purpose)
-        .await
-        .map_err(|e| ApiStatus::internal_server_error(anyhow::anyhow!(e), "get_key failed"))?;
-    let secret = key_response
-        .decode_key()
-        .map_err(|e| ApiStatus::internal_server_error(anyhow::anyhow!(e), "decode_key failed"))?;
-
-    let secret: [u8; 32] = secret.try_into().map_err(|s: Vec<u8>| {
-        ApiStatus::internal_server_error(
-            anyhow::anyhow!("secret wrong length: {}", s.len()),
-            "secret wrong length",
-        )
+    let derivation_path = generate_unique_derivation_path()?;
+    let secret: [u8; 32] = get_client_key(&derivation_path).await.map_err(|e| {
+        ApiStatus::internal_server_error(anyhow::anyhow!(e), "get_client_key failed")
     })?;
 
-    let secret_key = SecretKey::from_slice(&secret).unwrap();
+    let secret_key = SecretKey::from_slice(&secret).map_err(|e| {
+        ApiStatus::internal_server_error(anyhow::anyhow!(e), "SecretKey::from_slice failed")
+    })?;
     let public_key = secret_key.public_key();
     let public_key_bytes = public_key.as_affine().to_bytes();
-
     let public_key_string = bytes_to_hex(public_key_bytes);
-    let wallet_address = accounts::address_from_pubkey_bytes(&public_key_bytes)?;
+    let wallet_address = H160::from_slice(&keccak256(&public_key_bytes)[12..]);
 
     Ok((public_key_string, wallet_address, secret))
 }
@@ -132,7 +132,7 @@ pub async fn create_wallet(api_key: &str) -> Result<CreateWalletResponse, ApiSta
 
     // technically this is NOT a derivaton path at all, but it's a stand-in for now
     let derivation_path = accounts::derivation_path(wallet_address);
-    accounts::register_wallet_derivation(api_key, wallet_address, derivation_path, "", "").await?;
+    accounts::register_wallet_derivation(api_key, wallet_address, derivation_path, "Wallet", "Wallet").await?;
 
     Ok(CreateWalletResponse {
         wallet_address: bytes_to_hex(wallet_address.as_bytes()),
@@ -183,7 +183,11 @@ pub async fn add_pkp_to_group(
     req: Json<AddPkpToGroupRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
     let group_id = parse_u256(&req.group_id)?;
-    let wallet_address = accounts::address_from_pubkey(&req.pkp_public_key)?;
+    let wallet_address_bytes = hex_to_bytes(&req.pkp_id)?;
+    if wallet_address_bytes.len() != 20 {
+        return Err(ApiStatus::bad_request(anyhow::anyhow!("Invalid PKP ID"), "Invalid PKP ID"));
+    }
+    let wallet_address = H160::from_slice(&wallet_address_bytes);
     accounts::add_pkp_to_group(api_key, group_id, wallet_address)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "add_pkp_to_group failed"))?;
@@ -195,7 +199,11 @@ pub async fn remove_pkp_from_group(
     req: Json<RemovePkpFromGroupRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
     let group_id = parse_u256(&req.group_id)?;
-    let wallet_address = accounts::address_from_pubkey(&req.pkp_public_key)?;
+    let src = hex_to_bytes(&req.pkp_id)?;
+    if src.len() != 20 {
+        return Err(ApiStatus::bad_request(anyhow::anyhow!("Invalid PKP ID"), "Invalid PKP ID"));
+    }
+    let wallet_address = H160::from_slice(&src);
     accounts::remove_pkp_from_group(api_key, group_id, wallet_address)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "remove_pkp_from_group failed"))?;

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -54,20 +54,21 @@ fn get_random_secret() -> [u8; 32] {
 }
 
 // Generate a unique derivation path for a new wallet.
-fn generate_unique_derivation_path() -> Result<String, ApiStatus> {
+fn generate_unique_derivation_path() -> Result<(U256, String), ApiStatus> {
     let seed_bytes = get_random_secret();
-    let seed_address = H160::from_slice(&keccak256(&seed_bytes)[12..]);
-    let derivation_path = accounts::derivation_path(seed_address);
-    let mut derivation_bytes = [0; 32];
-    derivation_path.to_big_endian(&mut derivation_bytes);
+    let derivation_bytes = keccak256(seed_bytes);
+    let derivation_u256 = U256::from_big_endian(&derivation_bytes);
     let derivation_path = bytes_to_hex(derivation_bytes);
-    Ok(derivation_path)
+    Ok((derivation_u256, derivation_path))
 }
 
 // Create a new wallet and return the public key, wallet address, and secret.
-async fn create_new_wallet() -> Result<(String, H160, [u8; 32]), ApiStatus> {
-
-    let derivation_path = generate_unique_derivation_path()?;
+async fn create_new_wallet() -> Result<(String, H160, [u8; 32], U256), ApiStatus> {
+    let (derivation_u256, derivation_path) = generate_unique_derivation_path()?;
+    tracing::info!(
+        "Creating new wallet with derivation path: {}",
+        derivation_path
+    );
     let secret: [u8; 32] = get_client_key(&derivation_path).await.map_err(|e| {
         ApiStatus::internal_server_error(anyhow::anyhow!(e), "get_client_key failed")
     })?;
@@ -76,11 +77,12 @@ async fn create_new_wallet() -> Result<(String, H160, [u8; 32]), ApiStatus> {
         ApiStatus::internal_server_error(anyhow::anyhow!(e), "SecretKey::from_slice failed")
     })?;
     let public_key = secret_key.public_key();
+
     let public_key_bytes = public_key.as_affine().to_bytes();
     let public_key_string = bytes_to_hex(public_key_bytes);
-    let wallet_address = H160::from_slice(&keccak256(&public_key_bytes)[12..]);
+    let wallet_address = H160::from_slice(&keccak256(public_key_bytes)[12..]);
 
-    Ok((public_key_string, wallet_address, secret))
+    Ok((public_key_string, wallet_address, secret, derivation_u256))
 }
 
 pub async fn new_account(
@@ -89,7 +91,7 @@ pub async fn new_account(
     let account_name = new_account_request.account_name.clone();
     let account_description = new_account_request.account_description.clone();
 
-    let (_public_key, wallet_address, secret) = create_new_wallet().await?;
+    let (_public_key, wallet_address, secret, derivation_path) = create_new_wallet().await?;
     let api_key = base64_light::base64_encode_bytes(&secret);
 
     if let Err(e) = accounts::new_account(
@@ -104,7 +106,6 @@ pub async fn new_account(
     }
 
     // technically this is NOT a derivaton path at all, but it's a stand-in for now
-    let derivation_path = accounts::derivation_path(wallet_address);
     accounts::register_wallet_derivation(
         &api_key,
         wallet_address,
@@ -128,11 +129,17 @@ pub async fn account_exists(api_key: &str) -> Result<bool, ApiStatus> {
 }
 
 pub async fn create_wallet(api_key: &str) -> Result<CreateWalletResponse, ApiStatus> {
-    let (_public_key, wallet_address, _secret) = create_new_wallet().await?;
+    let (_public_key, wallet_address, _secret, derivation_u256) = create_new_wallet().await?;
 
     // technically this is NOT a derivaton path at all, but it's a stand-in for now
-    let derivation_path = accounts::derivation_path(wallet_address);
-    accounts::register_wallet_derivation(api_key, wallet_address, derivation_path, "Wallet", "Wallet").await?;
+    accounts::register_wallet_derivation(
+        api_key,
+        wallet_address,
+        derivation_u256,
+        "Wallet",
+        "Wallet",
+    )
+    .await?;
 
     Ok(CreateWalletResponse {
         wallet_address: bytes_to_hex(wallet_address.as_bytes()),
@@ -185,7 +192,10 @@ pub async fn add_pkp_to_group(
     let group_id = parse_u256(&req.group_id)?;
     let wallet_address_bytes = hex_to_bytes(&req.pkp_id)?;
     if wallet_address_bytes.len() != 20 {
-        return Err(ApiStatus::bad_request(anyhow::anyhow!("Invalid PKP ID"), "Invalid PKP ID"));
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Invalid PKP ID"),
+            "Invalid PKP ID",
+        ));
     }
     let wallet_address = H160::from_slice(&wallet_address_bytes);
     accounts::add_pkp_to_group(api_key, group_id, wallet_address)
@@ -201,7 +211,10 @@ pub async fn remove_pkp_from_group(
     let group_id = parse_u256(&req.group_id)?;
     let src = hex_to_bytes(&req.pkp_id)?;
     if src.len() != 20 {
-        return Err(ApiStatus::bad_request(anyhow::anyhow!("Invalid PKP ID"), "Invalid PKP ID"));
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Invalid PKP ID"),
+            "Invalid PKP ID",
+        ));
     }
     let wallet_address = H160::from_slice(&src);
     accounts::remove_pkp_from_group(api_key, group_id, wallet_address)
@@ -217,14 +230,14 @@ pub async fn add_usage_api_key(
     let expiration = parse_u256(&req.expiration)?;
     let balance = parse_u256(&req.balance)?;
 
-    let (_public_key, wallet_address, secret) = create_new_wallet().await?;
+    let (_public_key, wallet_address, secret, derivation_u256) = create_new_wallet().await?;
 
     // technically this is NOT a derivaton path at all, but it's a stand-in for now
-    let derivation_path = accounts::derivation_path(wallet_address);
+
     accounts::register_wallet_derivation(
         api_key,
         wallet_address,
-        derivation_path,
+        derivation_u256,
         "API Key Wallet",
         "Usage API Key Wallet",
     )

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -42,13 +42,13 @@ pub struct AddActionToGroupRequest {
 pub struct AddPkpToGroupRequest {
     /// Group ID (decimal or hex string).
     pub group_id: String,
-    pub pkp_public_key: String,
+    pub pkp_id: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RemovePkpFromGroupRequest {
     pub group_id: String,
-    pub pkp_public_key: String,
+    pub pkp_id: String,
 }
 
 /// Request for update_group (AccountConfig.updateGroup). API key via header.
@@ -108,7 +108,7 @@ pub struct RemoveUsageApiKeyRequest {
 /// API key via header.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SignWithPKPRequest {
-    pub pkp_public_key: String,
+    pub pkp_id: String,
     pub message: String,
     pub signing_scheme: String,
 }

--- a/lit-api-server/src/core/v1/models/response.rs
+++ b/lit-api-server/src/core/v1/models/response.rs
@@ -22,7 +22,7 @@ pub struct CreateWalletResponse {
 pub struct SignWithPkpResponse {
     pub signing_scheme: String,
     pub signed_digest: String,
-    pub public_key: String,
+    pub pkp_id: String,
     pub signature: String,
 }
 
@@ -31,7 +31,7 @@ impl From<SignedData> for SignWithPkpResponse {
         Self {
             signing_scheme: signed_data.signing_scheme,
             signed_digest: signed_data.digest,
-            public_key: signed_data.public_key,
+            pkp_id: signed_data.pkp_id,
             signature: signed_data.signature,
         }
     }

--- a/lit-api-server/src/dstack/v1/mod.rs
+++ b/lit-api-server/src/dstack/v1/mod.rs
@@ -1,3 +1,25 @@
+use ethers::utils::keccak256;
+
 mod dstack;
 pub mod endpoints;
-pub use dstack::get_key;
+
+/// Get the client key for a given derivation path.
+pub async fn get_client_key(derivation_path: &str) -> Result<[u8; 32], String> {
+    let path = format!("v1/{}", derivation_path);
+    let purpose = "client";
+    let key_response = dstack::get_key(path.as_str(), purpose)
+        .await
+        .map_err(|e| format!("failed to get key: {e}"))?;
+    let secret = key_response
+        .decode_key()
+        .map_err(|e| format!("failed to decode key: {e}"))?;
+
+    if secret.len() != 32 {
+        return Err(format!("secret wrong length: {}", secret.len()));
+    }
+
+    // While this looks a bit redundant, it's necessary to ensure that multiple secrets can be exported
+    // without compromising the security of the master key(s) used to derive them.
+    let secret = keccak256(&secret);
+    Ok(secret)
+}

--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -21,7 +21,7 @@ export const SIGNING_SCHEME_ECDSA_K256_SHA256 = 'EcdsaK256Sha256';
 /**
  * @typedef {Object} SignWithPkpOptions
  * @property {string} apiKey - Hex-encoded API key (from getApiKey)
- * @property {string} pkpPublicKey - PKP public key
+ * @property {string} pkpId - PKP ID
  * @property {string} message - Message to sign
  * @property {string} [signingScheme='EcdsaK256Sha256'] - Signing scheme (use SIGNING_SCHEME_ECDSA_K256_SHA256)
  */
@@ -57,14 +57,14 @@ export const SIGNING_SCHEME_ECDSA_K256_SHA256 = 'EcdsaK256Sha256';
  * @typedef {Object} AddPkpToGroupOptions
  * @property {string} apiKey - Account API key
  * @property {string} groupId - Group ID (decimal or hex string)
- * @property {string} pkpPublicKey - PKP public key (will be hashed on server)
+ * @property {string} pkpId - PKP ID
  */
 
 /**
  * @typedef {Object} RemovePkpFromGroupOptions
  * @property {string} apiKey - Account API key
  * @property {string} groupId - Group ID (decimal or hex string)
- * @property {string} pkpPublicKey - PKP public key (must match value used when adding)
+ * @property {string} pkpId - PKP ID (must match value used when adding)
  */
 
 /**
@@ -198,7 +198,7 @@ export const SHARE_TYPE_BLS = 'Bls';
  * @typedef {Object} SignWithPkpResponse
  * @property {string} signing_scheme - Signing scheme (e.g. EcdsaK256Sha256)
  * @property {string} signed_digest - Signed digest (hex)
- * @property {string} public_key - Public key (hex)
+ * @property {string} pkp_id - PKP ID
  * @property {string} share_type - 'Ecdsa' | 'Frost' | 'Bls'
  * @property {string} [big_r] - ECDSA big R (optional)
  * @property {string} [compressed_public_key] - Compressed public key (optional)
@@ -347,11 +347,11 @@ export class LitNodeSimpleApiClient {
    * Signs a message with the given PKP using the provided API key.
    * Uses EcdsaK256Sha256 signing scheme by default.
    * @param {SignWithPkpOptions} options
-   * @returns {Promise<SignWithPkpResponse>} { signing_scheme, signed_digest, public_key, share_type, shares, ... }
+   * @returns {Promise<SignWithPkpResponse>} { signing_scheme, signed_digest, pkp_id, signature }
    */
-  async signWithPkp({ apiKey, pkpPublicKey, message, signingScheme = SIGNING_SCHEME_ECDSA_K256_SHA256 }) {
+  async signWithPkp({ apiKey, pkpId, message, signingScheme = SIGNING_SCHEME_ECDSA_K256_SHA256 }) {
     const body = {
-      pkp_public_key: pkpPublicKey,
+      pkp_id: pkpId,
       message,
       signing_scheme: signingScheme,
     };
@@ -443,10 +443,10 @@ export class LitNodeSimpleApiClient {
    * @param {AddPkpToGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async addPkpToGroup({ apiKey, groupId, pkpPublicKey }) {
+  async addPkpToGroup({ apiKey, groupId, pkpId }) {
     const body = {
       group_id: groupId,
-      pkp_public_key: pkpPublicKey,
+      pkp_id: pkpId,
     };
     const res = await fetch(`${this.baseUrl}/add_pkp_to_group`, {
       method: 'POST',
@@ -462,10 +462,10 @@ export class LitNodeSimpleApiClient {
    * @param {RemovePkpFromGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async removePkpFromGroup({ apiKey, groupId, pkpPublicKey }) {
+  async removePkpFromGroup({ apiKey, groupId, pkpId }) {
     const body = {
       group_id: groupId,
-      pkp_public_key: pkpPublicKey,
+      pkp_id: pkpId,
     };
     const res = await fetch(`${this.baseUrl}/remove_pkp_from_group`, {
       method: 'POST',

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -420,8 +420,8 @@ function renderWalletsTable(items) {
     const description = item.description ?? '';
     const tr = document.createElement('tr');
     tr.innerHTML =
-      '<td class="mono cell-address"></td>' +
-      '<td class="mono">' + escapeHtml(description) + '</td>';
+      '<td class="mono">' + escapeHtml(description) + '</td>' +
+      '<td class="mono cell-address"></td>';
     const addressCell = tr.querySelector('.cell-address');
     const addressCopyBtn = document.createElement('button');
     addressCopyBtn.type = 'button';

--- a/lit-static/static/dapps/dashboard/index.html
+++ b/lit-static/static/dapps/dashboard/index.html
@@ -247,7 +247,7 @@
               <div class="card-body">
                 <div class="table-wrap">
                   <table class="data-table" id="wallets-table">
-                    <thead><tr><th>PkpId (Address)</th><th>Description</th></tr></thead>
+                    <thead><tr><th>Description</th><th>PkpId (Address)</th></tr></thead>
                     <tbody id="wallets-tbody"></tbody>
                   </table>
                   <p id="wallets-empty" class="empty-state" style="display: none;">No wallets.</p>


### PR DESCRIPTION
## Pull request overview

Migrates PKP identifiers from “PKP public key” to “PKP ID = wallet address” across the static dashboard, JS SDK bindings, gRPC schema, and API server request/response models to align client/server semantics.

**Changes:**
- Reworked Lit Actions + bindings (proto, Rust ops, JS SDK) to pass `pkp_id` instead of `public_key`.
- Updated core API server models/endpoints and client SDK (`core_sdk.js`) to use `pkp_id`.
- Introduced a dstack `get_client_key` helper and refactored wallet/key usage in account management + action helpers.
