### PR TITLE
BASE_CHAIN_RPC override for deployed system

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -23,6 +23,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      BASE_CHAIN_RPC: ${BASE_CHAIN_RPC}
       ROCKET_ADDRESS: "0.0.0.0"
       ROCKET_PORT: "8000"
     volumes:

--- a/lit-api-server/src/abstractions/intents/swaps/internal.rs
+++ b/lit-api-server/src/abstractions/intents/swaps/internal.rs
@@ -210,10 +210,10 @@ pub async fn get_quote_balances(quote_id: &str) -> Result<QuoteBalancesResponse,
         .map_err(|e| ApiStatus::from(e).add_message("Unsupported destination chain."))?;
 
     let pkp_address = swap_request.pkp_address;
-    let src_provider = Provider::<Http>::try_from(src_chain.info().rpc_url).map_err(|e| {
+    let src_provider = Provider::<Http>::try_from(src_chain.rpc_url().as_str()).map_err(|e| {
         ApiStatus::internal_server_error(e.into(), "Failed to create source chain provider.")
     })?;
-    let dst_provider = Provider::<Http>::try_from(dst_chain.info().rpc_url).map_err(|e| {
+    let dst_provider = Provider::<Http>::try_from(dst_chain.rpc_url().as_str()).map_err(|e| {
         ApiStatus::internal_server_error(e.into(), "Failed to create destination chain provider.")
     })?;
 
@@ -293,7 +293,7 @@ async fn get_signable_quote_contract()
 
     let wallet = LocalWallet::from_bytes(&secret)?.with_chain_id(chain_info.chain_id);
 
-    let provider = Provider::<Http>::try_from(chain_info.rpc_url)?;
+    let provider = Provider::<Http>::try_from(chain.rpc_url().as_str())?;
     let signing_provider = SignerMiddleware::new(provider.clone(), wallet);
 
     let client = Arc::new(signing_provider);

--- a/lit-api-server/src/abstractions/transfer/chain_info.rs
+++ b/lit-api-server/src/abstractions/transfer/chain_info.rs
@@ -1,6 +1,7 @@
 use crate::core::v1::models::signing_scheme::SigningScheme;
 use rocket::http::Status;
 use serde::{Deserialize, Serialize};
+use std::env;
 /// EVM chain RPC and wallet info.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 
@@ -1051,6 +1052,19 @@ impl Chain {
                 derivation_path: "m/44'/501'/0'/0'",
             },
         }
+    }
+
+    /// Returns the effective RPC URL for this chain. For Base mainnet, uses
+    /// BASE_CHAIN_RPC env var if set; otherwise uses the default public RPC.
+    pub fn rpc_url(self) -> String {
+        if self == Self::Base {
+            if let Ok(url) = env::var("BASE_CHAIN_RPC") {
+                if !url.trim().is_empty() {
+                    return url;
+                }
+            }
+        }
+        self.info().rpc_url.to_string()
     }
 
     pub fn all_chains() -> &'static [Chain] {

--- a/lit-api-server/src/abstractions/transfer/chain_info.rs
+++ b/lit-api-server/src/abstractions/transfer/chain_info.rs
@@ -1057,12 +1057,11 @@ impl Chain {
     /// Returns the effective RPC URL for this chain. For Base mainnet, uses
     /// BASE_CHAIN_RPC env var if set; otherwise uses the default public RPC.
     pub fn rpc_url(self) -> String {
-        if self == Self::Base {
-            if let Ok(url) = env::var("BASE_CHAIN_RPC") {
-                if !url.trim().is_empty() {
-                    return url;
-                }
-            }
+        if self == Self::Base
+            && let Ok(url) = env::var("BASE_CHAIN_RPC")
+            && !url.trim().is_empty()
+        {
+            return url;
         }
         self.info().rpc_url.to_string()
     }

--- a/lit-api-server/src/abstractions/transfer/chain_info.rs
+++ b/lit-api-server/src/abstractions/transfer/chain_info.rs
@@ -1061,7 +1061,7 @@ impl Chain {
             && let Ok(url) = env::var("BASE_CHAIN_RPC")
             && !url.trim().is_empty()
         {
-            return url;
+            return url.trim().to_string();
         }
         self.info().rpc_url.to_string()
     }

--- a/lit-api-server/src/abstractions/transfer/evm.rs
+++ b/lit-api-server/src/abstractions/transfer/evm.rs
@@ -40,7 +40,7 @@ pub async fn get_address_balance(
 }
 
 async fn get_balance(address: H160, chain: Chain) -> Result<GetBalanceResponse, ApiStatus> {
-    let provider = Provider::<Http>::try_from(chain.info().rpc_url)?;
+    let provider = Provider::<Http>::try_from(chain.rpc_url().as_str())?;
     info!("provider: {:?}", provider);
 
     let block = None;

--- a/lit-api-server/src/accounts/signable_contract.rs
+++ b/lit-api-server/src/accounts/signable_contract.rs
@@ -33,9 +33,9 @@ pub(crate) async fn init_chain_clients() -> Result<()> {
     let node_config = GLOBAL_NODE_CONFIG
         .get()
         .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))?;
-    let chain_info = node_config.chain.info();
+    let rpc_url = node_config.chain.rpc_url();
 
-    let provider = Provider::<Http>::try_from(chain_info.rpc_url)?.interval(Duration::from_secs(2));
+    let provider = Provider::<Http>::try_from(rpc_url.as_str())?.interval(Duration::from_secs(2));
     GLOBAL_READ_ONLY_CLIENT.get_or_init(|| Arc::new(provider));
     Ok(())
 }
@@ -82,7 +82,8 @@ pub async fn get_admin_api_signer() -> Result<SigningClient> {
         .map_err(|e| anyhow::anyhow!("Failed to get admin api payer key: {e}"))?;
     let wallet = LocalWallet::from_bytes(&secret)?.with_chain_id(chain_info.chain_id);
     let address = wallet.address();
-    let provider = Provider::<Http>::try_from(chain_info.rpc_url)?.interval(Duration::from_secs(2));
+    let rpc_url = node_config.chain.rpc_url();
+    let provider = Provider::<Http>::try_from(rpc_url.as_str())?.interval(Duration::from_secs(2));
     let signer = SignerMiddleware::new(provider, wallet);
     let nonce_manager = NonceManagerMiddleware::new(signer, address);
 

--- a/lit-api-server/src/accounts/signer_pool.rs
+++ b/lit-api-server/src/accounts/signer_pool.rs
@@ -108,8 +108,9 @@ pub async fn get_signer_entries(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         let wallet = LocalWallet::from_bytes(&secret)?.with_chain_id(chain_info.chain_id);
         let address = wallet.address();
+        let rpc_url = node_config.chain.rpc_url();
         let provider =
-            Provider::<Http>::try_from(chain_info.rpc_url)?.interval(Duration::from_secs(2));
+            Provider::<Http>::try_from(rpc_url.as_str())?.interval(Duration::from_secs(2));
         let signer = SignerMiddleware::new(provider, wallet);
         let nonce_manager = NonceManagerMiddleware::new(signer, address);
         tracing::info!("signer_pool: created signer {} address={:?}", i, address);

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -501,7 +501,7 @@ pub async fn get_chain_info() -> Result<NodeChainConfigResponse, ApiStatus> {
         is_evm: chain_info.is_evm,
         testnet: chain_info.testnet,
         token: chain_info.token.to_string(),
-        rpc_url: chain_info.rpc_url.to_string(),
+        rpc_url: node_config.chain.rpc_url(),
         contract_address: node_config.contract_address.to_string(),
     })
 }

--- a/lit-api-server/src/dstack/v1/dstack.rs
+++ b/lit-api-server/src/dstack/v1/dstack.rs
@@ -133,10 +133,11 @@ fn decode_quote(quote_str: &str) -> Vec<u8> {
     #[cfg(not(feature = "production"))]
     {
         let hex_str = s.strip_prefix("0x").unwrap_or(s);
-        if hex_str.len() > 200 && hex_str.chars().all(|c| c.is_ascii_hexdigit()) {
-            if let Ok(decoded) = hex::decode(hex_str) {
-                return decoded;
-            }
+        if hex_str.len() > 200
+            && hex_str.chars().all(|c| c.is_ascii_hexdigit())
+            && let Ok(decoded) = hex::decode(hex_str)
+        {
+            return decoded;
         }
     }
     base64_light::base64_decode(s)

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -6,6 +6,7 @@ pub mod core;
 pub mod dstack;
 pub mod error;
 
+use crate::abstractions::transfer::chain_info::Chain;
 use crate::accounts::signer_pool::start_signer_pool;
 use crate::actions::grpc::GrpcClientPool;
 use moka::future::Cache;
@@ -35,6 +36,17 @@ async fn main() -> Result<(), rocket::Error> {
     if let Err(e) = config::init_config() {
         eprintln!("Failed to initialize node configuration: {:?}. Exiting.", e);
         std::process::exit(1);
+    }
+
+    for chain in Chain::all_chains() {
+        let info = chain.info();
+        let rpc_url = chain.rpc_url();
+        tracing::debug!(
+            chain = %info.chain_name,
+            chain_id = info.chain_id,
+            "RPC: {}",
+            rpc_url
+        );
     }
 
     if let Err(e) = accounts::signable_contract::init_chain_clients().await {

--- a/lit-core/lit-core/src/config/mod.rs
+++ b/lit-core/lit-core/src/config/mod.rs
@@ -659,9 +659,9 @@ mod tests {
         .expect("failed to load config");
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "default".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), true);
+        assert!(cfg.config().get_bool("simple.other").unwrap());
         #[cfg(feature = "ipfs")]
         assert_eq!(cfg.ipfs_api(), DEFAULT_IPFS_API.to_string());
         #[cfg(feature = "ipfs")]
@@ -685,9 +685,9 @@ mod tests {
         .expect("failed to load config");
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "keyed".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), true);
+        assert!(cfg.config().get_bool("simple.other").unwrap());
         #[cfg(feature = "ipfs")]
         assert_eq!(cfg.ipfs_api(), "http://litos-host-other:2199".to_string());
         #[cfg(feature = "ipfs")]
@@ -713,9 +713,9 @@ mod tests {
         .expect("failed to load config");
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "home".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), true);
+        assert!(cfg.config().get_bool("simple.other").unwrap());
         #[cfg(feature = "ipfs")]
         assert_eq!(cfg.ipfs_api(), "http://litos-host-home:2199".to_string());
         #[cfg(feature = "ipfs")]
@@ -742,9 +742,9 @@ mod tests {
         .expect("failed to load config");
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "system".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), false);
+        assert!(!cfg.config().get_bool("simple.other").unwrap());
         assert_eq!(cfg.config().get_string("top.one").unwrap(), "1".to_string());
         assert_eq!(cfg.config().get_string("top.two").unwrap(), "2".to_string());
         assert_eq!(cfg.config().get_string("top.three").unwrap(), "3".to_string());

--- a/lit-core/lit-core/src/config/reloadable.rs
+++ b/lit-core/lit-core/src/config/reloadable.rs
@@ -73,16 +73,16 @@ mod tests {
         let cfg = reloader.load();
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "default".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), true);
+        assert!(cfg.config().get_bool("simple.other").unwrap());
 
         let cfg = reloader.reload().unwrap();
 
         assert_eq!(cfg.env().clone(), LitEnv::Dev);
-        assert_eq!(cfg.is_dev(), true);
+        assert!(cfg.is_dev());
         assert_eq!(cfg.config().get_string("simple.dummy").unwrap(), "default".to_string());
-        assert_eq!(cfg.config().get_bool("simple.other").unwrap(), true);
+        assert!(cfg.config().get_bool("simple.other").unwrap());
     }
 
     // Util

--- a/lit-core/lit-core/src/error/mod.rs
+++ b/lit-core/lit-core/src/error/mod.rs
@@ -813,9 +813,9 @@ mod tests {
         let err = sev_snp_err(err, Some("sev-snp".into()));
         let err = generic_err(err, Some("last".into()));
 
-        assert_eq!(err.is_kind(Kind::Generic, false), true);
-        assert_eq!(err.is_kind(Kind::SevSnp, false), false);
-        assert_eq!(err.is_kind(Kind::SevSnp, true), true);
+        assert!(err.is_kind(Kind::Generic, false));
+        assert!(!err.is_kind(Kind::SevSnp, false));
+        assert!(err.is_kind(Kind::SevSnp, true));
     }
 
     #[test]
@@ -824,8 +824,8 @@ mod tests {
         let err = err_code(err, EC::CoreFatal, Some("fatal-1".into()));
         let err = sev_snp_err(err, Some("sev-snp".into()));
 
-        assert_eq!(err.is_code(EC::CoreFatal, false), false);
-        assert_eq!(err.is_code(EC::CoreFatal, true), true);
+        assert!(!err.is_code(EC::CoreFatal, false));
+        assert!(err.is_code(EC::CoreFatal, true));
     }
 
     #[test]
@@ -833,11 +833,11 @@ mod tests {
         let err = generic_err("first", None);
         let err = generic_err(err, Some("second".into()));
 
-        assert_eq!(err.has_code(), false);
+        assert!(!err.has_code());
 
         let err = err_code(err, EC::CoreFatal, Some("fatal-1".into()));
         let err = sev_snp_err(err, Some("sev-snp".into()));
 
-        assert_eq!(err.has_code(), true);
+        assert!(err.has_code());
     }
 }

--- a/lit-core/lit-observability/src/logging/context_layer.rs
+++ b/lit-core/lit-observability/src/logging/context_layer.rs
@@ -428,7 +428,7 @@ mod tests {
             let _guard = span.enter();
 
             let initial = get_request_context();
-            assert!(initial.is_none() || !initial.as_ref().map_or(false, |c| c.has_context()));
+            assert!(initial.is_none() || !initial.as_ref().is_some_and(|c| c.has_context()));
 
             let expected_req_id = "test-req-id-12345".to_string();
             let expected_corr_id = "test-corr-id-67890".to_string();


### PR DESCRIPTION
### TL;DR

Added configurable RPC URL support for Base chain through the `BASE_CHAIN_RPC` environment variable.

### What changed?

- Added `BASE_CHAIN_RPC` environment variable to the Docker Compose configuration
- Implemented a new `rpc_url()` method on the `Chain` enum that returns the environment variable value for Base chain when set, falling back to the default public RPC
- Replaced all direct calls to `chain.info().rpc_url` with `chain.rpc_url()` throughout the codebase to use the new configurable RPC URL logic

### How to test?

1. Set the `BASE_CHAIN_RPC` environment variable to a custom Base chain RPC URL
2. Start the application and verify that Base chain operations use the custom RPC URL
3. Test without the environment variable set to ensure it falls back to the default RPC URL
4. Test operations on other chains to ensure they continue using their default RPC URLs

### Why make this change?

This allows operators to use custom or private RPC endpoints for Base chain operations instead of being limited to the hardcoded public RPC URL, providing better flexibility for production deployments and potentially improved reliability or performance.