### PR TITLE
fix: add otel-collector to deploy workflow

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -48,6 +48,7 @@ jobs:
       base_url: ${{ steps.set.outputs.base_url }}
       api_root_url: ${{ steps.set.outputs.api_root_url }}
       instance_type: ${{ steps.set.outputs.instance_type }}
+      gcp_project_id: ${{ steps.set.outputs.gcp_project_id }}
     steps:
       - name: Set deployment target
         id: set
@@ -55,10 +56,12 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "phala_app_name=lit-api-server" >> "$GITHUB_OUTPUT"
             echo "instance_type=tdx.large" >> "$GITHUB_OUTPUT"
+            echo "gcp_project_id=chipotle-dev" >> "$GITHUB_OUTPUT"
             BASE_URL="https://api.dev.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
             echo "phala_app_name=chipotle-next" >> "$GITHUB_OUTPUT"
             echo "instance_type=tdx.small" >> "$GITHUB_OUTPUT"
+            echo "gcp_project_id=chipotle-next" >> "$GITHUB_OUTPUT"
             BASE_URL="https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network"
           else
             echo "Unsupported branch for deployment"
@@ -145,6 +148,7 @@ jobs:
             -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
             -e "s|\${DOCKER_IMAGE_LIT_STATIC}|${{ vars.DOCKER_IMAGE }}-lit-static@${DIGEST_LIT_STATIC}|g" \
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
+            -e "s|\${GCP_PROJECT_ID}|${{ needs.determine-target.outputs.gcp_project_id }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
           cat docker-compose.deploy.yml
 

--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -1,4 +1,4 @@
-# Deploy lit-api-server + lit-actions + lit-static to Phala CVM (tdx.large instance)
+# Deploy lit-api-server + lit-actions + lit-static + otel-collector to Phala CVM (tdx.large instance)
 #
 # Branch-based deployment:
 #   push to main  → lit-api-server,      base_url https://api.dev.litprotocol.com
@@ -22,10 +22,11 @@
 #
 # Required vars:
 #   DOCKER_IMAGE - Base image path, e.g. docker.io/username/lit-node-express
-#                  Three images are pushed:
+#                  Four images are pushed:
 #                    ${DOCKER_IMAGE}-lit-actions
 #                    ${DOCKER_IMAGE}-lit-api-server
 #                    ${DOCKER_IMAGE}-lit-static
+#                    ${DOCKER_IMAGE}-otel-collector
 #   DOCKERHUB_USERNAME - Docker Hub username
 
 name: Deploy to Phala CVM
@@ -82,6 +83,8 @@ jobs:
             dockerfile: Dockerfile.lit-api-server
           - service: lit-static
             dockerfile: Dockerfile.lit-static
+          - service: otel-collector
+            dockerfile: Dockerfile.otel-collector
     steps:
       - uses: actions/checkout@v4
 
@@ -136,10 +139,12 @@ jobs:
           DIGEST_LIT_ACTIONS=$(cat digest-lit-actions.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_LIT_API_SERVER=$(cat digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_LIT_STATIC=$(cat digest-lit-static.txt | tr -d '\n' | sed 's/}[}]*$//')
+          DIGEST_OTEL_COLLECTOR=$(cat digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
           sed \
             -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|${{ vars.DOCKER_IMAGE }}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
             -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
             -e "s|\${DOCKER_IMAGE_LIT_STATIC}|${{ vars.DOCKER_IMAGE }}-lit-static@${DIGEST_LIT_STATIC}|g" \
+            -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
           cat docker-compose.deploy.yml
 


### PR DESCRIPTION
## Summary
- PR #2 added the `otel-collector` service to `docker-compose.phala.yml` but the deploy workflow was never updated to build the image or substitute `DOCKER_IMAGE_OTEL_COLLECTOR`
- CVM boot fails with: `service "otel-collector" has neither an image nor a build context specified`
- Adds `otel-collector` to the build matrix and adds the `sed` substitution for `DOCKER_IMAGE_OTEL_COLLECTOR` in the deploy step

## Test plan
- [ ] Verify deploy workflow builds all 4 images (lit-actions, lit-api-server, lit-static, otel-collector)
- [ ] Verify `docker-compose.deploy.yml` has all image references substituted with digest-pinned values
- [ ] Verify CVM boots successfully with otel-collector running

🤖 Generated with [Claude Code](https://claude.com/claude-code)