### PR TITLE
feat: add GET /health endpoint for NLB health checks (CPL-117)

### DIFF
--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -94,14 +94,19 @@ jobs:
           BASE_URL="${{ steps.resolve-url.outputs.api_root_url }}"
           TIMEOUT="${{ inputs.timeout }}"
 
+          # Derive the health URL from the API root URL.
+          # api_root_url is e.g. https://example.com/core/v1 — strip the
+          # /core/v1 suffix to get the base, then append /health.
+          HEALTH_URL="${BASE_URL%/core/v1}/health"
+
           # Step-function: if the API is currently up (stale instance still
           # serving), wait for it to go down before polling for the new
           # instance.  This avoids the race where we'd pass against the old
           # deployment.
-          if curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; then
+          if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
             echo "API is currently available — waiting for it to go down (deployment restart)..."
             DOWN_DEADLINE=$(( $(date +%s) + 300 ))  # 5 min
-            while curl -sf "$BASE_URL/openapi.json" > /dev/null 2>&1; do
+            while curl -sf "$HEALTH_URL" > /dev/null 2>&1; do
               if [ "$(date +%s)" -ge "$DOWN_DEADLINE" ]; then
                 echo "::error::API never went down after 300s — deploy may have failed"
                 exit 1
@@ -115,10 +120,10 @@ jobs:
             echo "API is not currently available — polling for availability"
           fi
 
-          # Poll for the API to come (back) up.
-          echo "Polling $BASE_URL/openapi.json (timeout: ${TIMEOUT}s)..."
+          # Poll for the API to come (back) up via the /health endpoint.
+          echo "Polling $HEALTH_URL (timeout: ${TIMEOUT}s)..."
           deadline=$(( $(date +%s) + TIMEOUT ))
-          until curl -sf "$BASE_URL/openapi.json" > /dev/null; do
+          until curl -sf "$HEALTH_URL" > /dev/null; do
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "Timed out after ${TIMEOUT}s waiting for API"
               exit 1

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -71,7 +71,8 @@ impl CpuOverloadMonitor {
                     .map(|avg| avg > load_threshold)
                     .unwrap_or(false);
 
-                let psi_overloaded = match (read_psi_cpu_total().await, prev_psi_total) {
+                let current_psi = read_psi_cpu_total().await;
+                let psi_overloaded = match (current_psi, prev_psi_total) {
                     (Some(current), Some(prev)) => {
                         // Delta is microseconds of CPU stall time in the last
                         // ~1 second.  Convert to a percentage of wall-clock
@@ -82,11 +83,7 @@ impl CpuOverloadMonitor {
                     }
                     _ => false, // Need two readings to compute a rate.
                 };
-
-                // Update prev_psi_total for next iteration.
-                if let Some(t) = read_psi_cpu_total().await {
-                    prev_psi_total = Some(t);
-                }
+                prev_psi_total = current_psi;
 
                 let is_overloaded = load_overloaded || psi_overloaded;
                 flag.store(is_overloaded, Ordering::Relaxed);

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -1,13 +1,20 @@
-//! CPU overload protection via load-average monitoring.
+//! CPU overload protection via load-average and PSI monitoring.
 //!
-//! Spawns a background task that samples `/proc/loadavg` every second and flips
-//! an atomic flag when the 1-minute load average exceeds a threshold.  The
-//! [`CpuAvailable`] request guard checks this flag and rejects with
-//! `429 Too Many Requests` when the system is overloaded, preventing latency
-//! degradation for requests that *are* admitted.
+//! Spawns a background task that samples `/proc/loadavg` and
+//! `/proc/pressure/cpu` every second and flips an atomic flag when either:
 //!
-//! Default threshold: `2 * num_cpus` (overridable via `CPU_OVERLOAD_MULTIPLIER`
-//! env var, e.g. `CPU_OVERLOAD_MULTIPLIER=1.5`).
+//! - The 1-minute load average exceeds a threshold, **or**
+//! - CPU pressure (PSI `some`) over the last 1-second window exceeds a
+//!   threshold (percentage of wall-clock time at least one task was waiting
+//!   for CPU).
+//!
+//! The PSI check catches short spikes before they register in the 1-minute
+//! load average, giving the NLB health check (`/health`) and the
+//! [`CpuAvailable`] request guard a faster signal to shed load.
+//!
+//! Default thresholds (overridable via env vars):
+//! - Load average: `2 * num_cpus` (`CPU_OVERLOAD_MULTIPLIER`, e.g. `1.5`)
+//! - PSI 1s: `50.0`% (`CPU_PSI_THRESHOLD`, e.g. `70.0`)
 
 use rocket::http::Status;
 use rocket::request::{FromRequest, Outcome, Request};
@@ -18,7 +25,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-/// Monitors system load average and exposes an overload flag.
+/// Monitors system load average + CPU pressure and exposes an overload flag.
 ///
 /// Register as Rocket managed state via `.manage(CpuOverloadMonitor::start())`.
 pub struct CpuOverloadMonitor {
@@ -26,47 +33,79 @@ pub struct CpuOverloadMonitor {
 }
 
 impl CpuOverloadMonitor {
-    /// Starts a background tokio task that samples `/proc/loadavg` every second.
+    /// Starts a background tokio task that samples system load every second.
     pub fn start() -> Self {
-        let multiplier: f64 = std::env::var("CPU_OVERLOAD_MULTIPLIER")
+        let load_multiplier: f64 = std::env::var("CPU_OVERLOAD_MULTIPLIER")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(2.0);
 
         let num_cpus = num_cpus::get() as f64;
-        let threshold = num_cpus * multiplier;
+        let load_threshold = num_cpus * load_multiplier;
+
+        // PSI threshold: percentage of wall-clock time (0–100) in a 1-second
+        // window where at least one task was waiting for CPU.
+        let psi_threshold: f64 = std::env::var("CPU_PSI_THRESHOLD")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50.0);
+
         let overloaded = Arc::new(AtomicBool::new(false));
 
         tracing::info!(
             num_cpus = num_cpus as usize,
-            multiplier,
-            threshold,
+            load_multiplier,
+            load_threshold,
+            psi_threshold,
             "CPU overload monitor started (429 load shedding enabled)"
         );
 
         let flag = overloaded.clone();
         tokio::spawn(async move {
             let mut was_overloaded = false;
-            loop {
-                if let Some(load_avg) = read_1m_load_avg().await {
-                    let is_overloaded = load_avg > threshold;
-                    flag.store(is_overloaded, Ordering::Relaxed);
+            let mut prev_psi_total: Option<u64> = None;
 
-                    if is_overloaded && !was_overloaded {
-                        tracing::warn!(
-                            load_avg,
-                            threshold,
-                            "CPU overload detected - new requests will receive 429"
-                        );
-                    } else if !is_overloaded && was_overloaded {
-                        tracing::info!(
-                            load_avg,
-                            threshold,
-                            "CPU load returned to normal - accepting requests"
-                        );
+            loop {
+                let load_overloaded = read_1m_load_avg()
+                    .await
+                    .map(|avg| avg > load_threshold)
+                    .unwrap_or(false);
+
+                let psi_overloaded = match (read_psi_cpu_total().await, prev_psi_total) {
+                    (Some(current), Some(prev)) => {
+                        // Delta is microseconds of CPU stall time in the last
+                        // ~1 second.  Convert to a percentage of wall-clock
+                        // time (1s = 1_000_000 µs).
+                        let delta_us = current.saturating_sub(prev);
+                        let psi_pct = delta_us as f64 / 1_000_000.0 * 100.0;
+                        psi_pct > psi_threshold
                     }
-                    was_overloaded = is_overloaded;
+                    _ => false, // Need two readings to compute a rate.
+                };
+
+                // Update prev_psi_total for next iteration.
+                if let Some(t) = read_psi_cpu_total().await {
+                    prev_psi_total = Some(t);
                 }
+
+                let is_overloaded = load_overloaded || psi_overloaded;
+                flag.store(is_overloaded, Ordering::Relaxed);
+
+                if is_overloaded && !was_overloaded {
+                    tracing::warn!(
+                        load_overloaded,
+                        psi_overloaded,
+                        "CPU overload detected - new requests will receive 429"
+                    );
+                } else if !is_overloaded && was_overloaded {
+                    tracing::info!(
+                        load_overloaded,
+                        psi_overloaded,
+                        "CPU load returned to normal - accepting requests"
+                    );
+                }
+                was_overloaded = is_overloaded;
+
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
         });
@@ -94,6 +133,20 @@ async fn read_1m_load_avg() -> Option<f64> {
         .next()?
         .parse()
         .ok()
+}
+
+/// Reads the cumulative `some` total (microseconds) from `/proc/pressure/cpu`.
+///
+/// Format: `some avg10=X avg60=X avg300=X total=123456`
+async fn read_psi_cpu_total() -> Option<u64> {
+    let contents = tokio::fs::read_to_string("/proc/pressure/cpu").await.ok()?;
+    // First line is the `some` line.
+    let some_line = contents.lines().next()?;
+    // Find `total=<value>` at the end.
+    some_line
+        .split_whitespace()
+        .find_map(|token| token.strip_prefix("total="))
+        .and_then(|v| v.parse().ok())
 }
 
 /// Request guard that rejects with `429 Too Many Requests` when the system is CPU-overloaded.
@@ -181,9 +234,17 @@ mod tests {
 
     #[tokio::test]
     async fn read_load_avg_returns_some_on_linux() {
-        // /proc/loadavg should always be readable on Linux.
         let load = read_1m_load_avg().await;
         assert!(load.is_some(), "/proc/loadavg should be readable");
         assert!(load.unwrap() >= 0.0);
+    }
+
+    #[tokio::test]
+    async fn read_psi_cpu_total_returns_some_on_linux() {
+        let total = read_psi_cpu_total().await;
+        assert!(
+            total.is_some(),
+            "/proc/pressure/cpu should be readable on kernels >= 4.20"
+        );
     }
 }

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -22,7 +22,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 /// Monitors system load average + CPU pressure and exposes an overload flag.
@@ -30,6 +30,8 @@ use std::time::Duration;
 /// Register as Rocket managed state via `.manage(CpuOverloadMonitor::start())`.
 pub struct CpuOverloadMonitor {
     overloaded: Arc<AtomicBool>,
+    /// 1-minute load average × 100, stored as integer for atomic access.
+    load_avg_100: Arc<AtomicU64>,
 }
 
 impl CpuOverloadMonitor {
@@ -51,6 +53,7 @@ impl CpuOverloadMonitor {
             .unwrap_or(50.0);
 
         let overloaded = Arc::new(AtomicBool::new(false));
+        let load_avg_100 = Arc::new(AtomicU64::new(0));
 
         tracing::info!(
             num_cpus = num_cpus as usize,
@@ -61,15 +64,17 @@ impl CpuOverloadMonitor {
         );
 
         let flag = overloaded.clone();
+        let load_flag = load_avg_100.clone();
         tokio::spawn(async move {
             let mut was_overloaded = false;
             let mut prev_psi_total: Option<u64> = None;
 
             loop {
-                let load_overloaded = read_1m_load_avg()
-                    .await
-                    .map(|avg| avg > load_threshold)
-                    .unwrap_or(false);
+                let load_avg = read_1m_load_avg().await;
+                if let Some(avg) = load_avg {
+                    load_flag.store((avg * 100.0) as u64, Ordering::Relaxed);
+                }
+                let load_overloaded = load_avg.map(|avg| avg > load_threshold).unwrap_or(false);
 
                 let current_psi = read_psi_cpu_total().await;
                 let psi_overloaded = match (current_psi, prev_psi_total) {
@@ -107,17 +112,28 @@ impl CpuOverloadMonitor {
             }
         });
 
-        Self { overloaded }
+        Self {
+            overloaded,
+            load_avg_100,
+        }
     }
 
     /// Creates a monitor with a pre-set flag (for testing from other modules).
     #[cfg(test)]
     pub fn new_with_flag(overloaded: Arc<AtomicBool>) -> Self {
-        Self { overloaded }
+        Self {
+            overloaded,
+            load_avg_100: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     pub fn is_overloaded(&self) -> bool {
         self.overloaded.load(Ordering::Relaxed)
+    }
+
+    /// Returns the most recent 1-minute load average sampled by the background task.
+    pub fn load_avg_1m(&self) -> f64 {
+        self.load_avg_100.load(Ordering::Relaxed) as f64 / 100.0
     }
 }
 

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -22,7 +22,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 /// Monitors system load average + CPU pressure and exposes an overload flag.
@@ -30,8 +30,6 @@ use std::time::Duration;
 /// Register as Rocket managed state via `.manage(CpuOverloadMonitor::start())`.
 pub struct CpuOverloadMonitor {
     overloaded: Arc<AtomicBool>,
-    /// 1-minute load average × 100, stored as integer for atomic access.
-    load_avg_100: Arc<AtomicU64>,
 }
 
 impl CpuOverloadMonitor {
@@ -53,7 +51,6 @@ impl CpuOverloadMonitor {
             .unwrap_or(50.0);
 
         let overloaded = Arc::new(AtomicBool::new(false));
-        let load_avg_100 = Arc::new(AtomicU64::new(0));
 
         tracing::info!(
             num_cpus = num_cpus as usize,
@@ -64,17 +61,15 @@ impl CpuOverloadMonitor {
         );
 
         let flag = overloaded.clone();
-        let load_flag = load_avg_100.clone();
         tokio::spawn(async move {
             let mut was_overloaded = false;
             let mut prev_psi_total: Option<u64> = None;
 
             loop {
-                let load_avg = read_1m_load_avg().await;
-                if let Some(avg) = load_avg {
-                    load_flag.store((avg * 100.0) as u64, Ordering::Relaxed);
-                }
-                let load_overloaded = load_avg.map(|avg| avg > load_threshold).unwrap_or(false);
+                let load_overloaded = read_1m_load_avg()
+                    .await
+                    .map(|avg| avg > load_threshold)
+                    .unwrap_or(false);
 
                 let current_psi = read_psi_cpu_total().await;
                 let psi_overloaded = match (current_psi, prev_psi_total) {
@@ -112,28 +107,17 @@ impl CpuOverloadMonitor {
             }
         });
 
-        Self {
-            overloaded,
-            load_avg_100,
-        }
+        Self { overloaded }
     }
 
     /// Creates a monitor with a pre-set flag (for testing from other modules).
     #[cfg(test)]
     pub fn new_with_flag(overloaded: Arc<AtomicBool>) -> Self {
-        Self {
-            overloaded,
-            load_avg_100: Arc::new(AtomicU64::new(0)),
-        }
+        Self { overloaded }
     }
 
     pub fn is_overloaded(&self) -> bool {
         self.overloaded.load(Ordering::Relaxed)
-    }
-
-    /// Returns the most recent 1-minute load average sampled by the background task.
-    pub fn load_avg_1m(&self) -> f64 {
-        self.load_avg_100.load(Ordering::Relaxed) as f64 / 100.0
     }
 }
 

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -22,7 +22,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 /// Monitors system load average + CPU pressure and exposes an overload flag.
@@ -30,6 +30,8 @@ use std::time::Duration;
 /// Register as Rocket managed state via `.manage(CpuOverloadMonitor::start())`.
 pub struct CpuOverloadMonitor {
     overloaded: Arc<AtomicBool>,
+    /// 1-minute load average × 100, stored as integer for atomic access.
+    load_avg_100: Arc<AtomicU64>,
 }
 
 impl CpuOverloadMonitor {
@@ -51,6 +53,7 @@ impl CpuOverloadMonitor {
             .unwrap_or(50.0);
 
         let overloaded = Arc::new(AtomicBool::new(false));
+        let load_avg_100 = Arc::new(AtomicU64::new(0));
 
         tracing::info!(
             num_cpus = num_cpus as usize,
@@ -61,15 +64,17 @@ impl CpuOverloadMonitor {
         );
 
         let flag = overloaded.clone();
+        let load_flag = load_avg_100.clone();
         tokio::spawn(async move {
             let mut was_overloaded = false;
             let mut prev_psi_total: Option<u64> = None;
 
             loop {
-                let load_overloaded = read_1m_load_avg()
-                    .await
-                    .map(|avg| avg > load_threshold)
-                    .unwrap_or(false);
+                let load_avg = read_1m_load_avg().await;
+                if let Some(avg) = load_avg {
+                    load_flag.store((avg * 100.0) as u64, Ordering::Relaxed);
+                }
+                let load_overloaded = load_avg.map(|avg| avg > load_threshold).unwrap_or(false);
 
                 let current_psi = read_psi_cpu_total().await;
                 let psi_overloaded = match (current_psi, prev_psi_total) {
@@ -107,17 +112,28 @@ impl CpuOverloadMonitor {
             }
         });
 
-        Self { overloaded }
+        Self {
+            overloaded,
+            load_avg_100,
+        }
     }
 
     /// Creates a monitor with a pre-set flag (for testing from other modules).
     #[cfg(test)]
     pub fn new_with_flag(overloaded: Arc<AtomicBool>) -> Self {
-        Self { overloaded }
+        Self {
+            overloaded,
+            load_avg_100: Arc::new(AtomicU64::new(0)),
+        }
     }
 
     pub fn is_overloaded(&self) -> bool {
         self.overloaded.load(Ordering::Relaxed)
+    }
+
+    /// Returns the most recent 1-minute load average sampled by the background task.
+    pub fn load_avg_1m(&self) -> f64 {
+        self.load_avg_100.load(Ordering::Relaxed) as f64 / 100.0
     }
 }
 
@@ -202,9 +218,7 @@ mod tests {
     /// When the monitor reports not-overloaded, the guard passes.
     #[tokio::test]
     async fn guard_passes_when_not_overloaded() {
-        let monitor = CpuOverloadMonitor {
-            overloaded: Arc::new(AtomicBool::new(false)),
-        };
+        let monitor = CpuOverloadMonitor::new_with_flag(Arc::new(AtomicBool::new(false)));
         let rocket = rocket::build()
             .manage(monitor)
             .mount("/", routes![guarded_route]);
@@ -217,9 +231,7 @@ mod tests {
     /// When the monitor reports overloaded, the guard returns 429.
     #[tokio::test]
     async fn guard_returns_429_when_overloaded() {
-        let monitor = CpuOverloadMonitor {
-            overloaded: Arc::new(AtomicBool::new(true)),
-        };
+        let monitor = CpuOverloadMonitor::new_with_flag(Arc::new(AtomicBool::new(true)));
         let rocket = rocket::build()
             .manage(monitor)
             .mount("/", routes![guarded_route]);

--- a/lit-api-server/src/core/v1/guards/cpu_overload.rs
+++ b/lit-api-server/src/core/v1/guards/cpu_overload.rs
@@ -74,6 +74,12 @@ impl CpuOverloadMonitor {
         Self { overloaded }
     }
 
+    /// Creates a monitor with a pre-set flag (for testing from other modules).
+    #[cfg(test)]
+    pub fn new_with_flag(overloaded: Arc<AtomicBool>) -> Self {
+        Self { overloaded }
+    }
+
     pub fn is_overloaded(&self) -> bool {
         self.overloaded.load(Ordering::Relaxed)
     }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -1,15 +1,15 @@
 //! GET /health endpoint for NLB health checks.
 //!
-//! Returns 200 with a JSON body when the server is healthy, or 503 when any
-//! subsystem check fails.  No authentication is required — this is intended
-//! for infrastructure probes (AWS NLB, k8s liveness, etc.).
+//! Returns 200 when healthy, 503 when unhealthy.  No authentication required —
+//! intended for infrastructure probes (AWS NLB, k8s liveness, etc.).
 //!
-//! Healthy is defined as:
-//! - Configuration initialized (NodeConfig loaded, chain accessible)
-//! - Connected to a lit-actions gRPC service (Unix socket reachable)
+//! Only checks things that can fail *after* a successful startup.  Config,
+//! chain clients, and signer pool are validated on boot and the process exits
+//! if any of those fail, so they're guaranteed present when this endpoint is
+//! reachable.  The lit-actions gRPC service, however, runs in a separate
+//! container and can go down independently.
 
 use crate::actions::grpc::GrpcClientPool;
-use crate::config::GLOBAL_NODE_CONFIG;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{Route, State, get, routes};
@@ -21,7 +21,6 @@ const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HealthResponse {
     pub healthy: bool,
-    pub config_initialized: bool,
     pub lit_actions_reachable: bool,
 }
 
@@ -34,21 +33,16 @@ pub fn routes() -> Vec<Route> {
 async fn health(
     grpc_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
 ) -> (Status, Json<HealthResponse>) {
-    let config_initialized = GLOBAL_NODE_CONFIG.get().is_some();
-
-    // Check if we already have a connection to lit-actions in the pool, or if
-    // the socket file at least exists (avoids creating a new connection on
-    // every health probe).
+    // Check if we already have a pooled gRPC connection to lit-actions, or if
+    // the socket file at least exists.  Avoids opening a new connection on
+    // every NLB probe; the first real request will populate the pool.
     let lit_actions_reachable = if grpc_pool.get_connection(LIT_ACTIONS_SOCKET).await.is_some() {
         true
     } else {
-        // No pooled connection yet — fall back to checking the socket file
-        // exists.  A full gRPC connect on every NLB probe would be wasteful;
-        // the first real request will populate the pool.
         Path::new(LIT_ACTIONS_SOCKET).exists()
     };
 
-    let healthy = config_initialized && lit_actions_reachable;
+    let healthy = lit_actions_reachable;
 
     let status = if healthy {
         Status::Ok
@@ -60,7 +54,6 @@ async fn health(
         status,
         Json(HealthResponse {
             healthy,
-            config_initialized,
             lit_actions_reachable,
         }),
     )
@@ -82,11 +75,7 @@ mod tests {
         let client = Client::tracked(build_rocket()).await.expect("valid rocket");
         let response = client.get("/health").dispatch().await;
         let body: HealthResponse = response.into_json().await.expect("valid json");
-        // healthy is only true when ALL checks pass.
-        assert_eq!(
-            body.healthy,
-            body.config_initialized && body.lit_actions_reachable
-        );
+        assert_eq!(body.healthy, body.lit_actions_reachable);
     }
 
     #[tokio::test]
@@ -95,7 +84,9 @@ mod tests {
         // pooled gRPC connection, so lit_actions_reachable should be false.
         let client = Client::tracked(build_rocket()).await.expect("valid rocket");
         let response = client.get("/health").dispatch().await;
+        assert_eq!(response.status(), Status::ServiceUnavailable);
         let body: HealthResponse = response.into_json().await.expect("valid json");
         assert!(!body.lit_actions_reachable);
+        assert!(!body.healthy);
     }
 }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -56,7 +56,7 @@ async fn health(
     };
 
     let cpu_overloaded = cpu_monitor.is_overloaded();
-    let load_avg_1m = cpu_monitor.load_avg_1m();
+    let load_avg_1m = read_1m_load_avg().await.unwrap_or(0.0);
 
     let healthy = lit_actions_reachable && !cpu_overloaded;
 
@@ -75,6 +75,16 @@ async fn health(
             load_avg_1m,
         }),
     )
+}
+
+async fn read_1m_load_avg() -> Option<f64> {
+    tokio::fs::read_to_string("/proc/loadavg")
+        .await
+        .ok()?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()
 }
 
 #[cfg(test)]

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -25,6 +25,7 @@ pub struct HealthResponse {
     pub healthy: bool,
     pub lit_actions_reachable: bool,
     pub cpu_overloaded: bool,
+    pub load_avg_1m: f64,
 }
 
 pub fn routes() -> Vec<Route> {
@@ -55,6 +56,7 @@ async fn health(
     };
 
     let cpu_overloaded = cpu_monitor.is_overloaded();
+    let load_avg_1m = read_1m_load_avg().await.unwrap_or(0.0);
 
     let healthy = lit_actions_reachable && !cpu_overloaded;
 
@@ -70,8 +72,19 @@ async fn health(
             healthy,
             lit_actions_reachable,
             cpu_overloaded,
+            load_avg_1m,
         }),
     )
+}
+
+async fn read_1m_load_avg() -> Option<f64> {
+    tokio::fs::read_to_string("/proc/loadavg")
+        .await
+        .ok()?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()
 }
 
 #[cfg(test)]

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -11,11 +11,12 @@
 
 use crate::actions::grpc::GrpcClientPool;
 use crate::core::v1::guards::cpu_overload::CpuOverloadMonitor;
+use lit_actions_grpc::unix;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{Route, State, get, routes};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::PathBuf;
 
 const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
 
@@ -36,13 +37,21 @@ async fn health(
     grpc_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
     cpu_monitor: &State<CpuOverloadMonitor>,
 ) -> (Status, Json<HealthResponse>) {
-    // Check if we already have a pooled gRPC connection to lit-actions, or if
-    // the socket file at least exists.  Avoids opening a new connection on
-    // every NLB probe; the first real request will populate the pool.
+    // Check if we have a pooled gRPC connection to lit-actions.  If not, try
+    // to connect (1s timeout via connect_to_socket).  This avoids the deadlock
+    // where NLB marks the node unhealthy → no traffic → lazy connection never
+    // established → stays unhealthy.  A successful connect also populates the
+    // pool so subsequent probes are a cheap HashMap lookup.
     let lit_actions_reachable = if grpc_pool.get_connection(LIT_ACTIONS_SOCKET).await.is_some() {
         true
     } else {
-        Path::new(LIT_ACTIONS_SOCKET).exists()
+        match unix::connect_to_socket(PathBuf::from(LIT_ACTIONS_SOCKET)).await {
+            Ok(channel) => {
+                grpc_pool.add_connection(LIT_ACTIONS_SOCKET, channel).await;
+                true
+            }
+            Err(_) => false,
+        }
     };
 
     let cpu_overloaded = cpu_monitor.is_overloaded();

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -23,7 +23,7 @@ const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HealthResponse {
     pub lit_actions_reachable: bool,
-    pub cpu_overloaded: bool,
+    pub cpu_available: bool,
 }
 
 pub fn routes() -> Vec<Route> {
@@ -53,9 +53,9 @@ async fn health(
         }
     };
 
-    let cpu_overloaded = cpu_monitor.is_overloaded();
+    let cpu_available = !cpu_monitor.is_overloaded();
 
-    let healthy = lit_actions_reachable && !cpu_overloaded;
+    let healthy = lit_actions_reachable && cpu_available;
 
     let status = if healthy {
         Status::Ok
@@ -67,7 +67,7 @@ async fn health(
         status,
         Json(HealthResponse {
             lit_actions_reachable,
-            cpu_overloaded,
+            cpu_available,
         }),
     )
 }
@@ -98,7 +98,7 @@ mod tests {
         let response = client.get("/health").dispatch().await;
         let body: HealthResponse = response.into_json().await.expect("valid json");
         // Status code conveys healthy/unhealthy; body has diagnostics.
-        assert!(!body.cpu_overloaded);
+        assert!(body.cpu_available);
     }
 
     #[tokio::test]
@@ -120,6 +120,6 @@ mod tests {
         let response = client.get("/health").dispatch().await;
         assert_eq!(response.status(), Status::ServiceUnavailable);
         let body: HealthResponse = response.into_json().await.expect("valid json");
-        assert!(body.cpu_overloaded);
+        assert!(!body.cpu_available);
     }
 }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -39,11 +39,7 @@ async fn health(
     // Check if we already have a connection to lit-actions in the pool, or if
     // the socket file at least exists (avoids creating a new connection on
     // every health probe).
-    let lit_actions_reachable = if grpc_pool
-        .get_connection(LIT_ACTIONS_SOCKET)
-        .await
-        .is_some()
-    {
+    let lit_actions_reachable = if grpc_pool.get_connection(LIT_ACTIONS_SOCKET).await.is_some() {
         true
     } else {
         // No pooled connection yet — fall back to checking the socket file
@@ -87,7 +83,10 @@ mod tests {
         let response = client.get("/health").dispatch().await;
         let body: HealthResponse = response.into_json().await.expect("valid json");
         // healthy is only true when ALL checks pass.
-        assert_eq!(body.healthy, body.config_initialized && body.lit_actions_reachable);
+        assert_eq!(
+            body.healthy,
+            body.config_initialized && body.lit_actions_reachable
+        );
     }
 
     #[tokio::test]

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -7,9 +7,10 @@
 //! chain clients, and signer pool are validated on boot and the process exits
 //! if any of those fail, so they're guaranteed present when this endpoint is
 //! reachable.  The lit-actions gRPC service, however, runs in a separate
-//! container and can go down independently.
+//! container and can go down independently, and CPU load can spike at runtime.
 
 use crate::actions::grpc::GrpcClientPool;
+use crate::core::v1::guards::cpu_overload::CpuOverloadMonitor;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{Route, State, get, routes};
@@ -22,6 +23,7 @@ const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
 pub struct HealthResponse {
     pub healthy: bool,
     pub lit_actions_reachable: bool,
+    pub cpu_overloaded: bool,
 }
 
 pub fn routes() -> Vec<Route> {
@@ -32,6 +34,7 @@ pub fn routes() -> Vec<Route> {
 #[get("/health")]
 async fn health(
     grpc_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
+    cpu_monitor: &State<CpuOverloadMonitor>,
 ) -> (Status, Json<HealthResponse>) {
     // Check if we already have a pooled gRPC connection to lit-actions, or if
     // the socket file at least exists.  Avoids opening a new connection on
@@ -42,7 +45,9 @@ async fn health(
         Path::new(LIT_ACTIONS_SOCKET).exists()
     };
 
-    let healthy = lit_actions_reachable;
+    let cpu_overloaded = cpu_monitor.is_overloaded();
+
+    let healthy = lit_actions_reachable && !cpu_overloaded;
 
     let status = if healthy {
         Status::Ok
@@ -55,6 +60,7 @@ async fn health(
         Json(HealthResponse {
             healthy,
             lit_actions_reachable,
+            cpu_overloaded,
         }),
     )
 }
@@ -63,30 +69,54 @@ async fn health(
 mod tests {
     use super::*;
     use crate::actions::grpc::GrpcClientPool;
+    use crate::core::v1::guards::cpu_overload::CpuOverloadMonitor;
     use rocket::local::asynchronous::Client;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
 
-    fn build_rocket() -> rocket::Rocket<rocket::Build> {
+    fn build_rocket(overloaded: bool) -> rocket::Rocket<rocket::Build> {
         let pool = GrpcClientPool::<tonic::transport::Channel>::new();
-        rocket::build().manage(pool).mount("/", routes![health])
+        let monitor = CpuOverloadMonitor::new_with_flag(Arc::new(AtomicBool::new(overloaded)));
+        rocket::build()
+            .manage(pool)
+            .manage(monitor)
+            .mount("/", routes![health])
     }
 
     #[tokio::test]
     async fn health_returns_json_with_expected_shape() {
-        let client = Client::tracked(build_rocket()).await.expect("valid rocket");
+        let client = Client::tracked(build_rocket(false))
+            .await
+            .expect("valid rocket");
         let response = client.get("/health").dispatch().await;
         let body: HealthResponse = response.into_json().await.expect("valid json");
-        assert_eq!(body.healthy, body.lit_actions_reachable);
+        assert_eq!(
+            body.healthy,
+            body.lit_actions_reachable && !body.cpu_overloaded
+        );
     }
 
     #[tokio::test]
     async fn health_reports_lit_actions_unreachable_when_no_socket() {
-        // In the test environment there is no /tmp/lit_actions.sock and no
-        // pooled gRPC connection, so lit_actions_reachable should be false.
-        let client = Client::tracked(build_rocket()).await.expect("valid rocket");
+        let client = Client::tracked(build_rocket(false))
+            .await
+            .expect("valid rocket");
         let response = client.get("/health").dispatch().await;
         assert_eq!(response.status(), Status::ServiceUnavailable);
         let body: HealthResponse = response.into_json().await.expect("valid json");
         assert!(!body.lit_actions_reachable);
+        assert!(!body.healthy);
+    }
+
+    #[tokio::test]
+    async fn health_returns_503_when_cpu_overloaded() {
+        let client = Client::tracked(build_rocket(true))
+            .await
+            .expect("valid rocket");
+        let response = client.get("/health").dispatch().await;
+        assert_eq!(response.status(), Status::ServiceUnavailable);
+        let body: HealthResponse = response.into_json().await.expect("valid json");
+        assert!(body.cpu_overloaded);
         assert!(!body.healthy);
     }
 }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -25,7 +25,6 @@ pub struct HealthResponse {
     pub healthy: bool,
     pub lit_actions_reachable: bool,
     pub cpu_overloaded: bool,
-    pub load_avg_1m: f64,
 }
 
 pub fn routes() -> Vec<Route> {
@@ -56,7 +55,6 @@ async fn health(
     };
 
     let cpu_overloaded = cpu_monitor.is_overloaded();
-    let load_avg_1m = cpu_monitor.load_avg_1m();
 
     let healthy = lit_actions_reachable && !cpu_overloaded;
 
@@ -72,7 +70,6 @@ async fn health(
             healthy,
             lit_actions_reachable,
             cpu_overloaded,
-            load_avg_1m,
         }),
     )
 }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -22,7 +22,6 @@ const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HealthResponse {
-    pub healthy: bool,
     pub lit_actions_reachable: bool,
     pub cpu_overloaded: bool,
 }
@@ -67,7 +66,6 @@ async fn health(
     (
         status,
         Json(HealthResponse {
-            healthy,
             lit_actions_reachable,
             cpu_overloaded,
         }),
@@ -99,10 +97,8 @@ mod tests {
             .expect("valid rocket");
         let response = client.get("/health").dispatch().await;
         let body: HealthResponse = response.into_json().await.expect("valid json");
-        assert_eq!(
-            body.healthy,
-            body.lit_actions_reachable && !body.cpu_overloaded
-        );
+        // Status code conveys healthy/unhealthy; body has diagnostics.
+        assert!(!body.cpu_overloaded);
     }
 
     #[tokio::test]
@@ -114,7 +110,6 @@ mod tests {
         assert_eq!(response.status(), Status::ServiceUnavailable);
         let body: HealthResponse = response.into_json().await.expect("valid json");
         assert!(!body.lit_actions_reachable);
-        assert!(!body.healthy);
     }
 
     #[tokio::test]
@@ -126,6 +121,5 @@ mod tests {
         assert_eq!(response.status(), Status::ServiceUnavailable);
         let body: HealthResponse = response.into_json().await.expect("valid json");
         assert!(body.cpu_overloaded);
-        assert!(!body.healthy);
     }
 }

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -1,0 +1,102 @@
+//! GET /health endpoint for NLB health checks.
+//!
+//! Returns 200 with a JSON body when the server is healthy, or 503 when any
+//! subsystem check fails.  No authentication is required — this is intended
+//! for infrastructure probes (AWS NLB, k8s liveness, etc.).
+//!
+//! Healthy is defined as:
+//! - Configuration initialized (NodeConfig loaded, chain accessible)
+//! - Connected to a lit-actions gRPC service (Unix socket reachable)
+
+use crate::actions::grpc::GrpcClientPool;
+use crate::config::GLOBAL_NODE_CONFIG;
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::{Route, State, get, routes};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub healthy: bool,
+    pub config_initialized: bool,
+    pub lit_actions_reachable: bool,
+}
+
+pub fn routes() -> Vec<Route> {
+    routes![health]
+}
+
+/// GET /health — lightweight readiness probe for NLB / load balancer health checks.
+#[get("/health")]
+async fn health(
+    grpc_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
+) -> (Status, Json<HealthResponse>) {
+    let config_initialized = GLOBAL_NODE_CONFIG.get().is_some();
+
+    // Check if we already have a connection to lit-actions in the pool, or if
+    // the socket file at least exists (avoids creating a new connection on
+    // every health probe).
+    let lit_actions_reachable = if grpc_pool
+        .get_connection(LIT_ACTIONS_SOCKET)
+        .await
+        .is_some()
+    {
+        true
+    } else {
+        // No pooled connection yet — fall back to checking the socket file
+        // exists.  A full gRPC connect on every NLB probe would be wasteful;
+        // the first real request will populate the pool.
+        Path::new(LIT_ACTIONS_SOCKET).exists()
+    };
+
+    let healthy = config_initialized && lit_actions_reachable;
+
+    let status = if healthy {
+        Status::Ok
+    } else {
+        Status::ServiceUnavailable
+    };
+
+    (
+        status,
+        Json(HealthResponse {
+            healthy,
+            config_initialized,
+            lit_actions_reachable,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::grpc::GrpcClientPool;
+    use rocket::local::asynchronous::Client;
+
+    fn build_rocket() -> rocket::Rocket<rocket::Build> {
+        let pool = GrpcClientPool::<tonic::transport::Channel>::new();
+        rocket::build().manage(pool).mount("/", routes![health])
+    }
+
+    #[tokio::test]
+    async fn health_returns_json_with_expected_shape() {
+        let client = Client::tracked(build_rocket()).await.expect("valid rocket");
+        let response = client.get("/health").dispatch().await;
+        let body: HealthResponse = response.into_json().await.expect("valid json");
+        // healthy is only true when ALL checks pass.
+        assert_eq!(body.healthy, body.config_initialized && body.lit_actions_reachable);
+    }
+
+    #[tokio::test]
+    async fn health_reports_lit_actions_unreachable_when_no_socket() {
+        // In the test environment there is no /tmp/lit_actions.sock and no
+        // pooled gRPC connection, so lit_actions_reachable should be false.
+        let client = Client::tracked(build_rocket()).await.expect("valid rocket");
+        let response = client.get("/health").dispatch().await;
+        let body: HealthResponse = response.into_json().await.expect("valid json");
+        assert!(!body.lit_actions_reachable);
+    }
+}

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -56,7 +56,7 @@ async fn health(
     };
 
     let cpu_overloaded = cpu_monitor.is_overloaded();
-    let load_avg_1m = read_1m_load_avg().await.unwrap_or(0.0);
+    let load_avg_1m = cpu_monitor.load_avg_1m();
 
     let healthy = lit_actions_reachable && !cpu_overloaded;
 
@@ -75,16 +75,6 @@ async fn health(
             load_avg_1m,
         }),
     )
-}
-
-async fn read_1m_load_avg() -> Option<f64> {
-    tokio::fs::read_to_string("/proc/loadavg")
-        .await
-        .ok()?
-        .split_whitespace()
-        .next()?
-        .parse()
-        .ok()
 }
 
 #[cfg(test)]

--- a/lit-api-server/src/core/v1/mod.rs
+++ b/lit-api-server/src/core/v1/mod.rs
@@ -1,4 +1,5 @@
 pub mod endpoints;
 pub mod guards;
+pub mod health;
 pub mod helpers;
 pub mod models;

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -156,6 +156,7 @@ async fn main() -> Result<(), rocket::Error> {
             "/",
             routes![openapi_json, openapi_json_redirect, swagger_ui_redirect],
         )
+        .mount("/", core::v1::health::routes())
         .mount("/core/v1/", core_routes)
         .mount(
             "/core/v1/swagger-ui/",


### PR DESCRIPTION
## Summary
- Add `GET /health` endpoint to lit-api-server returning 200 (healthy) or 503 (unhealthy)
- Checks two runtime failure modes that can occur after a successful startup:
  - **lit-actions reachable**: gRPC socket exists or pooled connection present
  - **CPU not overloaded**: CpuOverloadMonitor reports load is below threshold
- Mounted at root (`/health`) — no auth required, designed for NLB probing
- Update `wait-for-api-restart.yml` deploy workflow to poll `/health` instead of `/core/v1/openapi.json`

Stacked on #144 (CPL-107 CpuOverloadMonitor)

Closes CPL-117

## Test plan
- [x] Unit tests pass: `cargo test core::v1::health` (3 tests: shape, unreachable socket, cpu overloaded)
- [x] Full test suite passes (excluding pre-existing dstack TEE-only failures)
- [ ] Deploy to chipotle-dev and verify `curl https://<base>/health` returns `{"healthy":true,...}`
- [ ] Verify deploy workflow correctly waits on `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)