### PR TITLE
use new phala app URL for chipotle-dev

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -11,9 +11,7 @@ Auto-generated from the OpenAPI spec using [@grafana/openapi-to-k6](https://gith
 
 ```bash
 npm install -g @grafana/openapi-to-k6
-openapi-to-k6 --include-sample-script \
-  https://36da669c852c9bd4fdea27dd331c07ff776bd125-8000.dstack-pha-prod5.phala.network/openapi.json \
-  ./k6
+openapi-to-k6 https://f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network/openapi.json \ ./k6
 
 # Note: The OpenAPI spec paths omit the /core/v1 prefix. Set BASE_URL with /core/v1
 # when running against the Phala deployment, e.g. BASE_URL=.../core/v1

--- a/lit-static/static/dapps/monitor/index.html
+++ b/lit-static/static/dapps/monitor/index.html
@@ -195,7 +195,7 @@
       <select id="network">
         <option value="http://localhost:8000/core/v1/">Local Development</option>
         <option value="https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network/core/v1/">Next - Phala</option>
-        <option value="https://36da669c852c9bd4fdea27dd331c07ff776bd125-8000.dstack-pha-prod5.phala.network/core/v1/">Dev - Phala</option>
+        <option value="https://f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network/core/v1/">Dev - Phala</option>
       </select>
     </div>
 


### PR DESCRIPTION
### TL;DR

Updated the Dev - Phala environment endpoint from port 8000 to 8001 and changed the subdomain hash in both the k6 documentation and monitor interface.

### What changed?

- Modified the OpenAPI endpoint URL in k6/README.md from `36da669c852c9bd4fdea27dd331c07ff776bd125-8000.dstack-pha-prod5.phala.network` to `f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network`
- Updated the "Dev - Phala" network option in the monitor interface to use the same new endpoint
- Removed the `--include-sample-script` flag from the openapi-to-k6 command

### How to test?

1. Verify the new Dev - Phala endpoint is accessible at `https://f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network/core/v1/`
2. Test the monitor interface by selecting the "Dev - Phala" option and confirming it connects to the correct endpoint
3. Run the updated openapi-to-k6 command to ensure it generates the k6 tests correctly

### Why make this change?

The Dev - Phala environment has been migrated to a new deployment with a different subdomain hash and port number, requiring updates to maintain connectivity to the correct development environment.