### PR TITLE
ci: restrict Rust CI to pull requests only

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,11 +1,9 @@
 # Runs cargo fmt --check, cargo clippy, and cargo build --all-features
-# on every push to every branch and on every pull request.
+# on every pull request.
 
 name: Rust CI
 
 on:
-  push:
-    branches: [main, next]
   pull_request:
 
 # Cancel any in-progress run on the same branch/PR when a new commit is pushed.


### PR DESCRIPTION
## Summary
- Removes the `push` trigger on `main` and `next` branches from the Rust CI workflow
- The workflow now runs only on pull requests, reducing unnecessary CI load on direct pushes
- The `deploy` workflow builds the crates anyway