### PR TITLE
Refactor js params for easier lit-action

### DIFF
--- a/docs/api_direct.mdx
+++ b/docs/api_direct.mdx
@@ -197,13 +197,15 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
     const result = await client.litAction({
       apiKey: accountApiKey,  // or usageApiKey
       code: `
-        const message = "Hello from Lit Action";
-        const sig = await LitActions.signEcdsa({ toSign: new TextEncoder().encode(message), publicKey, sigName });
-        LitActions.setResponse({ response: { message, sig } });
+        async function main() {
+          const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
+          const sig = await wallet.signMessage("Hello from Lit Action");
+          return { sig };
+        }
       `,
-      jsParams: { publicKey: '0x...', sigName: 'sig1' }
+      jsParams: { pkpId: '0x...' }
     });
-    console.log(result.signatures, result.response, result.logs);
+    console.log(result.response, result.logs);
     ```
   </Tab>
   <Tab title="cURL">
@@ -212,7 +214,7 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
     curl -s -X POST "http://localhost:8000/core/v1/lit_action" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: KEY" \
-      -d '{"code":"const msg = \"hello\"; LitActions.setResponse({ response: msg });","js_params":null}'
+      -d '{"code":"async function main() { return \"hello\"; }","js_params":null}'
     ```
   </Tab>
 </Tabs>

--- a/docs/lit-actions/examples.mdx
+++ b/docs/lit-actions/examples.mdx
@@ -13,13 +13,13 @@ The simplest pattern: retrieve a PKP's private key and sign an arbitrary message
 
 ```javascript
 // js_params: { pkpId, message }
-(async () => {
+async function main() {
   const wallet = new ethers.Wallet(
     await Lit.Actions.getPrivateKey({ pkpId })
   );
   const signature = await wallet.signMessage(message);
-  Lit.Actions.setResponse({ response: { message, signature } });
-})();
+  return { message, signature };
+}
 ```
 
 The caller can verify the signature against the PKP's public key (or wallet address) to confirm the message originated from this action.
@@ -32,10 +32,10 @@ Encrypt a sensitive string so that only the holder of the PKP can later decrypt 
 
 ```javascript
 // js_params: { pkpId, secret }
-(async () => {
+async function main() {
   const ciphertext = await Lit.Actions.Encrypt({ pkpId, message: secret });
-  Lit.Actions.setResponse({ response: { ciphertext } });
-})();
+  return { ciphertext };
+}
 ```
 
 Store the returned `ciphertext` anywhere — IPFS, a smart contract, a database — and retrieve the plaintext only when needed using the Decrypt action below.
@@ -48,10 +48,10 @@ Decrypt a ciphertext that was previously produced by `Lit.Actions.Encrypt` using
 
 ```javascript
 // js_params: { pkpId, ciphertext }
-(async () => {
+async function main() {
   const plaintext = await Lit.Actions.Decrypt({ pkpId, ciphertext });
-  Lit.Actions.setResponse({ response: { plaintext } });
-})();
+  return { plaintext };
+}
 ```
 
 ---
@@ -62,7 +62,7 @@ Fetch the current price of ETH from a public API and sign the result. The caller
 
 ```javascript
 // js_params: { pkpId }
-(async () => {
+async function main() {
   const res = await fetch(
     "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd"
   );
@@ -70,8 +70,7 @@ Fetch the current price of ETH from a public API and sign the result. The caller
   const price = data?.ethereum?.usd;
 
   if (typeof price !== "number") {
-    Lit.Actions.setResponse({ response: { error: "Price fetch failed" } });
-    return;
+    return { error: "Price fetch failed" };
   }
 
   const payload = `ETH/USD: ${price}`;
@@ -80,8 +79,8 @@ Fetch the current price of ETH from a public API and sign the result. The caller
   );
   const signature = await wallet.signMessage(payload);
 
-  Lit.Actions.setResponse({ response: { price, payload, signature } });
-})();
+  return { price, payload, signature };
+}
 ```
 
 A smart contract can call `ecrecover` on the signature to confirm the price was signed by a specific, known PKP address — without trusting any off-chain intermediary.
@@ -95,7 +94,7 @@ Only sign a message if the current temperature at a given location exceeds a thr
 ```javascript
 // js_params: { pkpId, city, minTempCelsius, message }
 // Example: { pkpId: "0x...", city: "London", minTempCelsius: 20, message: "Approved" }
-(async () => {
+async function main() {
   const apiKey = await Lit.Actions.Decrypt({ pkpId, ciphertext: encryptedWeatherApiKey });
 
   const res = await fetch(
@@ -105,15 +104,11 @@ Only sign a message if the current temperature at a given location exceeds a thr
   const temp = data?.main?.temp;
 
   if (typeof temp !== "number") {
-    Lit.Actions.setResponse({ response: { error: "Weather fetch failed" } });
-    return;
+    return { error: "Weather fetch failed" };
   }
 
   if (temp < minTempCelsius) {
-    Lit.Actions.setResponse({
-      response: { signed: false, reason: `Temperature ${temp}°C is below threshold of ${minTempCelsius}°C` },
-    });
-    return;
+    return { signed: false, reason: `Temperature ${temp}°C is below threshold of ${minTempCelsius}°C` };
   }
 
   const wallet = new ethers.Wallet(
@@ -121,8 +116,8 @@ Only sign a message if the current temperature at a given location exceeds a thr
   );
   const signature = await wallet.signMessage(message);
 
-  Lit.Actions.setResponse({ response: { signed: true, temp, message, signature } });
-})();
+  return { signed: true, temp, message, signature };
+}
 ```
 
 Note the use of `Lit.Actions.Decrypt` to retrieve the weather API key securely at runtime — the key is stored as ciphertext and never exposed in the action code or `js_params`. Pass `encryptedWeatherApiKey` as a `js_params` value (produced by Example 2).
@@ -136,7 +131,7 @@ Call a view function on an EVM smart contract and return the result. Useful for 
 ```javascript
 // js_params: { pkpId, contractAddress, holderAddress }
 // Checks the ERC-20 balance of holderAddress and signs the result.
-(async () => {
+async function main() {
   const rpcUrl = "https://mainnet.base.org";
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
 
@@ -159,10 +154,8 @@ Call a view function on an EVM smart contract and return the result. Useful for 
   );
   const signature = await wallet.signMessage(payload);
 
-  Lit.Actions.setResponse({
-    response: { holder: holderAddress, balance: balanceFormatted, symbol, payload, signature },
-  });
-})();
+  return { holder: holderAddress, balance: balanceFormatted, symbol, payload, signature };
+}
 ```
 
 ---
@@ -174,7 +167,7 @@ Construct, sign, and broadcast an ETH transfer transaction from a PKP wallet. Th
 ```javascript
 // js_params: { pkpId, toAddress, amountEth, chainId, rpcUrl }
 // Example: { pkpId: "0x...", toAddress: "0x...", amountEth: "0.001", chainId: 8453, rpcUrl: "https://mainnet.base.org" }
-(async () => {
+async function main() {
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
   const wallet = new ethers.Wallet(
     await Lit.Actions.getPrivateKey({ pkpId }),
@@ -189,16 +182,14 @@ Construct, sign, and broadcast an ETH transfer transaction from a PKP wallet. Th
 
   const receipt = await tx.wait();
 
-  Lit.Actions.setResponse({
-    response: {
-      txHash: receipt.transactionHash,
-      from: wallet.address,
-      to: toAddress,
-      amountEth,
-      blockNumber: receipt.blockNumber,
-    },
-  });
-})();
+  return {
+    txHash: receipt.transactionHash,
+    from: wallet.address,
+    to: toAddress,
+    amountEth,
+    blockNumber: receipt.blockNumber,
+  };
+}
 ```
 
 <Warning>

--- a/docs/lit-actions/index.mdx
+++ b/docs/lit-actions/index.mdx
@@ -64,7 +64,8 @@ Inside a Lit Action, the `Lit.Actions` namespace exposes the current SDK. Key fu
 
 | Function | Description |
 |---|---|
-| `Lit.Actions.setResponse({ response })` | Return a value to the caller |
+| `return value` (from `main`) | Return a value to the caller — the preferred response method |
+| `Lit.Actions.setResponse({ response })` | Legacy: set the response returned to the caller |
 | `Lit.Actions.getPrivateKey({ pkpId })` | Retrieve a PKP private key for signing |
 | `Lit.Actions.getLitActionPrivateKey()` | Retrieve this action's own identity key |
 | `Lit.Actions.Encrypt({ pkpId, message })` | Encrypt a string with a PKP-derived AES key |
@@ -78,16 +79,18 @@ For the full API reference, see [Lit Actions SDK](/lit_actions).
 
 ```javascript
 // Fetch ETH price from an API and sign it with a PKP.
-// pkpId and sigName are injected via js_params.
-const res = await fetch("https://api.example.com/eth-price");
-const { price } = await res.json();
+// pkpId is injected via js_params.
+async function main() {
+  const res = await fetch("https://api.example.com/eth-price");
+  const { price } = await res.json();
 
-const wallet = new ethers.Wallet(
-  await Lit.Actions.getPrivateKey({ pkpId })
-);
-const signature = await wallet.signMessage(`ETH price: ${price}`);
+  const wallet = new ethers.Wallet(
+    await Lit.Actions.getPrivateKey({ pkpId })
+  );
+  const signature = await wallet.signMessage(`ETH price: ${price}`);
 
-Lit.Actions.setResponse({ response: { price, signature } });
+  return { price, signature };
+}
 ```
 
 The caller receives both the price and a signature that can be verified against the PKP's public key — a cryptographic proof that this specific action fetched and attested to this specific price.

--- a/docs/lit-actions/migration/changes.mdx
+++ b/docs/lit-actions/migration/changes.mdx
@@ -14,6 +14,53 @@ Many capabilities that previously required runtime API calls — permission chec
 
 ---
 
+## Breaking Change: Action Entry Point and Response
+
+**Lit Actions must now be written as a `async function main()` that returns a value directly.**
+
+```js
+// New pattern
+async function main() {
+  const result = await doSomething();
+  return result;
+}
+```
+
+The old patterns — IIFE (`(async () => { ... })()`) and `Lit.Actions.setResponse({ response })` — are no longer the recommended way to write actions. Use `return` from `main` to send a response to the caller.
+
+**Before:**
+```js
+(async () => {
+  const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
+  const sig = await wallet.signMessage(message);
+  Lit.Actions.setResponse({ response: { sig } });
+})();
+```
+
+**After:**
+```js
+async function main() {
+  const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
+  const sig = await wallet.signMessage(message);
+  return { sig };
+}
+```
+
+Early exits that previously called `setResponse` and then `return` now just `return` the value directly:
+
+```js
+async function main() {
+  if (!condition) {
+    return { error: "condition not met" };
+  }
+  // ...
+}
+```
+
+---
+
+---
+
 ## Current Actions
 
 These actions are available in the current SDK (`Lit.Actions.*`).
@@ -140,9 +187,11 @@ Previously asked the Lit Node to sign a message using the `eth_personalSign` alg
 
 **Replacement:** Use `Lit.Actions.getPrivateKey({ pkpId })` to retrieve the private key, then sign with `ethers.Wallet`:
 ```js
-const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
-const sig = await wallet.signMessage(message);
-Lit.Actions.setResponse({ response: sig });
+async function main() {
+  const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
+  const sig = await wallet.signMessage(message);
+  return sig;
+}
 ```
 
 ---

--- a/docs/lit-actions/migration/encryption.mdx
+++ b/docs/lit-actions/migration/encryption.mdx
@@ -40,32 +40,32 @@ Because the action is just an HTTP call, no SDK is required — you can call the
 
 ```js
 // jsParams: { pkpId, message, optional-userToken }
+async function main() {
+  // Optional gate: verify caller before encrypting
+  const authRes = await some-gated-check;
+  if (!authRes.ok) {
+    return { error: 'Unauthorized' };
+  }
 
-// Optional gate: verify caller before encrypting
-const authRes = await some-gated-check
-if (!authRes.ok) {
-  Lit.Actions.setResponse({ response: { error: 'Unauthorized' } });
-  return;
+  const ciphertext = await Lit.Actions.Encrypt({ pkpId, message });
+  return { ciphertext };
 }
-
-const ciphertext = await Lit.Actions.Encrypt({ pkpId, message });
-Lit.Actions.setResponse({ response: { ciphertext } });
 ```
 
 ### Decrypt (with optional gating)
 
 ```js
 // jsParams: { pkpId, ciphertext, optional-userToken }
+async function main() {
+  // Optional gate: check condition before decrypting
+  const authRes = await some-gated-check;
+  if (!authRes.ok) {
+    return { error: 'Unauthorized' };
+  }
 
-// Optional gate: check condition before decrypting
-const authRes = await some-gated-check
-if (!authRes.ok) {
-  Lit.Actions.setResponse({ response: { error: 'Unauthorized' } });
-  return;
+  const plaintext = await Lit.Actions.Decrypt({ pkpId, ciphertext });
+  return { plaintext };
 }
-
-const plaintext = await Lit.Actions.Decrypt({ pkpId, ciphertext });
-Lit.Actions.setResponse({ response: { plaintext } });
 ```
 
 The gate can be anything — an auth token check, a smart contract read, a price feed, a weather API, or simply a value in `jsParams`. The encrypt/decrypt calls only happen if your logic allows it.

--- a/k6/LitActionCode/decrypt.js
+++ b/k6/LitActionCode/decrypt.js
@@ -1,4 +1,4 @@
-(async () => {
+const main = async () => {
   const plaintext = await Lit.Actions.Decrypt({ pkpId, ciphertext });
-  Lit.Actions.setResponse({ response: plaintext });
-})();
+  return plaintext;
+};

--- a/k6/LitActionCode/ecdsa-sign.js
+++ b/k6/LitActionCode/ecdsa-sign.js
@@ -1,16 +1,13 @@
-const go = async () => {
+const main = async () => {
   const privateKey = await Lit.Actions.getLitActionPrivateKey();
 
   const wallet = new ethers.Wallet(privateKey);
   const signature = await wallet.signMessage("Chipotle Rocks!");
   const publicKey = wallet.publicKey;
 
-  const data = {
+  return {
     wallet_address: wallet.address,
     signature: signature,
     publicKey: publicKey,
   };
-
-  Lit.Actions.setResponse({ response: data });
 };
-go();

--- a/k6/LitActionCode/encrypt.js
+++ b/k6/LitActionCode/encrypt.js
@@ -1,4 +1,4 @@
-(async () => {
+const main = async () => {
   const ciphertext = await Lit.Actions.Encrypt({ pkpId, message: challenge });
-  Lit.Actions.setResponse({ response: ciphertext });
-})();
+  return ciphertext;
+};

--- a/k6/LitActionCode/hello-world.js
+++ b/k6/LitActionCode/hello-world.js
@@ -1,1 +1,3 @@
-Lit.Actions.setResponse({response: "Hello World!"})
+const main = async () => {
+  return "Hello World!";
+};

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -320,7 +320,9 @@ pub(crate) async fn execute_js(
     
         (async () => {{
         const data = await main( {{ {js_func_params} }} );
-        LitActions.setResponse( {{ response: data }} );
+        if (typeof data !== \"undefined\") {{
+          LitActions.setResponse( {{ response: data }} );
+        }}
     }})();"
     );
 

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -302,16 +302,8 @@ pub(crate) async fn execute_js(
     )
     .await?;
 
-    // Convert js_params to a string of key:value pairs
     let js_params = js_params.as_ref().unwrap_or_default();
-    let js_func_params = match js_params.as_object().ok_or("".to_string()) {
-        Ok(obj) => obj
-            .iter()
-            .map(|(key, value)| format!(" {} : {} ", key, value))
-            .collect::<Vec<String>>()
-            .join(", "),
-        Err(_) => "".to_string(),
-    };
+    let js_func_params = js_params.to_string();
 
     // Add a wrapper function so that we can catch "return" statements and set the response
     let code = format!(
@@ -319,7 +311,8 @@ pub(crate) async fn execute_js(
       {code}
     
         (async () => {{
-        const data = await main( {{ {js_func_params} }} );
+        const params = {js_func_params} ;
+         const data = await main(params);
         if (typeof data !== \"undefined\") {{
           LitActions.setResponse( {{ response: data }} );
         }}

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -259,14 +259,10 @@ pub(crate) async fn execute_js(
     let timeout_ms = timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
     let memory_limit_mb = memory_limit_mb.unwrap_or(DEFAULT_MEMORY_LIMIT_MB);
 
-    let mut worker = build_main_worker_and_inject_sdk(
-        &js_params,
-        &auth_context,
-        http_headers,
-        Some(memory_limit_mb),
-    )
-    .context("Error building main worker")
-    .map_err(|e| anyhow!("{e:#}"))?; // Ensure to keep context when downcasting JS errors later
+    let mut worker =
+        build_main_worker_and_inject_sdk(&None, &auth_context, http_headers, Some(memory_limit_mb))
+            .context("Error building main worker")
+            .map_err(|e| anyhow!("{e:#}"))?; // Ensure to keep context when downcasting JS errors later
 
     let op_state = worker.js_runtime.op_state();
     {
@@ -305,6 +301,28 @@ pub(crate) async fn execute_js(
         is_test_server,
     )
     .await?;
+
+    // Convert js_params to a string of key:value pairs
+    let js_params = js_params.as_ref().unwrap_or_default();
+    let js_func_params = match js_params.as_object().ok_or("".to_string()) {
+        Ok(obj) => obj
+            .iter()
+            .map(|(key, value)| format!(" {} : {} ", key, value))
+            .collect::<Vec<String>>()
+            .join(", "),
+        Err(_) => "".to_string(),
+    };
+
+    // Add a wrapper function so that we can catch "return" statements and set the response
+    let code = format!(
+        "
+      {code}
+    
+        (async () => {{
+        const data = await main( {{ {js_func_params} }} );
+        LitActions.setResponse( {{ response: data }} );
+    }})();"
+    );
 
     if let Err(e) = worker
         .js_runtime


### PR DESCRIPTION
### WHAT

Refactor to lit-actions code - every lit-action must now contain a `main` function that is the entry point ( from the user perspective ).    jsParams stay the same, but are turned into actual params that used by a immediate wrapper function that calls `main`, and catchs the return value from main, automatically setting the response.

<img width="814" height="664" alt="image" src="https://github.com/user-attachments/assets/48ab5e20-0746-4421-a5e2-6240fed3903d" />


### NOTES
- this is a breaking change for anyone that has written an action.
- Designed for async support functions only.