### PR TITLE
fix(k6): update tests for pkp_id migration (#67)

### DIFF
--- a/k6/integration.spec.ts
+++ b/k6/integration.spec.ts
@@ -88,7 +88,6 @@ export default function () {
   const newAccountRes = client.newAccount({
     account_name: "k6-integration-test",
     account_description: "Integration test account",
-    initial_balance: "10000",
   });
   if (!assertOk("newAccount", "POST /new_account", newAccountRes)) return;
   const newAccountData = newAccountRes.data as { api_key: string; wallet_address: string };
@@ -223,7 +222,7 @@ export default function () {
 
   // ── 11. addPkpToGroup ─────────────────────────────────────────────────────
   const addPkpRes = client.addPkpToGroup(
-    { group_id: groupId, pkp_public_key: walletAddress },
+    { group_id: groupId, pkp_id: walletAddress },
     authHeaders,
   );
   if (!assertOk("addPkpToGroup", "POST /add_pkp_to_group", addPkpRes)) return;
@@ -279,7 +278,7 @@ export default function () {
   // ── 14. addUsageApiKey ────────────────────────────────────────────────────
   const expiration = String(Math.floor(Date.now() / 1000) + 86400); // 24 h from now
   const addUsageKeyRes = client.addUsageApiKey(
-    { expiration, balance: "1000000000000000000" }, // 1 token in wei
+    { expiration, balance: "1000000000000000000", name: "k6-usage-key", description: "Integration test usage key" },
     authHeaders,
   );
   if (!assertOk("addUsageApiKey", "POST /add_usage_api_key", addUsageKeyRes)) return;
@@ -395,7 +394,7 @@ export default function () {
 
   // ── 20. removePkpFromGroup ────────────────────────────────────────────────
   const removePkpRes = client.removePkpFromGroup(
-    { group_id: groupId, pkp_public_key: walletAddress },
+    { group_id: groupId, pkp_id: walletAddress },
     authHeaders,
   );
   if (!assertOk("removePkpFromGroup", "POST /remove_pkp_from_group", removePkpRes)) return;

--- a/k6/lit-action-ecdsa-sign.spec.ts
+++ b/k6/lit-action-ecdsa-sign.spec.ts
@@ -2,8 +2,8 @@
  * Tests Lit.Actions.signEcdsa() — signs data using a PKP's ECDSA key.
  *
  * Flow:
- *   1. Create a fresh account and wallet (the wallet address IS the PKP public key)
- *   2. Run a Lit Action that calls signEcdsa with that public key
+ *   1. Create a fresh account and wallet (wallet address is used as pkpId)
+ *   2. Run a Lit Action that calls signEcdsa with the wallet address as pkpId
  *   3. Assert the response contains a non-empty hex signature with no error
  *
  * Usage:
@@ -24,14 +24,12 @@ const TO_SIGN = [
   2, 248, 239, 66, 165, 236, 95, 3, 187, 250, 37, 76, 176, 31, 173,
 ];
 
-// publicKey and sigName are injected via jsParams.
-// keySetId is ignored server-side; pass empty string.
+// pkpId (wallet address) and sigName are injected via jsParams.
 const ECDSA_SIGN_CODE = `(async () => {
   const sig = await Lit.Actions.signEcdsa({
     toSign,
-    publicKey,
+    pkpId,
     sigName,
-    keySetId: "",
   });
   Lit.Actions.setResponse({ response: JSON.stringify(sig) });
 })();`;
@@ -87,7 +85,6 @@ export default function () {
   const newAccountRes = client.newAccount({
     account_name: "k6-lit-action-ecdsa-sign",
     account_description: "k6 test account",
-    initial_balance: "10000",
   });
   if (!assertOk("newAccount", "POST /new_account", newAccountRes)) return;
   const apiKey = (newAccountRes.data as { api_key: string }).api_key;
@@ -103,35 +100,16 @@ export default function () {
       typeof walletAddress === "string" && walletAddress.length > 0,
   }, "createWallet");
 
-  // ── 3. List wallets to get the raw public key ─────────────────────────────
-  // createWallet returns only the Ethereum address; listWallets returns the
-  // full WalletItem including the raw uncompressed public key needed by signEcdsa.
-  const listRes = client.listWallets(
-    { page_number: "0", page_size: "10" },
-    authHeaders,
-  );
-  if (!assertOk("listWallets", "GET /list_wallets", listRes)) return;
-  const wallets = listRes.data as Array<{
-    wallet_address: string;
-    public_key: string;
-  }>;
-  const wallet = wallets.find((w) => w.wallet_address === walletAddress);
-  checkAndLog(listRes.response, {
-    "listWallets finds created wallet": () => wallet !== undefined,
-    "wallet has non-empty public_key": () =>
-      typeof wallet?.public_key === "string" && wallet.public_key.length > 0,
-  }, "listWallets");
-  if (!wallet) return;
-  const publicKey = wallet.public_key;
-  console.log(`publicKey: ${publicKey}`);
+  // ── 3. Sign with signEcdsa ────────────────────────────────────────────────
+  // signEcdsa identifies the key by pkpId (wallet address) since migration in #67.
+  console.log(`pkpId (walletAddress): ${walletAddress}`);
 
-  // ── 4. Sign with signEcdsa ────────────────────────────────────────────────
   const res = client.litAction(
     {
       code: ECDSA_SIGN_CODE,
       js_params: {
         toSign: TO_SIGN,
-        publicKey,
+        pkpId: walletAddress,
         sigName: "sig",
       },
     },


### PR DESCRIPTION
## Summary

- **`integration.spec.ts`**: Fix `addPkpToGroup` and `removePkpFromGroup` to send `pkp_id` instead of the old `pkp_public_key` field — causing the 422 in [run 22921825138](https://github.com/LIT-Protocol/lit-node-express/actions/runs/22921825138/job/66522367584). Also add required `name`/`description` fields to `addUsageApiKey`, and remove `initial_balance` from `newAccount` (removed from server schema in 6da2de5).
- **`lit-action-ecdsa-sign.spec.ts`**: After #67, `signEcdsa` takes `pkpId` (wallet address) not a raw public key. `WalletItem` no longer has a `public_key` field. Replaced the `listWallets → find by wallet_address → read public_key` flow with passing `walletAddress` directly as `pkpId` in the Lit Action jsParams. Updated `ECDSA_SIGN_CODE` to use `pkpId` instead of `publicKey`.

## Root causes

| Failure | Cause | Fix |
|---|---|---|
| `addPkpToGroup 422` | Test sends `pkp_public_key`, server requires `pkp_id` after #67 | Rename field |
| `listWallets finds created wallet` | `WalletItem.public_key` removed in 6da2de5; address format also mismatches (`0x` vs no-`0x`) | Remove listWallets step entirely — use `walletAddress` from `createWallet` as `pkpId` |
| `wallet has non-empty public_key` | Same as above | Same fix |

## Test plan

- [ ] Deploy to Phala CVM and trigger k6-integration via workflow_dispatch
- [ ] Deploy to Phala CVM and trigger k6-lit-action-ecdsa-sign via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)