### PR TITLE
fix: use 8000 (api url) instead of 8001

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -11,7 +11,7 @@ Auto-generated from the OpenAPI spec using [@grafana/openapi-to-k6](https://gith
 
 ```bash
 npm install -g @grafana/openapi-to-k6
-openapi-to-k6 https://f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network/openapi.json \ ./k6
+openapi-to-k6 https://f8fce543471dc9f5f5643aa217422398c36e5edc-8000.dstack-base-prod5.phala.network/openapi.json \ ./k6
 
 # Note: The OpenAPI spec paths omit the /core/v1 prefix. Set BASE_URL with /core/v1
 # when running against the Phala deployment, e.g. BASE_URL=.../core/v1

--- a/lit-static/static/dapps/monitor/index.html
+++ b/lit-static/static/dapps/monitor/index.html
@@ -195,7 +195,7 @@
       <select id="network">
         <option value="http://localhost:8000/core/v1/">Local Development</option>
         <option value="https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network/core/v1/">Next - Phala</option>
-        <option value="https://f8fce543471dc9f5f5643aa217422398c36e5edc-8001.dstack-base-prod5.phala.network/core/v1/">Dev - Phala</option>
+        <option value="https://f8fce543471dc9f5f5643aa217422398c36e5edc-8000.dstack-base-prod5.phala.network/core/v1/">Dev - Phala</option>
       </select>
     </div>
 


### PR DESCRIPTION
### TL;DR

Updated the Dev - Phala environment port from 8001 to 8000 in configuration files

### What changed?

Changed the port number from 8001 to 8000 for the Dev - Phala environment URL `f8fce543471dc9f5f5643aa217422398c36e5edc.dstack-base-prod5.phala.network` in both the k6 README documentation and the Lit Node Monitor network selector dropdown