### PR TITLE
fix: step-function check in wait-for-api for deployment restarts

### DIFF
--- a/.github/workflows/correctness.yml
+++ b/.github/workflows/correctness.yml
@@ -1,5 +1,5 @@
 # Run all k6/correctness specs sequentially.
-# Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
+# Called from Deploy to Phala CVM after wait-for-api-restart, or manually via workflow_dispatch.
 
 name: k6 Correctness
 

--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -177,7 +177,7 @@ jobs:
 
   wait-for-api-available:
     needs: [deploy, determine-target]
-    uses: ./.github/workflows/wait-for-api.yml
+    uses: ./.github/workflows/wait-for-api-restart.yml
     with:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
       runner: '["self-hosted"]'

--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -175,18 +175,8 @@ jobs:
             --cvm-id ${{ needs.determine-target.outputs.phala_app_name }} \
             --private-key "$PHALA_PRIVATE_KEY"
 
-  # Give the Phala CLI time to trigger the CVM restart and begin rebooting.
-  # Without this, the old instance may still be serving the API when wait-for-api-available
-  # starts polling, so we'd pass before the new deployment is actually live.
-  wait-after-deploy:
-    needs: [deploy]
-    runs-on: self-hosted
-    steps:
-      - name: Wait after Phala deploy
-        run: sleep 30
-
   wait-for-api-available:
-    needs: [wait-after-deploy, determine-target]
+    needs: [deploy, determine-target]
     uses: ./.github/workflows/wait-for-api.yml
     with:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -1,5 +1,5 @@
 # Run smoke.spec.ts.
-# Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
+# Called from Deploy to Phala CVM after wait-for-api-restart, or manually via workflow_dispatch.
 
 name: k6 Smoke Tests
 

--- a/.github/workflows/openapi-spec-check.yml
+++ b/.github/workflows/openapi-spec-check.yml
@@ -1,5 +1,5 @@
 # Run openapi-to-k6 against deployed OpenAPI spec and fail if litApiServer.ts has drifted.
-# Called from Deploy to Phala CVM after wait-for-api, or manually via workflow_dispatch.
+# Called from Deploy to Phala CVM after wait-for-api-restart, or manually via workflow_dispatch.
 
 name: OpenAPI Spec Check
 

--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -1,7 +1,7 @@
-# Reusable workflow: wait for an API endpoint to become available
+# Reusable workflow: wait for an API restart to complete
 #
 # Call with api_root_url (direct) or phala_app_name (get from Phala CLI):
-#   uses: ./.github/workflows/wait-for-api.yml
+#   uses: ./.github/workflows/wait-for-api-restart.yml
 #   with:
 #     api_root_url: "https://example.com/core/v1"   # OR phala_app_name
 #     # phala_app_name: "lit-api-server"        # CVM name; requires PHALA_CLOUD_API_KEY secret
@@ -10,7 +10,7 @@
 #   secrets:
 #     PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}  # when using phala_app_name
 
-name: Wait for API
+name: Wait for API restart
 
 on:
   workflow_call:

--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -101,22 +101,16 @@ jobs:
           if curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; then
             echo "API is currently available — waiting for it to go down (deployment restart)..."
             DOWN_DEADLINE=$(( $(date +%s) + 300 ))  # 5 min
-            WENT_DOWN=false
             while curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; do
               if [ "$(date +%s)" -ge "$DOWN_DEADLINE" ]; then
-                echo "API never went down after 300s — proceeding to poll anyway"
-                break
+                echo "::error::API never went down after 300s — deploy may have failed"
+                exit 1
               fi
               echo "Still up, rechecking in 5s..."
               sleep 5
             done
-            if ! curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; then
-              WENT_DOWN=true
-            fi
-            if [ "$WENT_DOWN" = true ]; then
-              echo "API is down — waiting 15s for clean restart..."
-              sleep 15
-            fi
+            echo "API is down — waiting 15s for clean restart..."
+            sleep 15
           else
             echo "API is not currently available — polling for availability"
           fi

--- a/.github/workflows/wait-for-api.yml
+++ b/.github/workflows/wait-for-api.yml
@@ -93,6 +93,35 @@ jobs:
         run: |
           BASE_URL="${{ steps.resolve-url.outputs.api_root_url }}"
           TIMEOUT="${{ inputs.timeout }}"
+
+          # Step-function: if the API is currently up (stale instance still
+          # serving), wait for it to go down before polling for the new
+          # instance.  This avoids the race where we'd pass against the old
+          # deployment.
+          if curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; then
+            echo "API is currently available — waiting for it to go down (deployment restart)..."
+            DOWN_DEADLINE=$(( $(date +%s) + 300 ))  # 5 min
+            WENT_DOWN=false
+            while curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; do
+              if [ "$(date +%s)" -ge "$DOWN_DEADLINE" ]; then
+                echo "API never went down after 300s — proceeding to poll anyway"
+                break
+              fi
+              echo "Still up, rechecking in 5s..."
+              sleep 5
+            done
+            if ! curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; then
+              WENT_DOWN=true
+            fi
+            if [ "$WENT_DOWN" = true ]; then
+              echo "API is down — waiting 15s for clean restart..."
+              sleep 15
+            fi
+          else
+            echo "API is not currently available — polling for availability"
+          fi
+
+          # Poll for the API to come (back) up.
           echo "Polling $BASE_URL/openapi.json (timeout: ${TIMEOUT}s)..."
           deadline=$(( $(date +%s) + TIMEOUT ))
           until curl -sf "$BASE_URL/openapi.json" > /dev/null; do


### PR DESCRIPTION
## Summary
- **wait-for-api.yml**: If the API is reachable when the workflow starts, it now waits for it to go down (up to 5 min timeout), pauses 15s for a clean restart, then polls for `openapi.json`. If already down, skips straight to polling.
- **deploy-phala.yml**: Removes the `wait-after-deploy` job (fixed 30s sleep) since the step-function check handles this properly.

## Test plan
- [ ] Deploy to `next` and verify the workflow log shows step-function behavior (detects API up → waits for down → 15s pause → polls for up)
- [ ] Verify a fresh deploy where the API is already down skips straight to polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)