### PR TITLE
chipotle-next: New (diamond) contracts

### DIFF
--- a/lit-api-server/NodeConfig.next.toml
+++ b/lit-api-server/NodeConfig.next.toml
@@ -1,3 +1,3 @@
 [chain]
 name = "base"
-contract_address = "0x6c4989c3c2aab271444b4b7b4ec3aca6da1bf1e5"
+contract_address = "0x8591a5d4043f6c808fbf049a8a392233afe7a5c3"

--- a/lit-api-server/NodeConfig.next.toml
+++ b/lit-api-server/NodeConfig.next.toml
@@ -1,3 +1,5 @@
 [chain]
 name = "base"
-contract_address = "0x8591a5d4043f6c808fbf049a8a392233afe7a5c3"
+contract_address = "0x98e501fab2d60a5119a185e1563f10cb54bc6068"
+
+# contract_address = "0x6c4989c3c2aab271444b4b7b4ec3aca6da1bf1e5" # old contracts, TODO: about 10 USD still sitting in api-payer signers

--- a/lit-api-server/blockchain/lit_node_express/generate-diamond-abi.mjs
+++ b/lit-api-server/blockchain/lit_node_express/generate-diamond-abi.mjs
@@ -64,12 +64,25 @@ for (const facet of FACETS) {
   console.log(`  + ${facet} (${artifact.abi?.length ?? 0} entries from ${artifactPath})`);
 }
 
-// Write to the same place hardhat-diamond-abi would have written it
+// Write to the same place hardhat-diamond-abi would have written it.
+// Preserve bytecode from the compiled AccountConfig.sol so the deployer can deploy it.
 const outDir = path.join(ARTIFACTS_DIR, `${OUT_NAME}.sol`);
 fs.mkdirSync(outDir, { recursive: true });
 const outPath = path.join(outDir, `${OUT_NAME}.json`);
-fs.writeFileSync(
-  outPath,
-  JSON.stringify({ contractName: OUT_NAME, abi: combined }, null, 2),
-);
+let compiled = {};
+try {
+  compiled = JSON.parse(fs.readFileSync(outPath, "utf8"));
+} catch {
+  console.warn(`No pre-existing ${OUT_NAME}.json; run "npx hardhat compile" first.`);
+}
+// Preserve constructor from compiled AccountConfig.sol (needed for deployment)
+const constructorItem = (compiled.abi ?? []).find((item) => item.type === "constructor");
+const abi = constructorItem ? [constructorItem, ...combined] : combined;
+
+const output = {
+  ...compiled,
+  contractName: OUT_NAME,
+  abi,
+};
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
 console.log(`\nDiamond ABI written → ${outPath} (${combined.length} total entries)`);

--- a/lit-api-server/blockchain/lit_node_express/generate-diamond-abi.mjs
+++ b/lit-api-server/blockchain/lit_node_express/generate-diamond-abi.mjs
@@ -64,25 +64,12 @@ for (const facet of FACETS) {
   console.log(`  + ${facet} (${artifact.abi?.length ?? 0} entries from ${artifactPath})`);
 }
 
-// Write to the same place hardhat-diamond-abi would have written it.
-// Preserve bytecode from the compiled AccountConfig.sol so the deployer can deploy it.
+// Write to the same place hardhat-diamond-abi would have written it
 const outDir = path.join(ARTIFACTS_DIR, `${OUT_NAME}.sol`);
 fs.mkdirSync(outDir, { recursive: true });
 const outPath = path.join(outDir, `${OUT_NAME}.json`);
-let compiled = {};
-try {
-  compiled = JSON.parse(fs.readFileSync(outPath, "utf8"));
-} catch {
-  console.warn(`No pre-existing ${OUT_NAME}.json; run "npx hardhat compile" first.`);
-}
-// Preserve constructor from compiled AccountConfig.sol (needed for deployment)
-const constructorItem = (compiled.abi ?? []).find((item) => item.type === "constructor");
-const abi = constructorItem ? [constructorItem, ...combined] : combined;
-
-const output = {
-  ...compiled,
-  contractName: OUT_NAME,
-  abi,
-};
-fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+fs.writeFileSync(
+  outPath,
+  JSON.stringify({ contractName: OUT_NAME, abi: combined }, null, 2),
+);
 console.log(`\nDiamond ABI written → ${outPath} (${combined.length} total entries)`);


### PR DESCRIPTION
### TL;DR

Updated the contract address in the base chain configuration to point to new contracts

### What changed?

The `contract_address` in `NodeConfig.next.toml` has been updated from `0x6c4989c3c2aab271444b4b7b4ec3aca6da1bf1e5` to `0x98e501fab2d60a5119a185e1563f10cb54bc6068`. The old contract address has been commented out with a note indicating there are still approximately 10 USD remaining in the old api-payer signers