### PR TITLE
feat: add GitHub Action for contract upgrades (CPL-109)

### DIFF
--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -1,0 +1,95 @@
+# Upgrade (or deploy) Diamond contracts on Base Sepolia or Base Mainnet.
+#
+# This workflow compiles the Solidity contracts, builds the Rust
+# contract_deployer binary, and runs it with the chosen action/network.
+#
+# Required secrets:
+#   CONTRACT_DEPLOYER_SECRET       - deployer wallet private key (Base Sepolia)
+#   CONTRACT_DEPLOYER_SECRET_BASE  - deployer wallet private key (Base Mainnet)
+
+name: Contract Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "deploy (new diamond) or update (existing diamond)"
+        required: true
+        type: choice
+        options:
+          - update
+          - deploy
+        default: update
+      network:
+        description: "Target network"
+        required: true
+        type: choice
+        options:
+          - base-sepolia
+          - base
+        default: base-sepolia
+      address:
+        description: "Diamond contract address (required for update)"
+        required: false
+        type: string
+
+concurrency:
+  group: contract-upgrade-${{ github.event.inputs.network }}
+  cancel-in-progress: false
+
+jobs:
+  contract-upgrade:
+    name: ${{ inputs.action }} on ${{ inputs.network }}
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.action }}" = "update" ] && [ -z "${{ inputs.address }}" ]; then
+            echo "::error::Diamond contract address is required for the update action."
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@1.91
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install contract dependencies
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: |
+          npx hardhat clean
+          npx hardhat compile
+          node generate-diamond-abi.mjs
+
+      - name: Build contract deployer
+        working-directory: lit-api-server/blockchain/rust_generator_and_deployer
+        run: cargo build --bin contract_deployer
+
+      - name: Select deployer secret
+        id: secret
+        run: |
+          if [ "${{ inputs.network }}" = "base" ]; then
+            echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_BASE }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run contract deployer
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: |
+          DEPLOYER=../rust_generator_and_deployer/target/debug/contract_deployer
+
+          ARGS="--action=${{ inputs.action }} --network=${{ inputs.network }} --abifolder=artifacts/contracts --secret=${{ steps.secret.outputs.key }}"
+
+          if [ "${{ inputs.action }}" = "update" ]; then
+            ARGS="$ARGS --address=${{ inputs.address }}"
+          fi
+
+          $DEPLOYER $ARGS

--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -1,32 +1,30 @@
 # Upgrade existing Diamond contract facets.
 #
-# Network and contract address are read from the NodeConfig file that
-# matches the branch the workflow runs on:
-#   main  → lit-api-server/NodeConfig.main.toml
-#   next  → lit-api-server/NodeConfig.next.toml
-#
-# Both values can be overridden via the optional workflow inputs.
+# Network and contract address are always read from the NodeConfig file
+# for the selected branch:
+#   main → lit-api-server/NodeConfig.main.toml
+#   next → lit-api-server/NodeConfig.next.toml
 #
 # Required secrets:
 #   CONTRACT_DEPLOYER_SECRET_SEPOLIA - deployer wallet private key (Base Sepolia)
-#   CONTRACT_DEPLOYER_SECRET_BASE  - deployer wallet private key (Base Mainnet)
+#   CONTRACT_DEPLOYER_SECRET_BASE    - deployer wallet private key (Base Mainnet)
 
 name: Contract Upgrade
 
 on:
   workflow_dispatch:
     inputs:
-      network:
-        description: "Target network (leave empty to read from NodeConfig)"
-        required: false
-        type: string
-      address:
-        description: "Diamond contract address (leave empty to read from NodeConfig)"
-        required: false
-        type: string
+      branch:
+        description: "Branch whose NodeConfig to use"
+        required: true
+        type: choice
+        options:
+          - next
+          - main
+        default: next
 
 concurrency:
-  group: contract-upgrade-${{ github.ref_name }}
+  group: contract-upgrade-${{ inputs.branch }}
   cancel-in-progress: false
 
 jobs:
@@ -34,52 +32,25 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Read config from NodeConfig
         id: config
         run: |
-          BRANCH="${{ github.ref_name }}"
+          CONFIG="lit-api-server/NodeConfig.${{ inputs.branch }}.toml"
 
-          if [ "$BRANCH" = "main" ]; then
-            CONFIG="lit-api-server/NodeConfig.main.toml"
-          elif [ "$BRANCH" = "next" ]; then
-            CONFIG="lit-api-server/NodeConfig.next.toml"
-          else
-            echo "::warning::Branch '$BRANCH' has no NodeConfig file — inputs are required."
-            CONFIG=""
-          fi
-
-          if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
-            CHAIN_NAME=$(grep '^name' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-            CONTRACT_ADDR=$(grep '^contract_address' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-            echo "config_network=$CHAIN_NAME" >> "$GITHUB_OUTPUT"
-            echo "config_address=$CONTRACT_ADDR" >> "$GITHUB_OUTPUT"
-            echo "Resolved from $CONFIG: network=$CHAIN_NAME address=$CONTRACT_ADDR"
-          fi
-
-      - name: Resolve network and address
-        id: resolve
-        run: |
-          # Prefer explicit inputs; fall back to NodeConfig values.
-          NETWORK="${{ inputs.network }}"
-          ADDRESS="${{ inputs.address }}"
-
-          [ -z "$NETWORK" ] && NETWORK="${{ steps.config.outputs.config_network }}"
-          [ -z "$ADDRESS" ] && ADDRESS="${{ steps.config.outputs.config_address }}"
-
-          if [ -z "$NETWORK" ]; then
-            echo "::error::Could not determine network — set it via input or ensure a NodeConfig exists for this branch."
+          if [ ! -f "$CONFIG" ]; then
+            echo "::error::$CONFIG not found."
             exit 1
           fi
 
-          if [ -z "$ADDRESS" ]; then
-            echo "::error::Could not determine contract address — set it via input or ensure a NodeConfig exists for this branch."
-            exit 1
-          fi
+          NETWORK=$(grep '^name' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          ADDRESS=$(grep '^contract_address' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
 
           echo "network=$NETWORK" >> "$GITHUB_OUTPUT"
           echo "address=$ADDRESS" >> "$GITHUB_OUTPUT"
-          echo "Resolved: network=$NETWORK address=$ADDRESS"
+          echo "Resolved from $CONFIG: network=$NETWORK address=$ADDRESS"
 
       - uses: dtolnay/rust-toolchain@1.91
 
@@ -105,7 +76,7 @@ jobs:
       - name: Select deployer secret
         id: secret
         run: |
-          if [ "${{ steps.resolve.outputs.network }}" = "base" ]; then
+          if [ "${{ steps.config.outputs.network }}" = "base" ]; then
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_BASE }}" >> "$GITHUB_OUTPUT"
           else
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_SEPOLIA }}" >> "$GITHUB_OUTPUT"
@@ -116,7 +87,7 @@ jobs:
         run: |
           ../rust_generator_and_deployer/target/debug/contract_deployer \
             --action=update \
-            --network=${{ steps.resolve.outputs.network }} \
+            --network=${{ steps.config.outputs.network }} \
             --abifolder=artifacts/contracts \
             --secret=${{ steps.secret.outputs.key }} \
-            --address=${{ steps.resolve.outputs.address }}
+            --address=${{ steps.config.outputs.address }}

--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -1,7 +1,11 @@
-# Upgrade (or deploy) Diamond contracts on Base Sepolia or Base Mainnet.
+# Upgrade (or deploy) Diamond contracts.
 #
-# This workflow compiles the Solidity contracts, builds the Rust
-# contract_deployer binary, and runs it with the chosen action/network.
+# Network and contract address are read from the NodeConfig file that
+# matches the branch the workflow runs on:
+#   main  → lit-api-server/NodeConfig.main.toml
+#   next  → lit-api-server/NodeConfig.next.toml
+#
+# Both values can be overridden via the optional workflow inputs.
 #
 # Required secrets:
 #   CONTRACT_DEPLOYER_SECRET       - deployer wallet private key (Base Sepolia)
@@ -21,35 +25,69 @@ on:
           - deploy
         default: update
       network:
-        description: "Target network"
-        required: true
-        type: choice
-        options:
-          - base-sepolia
-          - base
-        default: base-sepolia
+        description: "Target network (leave empty to read from NodeConfig)"
+        required: false
+        type: string
       address:
-        description: "Diamond contract address (required for update)"
+        description: "Diamond contract address (leave empty to read from NodeConfig)"
         required: false
         type: string
 
 concurrency:
-  group: contract-upgrade-${{ github.event.inputs.network }}
+  group: contract-upgrade-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   contract-upgrade:
-    name: ${{ inputs.action }} on ${{ inputs.network }}
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate inputs
+      - name: Read config from NodeConfig
+        id: config
         run: |
-          if [ "${{ inputs.action }}" = "update" ] && [ -z "${{ inputs.address }}" ]; then
-            echo "::error::Diamond contract address is required for the update action."
+          BRANCH="${{ github.ref_name }}"
+
+          if [ "$BRANCH" = "main" ]; then
+            CONFIG="lit-api-server/NodeConfig.main.toml"
+          elif [ "$BRANCH" = "next" ]; then
+            CONFIG="lit-api-server/NodeConfig.next.toml"
+          else
+            echo "::warning::Branch '$BRANCH' has no NodeConfig file — inputs are required."
+            CONFIG=""
+          fi
+
+          if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]; then
+            CHAIN_NAME=$(grep '^name' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+            CONTRACT_ADDR=$(grep '^contract_address' "$CONFIG" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+            echo "config_network=$CHAIN_NAME" >> "$GITHUB_OUTPUT"
+            echo "config_address=$CONTRACT_ADDR" >> "$GITHUB_OUTPUT"
+            echo "Resolved from $CONFIG: network=$CHAIN_NAME address=$CONTRACT_ADDR"
+          fi
+
+      - name: Resolve network and address
+        id: resolve
+        run: |
+          # Prefer explicit inputs; fall back to NodeConfig values.
+          NETWORK="${{ inputs.network }}"
+          ADDRESS="${{ inputs.address }}"
+
+          [ -z "$NETWORK" ] && NETWORK="${{ steps.config.outputs.config_network }}"
+          [ -z "$ADDRESS" ] && ADDRESS="${{ steps.config.outputs.config_address }}"
+
+          if [ -z "$NETWORK" ]; then
+            echo "::error::Could not determine network — set it via input or ensure a NodeConfig exists for this branch."
             exit 1
           fi
+
+          if [ "${{ inputs.action }}" = "update" ] && [ -z "$ADDRESS" ]; then
+            echo "::error::Could not determine contract address for update — set it via input or ensure a NodeConfig exists for this branch."
+            exit 1
+          fi
+
+          echo "network=$NETWORK" >> "$GITHUB_OUTPUT"
+          echo "address=$ADDRESS" >> "$GITHUB_OUTPUT"
+          echo "Resolved: action=${{ inputs.action }} network=$NETWORK address=$ADDRESS"
 
       - uses: dtolnay/rust-toolchain@1.91
 
@@ -75,7 +113,7 @@ jobs:
       - name: Select deployer secret
         id: secret
         run: |
-          if [ "${{ inputs.network }}" = "base" ]; then
+          if [ "${{ steps.resolve.outputs.network }}" = "base" ]; then
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_BASE }}" >> "$GITHUB_OUTPUT"
           else
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET }}" >> "$GITHUB_OUTPUT"
@@ -86,10 +124,10 @@ jobs:
         run: |
           DEPLOYER=../rust_generator_and_deployer/target/debug/contract_deployer
 
-          ARGS="--action=${{ inputs.action }} --network=${{ inputs.network }} --abifolder=artifacts/contracts --secret=${{ steps.secret.outputs.key }}"
+          ARGS="--action=${{ inputs.action }} --network=${{ steps.resolve.outputs.network }} --abifolder=artifacts/contracts --secret=${{ steps.secret.outputs.key }}"
 
           if [ "${{ inputs.action }}" = "update" ]; then
-            ARGS="$ARGS --address=${{ inputs.address }}"
+            ARGS="$ARGS --address=${{ steps.resolve.outputs.address }}"
           fi
 
           $DEPLOYER $ARGS

--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -7,7 +7,7 @@
 #
 # Required secrets:
 #   CONTRACT_DEPLOYER_SECRET_SEPOLIA - deployer wallet private key (Base Sepolia)
-#   CONTRACT_DEPLOYER_SECRET_BASE    - deployer wallet private key (Base Mainnet)
+#   PHALA_DSTACKAPP_PRIVATE_KEY    - deployer wallet private key (Base Mainnet)
 
 name: Contract Upgrade
 
@@ -77,7 +77,7 @@ jobs:
         id: secret
         run: |
           if [ "${{ steps.config.outputs.network }}" = "base" ]; then
-            echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_BASE }}" >> "$GITHUB_OUTPUT"
+            echo "key=${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}" >> "$GITHUB_OUTPUT"
           else
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_SEPOLIA }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -1,4 +1,4 @@
-# Upgrade (or deploy) Diamond contracts.
+# Upgrade existing Diamond contract facets.
 #
 # Network and contract address are read from the NodeConfig file that
 # matches the branch the workflow runs on:
@@ -16,14 +16,6 @@ name: Contract Upgrade
 on:
   workflow_dispatch:
     inputs:
-      action:
-        description: "deploy (new diamond) or update (existing diamond)"
-        required: true
-        type: choice
-        options:
-          - update
-          - deploy
-        default: update
       network:
         description: "Target network (leave empty to read from NodeConfig)"
         required: false
@@ -80,14 +72,14 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ inputs.action }}" = "update" ] && [ -z "$ADDRESS" ]; then
-            echo "::error::Could not determine contract address for update — set it via input or ensure a NodeConfig exists for this branch."
+          if [ -z "$ADDRESS" ]; then
+            echo "::error::Could not determine contract address — set it via input or ensure a NodeConfig exists for this branch."
             exit 1
           fi
 
           echo "network=$NETWORK" >> "$GITHUB_OUTPUT"
           echo "address=$ADDRESS" >> "$GITHUB_OUTPUT"
-          echo "Resolved: action=${{ inputs.action }} network=$NETWORK address=$ADDRESS"
+          echo "Resolved: network=$NETWORK address=$ADDRESS"
 
       - uses: dtolnay/rust-toolchain@1.91
 
@@ -119,15 +111,12 @@ jobs:
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run contract deployer
+      - name: Upgrade diamond facets
         working-directory: lit-api-server/blockchain/lit_node_express
         run: |
-          DEPLOYER=../rust_generator_and_deployer/target/debug/contract_deployer
-
-          ARGS="--action=${{ inputs.action }} --network=${{ steps.resolve.outputs.network }} --abifolder=artifacts/contracts --secret=${{ steps.secret.outputs.key }}"
-
-          if [ "${{ inputs.action }}" = "update" ]; then
-            ARGS="$ARGS --address=${{ steps.resolve.outputs.address }}"
-          fi
-
-          $DEPLOYER $ARGS
+          ../rust_generator_and_deployer/target/debug/contract_deployer \
+            --action=update \
+            --network=${{ steps.resolve.outputs.network }} \
+            --abifolder=artifacts/contracts \
+            --secret=${{ steps.secret.outputs.key }} \
+            --address=${{ steps.resolve.outputs.address }}

--- a/.github/workflows/contract-upgrade.yml
+++ b/.github/workflows/contract-upgrade.yml
@@ -8,7 +8,7 @@
 # Both values can be overridden via the optional workflow inputs.
 #
 # Required secrets:
-#   CONTRACT_DEPLOYER_SECRET       - deployer wallet private key (Base Sepolia)
+#   CONTRACT_DEPLOYER_SECRET_SEPOLIA - deployer wallet private key (Base Sepolia)
 #   CONTRACT_DEPLOYER_SECRET_BASE  - deployer wallet private key (Base Mainnet)
 
 name: Contract Upgrade
@@ -108,7 +108,7 @@ jobs:
           if [ "${{ steps.resolve.outputs.network }}" = "base" ]; then
             echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_BASE }}" >> "$GITHUB_OUTPUT"
           else
-            echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET }}" >> "$GITHUB_OUTPUT"
+            echo "key=${{ secrets.CONTRACT_DEPLOYER_SECRET_SEPOLIA }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upgrade diamond facets

--- a/lit-api-server/blockchain/lit_node_express/Makefile
+++ b/lit-api-server/blockchain/lit_node_express/Makefile
@@ -44,3 +44,7 @@ update_anvil: compile
 update_sepolia: compile
 	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
 	$(DEPLOYER_BIN) --action=update --network=base-sepolia --abifolder=artifacts/contracts --secret=$(DEPLOYER_SECRET) --address=$(address)
+
+update_base: compile
+	cd $(RUST_PROJECT) && cargo build --bin contract_deployer
+	$(DEPLOYER_BIN) --action=update --network=base --abifolder=artifacts/contracts --secret=$(BASE_DEPLOYER_SECRET) --address=$(address)


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` GitHub Action (`contract-upgrade.yml`) that automates the Diamond contract deploy/update flow on **Base Sepolia** or **Base Mainnet**
- Compiles Solidity contracts, builds the Rust `contract_deployer`, and runs it with the chosen action, network, and contract address
- Adds the missing `update_base` target to the contracts Makefile

## Inputs
| Input | Description |
|-------|-------------|
| `action` | `deploy` (new diamond) or `update` (existing diamond) |
| `network` | `base-sepolia` or `base` |
| `address` | Diamond contract address (required for `update`) |

## Secrets required
- `CONTRACT_DEPLOYER_SECRET` — deployer wallet private key (Base Sepolia)
- `CONTRACT_DEPLOYER_SECRET_BASE` — deployer wallet private key (Base Mainnet)

## Test plan
- [ ] Add `CONTRACT_DEPLOYER_SECRET` and `CONTRACT_DEPLOYER_SECRET_BASE` to repo secrets
- [ ] Run the workflow manually via Actions tab with `action=update`, `network=base-sepolia`, and a known diamond address
- [ ] Verify the deployer output shows facet cuts and successful update

Closes CPL-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)