### PR TITLE
use docker to fix dstack-verifier dependencies

### DIFF
--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -37,10 +37,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # ── 1. Build the dstack simulator and verifier (cached separately) ────
-      # Each artifact has its own cache keyed by the dstack HEAD SHA (obtained
-      # without cloning via git ls-remote). The verifier cache is shared with
-      # the verify-attestation workflow so a warm hit there avoids rebuilding
-      # here. On full cache hit the clone and all builds are skipped entirely.
+      # Simulator: built from source. Verifier: Docker image (bundles dstack-acpi-tables).
+      # Each cache is keyed by dstack HEAD SHA. The verifier image cache is shared with
+      # verify-attestation workflow so a warm hit there avoids rebuilding here.
       - name: Get dstack HEAD SHA
         id: dstack-sha
         run: |
@@ -54,12 +53,16 @@ jobs:
           path: ${{ github.workspace }}/dstack-cache/simulator
           key: dstack-simulator-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
-      - name: Restore verifier cache
+      - name: Restore verifier image cache
         id: verifier-cache
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/dstack-cache/verifier
-          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+          path: dstack-verifier-image.tar
+          key: dstack-verifier-image-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+
+      - name: Load cached Docker image
+        if: steps.verifier-cache.outputs.cache-hit == 'true'
+        run: docker load < dstack-verifier-image.tar
 
       - name: Fix dstack cache permissions
         if: steps.sim-cache.outputs.cache-hit == 'true' || steps.verifier-cache.outputs.cache-hit == 'true'
@@ -74,9 +77,9 @@ jobs:
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
           git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
 
-      # Use stable Rust for the dstack build (it may require features newer than 1.91).
-      - name: Install Rust (stable, for dstack)
-        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
+      # Use stable Rust for the dstack simulator build (verifier uses Docker, no Rust needed).
+      - name: Install Rust (stable, for dstack simulator)
+        if: steps.sim-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build dstack simulator
@@ -95,17 +98,17 @@ jobs:
              "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
              "${{ github.workspace }}/dstack-cache/simulator/"
 
-      - name: Build dstack-verifier
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
-
-      - name: Populate verifier cache
+      - name: Build verifier Docker image
         if: steps.verifier-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
-          cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
-             "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
-             "${{ github.workspace }}/dstack-cache/verifier/"
+          docker build -t dstack-verifier \
+            --build-arg DSTACK_REV="${{ steps.dstack-sha.outputs.sha }}" \
+            -f "$DSTACK_BUILD/verifier/builder/Dockerfile" \
+            "$DSTACK_BUILD/verifier"
+
+      - name: Save Docker image to cache
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
+        run: docker save dstack-verifier > dstack-verifier-image.tar
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''
@@ -175,18 +178,19 @@ jobs:
 
       # ── 3. dstack-verifier end-to-end attestation pipeline ─────────────────
       # Start simulator, start lit-api-server (attestation-only; fetches from simulator),
-      # get attestation from lit-api-server's /attestation endpoint, run dstack-verifier.
-      # Assert quote_verified=true; is_valid will be false (simulator uses a synthetic
-      # OS image hash not published on download.dstack.org) — that is expected.
+      # get attestation from lit-api-server's /attestation endpoint, run dstack-verifier
+      # (via Docker image with dstack-acpi-tables). Assert quote_verified=true;
+      # is_valid will be false (simulator uses a synthetic OS image hash not published
+      # on download.dstack.org) — that is expected.
       - name: Verify attestation pipeline with dstack-verifier
         run: |
           set -eu
           CACHE_DIR="${{ github.workspace }}/dstack-cache"
           SIM_SRC="$CACHE_DIR/simulator"
-          VERIFIER_BIN="$CACHE_DIR/verifier/dstack-verifier"
-          VERIFIER_CFG="$CACHE_DIR/verifier/dstack-verifier.toml"
+          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
           API_BIN="$(pwd)/lit-api-server/target/debug/lit-api-server"
 
+          mkdir -p "$IMAGE_CACHE"
           SIM_TMP=$(mktemp -d /tmp/dstack-sim-XXXXXX)
           SIM_SOCK="$SIM_TMP/dstack.sock"
 
@@ -251,14 +255,12 @@ jobs:
             'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
             > "$VERIFY_FILE"
 
-          # Use workspace for verifier image cache (avoids /tmp permission denied on self-hosted).
-          VERIFIER_CFG_OVERRIDE="$SIM_TMP/verifier.toml"
-          sed "s|image_cache_dir = .*|image_cache_dir = \"${{ github.workspace }}/dstack-cache/verifier-image-cache\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
-          mkdir -p "${{ github.workspace }}/dstack-cache/verifier-image-cache"
-
-          # Run verifier in oneshot mode. Exits 1 when is_valid=false (expected for
-          # the simulator) — ignore the exit code and check quote_verified directly.
-          "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true
+          # Run verifier via Docker (bundles dstack-acpi-tables). Exits 1 when
+          # is_valid=false (expected for simulator) — ignore and check quote_verified.
+          docker run --rm \
+            -v "$SIM_TMP:/data" \
+            -v "$IMAGE_CACHE:/var/lib/dstack-verifier" \
+            dstack-verifier --verify /data/verify-request.json || true
 
           # Assertion: quote_verified must be true.
           RESULT_FILE="${VERIFY_FILE}.verification.json"

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -225,23 +225,12 @@ jobs:
           kill "$SIM_PID" "$API_PID" 2>/dev/null || true
 
           # Fix empty digests and normalise format (same script used by verify-attestation.yml).
-          # Then inject spec_version into vm_config if missing: the simulator omits spec_version
-          # but the Docker verifier's older serde parser requires it to be present.
+          # Then inject spec_version=1 into vm_config if missing: the simulator omits it but
+          # the Docker verifier's serde parser requires it to be present in VmConfig.
           # (The verifier will still report os_image_hash_verified=false and is_valid=false
           # because the simulator's synthetic OS hash is not published — that is expected.)
           python3 scripts/fix-attestation-event-log.py "$SIM_TMP/attestation.json" \
-            | python3 -c '
-import sys, json
-d = json.load(sys.stdin)
-try:
-    vc = json.loads(d["vm_config"])
-    if "spec_version" not in vc:
-        vc["spec_version"] = 1
-    d["vm_config"] = json.dumps(vc, separators=(",", ":"))
-except Exception:
-    pass
-print(json.dumps(d))
-' \
+            | python3 scripts/inject-spec-version.py \
             > "$SIM_TMP/verify-request.json"
 
           # Run verifier via Docker (same image as verify-attestation.yml).

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -210,8 +210,8 @@ jobs:
             exit 1
           }
 
-          # Copy demo config to checkout (NodeConfig.toml is gitignored); run from lit-api-server dir.
-          cp lit-api-server/NodeConfig.demo.toml lit-api-server/NodeConfig.toml
+          # Copy next config to checkout (NodeConfig.toml is gitignored); run from lit-api-server dir.
+          cp lit-api-server/NodeConfig.next.toml lit-api-server/NodeConfig.toml
           (cd lit-api-server && DSTACK_SOCKET="$SIM_SOCK" "$API_BIN") >> "$SIM_TMP/lit-api-server.log" 2>&1 &
           API_PID=$!
           if ! kill -0 "$API_PID" 2>/dev/null; then

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -36,11 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ── 1. Build the dstack simulator and verifier (cached separately) ────
-      # Each artifact has its own cache keyed by the dstack HEAD SHA (obtained
-      # without cloning via git ls-remote). The verifier cache is shared with
-      # the verify-attestation workflow so a warm hit there avoids rebuilding
-      # here. On full cache hit the clone and all builds are skipped entirely.
+      # ── 1. Build the dstack simulator (cached by dstack HEAD SHA) ───────────
+      # The verifier is pulled as the dstacktee/dstack-verifier Docker image
+      # (same as verify-attestation.yml) — no source build or cache needed.
       - name: Get dstack HEAD SHA
         id: dstack-sha
         run: |
@@ -54,21 +52,14 @@ jobs:
           path: ${{ github.workspace }}/dstack-cache/simulator
           key: dstack-simulator-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
-      - name: Restore verifier cache
-        id: verifier-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/dstack-cache/verifier
-          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
-
       - name: Fix dstack cache permissions
-        if: steps.sim-cache.outputs.cache-hit == 'true' || steps.verifier-cache.outputs.cache-hit == 'true'
+        if: steps.sim-cache.outputs.cache-hit == 'true'
         run: |
           CACHE_DIR="${{ github.workspace }}/dstack-cache"
           [ -d "$CACHE_DIR" ] && chmod -R u+rwX "$CACHE_DIR" || true
 
       - name: Clone dstack repository
-        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
+        if: steps.sim-cache.outputs.cache-hit != 'true'
         run: |
           DSTACK_BUILD=$(mktemp -d)
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
@@ -76,7 +67,7 @@ jobs:
 
       # Use stable Rust for the dstack build (it may require features newer than 1.91).
       - name: Install Rust (stable, for dstack)
-        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
+        if: steps.sim-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build dstack simulator
@@ -95,17 +86,8 @@ jobs:
              "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
              "${{ github.workspace }}/dstack-cache/simulator/"
 
-      - name: Build dstack-verifier
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
-
-      - name: Populate verifier cache
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
-          cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
-             "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
-             "${{ github.workspace }}/dstack-cache/verifier/"
+      - name: Pull dstack-verifier image
+        run: docker pull --platform linux/amd64 dstacktee/dstack-verifier:latest
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''
@@ -181,10 +163,7 @@ jobs:
       - name: Verify attestation pipeline with dstack-verifier
         run: |
           set -eu
-          CACHE_DIR="${{ github.workspace }}/dstack-cache"
-          SIM_SRC="$CACHE_DIR/simulator"
-          VERIFIER_BIN="$CACHE_DIR/verifier/dstack-verifier"
-          VERIFIER_CFG="$CACHE_DIR/verifier/dstack-verifier.toml"
+          SIM_SRC="${{ github.workspace }}/dstack-cache/simulator"
           API_BIN="$(pwd)/lit-api-server/target/debug/lit-api-server"
 
           SIM_TMP=$(mktemp -d /tmp/dstack-sim-XXXXXX)
@@ -240,28 +219,26 @@ jobs:
           fi
 
           # Get attestation from lit-api-server (which got it from the simulator).
-          QUOTE_RESP=$(curl -sf http://localhost:8000/attestation)
+          curl -sf http://localhost:8000/attestation > "$SIM_TMP/attestation.json"
 
           # Teardown simulator and lit-api-server.
           kill "$SIM_PID" "$API_PID" 2>/dev/null || true
 
-          # Write the verifier request: strip 0x prefix, set attestation=null.
-          VERIFY_FILE="$SIM_TMP/verify-request.json"
-          printf '%s' "$QUOTE_RESP" | python3 -c \
-            'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
-            > "$VERIFY_FILE"
+          # Fix empty digests and normalise format (same script used by verify-attestation.yml).
+          python3 scripts/fix-attestation-event-log.py "$SIM_TMP/attestation.json" \
+            > "$SIM_TMP/verify-request.json"
 
-          # Use workspace for verifier image cache (avoids /tmp permission denied on self-hosted).
-          VERIFIER_CFG_OVERRIDE="$SIM_TMP/verifier.toml"
-          sed "s|image_cache_dir = .*|image_cache_dir = \"${{ github.workspace }}/dstack-cache/verifier-image-cache\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
-          mkdir -p "${{ github.workspace }}/dstack-cache/verifier-image-cache"
-
-          # Run verifier in oneshot mode. Exits 1 when is_valid=false (expected for
-          # the simulator) — ignore the exit code and check quote_verified directly.
-          "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true
+          # Run verifier via Docker (same image as verify-attestation.yml).
+          # Exits 1 when is_valid=false (expected for simulator) — ignore and check quote_verified.
+          docker run --rm \
+            -v "$SIM_TMP:/verify" \
+            -w /verify \
+            --platform linux/amd64 \
+            dstacktee/dstack-verifier:latest \
+            --verify /verify/verify-request.json || true
 
           # Assertion: quote_verified must be true.
-          RESULT_FILE="${VERIFY_FILE}.verification.json"
+          RESULT_FILE="$SIM_TMP/verify-request.json.verification.json"
           QUOTE_OK=$(python3 -c \
             'import sys,json; v=json.load(open(sys.argv[1]))["details"]["quote_verified"]; print("true" if v else "false")' \
             "$RESULT_FILE")

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -225,7 +225,10 @@ jobs:
           kill "$SIM_PID" "$API_PID" 2>/dev/null || true
 
           # Fix empty digests and normalise format (same script used by verify-attestation.yml).
+          # Then clear vm_config: the simulator produces a synthetic value that lacks
+          # spec_version, which the Docker verifier requires. Passing "" skips that check.
           python3 scripts/fix-attestation-event-log.py "$SIM_TMP/attestation.json" \
+            | python3 -c 'import sys,json; d=json.load(sys.stdin); d["vm_config"]=""; print(json.dumps(d))' \
             > "$SIM_TMP/verify-request.json"
 
           # Run verifier via Docker (same image as verify-attestation.yml).

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -37,9 +37,10 @@ jobs:
       - uses: actions/checkout@v4
 
       # ── 1. Build the dstack simulator and verifier (cached separately) ────
-      # Simulator: built from source. Verifier: Docker image (bundles dstack-acpi-tables).
-      # Each cache is keyed by dstack HEAD SHA. The verifier image cache is shared with
-      # verify-attestation workflow so a warm hit there avoids rebuilding here.
+      # Each artifact has its own cache keyed by the dstack HEAD SHA (obtained
+      # without cloning via git ls-remote). The verifier cache is shared with
+      # the verify-attestation workflow so a warm hit there avoids rebuilding
+      # here. On full cache hit the clone and all builds are skipped entirely.
       - name: Get dstack HEAD SHA
         id: dstack-sha
         run: |
@@ -53,16 +54,12 @@ jobs:
           path: ${{ github.workspace }}/dstack-cache/simulator
           key: dstack-simulator-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
-      - name: Restore verifier image cache
+      - name: Restore verifier cache
         id: verifier-cache
         uses: actions/cache@v4
         with:
-          path: dstack-verifier-image.tar
-          key: dstack-verifier-image-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
-
-      - name: Load cached Docker image
-        if: steps.verifier-cache.outputs.cache-hit == 'true'
-        run: docker load < dstack-verifier-image.tar
+          path: ${{ github.workspace }}/dstack-cache/verifier
+          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
       - name: Fix dstack cache permissions
         if: steps.sim-cache.outputs.cache-hit == 'true' || steps.verifier-cache.outputs.cache-hit == 'true'
@@ -77,9 +74,9 @@ jobs:
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
           git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
 
-      # Use stable Rust for the dstack simulator build (verifier uses Docker, no Rust needed).
-      - name: Install Rust (stable, for dstack simulator)
-        if: steps.sim-cache.outputs.cache-hit != 'true'
+      # Use stable Rust for the dstack build (it may require features newer than 1.91).
+      - name: Install Rust (stable, for dstack)
+        if: steps.sim-cache.outputs.cache-hit != 'true' || steps.verifier-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build dstack simulator
@@ -98,17 +95,17 @@ jobs:
              "$DSTACK_BUILD/sdk/simulator/dstack.toml" \
              "${{ github.workspace }}/dstack-cache/simulator/"
 
-      - name: Build verifier Docker image
+      - name: Build dstack-verifier
+        if: steps.verifier-cache.outputs.cache-hit != 'true'
+        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
+
+      - name: Populate verifier cache
         if: steps.verifier-cache.outputs.cache-hit != 'true'
         run: |
-          docker build -t dstack-verifier \
-            --build-arg DSTACK_REV="${{ steps.dstack-sha.outputs.sha }}" \
-            -f "$DSTACK_BUILD/verifier/builder/Dockerfile" \
-            "$DSTACK_BUILD/verifier"
-
-      - name: Save Docker image to cache
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        run: docker save dstack-verifier > dstack-verifier-image.tar
+          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
+          cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
+             "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
+             "${{ github.workspace }}/dstack-cache/verifier/"
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''
@@ -178,19 +175,18 @@ jobs:
 
       # ── 3. dstack-verifier end-to-end attestation pipeline ─────────────────
       # Start simulator, start lit-api-server (attestation-only; fetches from simulator),
-      # get attestation from lit-api-server's /attestation endpoint, run dstack-verifier
-      # (via Docker image with dstack-acpi-tables). Assert quote_verified=true;
-      # is_valid will be false (simulator uses a synthetic OS image hash not published
-      # on download.dstack.org) — that is expected.
+      # get attestation from lit-api-server's /attestation endpoint, run dstack-verifier.
+      # Assert quote_verified=true; is_valid will be false (simulator uses a synthetic
+      # OS image hash not published on download.dstack.org) — that is expected.
       - name: Verify attestation pipeline with dstack-verifier
         run: |
           set -eu
           CACHE_DIR="${{ github.workspace }}/dstack-cache"
           SIM_SRC="$CACHE_DIR/simulator"
-          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
+          VERIFIER_BIN="$CACHE_DIR/verifier/dstack-verifier"
+          VERIFIER_CFG="$CACHE_DIR/verifier/dstack-verifier.toml"
           API_BIN="$(pwd)/lit-api-server/target/debug/lit-api-server"
 
-          mkdir -p "$IMAGE_CACHE"
           SIM_TMP=$(mktemp -d /tmp/dstack-sim-XXXXXX)
           SIM_SOCK="$SIM_TMP/dstack.sock"
 
@@ -215,7 +211,7 @@ jobs:
           }
 
           # Copy demo config to checkout (NodeConfig.toml is gitignored); run from lit-api-server dir.
-          cp lit-api-server/NodeConfig.next.toml lit-api-server/NodeConfig.toml
+          cp lit-api-server/NodeConfig.demo.toml lit-api-server/NodeConfig.toml
           (cd lit-api-server && DSTACK_SOCKET="$SIM_SOCK" "$API_BIN") >> "$SIM_TMP/lit-api-server.log" 2>&1 &
           API_PID=$!
           if ! kill -0 "$API_PID" 2>/dev/null; then
@@ -255,12 +251,14 @@ jobs:
             'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
             > "$VERIFY_FILE"
 
-          # Run verifier via Docker (bundles dstack-acpi-tables). Exits 1 when
-          # is_valid=false (expected for simulator) — ignore and check quote_verified.
-          docker run --rm \
-            -v "$SIM_TMP:/data" \
-            -v "$IMAGE_CACHE:/var/lib/dstack-verifier" \
-            dstack-verifier --verify /data/verify-request.json || true
+          # Use workspace for verifier image cache (avoids /tmp permission denied on self-hosted).
+          VERIFIER_CFG_OVERRIDE="$SIM_TMP/verifier.toml"
+          sed "s|image_cache_dir = .*|image_cache_dir = \"${{ github.workspace }}/dstack-cache/verifier-image-cache\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
+          mkdir -p "${{ github.workspace }}/dstack-cache/verifier-image-cache"
+
+          # Run verifier in oneshot mode. Exits 1 when is_valid=false (expected for
+          # the simulator) — ignore the exit code and check quote_verified directly.
+          "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true
 
           # Assertion: quote_verified must be true.
           RESULT_FILE="${VERIFY_FILE}.verification.json"

--- a/.github/workflows/phala-simulator.yml
+++ b/.github/workflows/phala-simulator.yml
@@ -225,10 +225,23 @@ jobs:
           kill "$SIM_PID" "$API_PID" 2>/dev/null || true
 
           # Fix empty digests and normalise format (same script used by verify-attestation.yml).
-          # Then clear vm_config: the simulator produces a synthetic value that lacks
-          # spec_version, which the Docker verifier requires. Passing "" skips that check.
+          # Then inject spec_version into vm_config if missing: the simulator omits spec_version
+          # but the Docker verifier's older serde parser requires it to be present.
+          # (The verifier will still report os_image_hash_verified=false and is_valid=false
+          # because the simulator's synthetic OS hash is not published — that is expected.)
           python3 scripts/fix-attestation-event-log.py "$SIM_TMP/attestation.json" \
-            | python3 -c 'import sys,json; d=json.load(sys.stdin); d["vm_config"]=""; print(json.dumps(d))' \
+            | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+try:
+    vc = json.loads(d["vm_config"])
+    if "spec_version" not in vc:
+        vc["spec_version"] = 1
+    d["vm_config"] = json.dumps(vc, separators=(",", ":"))
+except Exception:
+    pass
+print(json.dumps(d))
+' \
             > "$SIM_TMP/verify-request.json"
 
           # Run verifier via Docker (same image as verify-attestation.yml).

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -1,6 +1,7 @@
 # Verify attestation from a deployed Phala CVM
 #
-# Fetches /attestation from the live API, builds the dstack-verifier,
+# Fetches /attestation from the live API, runs dstack-verifier (via its
+# Docker image which bundles dstack-acpi-tables and all dependencies),
 # and asserts is_valid=true.  Unlike the simulator CI job (which can only
 # check quote_verified), a real TDX deployment must produce a fully valid
 # attestation.
@@ -39,48 +40,45 @@ jobs:
     name: dstack-verifier (remote)
     runs-on: ${{ fromJson(inputs.runner) }}
     steps:
-      # ── 1. Build dstack-verifier (cached by upstream SHA) ────────────
+      # ── 1. Build the dstack-verifier Docker image (cached) ─────────────
+      # The image bundles the verifier binary, dstack-acpi-tables (custom
+      # QEMU build for RTMR0 measurement), shared libraries, and BIOS files
+      # — everything needed for full is_valid verification.
       - name: Get dstack HEAD SHA
         id: dstack-sha
         run: |
           SHA=$(git ls-remote https://github.com/Dstack-TEE/dstack.git HEAD | head -1 | cut -f1 | tr -d '[:space:]')
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-      # Shared with phala-simulator.yml — same key and path so either
-      # workflow can warm the cache for the other.
-      - name: Restore verifier cache
-        id: verifier-cache
+      - name: Restore verifier image cache
+        id: image-cache
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/dstack-cache/verifier
-          key: dstack-verifier-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+          path: dstack-verifier-image.tar
+          key: dstack-verifier-image-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
 
-      - name: Fix dstack cache permissions
-        if: steps.verifier-cache.outputs.cache-hit == 'true'
-        run: chmod -R u+rwX "${{ github.workspace }}/dstack-cache" 2>/dev/null || true
+      - name: Load cached Docker image
+        if: steps.image-cache.outputs.cache-hit == 'true'
+        run: docker load < dstack-verifier-image.tar
 
       - name: Clone dstack repository
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
+        if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
           DSTACK_BUILD=$(mktemp -d)
           echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
           git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
 
-      - name: Install Rust (stable, for dstack)
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build dstack-verifier
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path="$DSTACK_BUILD/verifier/Cargo.toml" --bin dstack-verifier
-
-      - name: Populate verifier cache
-        if: steps.verifier-cache.outputs.cache-hit != 'true'
+      - name: Build verifier Docker image
+        if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "${{ github.workspace }}/dstack-cache/verifier"
-          cp "$DSTACK_BUILD/target/debug/dstack-verifier" \
-             "$DSTACK_BUILD/verifier/dstack-verifier.toml" \
-             "${{ github.workspace }}/dstack-cache/verifier/"
+          docker build -t dstack-verifier \
+            --build-arg DSTACK_REV="${{ steps.dstack-sha.outputs.sha }}" \
+            -f "$DSTACK_BUILD/verifier/builder/Dockerfile" \
+            "$DSTACK_BUILD/verifier"
+
+      - name: Save Docker image to cache
+        if: steps.image-cache.outputs.cache-hit != 'true'
+        run: docker save dstack-verifier > dstack-verifier-image.tar
 
       - name: Remove dstack build directory
         if: always() && env.DSTACK_BUILD != ''
@@ -92,9 +90,9 @@ jobs:
           set -eu
           ATTESTATION_URL="${{ inputs.attestation_url }}"
           CACHE_DIR="${{ github.workspace }}/dstack-cache"
-          VERIFIER_BIN="$CACHE_DIR/verifier/dstack-verifier"
-          VERIFIER_CFG="$CACHE_DIR/verifier/dstack-verifier.toml"
           TMP_DIR=$(mktemp -d /tmp/verify-remote-XXXXXX)
+          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
+          mkdir -p "$IMAGE_CACHE"
 
           echo "Fetching attestation from $ATTESTATION_URL/attestation..."
           QUOTE_RESP=$(curl -sf "$ATTESTATION_URL/attestation") || {
@@ -109,16 +107,13 @@ jobs:
             'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
             > "$VERIFY_FILE"
 
-          # Use a writable image cache dir (avoids /tmp permission issues on self-hosted).
-          VERIFIER_CFG_OVERRIDE="$TMP_DIR/verifier.toml"
-          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
-          mkdir -p "$IMAGE_CACHE"
-          sed "s|image_cache_dir = .*|image_cache_dir = \"$IMAGE_CACHE\"|" "$VERIFIER_CFG" > "$VERIFIER_CFG_OVERRIDE"
+          echo "Running dstack-verifier (oneshot) via Docker..."
+          docker run --rm \
+            -v "$TMP_DIR:/data" \
+            -v "$IMAGE_CACHE:/var/lib/dstack-verifier" \
+            dstack-verifier --verify /data/verify-request.json || true
 
-          echo "Running dstack-verifier (oneshot)..."
-          "$VERIFIER_BIN" -c "$VERIFIER_CFG_OVERRIDE" --verify "$VERIFY_FILE" || true
-
-          RESULT_FILE="${VERIFY_FILE}.verification.json"
+          RESULT_FILE="$TMP_DIR/verify-request.json.verification.json"
           echo "--- Verifier output ---"
           cat "$RESULT_FILE"
           echo "--- end ---"

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -1,10 +1,9 @@
 # Verify attestation from a deployed Phala CVM
 #
-# Fetches /attestation from the live API, runs dstack-verifier (via its
-# Docker image which bundles dstack-acpi-tables and all dependencies),
-# and asserts is_valid=true.  Unlike the simulator CI job (which can only
-# check quote_verified), a real TDX deployment must produce a fully valid
-# attestation.
+# Fetches /attestation from the live API, runs the official
+# dstacktee/dstack-verifier Docker image, and asserts is_valid=true.
+# Unlike the simulator CI job (which can only check quote_verified),
+# a real TDX deployment must produce a fully valid attestation.
 #
 # Called from Deploy to Phala CVM after the API is available, or manually
 # via workflow_dispatch.
@@ -40,80 +39,44 @@ jobs:
     name: dstack-verifier (remote)
     runs-on: ${{ fromJson(inputs.runner) }}
     steps:
-      # ── 1. Build the dstack-verifier Docker image (cached) ─────────────
-      # The image bundles the verifier binary, dstack-acpi-tables (custom
-      # QEMU build for RTMR0 measurement), shared libraries, and BIOS files
-      # — everything needed for full is_valid verification.
-      - name: Get dstack HEAD SHA
-        id: dstack-sha
-        run: |
-          SHA=$(git ls-remote https://github.com/Dstack-TEE/dstack.git HEAD | head -1 | cut -f1 | tr -d '[:space:]')
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
 
-      - name: Restore verifier image cache
-        id: image-cache
-        uses: actions/cache@v4
-        with:
-          path: dstack-verifier-image.tar
-          key: dstack-verifier-image-${{ steps.dstack-sha.outputs.sha }}-${{ runner.os }}
+      - name: Pull dstack-verifier image
+        run: docker pull --platform linux/amd64 dstacktee/dstack-verifier:latest
 
-      - name: Load cached Docker image
-        if: steps.image-cache.outputs.cache-hit == 'true'
-        run: docker load < dstack-verifier-image.tar
-
-      - name: Clone dstack repository
-        if: steps.image-cache.outputs.cache-hit != 'true'
-        run: |
-          DSTACK_BUILD=$(mktemp -d)
-          echo "DSTACK_BUILD=$DSTACK_BUILD" >> "$GITHUB_ENV"
-          git clone --depth 1 https://github.com/Dstack-TEE/dstack.git "$DSTACK_BUILD"
-
-      - name: Build verifier Docker image
-        if: steps.image-cache.outputs.cache-hit != 'true'
-        run: |
-          docker build -t dstack-verifier \
-            --build-arg DSTACK_REV="${{ steps.dstack-sha.outputs.sha }}" \
-            -f "$DSTACK_BUILD/verifier/builder/Dockerfile" \
-            "$DSTACK_BUILD/verifier"
-
-      - name: Save Docker image to cache
-        if: steps.image-cache.outputs.cache-hit != 'true'
-        run: docker save dstack-verifier > dstack-verifier-image.tar
-
-      - name: Remove dstack build directory
-        if: always() && env.DSTACK_BUILD != ''
-        run: rm -rf "$DSTACK_BUILD"
-
-      # ── 2. Fetch attestation from deployed CVM, verify with dstack-verifier ─
       - name: Verify remote attestation
         run: |
           set -eu
           ATTESTATION_URL="${{ inputs.attestation_url }}"
-          CACHE_DIR="${{ github.workspace }}/dstack-cache"
           TMP_DIR=$(mktemp -d /tmp/verify-remote-XXXXXX)
-          IMAGE_CACHE="$CACHE_DIR/verifier-image-cache"
-          mkdir -p "$IMAGE_CACHE"
 
           echo "Fetching attestation from $ATTESTATION_URL/attestation..."
-          QUOTE_RESP=$(curl -sf "$ATTESTATION_URL/attestation") || {
+          curl -sf "$ATTESTATION_URL/attestation" > "$TMP_DIR/attestation.json" || {
             echo "::error::Failed to fetch $ATTESTATION_URL/attestation"
             rm -rf "$TMP_DIR"
             exit 1
           }
 
-          # Build verifier request: strip 0x prefix from quote, set attestation=null.
-          VERIFY_FILE="$TMP_DIR/verify-request.json"
-          printf '%s' "$QUOTE_RESP" | python3 -c \
-            'import sys,json; d=json.load(sys.stdin); q=d["quote"]; q=q[2:] if q.startswith("0x") else q; print(json.dumps({"quote":q,"event_log":d["event_log"],"vm_config":d["vm_config"],"attestation":None}))' \
-            > "$VERIFY_FILE"
+          # Fix empty digests in runtime events (dstack guest-agent strips them;
+          # the Docker verifier's parser rejects digest=""). See script docstring.
+          python3 scripts/fix-attestation-event-log.py "$TMP_DIR/attestation.json" \
+            > "$TMP_DIR/verify-request.json"
 
           echo "Running dstack-verifier (oneshot) via Docker..."
           docker run --rm \
-            -v "$TMP_DIR:/data" \
-            -v "$IMAGE_CACHE:/var/lib/dstack-verifier" \
-            dstack-verifier --verify /data/verify-request.json || true
+            -v "$TMP_DIR:/verify" \
+            -w /verify \
+            --platform linux/amd64 \
+            dstacktee/dstack-verifier:latest \
+            --verify /verify/verify-request.json || true
 
           RESULT_FILE="$TMP_DIR/verify-request.json.verification.json"
+          if [ ! -f "$RESULT_FILE" ]; then
+            echo "::error::Verifier did not produce result file"
+            rm -rf "$TMP_DIR"
+            exit 1
+          fi
+
           echo "--- Verifier output ---"
           cat "$RESULT_FILE"
           echo "--- end ---"

--- a/scripts/fix-attestation-event-log.py
+++ b/scripts/fix-attestation-event-log.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Fix event log for dstack verifier: compute digests for runtime events with empty digest.
+
+Why is digest empty? The dstack guest-agent strips digests from runtime events (RTMR3,
+event_type 0x08000001) to reduce response size. The digest is deterministically derived as
+SHA384(event_type || ":" || event || ":" || payload), so it can be recomputed. The verifier
+is meant to handle this, but the Docker verifier's serde parser rejects digest="".
+We fill in the computed digest before calling the verifier.
+"""
+import hashlib
+import json
+import struct
+import sys
+
+DSTACK_RUNTIME = 0x08000001
+
+
+def hex_to_bytes(s: str) -> bytes:
+    return bytes.fromhex(s) if s else b""
+
+
+def compute_digest(event: str, payload_hex: str) -> str:
+    payload = hex_to_bytes(payload_hex)
+    data = struct.pack("<I", DSTACK_RUNTIME) + b":" + event.encode() + b":" + payload
+    return hashlib.sha384(data).hexdigest()
+
+
+def main() -> None:
+    attest_path = sys.argv[1]
+    with open(attest_path) as f:
+        d = json.load(f)
+    events = json.loads(d["event_log"])
+    for e in events:
+        if e.get("digest") == "" and e.get("event_type") == DSTACK_RUNTIME:
+            e["digest"] = compute_digest(e.get("event", ""), e.get("event_payload", ""))
+    d["event_log"] = json.dumps(events)
+    q = d["quote"]
+    q = q[2:] if isinstance(q, str) and q.startswith("0x") else q
+    out = {"quote": q, "event_log": d["event_log"], "vm_config": d["vm_config"], "attestation": None}
+    json.dump(out, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inject-spec-version.py
+++ b/scripts/inject-spec-version.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Inject spec_version=1 into vm_config if missing.
+
+The dstack simulator omits spec_version from its vm_config JSON, but the
+dstack-verifier Docker image requires it for serde deserialization.
+This script reads a verify-request JSON from stdin, adds spec_version if
+absent, and writes the patched JSON to stdout.
+"""
+import json
+import sys
+
+
+def main() -> None:
+    d = json.load(sys.stdin)
+    try:
+        vc = json.loads(d["vm_config"])
+        if "spec_version" not in vc:
+            vc["spec_version"] = 1
+        d["vm_config"] = json.dumps(vc, separators=(",", ":"))
+    except Exception:
+        pass
+    json.dump(d, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### TL;DR

Replaced local dstack-verifier builds with the official Docker image and added a Python script to fix attestation event log formatting.

### What changed?

- **GitHub Actions workflows**: Removed dstack-verifier build steps and caching logic from both `phala-simulator.yml` and `verify-attestation.yml`
- **Docker integration**: Both workflows now pull and use the `dstacktee/dstack-verifier:latest` Docker image instead of building from source
- **Event log preprocessing**: Added `scripts/fix-attestation-event-log.py` to compute missing SHA384 digests for runtime events and format attestation data for the verifier
- **Worktree subprojects**: Added seven new Claude worktree subprojects under `.claude/worktrees/`

### How to test?

1. Run the Phala simulator workflow to verify it can pull the Docker image and process attestations
2. Run the verify-attestation workflow against a live deployment to ensure remote attestation verification works
3. Test the Python script directly: `python3 scripts/fix-attestation-event-log.py <attestation.json>`

### Why make this change?

- **Simplified CI**: Eliminates complex build caching and Rust toolchain setup by using the official pre-built Docker image
- **Consistency**: Both workflows now use the same verifier image, ensuring identical behavior
- **Compatibility**: The Python script resolves parsing issues where the Docker verifier rejects empty digest fields that the guest-agent strips from runtime events