### PR TITLE
use first api_payer for account_exists

### DIFF
--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -52,10 +52,9 @@ pub async fn account_exists(api_key: &str) -> Result<bool> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
     let api_payers = get_api_payers().await?;
-    let from = api_payers
-        .first()
-        .copied()
-        .ok_or_else(|| anyhow::anyhow!("No api_payers configured; cannot simulate account_exists"))?;
+    let from = api_payers.first().copied().ok_or_else(|| {
+        anyhow::anyhow!("No api_payers configured; cannot simulate account_exists")
+    })?;
     let exists = contract
         .account_exists_and_is_mutable(account_api_key_hash)
         .from(from)

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -45,11 +45,20 @@ pub async fn new_account(
     send_transaction(function_call, signer_pool, signer_address).await
 }
 
+/// Check whether an account exists and is mutable. Uses an api_payer address as the
+/// simulated caller (msg.sender) because accountExistsAndIsMutable requires the
+/// caller to be an api_payer (for managed accounts) or the creator.
 pub async fn account_exists(api_key: &str) -> Result<bool> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
+    let api_payers = get_api_payers().await?;
+    let from = api_payers
+        .first()
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("No api_payers configured; cannot simulate account_exists"))?;
     let exists = contract
         .account_exists_and_is_mutable(account_api_key_hash)
+        .from(from)
         .call()
         .await?;
     Ok(exists)


### PR DESCRIPTION
### TL;DR

Fixed the `account_exists` function to properly simulate calls using an api_payer address as the caller.

### What changed?

The `account_exists` function now retrieves the first available api_payer address and uses it as the `from` parameter when calling `account_exists_and_is_mutable`. Added error handling for cases where no api_payers are configured. Also added documentation explaining that the function uses an api_payer address as the simulated caller because the contract method requires the caller to be either an api_payer (for managed accounts) or the creator.

### How to test?

Test the `account_exists` function with various API keys to ensure it correctly determines account existence and mutability. Verify that the function fails gracefully when no api_payers are configured by testing in an environment without api_payers setup.

### Why make this change?

The `accountExistsAndIsMutable` contract method has access control restrictions that require the caller to be either an api_payer or the account creator. Without specifying a valid api_payer as the caller, the contract call would fail due to these permission checks.