### PR TITLE
feat: add dstack-ingress for custom domain TLS (CPL-118)

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -14,6 +14,12 @@
 # Required secrets (set as encrypted Phala CVM environment variables):
 #   GCP_SERVICE_ACCOUNT_JSON  - GCP service account key (raw JSON or base64-encoded)
 #   GCP_PROJECT_ID            - GCP project ID (e.g. "my-gcp-project")
+#
+# Additional secrets required for custom-domain profile (dstack-ingress):
+#   NODE_DOMAIN               - Per-node domain (e.g. "node1.api.dev.litprotocol.com")
+#   CERTBOT_EMAIL             - Email for Let's Encrypt certificate notifications
+#   AWS_ACCESS_KEY_ID         - AWS IAM key for Route 53 DNS-01 ACME challenges
+#   AWS_SECRET_ACCESS_KEY     - AWS IAM secret for Route 53 DNS-01 ACME challenges
 
 # RUST_LOG filter shared by lit-actions and lit-api-server.
 # App code stays at trace; per-module overrides suppress low-value internals:
@@ -104,5 +110,42 @@ services:
       ROCKET_PORT: "8001"
     restart: unless-stopped
 
+  # dstack-ingress — TLS termination + attestation cert for custom domain (CPL-5).
+  # Activated with: docker compose --profile custom-domain up
+  #
+  # Issues a cert with both NODE_DOMAIN and ALIAS_DOMAIN as SANs via DNS-01
+  # (Route 53). The cert contains the CVM attestation identity, proving TLS is
+  # controlled exclusively by the TEE. NLB does TCP passthrough on :443.
+  #
+  # Automatically handles:
+  #   - Per-node DNS record (NODE_DOMAIN → Phala gateway CNAME)
+  #   - Shared attestation TXT append (_dstack-app-address.ALIAS_DOMAIN)
+  #   - nginx server_name for both domains
+  #
+  # Requires ALIAS_DOMAIN support: https://github.com/Dstack-TEE/dstack-examples/pull/83
+  # ROUTE53_INITIAL_WEIGHT intentionally NOT set — NLB handles traffic routing.
+  dstack-ingress:
+    profiles: ["custom-domain"]
+    image: dstacktee/dstack-ingress:latest
+    ports:
+      - "443:443"
+    environment:
+      DOMAIN: "${NODE_DOMAIN}"
+      ALIAS_DOMAIN: "api.dev.litprotocol.com"
+      DNS_PROVIDER: "route53"
+      TARGET_ENDPOINT: "http://lit-api-server:8000"
+      CERTBOT_EMAIL: "${CERTBOT_EMAIL}"
+      SET_CAA: "true"
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - cert-data:/etc/letsencrypt
+    depends_on:
+      lit-api-server:
+        condition: service_started
+    restart: unless-stopped
+
 volumes:
   lit-socket:
+  cert-data:

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -110,7 +110,7 @@ services:
       ROCKET_PORT: "8001"
     restart: unless-stopped
 
-  # dstack-ingress — TLS termination + attestation cert for custom domain (CPL-5).
+  # dstack-ingress — TLS termination + attestation cert for custom domain (CPL-118).
   # Activated with: docker compose --profile custom-domain up
   #
   # Issues a cert with both NODE_DOMAIN and ALIAS_DOMAIN as SANs via DNS-01
@@ -126,7 +126,7 @@ services:
   # ROUTE53_INITIAL_WEIGHT intentionally NOT set — NLB handles traffic routing.
   dstack-ingress:
     profiles: ["custom-domain"]
-    image: dstacktee/dstack-ingress:latest
+    image: dstacktee/dstack-ingress:1.4@sha256:11c0481ca1e2ef9c959187ff3c01c7f59c26d631c7717a571ad994b96203bb0b
     ports:
       - "443:443"
     environment:


### PR DESCRIPTION
## Summary

- Add `dstack-ingress` service to `docker-compose.phala.yml` behind `profiles: ["custom-domain"]` so current deployments are unaffected
- dstack-ingress terminates TLS inside the TEE with an attestation-bound cert covering both the per-node `NODE_DOMAIN` and shared `api.dev.litprotocol.com` (ALIAS_DOMAIN SAN)
- Uses Route 53 for DNS-01 ACME challenges (natively supported by dstack-ingress)
- Adds `cert-data` volume for Let's Encrypt cert persistence
- Documents new CVM secrets: `NODE_DOMAIN`, `CERTBOT_EMAIL`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`

**Blocked on:** [dstack-examples PR #86](https://github.com/Dstack-TEE/dstack-examples/pull/86) (ALIAS_DOMAIN support)

## Non-disruptive merge reasoning

This PR **can be safely merged** before R53 delegation and custom domain DNS are in place:

1. **Profile gating** — dstack-ingress is behind `profiles: ["custom-domain"]` and will not start unless explicitly activated with `docker compose --profile custom-domain up`. Standard `docker compose up` (used by current Phala deploys) ignores profiled services entirely.
2. **No changes to existing services** — lit-api-server, lit-actions, otel-collector, and lit-static are untouched.
3. **Volume addition is inert** — the new `cert-data` volume is only mounted by dstack-ingress, which doesn't start without the profile.
4. **Deploy workflow unaffected** — the `sed` image substitution step only touches `${DOCKER_IMAGE_*}` placeholders; `dstack-ingress` uses a literal image reference.

## Test plan

- [x] `docker compose -f docker-compose.phala.yml config` validates without errors (only expected env var warnings)
- [ ] Verify `docker compose up` (no profile) does **not** start dstack-ingress
- [ ] Verify `docker compose --profile custom-domain up` starts dstack-ingress (once PR #86 lands and R53 is configured)

Resolves CPL-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)