### PR TITLE
Switch CORS proxy from corsproxy.io to whateverorigin.org

### DIFF
--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -285,11 +285,11 @@ async function parseResponse(res, context) {
 }
 
 const CHAINLIST_API = 'https://chainlistapi.com';
-const CORS_PROXY = 'https://corsproxy.io/?';
+const CORS_PROXY = 'https://whateverorigin.org/get?url=';
 
 /**
  * Resolve a public RPC URL for the given chain ID from chainlistapi.com.
- * Uses a CORS proxy to avoid cross-origin restrictions.
+ * Uses Whatever Origin CORS proxy (free, no domain whitelist) to avoid cross-origin restrictions.
  * @param {number} chainId - EVM chain ID
  * @returns {Promise<string|null>} First HTTP RPC URL, or null if not found
  */
@@ -299,7 +299,8 @@ export async function resolveRpcUrlFromChainlist(chainId) {
     const url = `${CORS_PROXY}${encodeURIComponent(`${CHAINLIST_API}/chains/${chainId}`)}`;
     const res = await fetch(url);
     if (!res.ok) return null;
-    const data = await res.json();
+    const wrapper = await res.json();
+    const data = typeof wrapper?.contents === 'string' ? JSON.parse(wrapper.contents) : wrapper;
     const rpcs = data?.rpc;
     if (!Array.isArray(rpcs)) return null;
     const entry = rpcs.find((r) => {

--- a/lit-static/static/dapps/monitor/app.js
+++ b/lit-static/static/dapps/monitor/app.js
@@ -248,10 +248,14 @@ async function getApiPayers(serverUrl) {
 
 async function loadNetwork() {
   const serverUrl = getServerUrl();
-  await Promise.all([
-    getNodeChainConfig(serverUrl),
-    getApiPayers(serverUrl),
-  ]);
+  await getNodeChainConfig(serverUrl); // Must run first to populate RPC URL
+  await getApiPayers(serverUrl);
+  await fetchContractValues();
+}
+
+async function refreshBalances() {
+  const serverUrl = getServerUrl();
+  await getApiPayers(serverUrl);
   await fetchContractValues();
 }
 
@@ -475,13 +479,13 @@ el('btn-set-rebalance-amount')?.addEventListener('click', async () => {
   }
 });
 
-el('cc-rpc-url')?.addEventListener('change', () => fetchContractValues());
+el('cc-rpc-url')?.addEventListener('change', () => refreshBalances());
 
 el('btn-refresh-contract')?.addEventListener('click', async () => {
   const btn = el('btn-refresh-contract');
   btn.disabled = true;
   try {
-    await fetchContractValues();
+    await refreshBalances();
   } finally {
     btn.disabled = false;
   }
@@ -518,6 +522,7 @@ el('btn-set-payer-count')?.addEventListener('click', async () => {
     await tx.wait();
 
     showSignerCountStatus('Done. Requested payer count updated to ' + newCount, false);
+    await refreshBalances();
   } catch (e) {
     showSignerCountStatus('Error: ' + (e?.reason || e?.message || String(e)), true);
   } finally {

--- a/lit-static/static/dapps/monitor/app.js
+++ b/lit-static/static/dapps/monitor/app.js
@@ -99,9 +99,9 @@ function getServerUrl() {
 }
 
 // ── resolveRpcUrlFromChainlist ───────────────────────────────────────────────────
-// Uses CORS proxy to fetch from chainlistapi.com (avoids cross-origin restrictions).
+// Uses Whatever Origin CORS proxy (free, no domain whitelist) to fetch from chainlistapi.com.
 
-const CORS_PROXY = 'https://corsproxy.io/?';
+const CORS_PROXY = 'https://whateverorigin.org/get?url=';
 
 async function resolveRpcUrlFromChainlist(chainId) {
   if (chainId == null || chainId === '') return null;
@@ -109,7 +109,8 @@ async function resolveRpcUrlFromChainlist(chainId) {
     const url = `${CORS_PROXY}${encodeURIComponent(`https://chainlistapi.com/chains/${chainId}`)}`;
     const res = await fetch(url);
     if (!res.ok) return null;
-    const data = await res.json();
+    const wrapper = await res.json();
+    const data = typeof wrapper?.contents === 'string' ? JSON.parse(wrapper.contents) : wrapper;
     const rpcs = data?.rpc;
     if (!Array.isArray(rpcs)) return null;
     const entry = rpcs.find((r) => {


### PR DESCRIPTION
### TL;DR

Switched CORS proxy from [corsproxy.io](http://corsproxy.io) to [whateverorigin.org](http://whateverorigin.org) and improved balance refresh handling in the monitor app.

### What changed?

- Replaced `https://corsproxy.io/?` with `https://whateverorigin.org/get?url=` as the CORS proxy service
- Added a new `refreshBalances()` function that fetches API payers and contract values
- Modified the network loading sequence to run `getNodeChainConfig()` first before other operations
- Updated refresh button and RPC URL change handler to use the new `refreshBalances()` function
- Added automatic balance refresh after updating payer count