### PR TITLE
Add tracing intrumentation

### DIFF
--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -15,6 +15,7 @@ use crate::core::v1::models::request::AddUsageApiKeyRequest;
 use crate::utils::parse_with_hash::api_key_hash;
 use crate::utils::parse_with_hash::ipfs_cid_to_u256;
 use ethers::types::{Address, H160, U256};
+use tracing::instrument;
 
 /// Create a new account. `initial_balance` is stored on the account's apiKey (AccountConfig.accountApiKey.balance).
 pub async fn new_account(
@@ -315,6 +316,12 @@ pub async fn register_wallet_derivation(
 
 /// Get the derivation path for a wallet address under an account (read-only).
 /// `wallet_address` is the hex address (with or without 0x). Returns the U256 derivation path, or errors if not set.
+#[instrument(
+    name = "accounts::get_wallet_derivation",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn get_wallet_derivation(api_key: &str, wallet_address: H160) -> Result<U256> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
@@ -453,6 +460,7 @@ pub async fn get_rebalance_amount() -> Result<U256> {
     Ok(rebalance_amount)
 }
 
+#[instrument(name = "accounts::can_execute_action", level = "debug", skip_all, err)]
 pub async fn can_execute_action(api_key: &str, cid_hash: U256) -> Result<bool> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
@@ -463,6 +471,12 @@ pub async fn can_execute_action(api_key: &str, cid_hash: U256) -> Result<bool> {
     Ok(can_execute)
 }
 
+#[instrument(
+    name = "accounts::can_use_wallet_in_action",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn can_use_wallet_in_action(
     api_key: &str,
     cid_hash: U256,

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -14,18 +14,6 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use tracing::instrument;
 
-#[instrument(
-    level = "debug",
-    skip(
-        request_span,
-        api_key,
-        grpc_client_pool,
-        ipfs_cache,
-        http_client,
-        lit_action_request
-    ),
-    err
-)]
 #[instrument(name = "core_features::lit_action", level = "debug", skip_all, err)]
 pub async fn lit_action(
     request_span: &RequestSpan,

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -26,6 +26,7 @@ use tracing::instrument;
     ),
     err
 )]
+#[instrument(name = "core_features::lit_action", level = "debug", skip_all, err)]
 pub async fn lit_action(
     request_span: &RequestSpan,
     api_key: &str,

--- a/lit-api-server/src/dstack/v1/mod.rs
+++ b/lit-api-server/src/dstack/v1/mod.rs
@@ -32,7 +32,7 @@ pub async fn get_admin_api_payer_key() -> Result<[u8; 32], String> {
     get_key(path.as_str(), purpose).await
 }
 
-#[instrument(name = "dstack::v1::get_key", level = "debug", err)]
+#[instrument(name = "dstack::v1::get_key", level = "debug", err, skip_all)]
 async fn get_key(path: &str, purpose: &str) -> Result<[u8; 32], String> {
     let key_response = dstack::get_key(path, purpose)
         .await

--- a/lit-api-server/src/dstack/v1/mod.rs
+++ b/lit-api-server/src/dstack/v1/mod.rs
@@ -1,6 +1,6 @@
-use ethers::utils::keccak256;
-
 use crate::utils::generate_lit_action_derivation_path;
+use ethers::utils::keccak256;
+use tracing::instrument;
 mod dstack;
 pub mod endpoints;
 
@@ -32,6 +32,7 @@ pub async fn get_admin_api_payer_key() -> Result<[u8; 32], String> {
     get_key(path.as_str(), purpose).await
 }
 
+#[instrument(name = "dstack::v1::get_key", level = "debug", err)]
 async fn get_key(path: &str, purpose: &str) -> Result<[u8; 32], String> {
     let key_response = dstack::get_key(path, purpose)
         .await


### PR DESCRIPTION
### WHAT

Adds tracing for key security,  key derivation and api checks as they pertain to on-chain & KMS lookups.

Tracing internal to actual action code isn't directly possible with instrumentation, though console logging is available by crafting actions like this: 

```
const go = async () => {
  const start = Date.now();
  const privateKey = await Lit.Actions.getPrivateKey( {pkpId});
  console.log('Time taken to get private key: ' + (Date.now() - start) + 'ms');

  const wstart = Date.now();
  const wallet = new ethers.Wallet(privateKey);
  console.log('Time taken to generate an ethers wallet: ' + (Date.now() - wstart) + 'ms');

  const s_start = Date.now();
  const signature = await wallet.signMessage("Chipotle Rocks!");
  console.log('Time taken to sign a message: ' + (Date.now() - s_start) + 'ms');
  const publicKey = wallet.publicKey;

  const data = {
    wallet_address: wallet.address,
    signature: signature,
    publicKey: publicKey,
  };

  Lit.Actions.setResponse({ response: data });
};
go();
```