### PR TITLE
fix: remove unsupported retry_on_failure from otel-collector config, fix healthcheck

### DIFF
--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -1,16 +1,7 @@
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.46
 ARG OTEL_COLLECTOR_VERSION=0.104.0
 
 # Copy the statically-linked collector binary out of the official distroless image.
 FROM otel/opentelemetry-collector-contrib:${OTEL_COLLECTOR_VERSION} AS collector
-
-# Download grpc_health_probe for the HEALTHCHECK.
-FROM alpine:3.19 AS grpc-probe
-ARG GRPC_HEALTH_PROBE_VERSION
-RUN apk add --no-cache wget && \
-    wget -qO /grpc_health_probe \
-      "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
-    chmod +x /grpc_health_probe
 
 # Alpine runtime — provides /bin/sh so the entrypoint script can run.
 FROM alpine:3.19
@@ -18,7 +9,6 @@ FROM alpine:3.19
 RUN adduser -D -u 10001 otel
 
 COPY --from=collector /otelcol-contrib /otelcol-contrib
-COPY --from=grpc-probe /grpc_health_probe /usr/local/bin/grpc_health_probe
 
 COPY otel-collector/config.yaml /etc/otelcol-contrib/config.yaml
 COPY --chmod=755 otel-collector/entrypoint.sh /entrypoint.sh
@@ -26,6 +16,6 @@ COPY --chmod=755 otel-collector/entrypoint.sh /entrypoint.sh
 USER 10001
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 \
-  CMD ["/usr/local/bin/grpc_health_probe", "-addr=localhost:4317"]
+  CMD ["wget", "--spider", "-q", "http://localhost:13133"]
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -47,13 +47,6 @@ exporters:
       # Default log name for signals that don't carry their own log name.
       default_log_name: lit-protocol/app
 
-    # Retry on transient GCP API errors.
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-
   # Internal collector health — visible in Cloud Logging under lit-protocol/otel-collector.
   debug:
     verbosity: basic

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -10,6 +10,10 @@
 #
 # See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
 
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 receivers:
   otlp:
     protocols:
@@ -54,6 +58,7 @@ exporters:
     sampling_thereafter: 500
 
 service:
+  extensions: [health_check]
   telemetry:
     logs:
       level: warn


### PR DESCRIPTION
## Summary
- The `googlecloud` exporter in collector v0.104.0 does not support `retry_on_failure` as a top-level key
- Collector crashes on startup with `'' has invalid keys: retry_on_failure`
- Remove the unsupported block (the exporter handles retries internally)

## Test plan
- [x] Verified locally: collector starts with fixed config

🤖 Generated with [Claude Code](https://claude.com/claude-code)