### PR TITLE
fix: k6 observability-headers test fails with COMMON_PARAMS correlation ID

### DIFF
--- a/k6/correctness/observability-headers.spec.ts
+++ b/k6/correctness/observability-headers.spec.ts
@@ -160,7 +160,9 @@ export default function (data: ObservabilitySetupData) {
 
   // ── 8. lit_action: no correlation header when not sent ─────────────────
   {
-    const laRes = client.litAction(
+    // Use a client without COMMON_PARAMS so X-Correlation-Id is truly absent.
+    const bareClient = new LitApiServerClient({ baseUrl: BASE_URL });
+    const laRes = bareClient.litAction(
       { code: HELLO_WORLD_CODE, js_params: null },
       { "X-Api-Key": usageApiKey } as any,
     );


### PR DESCRIPTION
## Summary
- The `lit_action no-corr: X-Correlation-Id absent` test fails because `COMMON_PARAMS` (added in #141) now injects `X-Correlation-Id` on every request, including the test case that verifies the header is absent when not sent.
- Fix: use a bare `LitApiServerClient` without `COMMON_PARAMS` for this specific test case.

## Test plan
- [x] Run `k6 run k6/correctness/observability-headers.spec.ts` locally — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)