### PR TITLE
feat: expose idle signer count as otel gauge metric (CPL-102)

### DIFF
--- a/lit-actions/clippy.toml
+++ b/lit-actions/clippy.toml
@@ -1,0 +1,8 @@
+# Our OTel metrics recorder bridge does not support Counter::absolute()
+# because OpenTelemetry counters are additive-only — there is no way to
+# set a counter to an absolute value.  Calling absolute() silently drops
+# the value and emits a warning at runtime.  Catching it at lint time is
+# strictly better.
+disallowed-methods = [
+    { path = "metrics::Counter::absolute", reason = "not supported by the OTel recorder bridge in lit-observability — use increment() instead" },
+]

--- a/lit-api-server/Cargo.lock
+++ b/lit-api-server/Cargo.lock
@@ -54,6 +54,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4512,6 +4524,7 @@ dependencies = [
  "lit-core",
  "lit-core-derive",
  "lit-observability",
+ "metrics",
  "moka",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4602,6 +4615,7 @@ dependencies = [
  "lit-core",
  "lit-core-derive",
  "lit-logging",
+ "metrics",
  "nu-ansi-term",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4709,6 +4723,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "metrics"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
 
 [[package]]
 name = "mime"
@@ -5744,7 +5768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5764,7 +5788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/lit-api-server/Cargo.toml
+++ b/lit-api-server/Cargo.toml
@@ -30,6 +30,7 @@ ethers = { version = "2.0.8", features = ["abigen", "legacy"] }
 ethers-providers = "2"
 
 flume = "0.11.0"
+metrics = "0.23"
 futures = "0.3.31"
 hex = "0.4"
 sha3 = "0.10"

--- a/lit-api-server/clippy.toml
+++ b/lit-api-server/clippy.toml
@@ -1,0 +1,8 @@
+# Our OTel metrics recorder bridge does not support Counter::absolute()
+# because OpenTelemetry counters are additive-only — there is no way to
+# set a counter to an absolute value.  Calling absolute() silently drops
+# the value and emits a warning at runtime.  Catching it at lint time is
+# strictly better.
+disallowed-methods = [
+    { path = "metrics::Counter::absolute", reason = "not supported by the OTel recorder bridge in lit-observability — use increment() instead" },
+]

--- a/lit-api-server/src/accounts/signer_pool.rs
+++ b/lit-api-server/src/accounts/signer_pool.rs
@@ -8,6 +8,8 @@ use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{H160, U256};
 use ethers_providers::Middleware;
 
+use lit_observability::metrics::{LitMetric, gauge};
+
 use crate::accounts::signable_contract::{
     SigningClient, get_admin_api_payer_contract, get_admin_api_signer,
     get_read_only_account_config_contract,
@@ -18,6 +20,37 @@ use crate::dstack::v1::get_lit_payer_key;
 
 const STALE_LEASE_SECS: u64 = 10;
 const CLEANUP_INTERVAL_SECS: u64 = 5;
+
+enum SignerPoolMetrics {
+    IdleSigners,
+}
+
+impl LitMetric for SignerPoolMetrics {
+    fn get_meter(&self) -> &str {
+        "lit.signer_pool"
+    }
+    fn get_namespace(&self) -> &str {
+        "signer_pool"
+    }
+    fn get_name(&self) -> &str {
+        match self {
+            Self::IdleSigners => "idle_signers",
+        }
+    }
+    fn get_description(&self) -> &str {
+        match self {
+            Self::IdleSigners => "Number of currently idle signers in the pool.",
+        }
+    }
+    fn get_unit(&self) -> &str {
+        ""
+    }
+}
+
+fn record_idle_signers(entries: &[SigningPoolEntry]) {
+    let idle = entries.iter().filter(|e| !e.in_use).count();
+    gauge::record(SignerPoolMetrics::IdleSigners, idle as u64, &[]);
+}
 
 #[derive(Clone)]
 pub struct SigningPoolEntry {
@@ -129,6 +162,7 @@ pub async fn get_signer_entries(
 async fn run_pool(mut entries: Vec<SigningPoolEntry>, rx: flume::Receiver<SigningPoolMessage>) {
     let mut payer_count = entries.len();
     tracing::info!("signer_pool: signer count: {payer_count}");
+    record_idle_signers(&entries);
     let mut interval = tokio::time::interval(Duration::from_secs(CLEANUP_INTERVAL_SECS));
     interval.tick().await; // discard the immediate first tick
 
@@ -170,6 +204,7 @@ async fn run_pool(mut entries: Vec<SigningPoolEntry>, rx: flume::Receiver<Signin
                                 });
                             }
                         }
+                        record_idle_signers(&entries);
                     }
                     Ok(SigningPoolMessage::Release { address }) => {
                         if let Some(entry) =
@@ -184,6 +219,7 @@ async fn run_pool(mut entries: Vec<SigningPoolEntry>, rx: flume::Receiver<Signin
                                 address
                             );
                         }
+                        record_idle_signers(&entries);
                     }
                     Err(_) => {
                         tracing::info!("signer_pool: channel closed, shutting down");
@@ -194,6 +230,7 @@ async fn run_pool(mut entries: Vec<SigningPoolEntry>, rx: flume::Receiver<Signin
             _ = interval.tick() => {
                 check_for_new_api_payer_count(&mut entries, &mut payer_count).await;
                 release_stale_leases(&mut entries).await;
+                record_idle_signers(&entries);
             }
         }
     }

--- a/lit-api-server/src/accounts/signer_pool.rs
+++ b/lit-api-server/src/accounts/signer_pool.rs
@@ -8,8 +8,6 @@ use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{H160, U256};
 use ethers_providers::Middleware;
 
-use lit_observability::metrics::{LitMetric, gauge};
-
 use crate::accounts::signable_contract::{
     SigningClient, get_admin_api_payer_contract, get_admin_api_signer,
     get_read_only_account_config_contract,
@@ -21,35 +19,9 @@ use crate::dstack::v1::get_lit_payer_key;
 const STALE_LEASE_SECS: u64 = 10;
 const CLEANUP_INTERVAL_SECS: u64 = 5;
 
-enum SignerPoolMetrics {
-    IdleSigners,
-}
-
-impl LitMetric for SignerPoolMetrics {
-    fn get_meter(&self) -> &str {
-        "lit.signer_pool"
-    }
-    fn get_namespace(&self) -> &str {
-        "signer_pool"
-    }
-    fn get_name(&self) -> &str {
-        match self {
-            Self::IdleSigners => "idle_signers",
-        }
-    }
-    fn get_description(&self) -> &str {
-        match self {
-            Self::IdleSigners => "Number of currently idle signers in the pool.",
-        }
-    }
-    fn get_unit(&self) -> &str {
-        ""
-    }
-}
-
 fn record_idle_signers(entries: &[SigningPoolEntry]) {
     let idle = entries.iter().filter(|e| !e.in_use).count();
-    gauge::record(SignerPoolMetrics::IdleSigners, idle as u64, &[]);
+    metrics::gauge!("signer_pool.idle_signers").set(idle as f64);
 }
 
 #[derive(Clone)]

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<(), rocket::Error> {
                 global::set_text_map_propagator(TraceContextPropagator::new());
                 global::set_tracer_provider(tracing_provider.clone());
                 global::set_meter_provider(metrics_provider.clone());
+                lit_observability::metrics::install_recorder();
 
                 let tracer = tracing_provider.tracer("lit-api-server");
                 let otel_trace_layer =

--- a/lit-core/Cargo.lock
+++ b/lit-core/Cargo.lock
@@ -2077,6 +2077,7 @@ dependencies = [
  "lit-core",
  "lit-core-derive",
  "lit-observability",
+ "metrics",
  "num_cpus",
  "once_cell",
  "openssl",
@@ -2175,6 +2176,7 @@ dependencies = [
  "lit-core",
  "lit-core-derive",
  "lit-logging",
+ "metrics",
  "nu-ansi-term",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2251,6 +2253,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "metrics"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
 
 [[package]]
 name = "mime"
@@ -2808,6 +2820,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"

--- a/lit-core/clippy.toml
+++ b/lit-core/clippy.toml
@@ -1,0 +1,8 @@
+# Our OTel metrics recorder bridge does not support Counter::absolute()
+# because OpenTelemetry counters are additive-only — there is no way to
+# set a counter to an absolute value.  Calling absolute() silently drops
+# the value and emits a warning at runtime.  Catching it at lint time is
+# strictly better.
+disallowed-methods = [
+    { path = "metrics::Counter::absolute", reason = "not supported by the OTel recorder bridge in lit-observability — use increment() instead" },
+]

--- a/lit-core/lit-api-core/Cargo.toml
+++ b/lit-core/lit-api-core/Cargo.toml
@@ -28,6 +28,7 @@ hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }
 hyperlocal = { workspace = true, optional = true }
 ip_rfc = { version = "0.1.0" }
+metrics = "0.23"
 num_cpus = { version = "1.16" }
 once_cell.workspace = true
 openssl = { version = "0.10.71" }

--- a/lit-core/lit-api-core/src/context/mod.rs
+++ b/lit-core/lit-api-core/src/context/mod.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 
 use lit_observability::PRIVACY_MODE_TAG;
 use lit_observability::logging::set_request_context;
-use lit_observability::metrics::counter;
 use opentelemetry::propagation::Injector;
 use rocket::Request;
 use rocket::request::{FromRequest, Outcome};
@@ -15,7 +14,6 @@ use tokio::task::futures::TaskLocalFuture;
 use tokio::task_local;
 
 use crate::error::{EC, Error, Result, conversion_err_code, validation_err_code};
-use crate::observability::http::HttpMetrics;
 
 pub const HEADER_KEY_X_CORRELATION_ID: &str = "X-Correlation-Id";
 pub const HEADER_KEY_X_REQUEST_ID: &str = "X-Request-Id";
@@ -213,7 +211,7 @@ pub(crate) fn extract_request_and_correlation_ids(
     let mut correlation_id = x_correlation_id.or(x_request_id);
 
     if x_privacy_mode.is_some() {
-        counter::add_one(HttpMetrics::PrivacyModeRequest, &[]);
+        metrics::counter!("service.request.privacy_mode").increment(1);
 
         let privacy_suffix = format!("_{}", PRIVACY_MODE_TAG);
         if let Some(ref id) = request_id

--- a/lit-core/lit-api-core/src/observability/mod.rs
+++ b/lit-core/lit-api-core/src/observability/mod.rs
@@ -1,7 +1,4 @@
 use ahash::{HashSet, HashSetExt};
-use lit_observability::metrics::counter;
-use opentelemetry::KeyValue;
-use opentelemetry_semantic_conventions::resource::{HTTP_METHOD, HTTP_STATUS_CODE, URL_PATH};
 use rocket::{Data, Request, Response, Route, fairing::Fairing};
 
 use crate::context::HEADER_KEY_X_LIT_SDK_VERSION;
@@ -42,14 +39,13 @@ impl Fairing for MetricsFairings {
         // Get the SDK-Version header value.
         let sdk_version = req.headers().get_one(HEADER_KEY_X_LIT_SDK_VERSION).unwrap_or("unknown");
 
-        counter::add_one(
-            http::HttpMetrics::ServiceRequest,
-            &[
-                KeyValue::new(HTTP_METHOD, req.method().as_str()),
-                KeyValue::new(URL_PATH, req.uri().path().to_string()),
-                KeyValue::new("sdk.version", sdk_version.to_owned()),
-            ],
-        );
+        metrics::counter!(
+            "service.request",
+            "http.method" => req.method().as_str().to_owned(),
+            "url.path" => req.uri().path().to_string(),
+            "sdk.version" => sdk_version.to_owned(),
+        )
+        .increment(1);
     }
 
     async fn on_response<'r>(&self, req: &'r Request<'_>, res: &mut Response<'r>) {
@@ -58,44 +54,11 @@ impl Fairing for MetricsFairings {
             return;
         }
 
-        counter::add_one(
-            http::HttpMetrics::ServiceResponse,
-            &[
-                KeyValue::new(HTTP_METHOD, req.method().as_str()),
-                KeyValue::new(HTTP_STATUS_CODE, res.status().to_string()),
-            ],
-        );
-    }
-}
-
-pub mod http {
-    use lit_observability::metrics::LitMetric;
-
-    pub enum HttpMetrics {
-        ServiceRequest,
-        PrivacyModeRequest,
-        ServiceResponse,
-    }
-
-    impl LitMetric for HttpMetrics {
-        fn get_meter(&self) -> &str {
-            "lit.http"
-        }
-        fn get_description(&self) -> &str {
-            "Counter for HTTP requests and responses."
-        }
-        fn get_unit(&self) -> &str {
-            ""
-        }
-        fn get_namespace(&self) -> &str {
-            "service"
-        }
-        fn get_name(&self) -> &str {
-            match self {
-                Self::ServiceRequest => "request",
-                Self::PrivacyModeRequest => "request.privacy_mode",
-                Self::ServiceResponse => "response",
-            }
-        }
+        metrics::counter!(
+            "service.response",
+            "http.method" => req.method().as_str().to_owned(),
+            "http.status_code" => res.status().to_string(),
+        )
+        .increment(1);
     }
 }

--- a/lit-core/lit-observability/Cargo.toml
+++ b/lit-core/lit-observability/Cargo.toml
@@ -16,6 +16,7 @@ otlp = ["dep:opentelemetry-otlp", "dep:opentelemetry_sdk", "dep:tracing-opentele
 [dependencies]
 dashmap = "6"
 derive_more.workspace = true
+metrics = "0.23"
 flume = { version = "0.11", optional = true }
 nu-ansi-term = { version = "0.50.1" }
 opentelemetry.workspace = true

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -64,8 +64,11 @@ impl CounterFn for OtelCounter {
         self.inner.add(value, &self.attributes);
     }
 
-    fn absolute(&self, _value: u64) {
-        // OTel counters are additive-only; absolute set is not supported.
+    fn absolute(&self, value: u64) {
+        tracing::warn!(
+            value,
+            "metrics::Counter::absolute() is not supported by the OTel bridge; use increment() instead"
+        );
     }
 }
 

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -33,198 +33,214 @@ pub(crate) fn init_metrics_provider(
 }
 
 // ---------------------------------------------------------------------------
-// OTel-backed `metrics` facade recorder
+// OTel-backed `metrics` facade recorder (only available with the otlp feature)
 // ---------------------------------------------------------------------------
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "otlp")]
+mod recorder {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-use dashmap::DashMap;
-use metrics::{
-    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
-    SharedString, Unit,
-};
-use opentelemetry::{KeyValue, global};
+    use dashmap::DashMap;
+    use metrics::{
+        Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata,
+        Recorder, SharedString, Unit,
+    };
+    use opentelemetry::{KeyValue, global};
 
-const METER_NAME: &str = "lit";
+    const METER_NAME: &str = "lit";
 
-fn key_to_attributes(key: &Key) -> Vec<KeyValue> {
-    key.labels().map(|l| KeyValue::new(l.key().to_string(), l.value().to_string())).collect()
-}
-
-// --- Counter bridge ---
-
-struct OtelCounter {
-    inner: opentelemetry::metrics::Counter<u64>,
-    attributes: Vec<KeyValue>,
-}
-
-impl CounterFn for OtelCounter {
-    fn increment(&self, value: u64) {
-        self.inner.add(value, &self.attributes);
+    fn key_to_attributes(key: &Key) -> Vec<KeyValue> {
+        key.labels().map(|l| KeyValue::new(l.key().to_string(), l.value().to_string())).collect()
     }
 
-    fn absolute(&self, value: u64) {
-        tracing::warn!(
-            value,
-            "metrics::Counter::absolute() is not supported by the OTel bridge; use increment() instead"
-        );
+    // --- Counter bridge ---
+
+    struct OtelCounter {
+        inner: opentelemetry::metrics::Counter<u64>,
+        attributes: Vec<KeyValue>,
     }
-}
 
-// --- Gauge bridge ---
+    impl CounterFn for OtelCounter {
+        fn increment(&self, value: u64) {
+            self.inner.add(value, &self.attributes);
+        }
 
-struct OtelGauge {
-    inner: opentelemetry::metrics::Gauge<f64>,
-    attributes: Vec<KeyValue>,
-    current: AtomicU64, // stores f64 bits
-}
+        fn absolute(&self, value: u64) {
+            tracing::warn!(
+                value,
+                "metrics::Counter::absolute() is not supported by the OTel bridge; use increment() instead"
+            );
+        }
+    }
 
-impl GaugeFn for OtelGauge {
-    fn increment(&self, value: f64) {
-        loop {
-            let bits = self.current.load(Ordering::Relaxed);
-            let new = f64::from_bits(bits) + value;
-            if self
-                .current
-                .compare_exchange_weak(bits, new.to_bits(), Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                self.inner.record(new, &self.attributes);
-                break;
+    // --- Gauge bridge ---
+
+    struct OtelGauge {
+        inner: opentelemetry::metrics::Gauge<f64>,
+        attributes: Vec<KeyValue>,
+        current: AtomicU64, // stores f64 bits
+    }
+
+    impl GaugeFn for OtelGauge {
+        fn increment(&self, value: f64) {
+            loop {
+                let bits = self.current.load(Ordering::Relaxed);
+                let new = f64::from_bits(bits) + value;
+                if self
+                    .current
+                    .compare_exchange_weak(
+                        bits,
+                        new.to_bits(),
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    self.inner.record(new, &self.attributes);
+                    break;
+                }
             }
         }
-    }
 
-    fn decrement(&self, value: f64) {
-        self.increment(-value);
-    }
+        fn decrement(&self, value: f64) {
+            self.increment(-value);
+        }
 
-    fn set(&self, value: f64) {
-        self.current.store(value.to_bits(), Ordering::Relaxed);
-        self.inner.record(value, &self.attributes);
-    }
-}
-
-// --- Histogram bridge ---
-
-struct OtelHistogram {
-    inner: opentelemetry::metrics::Histogram<f64>,
-    attributes: Vec<KeyValue>,
-}
-
-impl HistogramFn for OtelHistogram {
-    fn record(&self, value: f64) {
-        self.inner.record(value, &self.attributes);
-    }
-}
-
-// --- Recorder ---
-
-struct OtelRecorder {
-    otel_counters: DashMap<String, opentelemetry::metrics::Counter<u64>>,
-    otel_gauges: DashMap<String, opentelemetry::metrics::Gauge<f64>>,
-    otel_histograms: DashMap<String, opentelemetry::metrics::Histogram<f64>>,
-    descriptions: DashMap<String, String>,
-}
-
-impl OtelRecorder {
-    fn new() -> Self {
-        Self {
-            otel_counters: DashMap::new(),
-            otel_gauges: DashMap::new(),
-            otel_histograms: DashMap::new(),
-            descriptions: DashMap::new(),
+        fn set(&self, value: f64) {
+            self.current.store(value.to_bits(), Ordering::Relaxed);
+            self.inner.record(value, &self.attributes);
         }
     }
 
-    fn get_description(&self, name: &str) -> Option<String> {
-        self.descriptions.get(name).map(|d| d.value().clone())
+    // --- Histogram bridge ---
+
+    struct OtelHistogram {
+        inner: opentelemetry::metrics::Histogram<f64>,
+        attributes: Vec<KeyValue>,
+    }
+
+    impl HistogramFn for OtelHistogram {
+        fn record(&self, value: f64) {
+            self.inner.record(value, &self.attributes);
+        }
+    }
+
+    // --- Recorder ---
+
+    struct OtelRecorder {
+        otel_counters: DashMap<String, opentelemetry::metrics::Counter<u64>>,
+        otel_gauges: DashMap<String, opentelemetry::metrics::Gauge<f64>>,
+        otel_histograms: DashMap<String, opentelemetry::metrics::Histogram<f64>>,
+        descriptions: DashMap<String, String>,
+    }
+
+    impl OtelRecorder {
+        fn new() -> Self {
+            Self {
+                otel_counters: DashMap::new(),
+                otel_gauges: DashMap::new(),
+                otel_histograms: DashMap::new(),
+                descriptions: DashMap::new(),
+            }
+        }
+
+        fn get_description(&self, name: &str) -> Option<String> {
+            self.descriptions.get(name).map(|d| d.value().clone())
+        }
+    }
+
+    impl Recorder for OtelRecorder {
+        fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+            self.descriptions.insert(key.as_str().to_string(), description.to_string());
+        }
+
+        fn describe_gauge(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+            self.descriptions.insert(key.as_str().to_string(), description.to_string());
+        }
+
+        fn describe_histogram(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+            self.descriptions.insert(key.as_str().to_string(), description.to_string());
+        }
+
+        fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+            let name = key.name().to_string();
+            let attributes = key_to_attributes(key);
+
+            let otel_counter = self
+                .otel_counters
+                .entry(name.clone())
+                .or_insert_with(|| {
+                    let meter = global::meter(METER_NAME);
+                    let mut builder = meter.u64_counter(name.clone());
+                    if let Some(desc) = self.get_description(&name) {
+                        builder = builder.with_description(desc);
+                    }
+                    builder.init()
+                })
+                .clone();
+
+            Counter::from_arc(Arc::new(OtelCounter { inner: otel_counter, attributes }))
+        }
+
+        fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+            let name = key.name().to_string();
+            let attributes = key_to_attributes(key);
+
+            let otel_gauge = self
+                .otel_gauges
+                .entry(name.clone())
+                .or_insert_with(|| {
+                    let meter = global::meter(METER_NAME);
+                    let mut builder = meter.f64_gauge(name.clone());
+                    if let Some(desc) = self.get_description(&name) {
+                        builder = builder.with_description(desc);
+                    }
+                    builder.init()
+                })
+                .clone();
+
+            Gauge::from_arc(Arc::new(OtelGauge {
+                inner: otel_gauge,
+                attributes,
+                current: AtomicU64::new(0f64.to_bits()),
+            }))
+        }
+
+        fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+            let name = key.name().to_string();
+            let attributes = key_to_attributes(key);
+
+            let otel_histogram = self
+                .otel_histograms
+                .entry(name.clone())
+                .or_insert_with(|| {
+                    let meter = global::meter(METER_NAME);
+                    let mut builder = meter.f64_histogram(name.clone());
+                    if let Some(desc) = self.get_description(&name) {
+                        builder = builder.with_description(desc);
+                    }
+                    builder.init()
+                })
+                .clone();
+
+            Histogram::from_arc(Arc::new(OtelHistogram { inner: otel_histogram, attributes }))
+        }
+    }
+
+    /// Install the OTel-backed metrics recorder as the global `metrics` facade
+    /// backend. Call this after the OTel `MeterProvider` has been set globally.
+    pub fn install() {
+        if let Err(e) = metrics::set_global_recorder(OtelRecorder::new()) {
+            tracing::warn!("metrics recorder already installed: {e}");
+        }
     }
 }
 
-impl Recorder for OtelRecorder {
-    fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
-        self.descriptions.insert(key.as_str().to_string(), description.to_string());
-    }
-
-    fn describe_gauge(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
-        self.descriptions.insert(key.as_str().to_string(), description.to_string());
-    }
-
-    fn describe_histogram(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
-        self.descriptions.insert(key.as_str().to_string(), description.to_string());
-    }
-
-    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        let name = key.name().to_string();
-        let attributes = key_to_attributes(key);
-
-        let otel_counter = self
-            .otel_counters
-            .entry(name.clone())
-            .or_insert_with(|| {
-                let meter = global::meter(METER_NAME);
-                let mut builder = meter.u64_counter(name.clone());
-                if let Some(desc) = self.get_description(&name) {
-                    builder = builder.with_description(desc);
-                }
-                builder.init()
-            })
-            .clone();
-
-        Counter::from_arc(Arc::new(OtelCounter { inner: otel_counter, attributes }))
-    }
-
-    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
-        let name = key.name().to_string();
-        let attributes = key_to_attributes(key);
-
-        let otel_gauge = self
-            .otel_gauges
-            .entry(name.clone())
-            .or_insert_with(|| {
-                let meter = global::meter(METER_NAME);
-                let mut builder = meter.f64_gauge(name.clone());
-                if let Some(desc) = self.get_description(&name) {
-                    builder = builder.with_description(desc);
-                }
-                builder.init()
-            })
-            .clone();
-
-        Gauge::from_arc(Arc::new(OtelGauge {
-            inner: otel_gauge,
-            attributes,
-            current: AtomicU64::new(0f64.to_bits()),
-        }))
-    }
-
-    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
-        let name = key.name().to_string();
-        let attributes = key_to_attributes(key);
-
-        let otel_histogram = self
-            .otel_histograms
-            .entry(name.clone())
-            .or_insert_with(|| {
-                let meter = global::meter(METER_NAME);
-                let mut builder = meter.f64_histogram(name.clone());
-                if let Some(desc) = self.get_description(&name) {
-                    builder = builder.with_description(desc);
-                }
-                builder.init()
-            })
-            .clone();
-
-        Histogram::from_arc(Arc::new(OtelHistogram { inner: otel_histogram, attributes }))
-    }
-}
-
-/// Install the OTel-backed metrics recorder as the global `metrics` facade
-/// backend. Call this after the OTel `MeterProvider` has been set globally.
+/// Install the OTel-backed metrics recorder. Without the `otlp` feature this
+/// is a no-op — call sites can still use `metrics::counter!` / `metrics::gauge!`
+/// freely; the values simply won't be exported.
 pub fn install_recorder() {
-    if let Err(e) = metrics::set_global_recorder(OtelRecorder::new()) {
-        tracing::warn!("metrics recorder already installed: {e}");
-    }
+    #[cfg(feature = "otlp")]
+    recorder::install();
 }

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -49,9 +49,7 @@ use opentelemetry::{KeyValue, global};
 const METER_NAME: &str = "lit";
 
 fn key_to_attributes(key: &Key) -> Vec<KeyValue> {
-    key.labels()
-        .map(|l| KeyValue::new(l.key().to_string(), l.value().to_string()))
-        .collect()
+    key.labels().map(|l| KeyValue::new(l.key().to_string(), l.value().to_string())).collect()
 }
 
 // --- Counter bridge ---

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -72,24 +72,35 @@ pub mod counter {
 }
 
 pub mod gauge {
+    use std::sync::OnceLock;
+
+    use dashmap::DashMap;
+    use opentelemetry::metrics::Gauge;
     use opentelemetry::{KeyValue, global};
 
+    static GAUGES: OnceLock<DashMap<String, Gauge<u64>>> = OnceLock::new();
+
     pub fn record(metric: impl super::LitMetric, value: u64, attributes: &[KeyValue]) {
-        let meter = global::meter(metric.get_meter().to_string());
-        let name = metric.get_full_name().to_string();
-        let description = metric.get_description().to_string();
-        let unit = metric.get_unit().to_owned();
+        let gauges = GAUGES.get_or_init(DashMap::new);
+        let name = metric.get_full_name();
 
-        let mut gauge = meter.u64_gauge(name);
+        let gauge = gauges.entry(name.clone()).or_insert_with(|| {
+            let meter = global::meter(metric.get_meter().to_string());
+            let description = metric.get_description().to_string();
+            let unit = metric.get_unit().to_owned();
 
-        if !description.is_empty() {
-            gauge = gauge.with_description(description);
-        }
-        if !unit.is_empty() {
-            gauge = gauge.with_unit(unit);
-        }
+            let mut builder = meter.u64_gauge(name);
 
-        let gauge = gauge.init();
+            if !description.is_empty() {
+                builder = builder.with_description(description);
+            }
+            if !unit.is_empty() {
+                builder = builder.with_unit(unit);
+            }
+
+            builder.init()
+        });
+
         gauge.record(value, attributes);
     }
 }

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -44,29 +44,39 @@ pub trait LitMetric {
 }
 
 pub mod counter {
+    use std::sync::OnceLock;
+
+    use dashmap::DashMap;
+    use opentelemetry::metrics::Counter;
     use opentelemetry::{KeyValue, global};
+
+    static COUNTERS: OnceLock<DashMap<String, Counter<u64>>> = OnceLock::new();
 
     pub fn add_one(metric: impl super::LitMetric, attributes: &[KeyValue]) {
         add_value(metric, 1, attributes)
     }
 
     pub fn add_value(metric: impl super::LitMetric, value: u64, attributes: &[KeyValue]) {
-        // shallow wrapper - this could probably all be cached?  What's the best practice?
-        let meter = global::meter(metric.get_meter().to_string());
-        let name = metric.get_full_name().to_string();
-        let description = metric.get_description().to_string();
-        let unit = metric.get_unit().to_owned();
+        let counters = COUNTERS.get_or_init(DashMap::new);
+        let name = metric.get_full_name();
 
-        let mut counter = meter.u64_counter(name);
+        let counter = counters.entry(name.clone()).or_insert_with(|| {
+            let meter = global::meter(metric.get_meter().to_string());
+            let description = metric.get_description().to_string();
+            let unit = metric.get_unit().to_owned();
 
-        if !description.is_empty() {
-            counter = counter.with_description(description);
-        }
-        if !unit.is_empty() {
-            counter = counter.with_unit(unit);
-        }
+            let mut builder = meter.u64_counter(name);
 
-        let counter = counter.init();
+            if !description.is_empty() {
+                builder = builder.with_description(description);
+            }
+            if !unit.is_empty() {
+                builder = builder.with_unit(unit);
+            }
+
+            builder.init()
+        });
+
         counter.add(value, attributes);
     }
 }

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -32,85 +32,198 @@ pub(crate) fn init_metrics_provider(
         })
 }
 
-pub trait LitMetric {
-    fn get_meter(&self) -> &str;
-    fn get_namespace(&self) -> &str;
-    fn get_name(&self) -> &str;
-    fn get_full_name(&self) -> String {
-        format!("{}.{}", self.get_namespace(), self.get_name())
-    }
-    fn get_description(&self) -> &str;
-    fn get_unit(&self) -> &str;
+// ---------------------------------------------------------------------------
+// OTel-backed `metrics` facade recorder
+// ---------------------------------------------------------------------------
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+use metrics::{
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
+    SharedString, Unit,
+};
+use opentelemetry::{KeyValue, global};
+
+const METER_NAME: &str = "lit";
+
+fn key_to_attributes(key: &Key) -> Vec<KeyValue> {
+    key.labels()
+        .map(|l| KeyValue::new(l.key().to_string(), l.value().to_string()))
+        .collect()
 }
 
-pub mod counter {
-    use std::sync::OnceLock;
+// --- Counter bridge ---
 
-    use dashmap::DashMap;
-    use opentelemetry::metrics::Counter;
-    use opentelemetry::{KeyValue, global};
+struct OtelCounter {
+    inner: opentelemetry::metrics::Counter<u64>,
+    attributes: Vec<KeyValue>,
+}
 
-    static COUNTERS: OnceLock<DashMap<String, Counter<u64>>> = OnceLock::new();
-
-    pub fn add_one(metric: impl super::LitMetric, attributes: &[KeyValue]) {
-        add_value(metric, 1, attributes)
+impl CounterFn for OtelCounter {
+    fn increment(&self, value: u64) {
+        self.inner.add(value, &self.attributes);
     }
 
-    pub fn add_value(metric: impl super::LitMetric, value: u64, attributes: &[KeyValue]) {
-        let counters = COUNTERS.get_or_init(DashMap::new);
-        let name = metric.get_full_name();
-
-        let counter = counters.entry(name.clone()).or_insert_with(|| {
-            let meter = global::meter(metric.get_meter().to_string());
-            let description = metric.get_description().to_string();
-            let unit = metric.get_unit().to_owned();
-
-            let mut builder = meter.u64_counter(name);
-
-            if !description.is_empty() {
-                builder = builder.with_description(description);
-            }
-            if !unit.is_empty() {
-                builder = builder.with_unit(unit);
-            }
-
-            builder.init()
-        });
-
-        counter.add(value, attributes);
+    fn absolute(&self, _value: u64) {
+        // OTel counters are additive-only; absolute set is not supported.
     }
 }
 
-pub mod gauge {
-    use std::sync::OnceLock;
+// --- Gauge bridge ---
 
-    use dashmap::DashMap;
-    use opentelemetry::metrics::Gauge;
-    use opentelemetry::{KeyValue, global};
+struct OtelGauge {
+    inner: opentelemetry::metrics::Gauge<f64>,
+    attributes: Vec<KeyValue>,
+    current: AtomicU64, // stores f64 bits
+}
 
-    static GAUGES: OnceLock<DashMap<String, Gauge<u64>>> = OnceLock::new();
-
-    pub fn record(metric: impl super::LitMetric, value: u64, attributes: &[KeyValue]) {
-        let gauges = GAUGES.get_or_init(DashMap::new);
-        let name = metric.get_full_name();
-
-        let gauge = gauges.entry(name.clone()).or_insert_with(|| {
-            let meter = global::meter(metric.get_meter().to_string());
-            let description = metric.get_description().to_string();
-            let unit = metric.get_unit().to_owned();
-
-            let mut builder = meter.u64_gauge(name);
-
-            if !description.is_empty() {
-                builder = builder.with_description(description);
+impl GaugeFn for OtelGauge {
+    fn increment(&self, value: f64) {
+        loop {
+            let bits = self.current.load(Ordering::Relaxed);
+            let new = f64::from_bits(bits) + value;
+            if self
+                .current
+                .compare_exchange_weak(bits, new.to_bits(), Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                self.inner.record(new, &self.attributes);
+                break;
             }
-            if !unit.is_empty() {
-                builder = builder.with_unit(unit);
-            }
+        }
+    }
 
-            builder.init()
-        });
+    fn decrement(&self, value: f64) {
+        self.increment(-value);
+    }
 
-        gauge.record(value, attributes);
+    fn set(&self, value: f64) {
+        self.current.store(value.to_bits(), Ordering::Relaxed);
+        self.inner.record(value, &self.attributes);
+    }
+}
+
+// --- Histogram bridge ---
+
+struct OtelHistogram {
+    inner: opentelemetry::metrics::Histogram<f64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl HistogramFn for OtelHistogram {
+    fn record(&self, value: f64) {
+        self.inner.record(value, &self.attributes);
+    }
+}
+
+// --- Recorder ---
+
+struct OtelRecorder {
+    otel_counters: DashMap<String, opentelemetry::metrics::Counter<u64>>,
+    otel_gauges: DashMap<String, opentelemetry::metrics::Gauge<f64>>,
+    otel_histograms: DashMap<String, opentelemetry::metrics::Histogram<f64>>,
+    descriptions: DashMap<String, String>,
+}
+
+impl OtelRecorder {
+    fn new() -> Self {
+        Self {
+            otel_counters: DashMap::new(),
+            otel_gauges: DashMap::new(),
+            otel_histograms: DashMap::new(),
+            descriptions: DashMap::new(),
+        }
+    }
+
+    fn get_description(&self, name: &str) -> Option<String> {
+        self.descriptions.get(name).map(|d| d.value().clone())
+    }
+}
+
+impl Recorder for OtelRecorder {
+    fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+        self.descriptions.insert(key.as_str().to_string(), description.to_string());
+    }
+
+    fn describe_gauge(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+        self.descriptions.insert(key.as_str().to_string(), description.to_string());
+    }
+
+    fn describe_histogram(&self, key: KeyName, _unit: Option<Unit>, description: SharedString) {
+        self.descriptions.insert(key.as_str().to_string(), description.to_string());
+    }
+
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        let name = key.name().to_string();
+        let attributes = key_to_attributes(key);
+
+        let otel_counter = self
+            .otel_counters
+            .entry(name.clone())
+            .or_insert_with(|| {
+                let meter = global::meter(METER_NAME);
+                let mut builder = meter.u64_counter(name.clone());
+                if let Some(desc) = self.get_description(&name) {
+                    builder = builder.with_description(desc);
+                }
+                builder.init()
+            })
+            .clone();
+
+        Counter::from_arc(Arc::new(OtelCounter { inner: otel_counter, attributes }))
+    }
+
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        let name = key.name().to_string();
+        let attributes = key_to_attributes(key);
+
+        let otel_gauge = self
+            .otel_gauges
+            .entry(name.clone())
+            .or_insert_with(|| {
+                let meter = global::meter(METER_NAME);
+                let mut builder = meter.f64_gauge(name.clone());
+                if let Some(desc) = self.get_description(&name) {
+                    builder = builder.with_description(desc);
+                }
+                builder.init()
+            })
+            .clone();
+
+        Gauge::from_arc(Arc::new(OtelGauge {
+            inner: otel_gauge,
+            attributes,
+            current: AtomicU64::new(0f64.to_bits()),
+        }))
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        let name = key.name().to_string();
+        let attributes = key_to_attributes(key);
+
+        let otel_histogram = self
+            .otel_histograms
+            .entry(name.clone())
+            .or_insert_with(|| {
+                let meter = global::meter(METER_NAME);
+                let mut builder = meter.f64_histogram(name.clone());
+                if let Some(desc) = self.get_description(&name) {
+                    builder = builder.with_description(desc);
+                }
+                builder.init()
+            })
+            .clone();
+
+        Histogram::from_arc(Arc::new(OtelHistogram { inner: otel_histogram, attributes }))
+    }
+}
+
+/// Install the OTel-backed metrics recorder as the global `metrics` facade
+/// backend. Call this after the OTel `MeterProvider` has been set globally.
+pub fn install_recorder() {
+    if let Err(e) = metrics::set_global_recorder(OtelRecorder::new()) {
+        tracing::warn!("metrics recorder already installed: {e}");
     }
 }

--- a/lit-core/lit-observability/src/metrics.rs
+++ b/lit-core/lit-observability/src/metrics.rs
@@ -70,3 +70,26 @@ pub mod counter {
         counter.add(value, attributes);
     }
 }
+
+pub mod gauge {
+    use opentelemetry::{KeyValue, global};
+
+    pub fn record(metric: impl super::LitMetric, value: u64, attributes: &[KeyValue]) {
+        let meter = global::meter(metric.get_meter().to_string());
+        let name = metric.get_full_name().to_string();
+        let description = metric.get_description().to_string();
+        let unit = metric.get_unit().to_owned();
+
+        let mut gauge = meter.u64_gauge(name);
+
+        if !description.is_empty() {
+            gauge = gauge.with_description(description);
+        }
+        if !unit.is_empty() {
+            gauge = gauge.with_unit(unit);
+        }
+
+        let gauge = gauge.init();
+        gauge.record(value, attributes);
+    }
+}


### PR DESCRIPTION
## Summary
- **CPL-102**: Exposes the number of currently idle signers in the pool as an otel gauge metric (`signer_pool.idle_signers`), recorded after every pool state change (request, release, stale-lease cleanup, pool resize).
- **CPL-106**: Replaces the custom `LitMetric` trait and `counter`/`gauge` wrapper modules in `lit-observability` with the [`metrics`](https://crates.io/crates/metrics) facade crate. Implements an in-house `metrics::Recorder` bridge in `lit-observability` that forwards to the existing OTel `MeterProvider`, with DashMap-based instrument caching. All call sites now use standard `metrics::counter!` / `metrics::gauge!` macros — no more per-metric enum + 5-method trait boilerplate.

Closes CPL-102
Closes CPL-106

## Test plan
- [x] `cargo check` passes for lit-observability, lit-api-core, lit-api-server
- [x] `cargo test` — all relevant tests pass (2 pre-existing dstack TEE-only failures unrelated)
- [ ] Verify metrics appear in OTLP collector/Grafana in a deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)