### PR TITLE
feat: add run-specific X-Correlation-Id to k6 tests

### DIFF
--- a/.github/workflows/correctness.yml
+++ b/.github/workflows/correctness.yml
@@ -29,28 +29,33 @@ jobs:
       - name: observability-headers.spec.ts
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-observability-headers
         run: k6 run k6/correctness/observability-headers.spec.ts
 
       - name: integration.spec.ts
         if: ${{ !cancelled() }}
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-integration
         run: k6 run k6/correctness/integration.spec.ts
 
       - name: new-account.spec.ts
         if: ${{ !cancelled() }}
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-new-account
         run: k6 run k6/correctness/new-account.spec.ts
 
       - name: lit-action-ecdsa-sign.spec.ts
         if: ${{ !cancelled() }}
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-ecdsa-sign
         run: k6 run k6/correctness/lit-action-ecdsa-sign.spec.ts
 
       - name: lit-action-encrypt-decrypt.spec.ts
         if: ${{ !cancelled() }}
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-encrypt-decrypt
         run: k6 run k6/correctness/lit-action-encrypt-decrypt.spec.ts

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -29,4 +29,5 @@ jobs:
       - name: smoke.spec.ts
         env:
           BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-smoke
         run: k6 run k6/smoke.spec.ts

--- a/justfile
+++ b/justfile
@@ -81,11 +81,12 @@ test *names='smoke':
     set -eu
     command -v k6 >/dev/null 2>&1 || { echo "error: k6 not found. Install from https://grafana.com/docs/k6/latest/set-up/install-k6/"; exit 1; }
     for t in {{names}}; do
+        corr_id="k6-$(date +%s)-$(head -c 3 /dev/urandom | od -An -tx1 | tr -d ' \n')"
         case "$t" in
-            smoke)       k6 run k6/smoke.spec.ts ;;
-            integration) k6 run k6/integration.spec.ts ;;
-            ecdsa-sign)  k6 run k6/lit-action-ecdsa-sign.spec.ts ;;
-            sample)      k6 run k6/k6-script.sample.ts ;;
+            smoke)       K6_CORRELATION_ID="$corr_id" k6 run k6/smoke.spec.ts ;;
+            integration) K6_CORRELATION_ID="$corr_id" k6 run k6/integration.spec.ts ;;
+            ecdsa-sign)  K6_CORRELATION_ID="$corr_id" k6 run k6/lit-action-ecdsa-sign.spec.ts ;;
+            sample)      K6_CORRELATION_ID="$corr_id" k6 run k6/k6-script.sample.ts ;;
             *) echo "error: unknown test '$t'. Available: smoke, integration, ecdsa-sign, sample"; exit 1 ;;
         esac
     done

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -11,7 +11,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { createAccountAndUsageKey } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 export interface IntegrationSetupData {
   apiKey: string;
@@ -42,7 +42,7 @@ export const options = {
 };
 
 export default function (data: IntegrationSetupData) {
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
   const authHeaders = { "X-Api-Key": data.apiKey };
 
   // ── 1. getNodeChainConfig ─────────────────────────────────────────────────

--- a/k6/correctness/lit-action-ecdsa-sign.spec.ts
+++ b/k6/correctness/lit-action-ecdsa-sign.spec.ts
@@ -14,7 +14,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { createAccountAndUsageKey } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ECDSA_SIGN_CODE } from "../LitActionCode/index.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 export const options = {
   vus: 1,
@@ -39,7 +39,7 @@ export function setup() {
 }
 
 export default function (data: { usageKeyHeaders: { "X-Api-Key": string } }) {
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
 
   const litActionRes = client.litAction(
     {

--- a/k6/correctness/lit-action-encrypt-decrypt.spec.ts
+++ b/k6/correctness/lit-action-encrypt-decrypt.spec.ts
@@ -18,7 +18,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { createAccountAndUsageKey } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ENCRYPT_CODE, DECRYPT_CODE } from "../LitActionCode/index.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 export interface EncryptDecryptSetupData {
   usageApiKey: string;
@@ -48,7 +48,7 @@ export const options = {
 };
 
 export default function (data: EncryptDecryptSetupData) {
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
   const { usageApiKey, pkpId } = data;
   const usageKeyHeaders = { "X-Api-Key": usageApiKey };
 

--- a/k6/correctness/new-account.spec.ts
+++ b/k6/correctness/new-account.spec.ts
@@ -9,7 +9,7 @@ import { sleep } from "k6";
 import { checkAndLog } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";
 import { assertOk } from "../helpers.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 export const options = {
   vus: 2,
@@ -25,7 +25,7 @@ export default function () {
   // Stagger start to reduce simultaneous blockchain tx submissions (avoids nonce conflicts)
   sleep(Math.random() * 2);
 
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
 
   // Unique account name per VU/iteration to avoid conflicts under concurrency
   const accountName = `k6-new-account-vu${__VU}-i${__ITER}-${Date.now()}`;

--- a/k6/correctness/new-account.spec.ts
+++ b/k6/correctness/new-account.spec.ts
@@ -9,7 +9,7 @@ import { sleep } from "k6";
 import { checkAndLog } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";
 import { assertOk } from "../helpers.ts";
-import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "../defaults.ts";
 
 export const options = {
   vus: 2,
@@ -20,6 +20,10 @@ export const options = {
     checks: ["rate==1"],
   },
 };
+
+export function setup() {
+  console.log(`k6 run correlation id: ${K6_RUN_ID}`);
+}
 
 export default function () {
   // Stagger start to reduce simultaneous blockchain tx submissions (avoids nonce conflicts)

--- a/k6/correctness/observability-headers.spec.ts
+++ b/k6/correctness/observability-headers.spec.ts
@@ -18,7 +18,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { createAccountAndUsageKey } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 const SIMPLE_ENDPOINT = `${BASE_URL}/get_node_chain_config`;
 
@@ -54,7 +54,7 @@ export function setup(): ObservabilitySetupData {
 
 export default function (data: ObservabilitySetupData) {
   const { usageApiKey } = data;
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
 
   // ── 1. Simple endpoint: X-Request-Id is present and UUID v4 ────────────
   {

--- a/k6/defaults.ts
+++ b/k6/defaults.ts
@@ -10,9 +10,14 @@ export const BASE_URL =
 /**
  * A unique ID for this k6 run, used as the X-Correlation-Id header so that
  * every request from a single run can be correlated in server-side logs.
+ *
+ * Pass K6_CORRELATION_ID as an env var to ensure the same ID is used across
+ * all k6 phases (init, setup, VU, teardown). The justfile recipes do this
+ * automatically. Without it, each phase generates its own ID.
  */
-export const K6_RUN_ID = `k6-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-console.log(`k6 run correlation id: ${K6_RUN_ID}`);
+export const K6_RUN_ID =
+  __ENV.K6_CORRELATION_ID ||
+  `k6-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 /**
  * Common request parameters applied to every LitApiServerClient instance.

--- a/k6/defaults.ts
+++ b/k6/defaults.ts
@@ -12,6 +12,7 @@ export const BASE_URL =
  * every request from a single run can be correlated in server-side logs.
  */
 export const K6_RUN_ID = `k6-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+console.log(`k6 run correlation id: ${K6_RUN_ID}`);
 
 /**
  * Common request parameters applied to every LitApiServerClient instance.

--- a/k6/defaults.ts
+++ b/k6/defaults.ts
@@ -2,5 +2,23 @@
  * Shared defaults for k6 tests.
  * BASE_URL can be overridden via the BASE_URL environment variable.
  */
+import type { Params } from "k6/http";
+
 export const BASE_URL =
   __ENV.BASE_URL || "https://api.dev.litprotocol.com/core/v1";
+
+/**
+ * A unique ID for this k6 run, used as the X-Correlation-Id header so that
+ * every request from a single run can be correlated in server-side logs.
+ */
+export const K6_RUN_ID = `k6-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/**
+ * Common request parameters applied to every LitApiServerClient instance.
+ * Injects the run-specific X-Correlation-Id header.
+ */
+export const COMMON_PARAMS: Params = {
+  headers: {
+    "X-Correlation-Id": K6_RUN_ID,
+  },
+};

--- a/k6/helpers.ts
+++ b/k6/helpers.ts
@@ -39,6 +39,19 @@ export function checkAndLog<T>(
 }
 
 /**
+ * Extract X-Correlation-Id and X-Request-Id from a response for diagnostics.
+ */
+function responseTraceIds(response: Response | undefined): string {
+  if (!response?.headers) return "";
+  const correlationId = response.headers["X-Correlation-Id"] ?? "";
+  const requestId = response.headers["X-Request-Id"] ?? "";
+  const parts: string[] = [];
+  if (correlationId) parts.push(`correlation_id=${correlationId}`);
+  if (requestId) parts.push(`request_id=${requestId}`);
+  return parts.length > 0 ? ` | ${parts.join(" ")}` : "";
+}
+
+/**
  * Assert HTTP response is 2xx. Logs failure and runs checkAndLog for k6 metrics.
  * Returns true if ok, false otherwise.
  */
@@ -66,7 +79,7 @@ export function assertOk(
         msg = (response.body as string) || "(no body)";
       }
     }
-    console.error(`FAIL ${name} | ${endpoint} | ${status} | ${msg}`);
+    console.error(`FAIL ${name} | ${endpoint} | ${status} | ${msg}${responseTraceIds(response)}`);
   }
   checkAndLog(response, {
     [`${name} 2xx`]: (r) =>

--- a/k6/justfile
+++ b/k6/justfile
@@ -10,15 +10,16 @@
 #   just spike BASE_URL='https://other.example.com/core/v1'
 
 _default_base_url := 'https://api.dev.litprotocol.com/core/v1'
+_corr_id := `echo "k6-$(date +%s)-$(head -c 3 /dev/urandom | od -An -tx1 | tr -d ' \n')"`
 
 soak BASE_URL=_default_base_url:
-    BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/soak.spec.ts
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/soak.spec.ts
 
 soak-local BASE_URL=_default_base_url:
-    BASE_URL={{BASE_URL}} k6 run loadtest/soak.spec.ts
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run loadtest/soak.spec.ts
 
 spike BASE_URL=_default_base_url:
-    BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/spike.spec.ts
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/spike.spec.ts
 
 spike-local BASE_URL=_default_base_url:
-    BASE_URL={{BASE_URL}} k6 run loadtest/spike.spec.ts
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run loadtest/spike.spec.ts

--- a/k6/justfile
+++ b/k6/justfile
@@ -2,6 +2,8 @@
 # Or cd k6 && just <recipe>
 #
 # Usage:
+#   just smoke
+#   just smoke-local
 #   just soak
 #   just soak-local
 #   just spike
@@ -12,8 +14,15 @@
 _default_base_url := 'https://api.dev.litprotocol.com/core/v1'
 _corr_id := `echo "k6-$(date +%s)-$(head -c 3 /dev/urandom | od -An -tx1 | tr -d ' \n')"`
 
+smoke BASE_URL=_default_base_url:
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run --out cloud smoke.spec.ts
+
+smoke-local BASE_URL=_default_base_url:
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run smoke.spec.ts
+
 soak BASE_URL=_default_base_url:
-    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/soak.spec.ts
+    # K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/soak.spec.ts
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run --out cloud loadtest/soak.spec.ts
 
 soak-local BASE_URL=_default_base_url:
     K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 run loadtest/soak.spec.ts

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -38,7 +38,7 @@ import {
   ENCRYPT_CODE,
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
-import { BASE_URL } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
 
 // Parse duration: "1h", "30m", "10m" etc.
 const SOAK_DURATION = __ENV.SOAK_DURATION || "30m";
@@ -117,7 +117,7 @@ export function setup(): SoakSetupData {
 }
 
 export default function (setupData: SoakSetupData) {
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
   const account = setupData[__VU - 1];
   const usageKeyHeaders = { "X-Api-Key": account.usageApiKey };
 

--- a/k6/setup.ts
+++ b/k6/setup.ts
@@ -4,7 +4,7 @@
  */
 import { LitApiServerClient } from "./litApiServer.ts";
 import { assertOk } from "./helpers.ts";
-import { BASE_URL } from "./defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
 
 export interface AccountAndUsageKey {
   apiKey: string;
@@ -26,6 +26,7 @@ export function createAccountAndUsageKey(options: {
 }): AccountAndUsageKey {
   const client = new LitApiServerClient({
     baseUrl: options.baseUrl ?? BASE_URL,
+    commonRequestParameters: COMMON_PARAMS,
   });
   const prefix = options.setupContext ? `${options.setupContext}/` : "setup/";
 

--- a/k6/setup.ts
+++ b/k6/setup.ts
@@ -4,7 +4,7 @@
  */
 import { LitApiServerClient } from "./litApiServer.ts";
 import { assertOk } from "./helpers.ts";
-import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
+import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "./defaults.ts";
 
 export interface AccountAndUsageKey {
   apiKey: string;
@@ -24,6 +24,7 @@ export function createAccountAndUsageKey(options: {
   usageKeyDescription: string;
   setupContext?: string;
 }): AccountAndUsageKey {
+  console.log(`k6 run correlation id: ${K6_RUN_ID}`);
   const client = new LitApiServerClient({
     baseUrl: options.baseUrl ?? BASE_URL,
     commonRequestParameters: COMMON_PARAMS,

--- a/k6/smoke.spec.ts
+++ b/k6/smoke.spec.ts
@@ -7,7 +7,7 @@ import { LitApiServerClient } from "./litApiServer.ts";
 import { createAccountAndUsageKey } from "./setup.ts";
 import { assertOk } from "./helpers.ts";
 import { HELLO_WORLD_CODE } from "./LitActionCode/index.ts";
-import { BASE_URL } from "./defaults.ts";
+import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
 
 export const options = {
   vus: 1,
@@ -35,7 +35,7 @@ export function setup(): SmokeSetupData {
 }
 
 export default function (data: SmokeSetupData) {
-  const client = new LitApiServerClient({ baseUrl: BASE_URL });
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
   const usageKeyHeaders = { "X-Api-Key": data.usageApiKey };
 
   // 1. Public endpoint (no auth)


### PR DESCRIPTION
## Summary
- Generates a unique `K6_RUN_ID` (e.g., `k6-1710648000000-a3b2c1`) per test run and sends it as the `X-Correlation-Id` header on every HTTP request via `commonRequestParameters`
- On failed requests, `assertOk` now logs the `X-Correlation-Id` and `X-Request-Id` response headers so failures can be traced to server-side logs
- Updated all 9 `LitApiServerClient` construction sites across specs, setup, and load tests

## Test plan
- [x] All k6 scripts updated consistently
- [ ] Run a k6 smoke test and verify correlation ID appears in request headers and failure output

🤖 Generated with [Claude Code](https://claude.com/claude-code)