### PR TITLE
fix: use UID 0 instead of USER root in otel-collector Dockerfile

### DIFF
--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -17,7 +17,7 @@ COPY --from=grpc-probe /grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY otel-collector/config.yaml /etc/otelcol-contrib/config.yaml
 COPY otel-collector/entrypoint.sh /entrypoint.sh
 
-USER root
+USER 0
 RUN chmod +x /entrypoint.sh
 USER 10001
 


### PR DESCRIPTION
## Summary
- The `otel/opentelemetry-collector-contrib` base image lacks `/etc/passwd` entries, so `USER root` fails with `unable to find user root: invalid argument`
- Use `USER 0` (numeric UID) which works without passwd entries

## Test plan
- [ ] Verify otel-collector image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)