### PR TITLE
feat: propagate root HTTP request span through full request lifecycle

### DIFF
--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -7,7 +7,9 @@ use deno_core::futures::TryFutureExt as _;
 use deno_lib::util::result::any_and_jserrorbox_downcast_ref;
 use deno_runtime::tokio_util::create_and_run_current_thread;
 use lit_actions_grpc::{proto::*, unix};
-use lit_api_core::context::{HEADER_KEY_X_PRIVACY_MODE, HEADER_KEY_X_REQUEST_ID};
+use lit_api_core::context::{
+    HEADER_KEY_X_CORRELATION_ID, HEADER_KEY_X_PRIVACY_MODE, HEADER_KEY_X_REQUEST_ID,
+};
 use lit_observability::{
     PRIVACY_MODE_TAG,
     channels::{ChannelMsg, new_traced_bounded_channel},
@@ -111,24 +113,30 @@ impl Action for Server {
                     }
 
                     std::thread::spawn(move || {
-                        // Set request context for log injection; no fallback IDs.
-                        let none = &"none".to_string();
+                        // Extract IDs from http_headers for log injection context.
                         let privacy_mode = req
                             .http_headers
                             .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-                            .unwrap_or(none);
+                            .map(|v| v.as_str() == "true")
+                            .unwrap_or(false);
                         let request_id = req
                             .http_headers
                             .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
-                            .unwrap_or(none);
-                        let request_id = if privacy_mode == "true" {
-                            format!("{request_id}_{PRIVACY_MODE_TAG}")
-                        } else {
-                            request_id.to_string()
-                        };
+                            .cloned()
+                            .map(|id| {
+                                if privacy_mode {
+                                    format!("{id}_{PRIVACY_MODE_TAG}")
+                                } else {
+                                    id
+                                }
+                            });
+                        let correlation_id = req
+                            .http_headers
+                            .get(&HEADER_KEY_X_CORRELATION_ID.to_ascii_lowercase())
+                            .cloned();
 
-                        if request_id != "none" {
-                            set_request_context(Some(request_id), None);
+                        if request_id.is_some() || correlation_id.is_some() {
+                            set_request_context(request_id, correlation_id);
                         }
 
                         create_and_run_current_thread(

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -7,9 +7,7 @@ use deno_core::futures::TryFutureExt as _;
 use deno_lib::util::result::any_and_jserrorbox_downcast_ref;
 use deno_runtime::tokio_util::create_and_run_current_thread;
 use lit_actions_grpc::{proto::*, unix};
-use lit_api_core::context::{
-    HEADER_KEY_X_CORRELATION_ID, HEADER_KEY_X_PRIVACY_MODE, HEADER_KEY_X_REQUEST_ID,
-};
+use lit_api_core::context::{HEADER_KEY_X_CORRELATION_ID, HEADER_KEY_X_REQUEST_ID};
 use lit_observability::{
     PRIVACY_MODE_TAG,
     channels::{ChannelMsg, new_traced_bounded_channel},
@@ -100,13 +98,14 @@ impl Action for Server {
             #[allow(clippy::single_match)]
             match req.union {
                 Some(UnionRequest::Execute(req)) => {
-                    // we're outside of the spawned thread, so we can't use the request context
-                    if req
+                    // Privacy mode is indicated by the PRIVACY_MODE_TAG suffix
+                    // on the request_id, tagged at the origin (lit-api-server fairing).
+                    let privacy_mode = req
                         .http_headers
-                        .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-                        .unwrap_or(&"false".to_string())
-                        == "true"
-                    {
+                        .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
+                        .is_some_and(|id| id.ends_with(PRIVACY_MODE_TAG));
+
+                    if privacy_mode {
                         debug!("ExecuteJsRequest: **PRIVACY MODE**");
                     } else {
                         debug!("{:?}", DebugExecutionRequest::from(&req));
@@ -114,11 +113,8 @@ impl Action for Server {
 
                     std::thread::spawn(move || {
                         // Extract IDs from http_headers for log injection context.
-                        let privacy_mode = req
-                            .http_headers
-                            .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-                            .map(|v| v.as_str() == "true")
-                            .unwrap_or(false);
+                        // The request_id arrives pre-tagged with PRIVACY_MODE_TAG
+                        // from lit-api-server if privacy mode was requested.
                         let request_id = req
                             .http_headers
                             .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
@@ -128,15 +124,7 @@ impl Action for Server {
                             .get(&HEADER_KEY_X_CORRELATION_ID.to_ascii_lowercase())
                             .cloned();
 
-                        if privacy_mode {
-                            // Always set context in privacy mode, tagging the request_id
-                            // even if no request_id was provided.
-                            let tagged_id = match request_id {
-                                Some(id) => format!("{id}_{PRIVACY_MODE_TAG}"),
-                                None => PRIVACY_MODE_TAG.to_string(),
-                            };
-                            set_request_context(Some(tagged_id), correlation_id);
-                        } else if request_id.is_some() || correlation_id.is_some() {
+                        if request_id.is_some() || correlation_id.is_some() {
                             set_request_context(request_id, correlation_id);
                         }
 

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -122,20 +122,21 @@ impl Action for Server {
                         let request_id = req
                             .http_headers
                             .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
-                            .cloned()
-                            .map(|id| {
-                                if privacy_mode {
-                                    format!("{id}_{PRIVACY_MODE_TAG}")
-                                } else {
-                                    id
-                                }
-                            });
+                            .cloned();
                         let correlation_id = req
                             .http_headers
                             .get(&HEADER_KEY_X_CORRELATION_ID.to_ascii_lowercase())
                             .cloned();
 
-                        if request_id.is_some() || correlation_id.is_some() {
+                        if privacy_mode {
+                            // Always set context in privacy mode, tagging the request_id
+                            // even if no request_id was provided.
+                            let tagged_id = match request_id {
+                                Some(id) => format!("{id}_{PRIVACY_MODE_TAG}"),
+                                None => PRIVACY_MODE_TAG.to_string(),
+                            };
+                            set_request_context(Some(tagged_id), correlation_id);
+                        } else if request_id.is_some() || correlation_id.is_some() {
                             set_request_context(request_id, correlation_id);
                         }
 

--- a/lit-api-server/src/actions/client/client.rs
+++ b/lit-api-server/src/actions/client/client.rs
@@ -55,17 +55,27 @@ impl Client {
 
     pub fn metadata(&self) -> Result<MetadataMap> {
         let mut md = MetadataMap::new();
-        // md.insert(
-        //     "x-host",
-        //     self.lit_config()
-        //         .external_addr()
-        //         .unwrap_or_default()
-        //         .parse()?,
-        // );
         md.insert("x-request-id", self.request_id().parse()?);
 
-        // Add trace context to the metadata for distributed tracing.
-        // inject_tracing_metadata(&mut md);
+        // TODO: x-correlation-id is also sent via ExecutionRequest.http_headers —
+        // this redundancy in gRPC metadata could be simplified later.
+        if let Some(cid) = self.http_headers.get("x-correlation-id") {
+            md.insert("x-correlation-id", cid.parse()?);
+        }
+
+        // Inject W3C TraceContext headers into gRPC metadata for distributed tracing.
+        // This allows TracingMiddleware on the lit-actions side to reconstruct the parent span.
+        #[cfg(feature = "otlp")]
+        {
+            use lit_observability::opentelemetry::propagation::TextMapPropagator;
+            use lit_observability::opentelemetry_sdk::propagation::TraceContextPropagator;
+            use lit_observability::tracing_opentelemetry::OpenTelemetrySpanExt;
+
+            let cx = tracing::Span::current().context();
+            let propagator = TraceContextPropagator::new();
+            let mut injector = lit_observability::tracing::propagation::TonicMetadataMap(&mut md);
+            propagator.inject_context(&cx, &mut injector);
+        }
 
         Ok(md)
     }

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -5,25 +5,41 @@ use crate::actions::grpc::GrpcClientPool;
 use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::LitActionRequest;
 use crate::core::v1::models::response::LitActionResponse;
+use crate::observability::RequestSpan;
 use crate::utils::parse_with_hash::ipfs_cid_to_u256;
 use ipfs_hasher::IpfsHasher;
 use moka::future::Cache;
 use rocket::serde::json::Json;
+use std::collections::BTreeMap;
 use tracing::instrument;
 
 #[instrument(
     level = "debug",
-    skip(api_key, grpc_client_pool, ipfs_cache, http_client, lit_action_request),
+    skip(
+        request_span,
+        api_key,
+        grpc_client_pool,
+        ipfs_cache,
+        http_client,
+        lit_action_request
+    ),
     err
 )]
 pub async fn lit_action(
+    request_span: &RequestSpan,
     api_key: &str,
     grpc_client_pool: &GrpcClientPool<tonic::transport::Channel>,
     ipfs_cache: &Cache<String, String>,
     http_client: &reqwest::Client,
     lit_action_request: Json<LitActionRequest>,
 ) -> Result<LitActionResponse, ApiStatus> {
-    let request_id = Some("test".to_string());
+    let request_id = Some(request_span.request_id.clone());
+
+    let mut http_headers = BTreeMap::new();
+    http_headers.insert("x-request-id".to_string(), request_span.request_id.clone());
+    if let Some(ref cid) = request_span.correlation_id {
+        http_headers.insert("x-correlation-id".to_string(), cid.clone());
+    }
 
     let code_to_run = lit_action_request.code.clone();
     let derived_ipfs_id = get_lit_action_ipfs_id(code_to_run.clone());
@@ -43,6 +59,7 @@ pub async fn lit_action(
     let mut client = match ClientBuilder::default()
         .js_env(deno_execution_env)
         .request_id(request_id.clone())
+        .http_headers(http_headers)
         .api_key(api_key.to_string())
         .ipfs_id(derived_ipfs_id.clone())
         .client_grpc_channels((*grpc_client_pool).clone())

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -33,10 +33,10 @@ pub async fn lit_action(
     http_client: &reqwest::Client,
     lit_action_request: Json<LitActionRequest>,
 ) -> Result<LitActionResponse, ApiStatus> {
-    let request_id = Some(request_span.request_id.clone());
+    let request_id = request_span.request_id.clone();
 
     let mut http_headers = BTreeMap::new();
-    http_headers.insert("x-request-id".to_string(), request_span.request_id.clone());
+    http_headers.insert("x-request-id".to_string(), request_id.clone());
     if let Some(ref cid) = request_span.correlation_id {
         http_headers.insert("x-correlation-id".to_string(), cid.clone());
     }

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -19,6 +19,7 @@ use crate::core::v1::models::response::{
     AccountOpResponse, AddUsageApiKeyResponse, CreateWalletResponse, ListMetadataItem,
     LitActionResponse, NewAccountResponse, NodeChainConfigResponse,
 };
+use crate::observability::RequestSpan;
 use moka::future::Cache;
 use rocket::Route;
 use rocket::State;
@@ -96,7 +97,9 @@ async fn create_wallet(
 
 #[openapi(tag = "Actions")]
 #[post("/lit_action", format = "json", data = "<lit_action_request>")]
+#[tracing::instrument(name = "endpoint::lit_action", skip_all, parent = &request_span.span)]
 async fn lit_action(
+    request_span: RequestSpan,
     api_key: ApiKey,
     grpc_client_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
     ipfs_cache: &State<Cache<String, String>>,
@@ -106,6 +109,7 @@ async fn lit_action(
     OpenApiResponse {
         response: ApiResult(
             core_features::lit_action(
+                &request_span,
                 api_key.0.as_str(),
                 grpc_client_pool.inner(),
                 ipfs_cache.inner(),

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -15,6 +15,7 @@ use tracing::{field, info_span};
 use uuid::Uuid;
 
 const HEADER_X_CORRELATION_ID: &str = "X-Correlation-Id";
+const HEADER_X_PRIVACY_MODE: &str = "X-Privacy-Mode";
 const HEADER_X_REQUEST_ID: &str = "X-Request-Id";
 
 /// Context stored per request for response header injection and span propagation.
@@ -156,7 +157,15 @@ impl Fairing for ObservabilityFairing {
 
         // X-Request-Id must NOT be provided by the user. Always generate a new random UUID.
         // Per requirements: if user sends X-Request-Id, it must be ignored.
-        let request_id = Uuid::new_v4().to_string();
+        let privacy_mode = req
+            .headers()
+            .get_one(HEADER_X_PRIVACY_MODE)
+            .is_some_and(|v| v == "true");
+        let request_id = if privacy_mode {
+            format!("{}_{}", Uuid::new_v4(), lit_observability::PRIVACY_MODE_TAG)
+        } else {
+            Uuid::new_v4().to_string()
+        };
 
         let span = info_span!(
             "http_request",

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -17,15 +17,21 @@ use uuid::Uuid;
 const HEADER_X_CORRELATION_ID: &str = "X-Correlation-Id";
 const HEADER_X_REQUEST_ID: &str = "X-Request-Id";
 
-/// Context stored per request for response header injection.
-/// Note: We store only IDs (Send + Sync) because EnteredSpan is !Send and cannot
-/// live in Rocket's local_cache. The request span covers on_request only.
+/// Context stored per request for response header injection and span propagation.
+/// The root span is stored as a non-entered `tracing::Span` (which is Send + Sync)
+/// because `EnteredSpan` is !Send and cannot live in Rocket's `local_cache`.
+/// The span stays alive for the full request lifecycle because `local_cache` is
+/// dropped only after the response is sent.
 struct RequestTracingContext {
     /// User-provided X-Correlation-Id, if any. Only set when user explicitly sent the header.
     /// Per requirements: X-Correlation-Id MUST NOT be on response if user did not provide it.
     user_provided_correlation_id: Option<String>,
     /// Span/request ID. Always present. Propagated as X-Request-Id on response.
     request_id: String,
+    /// Root span covering the full request lifecycle. Closed when local_cache is dropped
+    /// (after response is sent), satisfying the requirement that the root span covers
+    /// both success and failure responses.
+    span: tracing::Span,
 }
 
 impl RequestTracingContext {
@@ -33,6 +39,7 @@ impl RequestTracingContext {
         Self {
             user_provided_correlation_id: None,
             request_id: String::new(),
+            span: tracing::Span::none(),
         }
     }
 }
@@ -96,6 +103,41 @@ impl<'r> OpenApiFromRequest<'r> for CorrelationId {
     }
 }
 
+/// Request guard providing the root span and request/correlation IDs.
+/// Handlers that take this guard can use `.instrument(span)` or `#[instrument(parent = span)]`
+/// to make their work appear as child spans of the root HTTP request span.
+#[derive(Clone, Debug)]
+pub struct RequestSpan {
+    pub span: tracing::Span,
+    pub request_id: String,
+    pub correlation_id: Option<String>,
+}
+
+#[rocket::async_trait]
+impl<'r> rocket::request::FromRequest<'r> for RequestSpan {
+    type Error = std::convert::Infallible;
+
+    async fn from_request(req: &'r Request<'_>) -> rocket::request::Outcome<Self, Self::Error> {
+        let ctx = req.local_cache(RequestTracingContext::dummy);
+        rocket::request::Outcome::Success(RequestSpan {
+            span: ctx.span.clone(),
+            request_id: ctx.request_id.clone(),
+            correlation_id: ctx.user_provided_correlation_id.clone(),
+        })
+    }
+}
+
+impl<'r> OpenApiFromRequest<'r> for RequestSpan {
+    fn from_request_input(
+        _generator: &mut OpenApiGenerator,
+        _name: String,
+        _required: bool,
+    ) -> RocketOkapiResult<RequestHeaderInput> {
+        // Internal guard — no user-visible header input.
+        Ok(RequestHeaderInput::None)
+    }
+}
+
 #[rocket::async_trait]
 impl Fairing for ObservabilityFairing {
     fn info(&self) -> Info {
@@ -116,33 +158,41 @@ impl Fairing for ObservabilityFairing {
         // Per requirements: if user sends X-Request-Id, it must be ignored.
         let request_id = Uuid::new_v4().to_string();
 
-        let _span = info_span!(
+        let span = info_span!(
             "http_request",
             method = %req.method(),
             uri = %req.uri(),
             correlation_id = field::Empty,
             request_id = %request_id,
-        )
-        .entered();
+            http.status_code = field::Empty,
+        );
 
         if let Some(ref cid) = user_provided_correlation_id {
-            _span.record("correlation_id", cid.as_str());
+            span.record("correlation_id", cid.as_str());
         }
 
-        lit_observability::logging::set_request_context(
-            Some(request_id.clone()),
-            user_provided_correlation_id.clone(),
-        );
+        // Enter the span briefly to set task-local request context for log correlation.
+        span.in_scope(|| {
+            lit_observability::logging::set_request_context(
+                Some(request_id.clone()),
+                user_provided_correlation_id.clone(),
+            );
+        });
 
         let ctx = RequestTracingContext {
             user_provided_correlation_id,
             request_id,
+            span,
         };
         let _ = req.local_cache(|| ctx);
     }
 
     async fn on_response<'r>(&self, req: &'r Request<'_>, res: &mut Response<'r>) {
         let ctx = req.local_cache(RequestTracingContext::dummy);
+
+        // Record the response status on the root span so traces include the outcome.
+        ctx.span.record("http.status_code", res.status().code);
+
         if let Some(ref id) = ctx.user_provided_correlation_id {
             res.set_header(Header::new(HEADER_X_CORRELATION_ID, id.clone()));
         }
@@ -150,7 +200,9 @@ impl Fairing for ObservabilityFairing {
             res.set_header(Header::new(HEADER_X_REQUEST_ID, ctx.request_id.clone()));
         }
         // Clear task-local context to prevent stale entries if tokio reuses this task ID.
-        lit_observability::logging::clear_task_request_context();
+        ctx.span.in_scope(|| {
+            lit_observability::logging::clear_task_request_context();
+        });
     }
 }
 

--- a/lit-api-server/src/observability/fairing.rs
+++ b/lit-api-server/src/observability/fairing.rs
@@ -157,10 +157,7 @@ impl Fairing for ObservabilityFairing {
 
         // X-Request-Id must NOT be provided by the user. Always generate a new random UUID.
         // Per requirements: if user sends X-Request-Id, it must be ignored.
-        let privacy_mode = req
-            .headers()
-            .get_one(HEADER_X_PRIVACY_MODE)
-            .is_some_and(|v| v == "true");
+        let privacy_mode = req.headers().get_one(HEADER_X_PRIVACY_MODE).is_some();
         let request_id = if privacy_mode {
             format!("{}_{}", Uuid::new_v4(), lit_observability::PRIVACY_MODE_TAG)
         } else {

--- a/lit-api-server/src/observability/mod.rs
+++ b/lit-api-server/src/observability/mod.rs
@@ -1,3 +1,3 @@
 pub mod fairing;
 
-pub use fairing::{CorrelationId, ObservabilityFairing};
+pub use fairing::{CorrelationId, ObservabilityFairing, RequestSpan};


### PR DESCRIPTION
## Summary
- Store root `tracing::Span` in Rocket's `local_cache` so it covers the full request lifecycle (created in `on_request`, closed when the response is sent). Record `http.status_code` on the span in `on_response`.
- Add `RequestSpan` request guard that provides the root span + request/correlation IDs to handlers. The `lit_action` endpoint uses `#[instrument(parent = &request_span.span)]` so all handler work (including `#[instrument]`-annotated sub-calls) appears as child spans of the root.
- Fix hardcoded `request_id = "test"` in `core_features::lit_action` — now uses the real UUID from the fairing. Populate `Client.http_headers` with `x-request-id` and `x-correlation-id` for downstream propagation to lit-actions.
- Uncomment and implement W3C TraceContext injection in `Client.metadata()` (feature-gated behind `otlp`) using `TraceContextPropagator` + `TonicMetadataMap`, enabling distributed tracing into lit-actions.
- **lit-actions**: Extract `x-correlation-id` from `ExecutionRequest.http_headers` and pass it to `set_request_context` (previously always `None`). Set context when either ID is present.
- **Privacy mode**: Tag `request_id` with `PRIVACY_MODE_TAG` suffix at the origin (lit-api-server fairing) when `X-Privacy-Mode` header is present (presence-based, no value check). The tagged ID flows unchanged through the entire request chain. lit-actions detects privacy mode by checking if the request_id ends with the tag — no mutation needed downstream.

## Files changed
| File | Change |
|------|--------|
| `lit-api-server/src/observability/fairing.rs` | Store `Span` in `RequestTracingContext`, add `RequestSpan` guard, record status in `on_response`, tag request_id on `X-Privacy-Mode` header presence |
| `lit-api-server/src/observability/mod.rs` | Re-export `RequestSpan` |
| `lit-api-server/src/core/core_features.rs` | Accept `&RequestSpan`, use real request_id, populate `http_headers` |
| `lit-api-server/src/core/v1/endpoints.rs` | Add `RequestSpan` guard to `lit_action` handler, `#[instrument]` with root span as parent |
| `lit-api-server/src/actions/client/client.rs` | Inject `x-correlation-id` + OTel trace context in `metadata()` |
| `lit-actions/server/server.rs` | Pass `correlation_id` to `set_request_context`, detect privacy mode from request_id tag instead of reading/mutating X-Privacy-Mode header |

## Test plan
- [x] All existing observability fairing tests pass (8/8)
- [x] Compiles clean with default features and `--features otlp`
- [x] `cargo clippy -- -D warnings` passes (both default and otlp for api-server, default for lit-actions)
- [x] `cargo fmt --check` passes
- [ ] Integration test: verify `X-Request-Id` from HTTP response matches `x-request-id` received by lit-actions
- [ ] Integration test with OTLP: verify `traceparent` header appears in gRPC metadata when otlp feature is enabled
- [ ] Integration test: verify privacy mode request returns `X-Request-Id` with `_lit_privacy_mode` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)