### PR TITLE
fix: extend http_request span to cover full request lifecycle

### DIFF
--- a/lit-actions/cli/main.rs
+++ b/lit-actions/cli/main.rs
@@ -107,8 +107,8 @@ async fn init_observability() -> ObservabilityProviders {
         global::set_meter_provider(metrics_provider.clone());
 
         let tracer = tracing_provider.tracer("lit-actions");
-        let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
-            .with_tracer(tracer);
+        let otel_trace_layer =
+            lit_observability::tracing_opentelemetry::layer().with_tracer(tracer);
         let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
         lit_observability::init_subscriber(&log_level)
             .expect("Failed to init tracing subscriber (invalid RUST_LOG or filter config)")

--- a/lit-actions/cli/main.rs
+++ b/lit-actions/cli/main.rs
@@ -70,7 +70,7 @@ async fn init_observability() -> ObservabilityProviders {
     {
         use lit_observability::{
             logging::ContextAwareOtelLogLayer,
-            opentelemetry::{KeyValue, global},
+            opentelemetry::{KeyValue, global, trace::TracerProvider},
             opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace as sdktrace},
             opentelemetry_semantic_conventions::resource::SERVICE_NAME,
         };
@@ -106,9 +106,13 @@ async fn init_observability() -> ObservabilityProviders {
         global::set_tracer_provider(tracing_provider.clone());
         global::set_meter_provider(metrics_provider.clone());
 
+        let tracer = tracing_provider.tracer("lit-actions");
+        let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
+            .with_tracer(tracer);
         let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
         lit_observability::init_subscriber(&log_level)
             .expect("Failed to init tracing subscriber (invalid RUST_LOG or filter config)")
+            .with(otel_trace_layer)
             .with(otel_log_layer)
             .init();
 

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), rocket::Error> {
     let _otlp_providers = {
         use lit_observability::{
             logging::ContextAwareOtelLogLayer,
-            opentelemetry::{KeyValue, global},
+            opentelemetry::{KeyValue, global, trace::TracerProvider},
             opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace as sdktrace},
             opentelemetry_semantic_conventions::resource::SERVICE_NAME,
         };
@@ -62,9 +62,13 @@ async fn main() -> Result<(), rocket::Error> {
                 global::set_tracer_provider(tracing_provider.clone());
                 global::set_meter_provider(metrics_provider.clone());
 
+                let tracer = tracing_provider.tracer("lit-api-server");
+                let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
+                    .with_tracer(tracer);
                 let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
                 let subscriber = lit_observability::init_subscriber(&obs.log_level)
                     .expect("Failed to setup tracing")
+                    .with(otel_trace_layer)
                     .with(otel_log_layer);
                 tracing::subscriber::set_global_default(subscriber)
                     .expect("setting default subscriber failed");

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> Result<(), rocket::Error> {
                 global::set_meter_provider(metrics_provider.clone());
 
                 let tracer = tracing_provider.tracer("lit-api-server");
-                let otel_trace_layer = lit_observability::tracing_opentelemetry::layer()
-                    .with_tracer(tracer);
+                let otel_trace_layer =
+                    lit_observability::tracing_opentelemetry::layer().with_tracer(tracer);
                 let otel_log_layer = ContextAwareOtelLogLayer::new(&logger_provider);
                 let subscriber = lit_observability::init_subscriber(&obs.log_level)
                     .expect("Failed to setup tracing")

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -116,22 +116,18 @@ impl Fairing for ObservabilityFairing {
         // Per requirements: if user sends X-Request-Id, it must be ignored.
         let request_id = Uuid::new_v4().to_string();
 
-        let correlation_id_for_logging = user_provided_correlation_id
-            .as_deref()
-            .unwrap_or(&request_id);
-
         let _span = info_span!(
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
-            correlation_id = %correlation_id_for_logging,
+            correlation_id = user_provided_correlation_id.as_deref().unwrap_or(""),
             request_id = %request_id,
         )
         .entered();
 
         lit_observability::logging::set_request_context(
             Some(request_id.clone()),
-            Some(correlation_id_for_logging.to_string()),
+            user_provided_correlation_id.clone(),
         );
 
         let ctx = RequestTracingContext {

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -11,7 +11,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::okapi::openapi3::{Object, Parameter, ParameterValue};
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
-use tracing::info_span;
+use tracing::{field, info_span};
 use uuid::Uuid;
 
 const HEADER_X_CORRELATION_ID: &str = "X-Correlation-Id";
@@ -120,10 +120,14 @@ impl Fairing for ObservabilityFairing {
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
-            correlation_id = user_provided_correlation_id.as_deref().unwrap_or(""),
+            correlation_id = field::Empty,
             request_id = %request_id,
         )
         .entered();
+
+        if let Some(ref cid) = user_provided_correlation_id {
+            _span.record("correlation_id", cid.as_str());
+        }
 
         lit_observability::logging::set_request_context(
             Some(request_id.clone()),

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -17,15 +17,17 @@ use uuid::Uuid;
 const HEADER_X_CORRELATION_ID: &str = "X-Correlation-Id";
 const HEADER_X_REQUEST_ID: &str = "X-Request-Id";
 
-/// Context stored per request for response header injection.
-/// Note: We store only IDs (Send + Sync) because EnteredSpan is !Send and cannot
-/// live in Rocket's local_cache. The request span covers on_request only.
+/// Context stored per request for response header injection and request-scoped tracing.
+/// The `Span` (Send + Sync) is stored here instead of an `EnteredSpan` (!Send) so it
+/// can live in Rocket's `local_cache`. The OTel layer records span duration from
+/// creation (on_request) to drop (after on_response), covering the full request lifecycle.
 struct RequestTracingContext {
-    /// User-provided X-Correlation-Id, if any. Only set when user explicitly sent the header.
-    /// Per requirements: X-Correlation-Id MUST NOT be on response if user did not provide it.
     user_provided_correlation_id: Option<String>,
-    /// Span/request ID. Always present. Propagated as X-Request-Id on response.
     request_id: String,
+    /// Span covering the full request lifecycle. Not entered — stored for lifetime only.
+    /// Never read directly; the span is kept alive by this field and closed on drop.
+    #[allow(dead_code)]
+    span: tracing::Span,
 }
 
 impl RequestTracingContext {
@@ -33,6 +35,7 @@ impl RequestTracingContext {
         Self {
             user_provided_correlation_id: None,
             request_id: String::new(),
+            span: tracing::Span::none(),
         }
     }
 }
@@ -116,27 +119,32 @@ impl Fairing for ObservabilityFairing {
         // Per requirements: if user sends X-Request-Id, it must be ignored.
         let request_id = Uuid::new_v4().to_string();
 
-        let _span = info_span!(
+        let span = info_span!(
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
             correlation_id = field::Empty,
             request_id = %request_id,
-        )
-        .entered();
+        );
 
         if let Some(ref cid) = user_provided_correlation_id {
-            _span.record("correlation_id", cid.as_str());
+            span.record("correlation_id", cid.as_str());
         }
 
-        lit_observability::logging::set_request_context(
-            Some(request_id.clone()),
-            user_provided_correlation_id.clone(),
-        );
+        // Enter briefly so set_request_context (which uses Span::current()) attaches
+        // IDs to this span's extensions. The span itself stays alive in local_cache.
+        {
+            let _guard = span.enter();
+            lit_observability::logging::set_request_context(
+                Some(request_id.clone()),
+                user_provided_correlation_id.clone(),
+            );
+        }
 
         let ctx = RequestTracingContext {
             user_provided_correlation_id,
             request_id,
+            span,
         };
         let _ = req.local_cache(|| ctx);
     }

--- a/lit-core/lit-observability/src/lib.rs
+++ b/lit-core/lit-observability/src/lib.rs
@@ -22,6 +22,8 @@ pub use opentelemetry;
 pub use opentelemetry_sdk;
 #[cfg(feature = "otlp")]
 pub use opentelemetry_semantic_conventions;
+#[cfg(feature = "otlp")]
+pub use tracing_opentelemetry;
 pub use tonic_middleware;
 
 /// Initializes the primary tracing subscriber with fmt (stdout) and privacy filtering.

--- a/lit-core/lit-observability/src/lib.rs
+++ b/lit-core/lit-observability/src/lib.rs
@@ -22,9 +22,9 @@ pub use opentelemetry;
 pub use opentelemetry_sdk;
 #[cfg(feature = "otlp")]
 pub use opentelemetry_semantic_conventions;
+pub use tonic_middleware;
 #[cfg(feature = "otlp")]
 pub use tracing_opentelemetry;
-pub use tonic_middleware;
 
 /// Initializes the primary tracing subscriber with fmt (stdout) and privacy filtering.
 /// `log_level` is the minimum log level (e.g. "info", "debug"). Overridden by `RUST_LOG`.


### PR DESCRIPTION
## Summary
- The `http_request` `info_span` was `.entered()` and dropped at the end of `on_request`, giving it near-zero duration in traces
- Now the `Span` (which is `Send + Sync`, unlike `EnteredSpan`) is stored in Rocket's `local_cache`, so it lives from `on_request` through `on_response`
- The OTel layer records span duration from creation to drop, producing a trace span that covers actual request handling time
- The span is briefly entered during `on_request` to set request context (via `Span::current()`), then stored un-entered for the rest of its lifetime

Depends on #120 (adds the `OpenTelemetryLayer` that exports these spans).

## Test plan
- [ ] Deploy with #120 merged and verify `http_request` spans in GCP Cloud Trace have meaningful duration (not near-zero)
- [ ] Verify `request_id` and `correlation_id` attributes appear on the span
- [ ] All fairing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)