### PR TITLE
feat: CVM system observability via hostmetrics receiver

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -84,11 +84,13 @@ services:
       # Phala CVM secrets in the deployment manifest.
       GCP_SERVICE_ACCOUNT_JSON: ${GCP_SERVICE_ACCOUNT_JSON}
       GCP_PROJECT_ID: ${GCP_PROJECT_ID}
-    # Host filesystem + pid namespace for the hostmetrics receiver to report
-    # accurate CVM-level CPU, memory, disk, and network metrics.
+    # Host pid namespace + /proc and /sys mounts for the hostmetrics receiver
+    # to report accurate CVM-level CPU, memory, disk, and network metrics.
+    # We avoid mounting the entire root filesystem to limit the read surface.
     pid: host
     volumes:
-      - '/:/host:ro,rslave'
+      - '/proc:/host/proc:ro'
+      - '/sys:/host/sys:ro'
     restart: unless-stopped
 
   lit-static:

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -97,5 +97,19 @@ services:
       ROCKET_PORT: "8001"
     restart: unless-stopped
 
+  # Prometheus Node Exporter — exposes CVM host metrics (CPU, memory, disk, network)
+  # on port 9100 for the OTel Collector to scrape. The /host bind-mount + --path.rootfs
+  # gives accurate host-level readings from inside the container. pid:host is required
+  # for per-process and CPU metrics.
+  # See: https://docs.phala.com/phala-cloud/production-checklist
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.0
+    command:
+      - '--path.rootfs=/host'
+    pid: host
+    volumes:
+      - '/:/host:ro,rslave'
+    restart: unless-stopped
+
 volumes:
   lit-socket:

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -84,6 +84,11 @@ services:
       # Phala CVM secrets in the deployment manifest.
       GCP_SERVICE_ACCOUNT_JSON: ${GCP_SERVICE_ACCOUNT_JSON}
       GCP_PROJECT_ID: ${GCP_PROJECT_ID}
+    # Host filesystem + pid namespace for the hostmetrics receiver to report
+    # accurate CVM-level CPU, memory, disk, and network metrics.
+    pid: host
+    volumes:
+      - '/:/host:ro,rslave'
     restart: unless-stopped
 
   lit-static:
@@ -95,20 +100,6 @@ services:
     environment:
       ROCKET_ADDRESS: "0.0.0.0"
       ROCKET_PORT: "8001"
-    restart: unless-stopped
-
-  # Prometheus Node Exporter — exposes CVM host metrics (CPU, memory, disk, network)
-  # on port 9100 for the OTel Collector to scrape. The /host bind-mount + --path.rootfs
-  # gives accurate host-level readings from inside the container. pid:host is required
-  # for per-process and CPU metrics.
-  # See: https://docs.phala.com/phala-cloud/production-checklist
-  node-exporter:
-    image: quay.io/prometheus/node-exporter:v1.9.0
-    command:
-      - '--path.rootfs=/host'
-    pid: host
-    volumes:
-      - '/:/host:ro,rslave'
     restart: unless-stopped
 
 volumes:

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -22,15 +22,19 @@ receivers:
         # collector via the otel-collector hostname on the compose bridge network.
         endpoint: 0.0.0.0:4317
 
-  # Scrape CVM host metrics (CPU, memory, disk, network) from the node-exporter
-  # sidecar. These appear in GCP Cloud Monitoring under the prometheus/ prefix.
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: 'node-exporter'
-          scrape_interval: 30s
-          static_configs:
-            - targets: ['node-exporter:9100']
+  # CVM host metrics — CPU, memory, disk, network, and load averages.
+  # root_path tells the receiver to read /proc and /sys from the host
+  # bind-mount rather than the container's own filesystem.
+  hostmetrics:
+    root_path: /host
+    collection_interval: 30s
+    scrapers:
+      cpu:
+      memory:
+      disk:
+      filesystem:
+      network:
+      load:
 
 processors:
   memory_limiter:
@@ -80,7 +84,7 @@ service:
       exporters: [googlecloud]
 
     metrics:
-      receivers: [otlp, prometheus]
+      receivers: [otlp, hostmetrics]
       processors: [memory_limiter, resource, batch]
       exporters: [googlecloud]
 

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -22,9 +22,13 @@ receivers:
         # collector via the otel-collector hostname on the compose bridge network.
         endpoint: 0.0.0.0:4317
 
-  # CVM host metrics — CPU, memory, disk, network, and load averages.
+  # CVM host metrics — CPU, memory, disk I/O, network, and load averages.
   # root_path tells the receiver to read /proc and /sys from the host
-  # bind-mount rather than the container's own filesystem.
+  # bind-mounts rather than the container's own filesystem.
+  # NOTE: the filesystem scraper (disk *space*) is omitted because it needs
+  # statfs() on real mount points, which would require mounting the entire
+  # host root filesystem into the container. The disk scraper still reports
+  # I/O throughput via /proc/diskstats.
   hostmetrics:
     root_path: /host
     collection_interval: 30s
@@ -32,7 +36,9 @@ receivers:
       cpu:
       memory:
       disk:
-      filesystem:
+        exclude:
+          devices: ["loop.*", "fd.*", "sr.*"]
+          match_type: regexp
       network:
       load:
 

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -22,6 +22,16 @@ receivers:
         # collector via the otel-collector hostname on the compose bridge network.
         endpoint: 0.0.0.0:4317
 
+  # Scrape CVM host metrics (CPU, memory, disk, network) from the node-exporter
+  # sidecar. These appear in GCP Cloud Monitoring under the prometheus/ prefix.
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'node-exporter'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['node-exporter:9100']
+
 processors:
   memory_limiter:
     check_interval: 1s
@@ -70,7 +80,7 @@ service:
       exporters: [googlecloud]
 
     metrics:
-      receivers: [otlp]
+      receivers: [otlp, prometheus]
       processors: [memory_limiter, resource, batch]
       exporters: [googlecloud]
 


### PR DESCRIPTION
## Summary
- Configures the **OTel Collector** `hostmetrics` receiver to collect CVM-level CPU, memory, disk I/O, network, and load metrics directly — no extra sidecar needed
- Mounts only `/proc` and `/sys` (read-only) into the collector container to minimise the host read surface
- Wires scraped metrics into the existing `metrics` pipeline so system stats flow to **GCP Cloud Monitoring** alongside existing application telemetry

## Changes
| File | What |
|---|---|
| `docker-compose.phala.yml` | `pid: host` and targeted `/proc`, `/sys` bind-mounts on the otel-collector service |
| `otel-collector/config.yaml` | `hostmetrics` receiver with cpu, memory, disk, network, load scrapers; disk excludes virtual devices; metrics pipeline updated to `[otlp, hostmetrics]` |

## Design decisions
- **No node-exporter sidecar** — otel-collector-contrib ships the `hostmetrics` receiver, so we collect metrics directly without an extra container
- **No full root mount** — only `/proc` and `/sys` are mounted to limit the read surface in the CVM. This means the `filesystem` scraper (disk *space*) is omitted since it requires `statfs()` on real mount points. Disk I/O throughput is still reported via `/proc/diskstats`
- **Disk device excludes** — `loop.*`, `fd.*`, `sr.*` are filtered out to avoid noisy virtual-device metrics

## Metrics available after merge
- `system.cpu.time` — per-CPU mode time (user, system, idle, iowait, etc.)
- `system.cpu.load_average.1m`, `5m`, `15m` — system load averages
- `system.memory.usage` — RAM usage by state (used, free, buffered, cached, etc.)
- `system.disk.io`, `system.disk.operations` — disk I/O throughput and ops
- `system.network.io`, `system.network.packets` — network I/O

## Test plan
- [ ] Verify the `next` branch deploy-phala workflow succeeds
- [ ] Confirm otel-collector starts without errors related to the hostmetrics receiver
- [ ] Validate metrics appear in GCP Cloud Monitoring (Metrics Explorer → `system.cpu.time`)
- [ ] Check OTel Collector logs for successful hostmetrics scrape cycles (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)