### PR TITLE
clean before deploying contracts

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/Makefile
+++ b/lit-api-server/blockchain/lit_node_express/Makefile
@@ -1,4 +1,4 @@
-# Run from blockchain/swaps/ (directory containing this MakeFile).
+# Run from blockchain/lit_node_express/ (directory containing this Makefile).
 # Paths artifacts/contracts and ../../src/... are relative to this directory.
 
 RUST_PROJECT := ../rust_generator_and_deployer
@@ -8,6 +8,8 @@ DEPLOYER_SECRET := 0xd9884c772d9e85843d36fc4b18972068efc02ec6f50924725d2cc39ecef
 BASE_DEPLOYER_SECRET := 0x747ea873f95c08f90634f496bbdbf53b852e297704499dfd3494e3046d44f016
 ANVIL_SECRET := 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
+clean:
+	npx hardhat clean
 # 1. Compile Solidity contracts with Hardhat
 compile:
 	npx hardhat compile
@@ -18,16 +20,16 @@ generate: compile
 	$(GENERATOR_BIN) artifacts/contracts ../../src/accounts/contracts/
 
 # 3. Deploy contracts to Base mainnet. Args: network (3 = Base), abis_folder
-deploy_base: generate
+deploy_base: clean generate
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) 3 artifacts/contracts $(BASE_DEPLOYER_SECRET)
 
 # 4. Deploy contracts to Base Sepolia. Args: network (2 = Base Sepolia), abis_folder
-deploy_sepolia: generate
+deploy_sepolia: clean generate
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) 2 artifacts/contracts $(DEPLOYER_SECRET)
 
 # 5. Deploy contracts to Anvil. Args: network (0 = Anvil), abis_folder
-deploy_anvil: generate
+deploy_anvil: clean generate
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) 0 artifacts/contracts $(ANVIL_SECRET)


### PR DESCRIPTION
### TL;DR

Added a clean target to the Makefile and updated deployment targets to run clean before generating contracts.

### What changed?

- Added a new `clean` target that runs `npx hardhat clean`
- Updated `deploy_base`, `deploy_sepolia`, and `deploy_anvil` targets to depend on `clean` in addition to `generate`
- Fixed the directory path comment from `blockchain/swaps/` to `blockchain/lit_node_express/`
- Corrected "MakeFile" to "Makefile" in the comment

### How to test?

Run any of the deployment commands (`make deploy_base`, `make deploy_sepolia`, or `make deploy_anvil`) and verify that the clean step executes before contract generation and deployment.

### Why make this change?

Ensures a clean build state before each deployment by removing previous compilation artifacts, which helps prevent issues with stale or corrupted build files during the contract deployment process.