### PR TITLE
fix: add OpenTelemetry trace layer and stop faking correlation_id

### DIFF
--- a/lit-actions/cli/main.rs
+++ b/lit-actions/cli/main.rs
@@ -107,8 +107,8 @@ async fn init_observability() -> ObservabilityProviders {
         global::set_meter_provider(metrics_provider.clone());
 
         let tracer = tracing_provider.tracer("lit-actions");
-        let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
-            .with_tracer(tracer);
+        let otel_trace_layer =
+            lit_observability::tracing_opentelemetry::layer().with_tracer(tracer);
         let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
         lit_observability::init_subscriber(&log_level)
             .expect("Failed to init tracing subscriber (invalid RUST_LOG or filter config)")

--- a/lit-actions/cli/main.rs
+++ b/lit-actions/cli/main.rs
@@ -70,7 +70,7 @@ async fn init_observability() -> ObservabilityProviders {
     {
         use lit_observability::{
             logging::ContextAwareOtelLogLayer,
-            opentelemetry::{KeyValue, global},
+            opentelemetry::{KeyValue, global, trace::TracerProvider},
             opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace as sdktrace},
             opentelemetry_semantic_conventions::resource::SERVICE_NAME,
         };
@@ -106,9 +106,13 @@ async fn init_observability() -> ObservabilityProviders {
         global::set_tracer_provider(tracing_provider.clone());
         global::set_meter_provider(metrics_provider.clone());
 
+        let tracer = tracing_provider.tracer("lit-actions");
+        let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
+            .with_tracer(tracer);
         let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
         lit_observability::init_subscriber(&log_level)
             .expect("Failed to init tracing subscriber (invalid RUST_LOG or filter config)")
+            .with(otel_trace_layer)
             .with(otel_log_layer)
             .init();
 

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), rocket::Error> {
     let _otlp_providers = {
         use lit_observability::{
             logging::ContextAwareOtelLogLayer,
-            opentelemetry::{KeyValue, global},
+            opentelemetry::{KeyValue, global, trace::TracerProvider},
             opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace as sdktrace},
             opentelemetry_semantic_conventions::resource::SERVICE_NAME,
         };
@@ -62,9 +62,13 @@ async fn main() -> Result<(), rocket::Error> {
                 global::set_tracer_provider(tracing_provider.clone());
                 global::set_meter_provider(metrics_provider.clone());
 
+                let tracer = tracing_provider.tracer("lit-api-server");
+                let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
+                    .with_tracer(tracer);
                 let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
                 let subscriber = lit_observability::init_subscriber(&obs.log_level)
                     .expect("Failed to setup tracing")
+                    .with(otel_trace_layer)
                     .with(otel_log_layer);
                 tracing::subscriber::set_global_default(subscriber)
                     .expect("setting default subscriber failed");

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> Result<(), rocket::Error> {
                 global::set_meter_provider(metrics_provider.clone());
 
                 let tracer = tracing_provider.tracer("lit-api-server");
-                let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
-                    .with_tracer(tracer);
+                let otel_trace_layer =
+                    lit_observability::tracing_opentelemetry::layer().with_tracer(tracer);
                 let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
                 let subscriber = lit_observability::init_subscriber(&obs.log_level)
                     .expect("Failed to setup tracing")

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -116,22 +116,18 @@ impl Fairing for ObservabilityFairing {
         // Per requirements: if user sends X-Request-Id, it must be ignored.
         let request_id = Uuid::new_v4().to_string();
 
-        let correlation_id_for_logging = user_provided_correlation_id
-            .as_deref()
-            .unwrap_or(&request_id);
-
         let _span = info_span!(
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
-            correlation_id = %correlation_id_for_logging,
+            correlation_id = user_provided_correlation_id.as_deref().unwrap_or(""),
             request_id = %request_id,
         )
         .entered();
 
         lit_observability::logging::set_request_context(
             Some(request_id.clone()),
-            Some(correlation_id_for_logging.to_string()),
+            user_provided_correlation_id.clone(),
         );
 
         let ctx = RequestTracingContext {

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -11,7 +11,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::okapi::openapi3::{Object, Parameter, ParameterValue};
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
-use tracing::info_span;
+use tracing::{field, info_span};
 use uuid::Uuid;
 
 const HEADER_X_CORRELATION_ID: &str = "X-Correlation-Id";
@@ -120,10 +120,14 @@ impl Fairing for ObservabilityFairing {
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
-            correlation_id = user_provided_correlation_id.as_deref().unwrap_or(""),
+            correlation_id = field::Empty,
             request_id = %request_id,
         )
         .entered();
+
+        if let Some(ref cid) = user_provided_correlation_id {
+            _span.record("correlation_id", cid.as_str());
+        }
 
         lit_observability::logging::set_request_context(
             Some(request_id.clone()),

--- a/lit-core/lit-observability/src/lib.rs
+++ b/lit-core/lit-observability/src/lib.rs
@@ -22,6 +22,8 @@ pub use opentelemetry;
 pub use opentelemetry_sdk;
 #[cfg(feature = "otlp")]
 pub use opentelemetry_semantic_conventions;
+#[cfg(feature = "otlp")]
+pub use tracing_opentelemetry;
 pub use tonic_middleware;
 
 /// Initializes the primary tracing subscriber with fmt (stdout) and privacy filtering.

--- a/lit-core/lit-observability/src/lib.rs
+++ b/lit-core/lit-observability/src/lib.rs
@@ -22,9 +22,9 @@ pub use opentelemetry;
 pub use opentelemetry_sdk;
 #[cfg(feature = "otlp")]
 pub use opentelemetry_semantic_conventions;
+pub use tonic_middleware;
 #[cfg(feature = "otlp")]
 pub use tracing_opentelemetry;
-pub use tonic_middleware;
 
 /// Initializes the primary tracing subscriber with fmt (stdout) and privacy filtering.
 /// `log_level` is the minimum log level (e.g. "info", "debug"). Overridden by `RUST_LOG`.


### PR DESCRIPTION
## Summary
- **No trace spans in GCP Cloud Trace**: The subscriber stack had `ContextAwareOtelLogLayer` (bridges tracing events → OTel log records) but no `tracing_opentelemetry::OpenTelemetryLayer` (bridges tracing spans → OTel trace spans). The `TracerProvider` was created and registered globally but nothing fed spans into it. Added the layer to both `lit-api-server` and `lit-actions`.
- **Fake correlation_id in logs**: When no `X-Correlation-ID` header was sent, the fairing silently used `request_id` as `correlation_id`, making every log appear correlated. Now `correlation_id` is `None` when the header is absent, so uncorrelated requests are distinguishable.

## Test plan
- [ ] Deploy and verify trace spans appear in GCP Cloud Trace
- [ ] Verify logs still arrive in GCP Cloud Logging with `request_id`
- [ ] Run K6 smoke test without `X-Correlation-ID` → confirm `correlation_id` is empty in logs
- [ ] Send request with `X-Correlation-ID` header → confirm it appears in both logs and trace span attributes
- [ ] `cargo check` / `cargo check --all-features` passes for both `lit-api-server` and `lit-actions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)