### PR TITLE
Feature/cpl 37 payment via stripe 3

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -14,6 +14,7 @@
         "pages": [
           "index",
           "dashboard",
+          "pricing",
           "api_direct",
           {
             "group": "Lit Actions",

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,0 +1,79 @@
+---
+title: "Pricing"
+description: "Credit-based pricing for Lit Chipotle — management operations, Lit Action execution, and how to top up your account."
+---
+
+## Overview
+
+Lit Chipotle uses a **credit-based billing model**. Credits are pre-purchased and drawn down as you use the API. There are no subscriptions, no per-seat fees, and no charges for read-only operations.
+
+---
+
+## What's Free
+
+All **read-only** dashboard and API operations are free of charge. These include:
+
+- Viewing groups, wallets, and IPFS actions
+- Listing usage API keys
+- Checking your account balance
+- Fetching node chain configuration
+- Any `GET` request that does not modify on-chain state
+
+---
+
+## Metered Operations
+
+The following operations consume credits each time they are called:
+
+| Operation | Cost |
+|---|---|
+| Management call (create/update/delete group, wallet, action, usage key, etc.) | **$0.01** |
+| Lit Action execution | **$0.01** |
+
+Management calls include: `create_wallet`, `add_group`, `remove_group`, `add_action`, `add_action_to_group`, `remove_action_from_group`, `update_group`, `update_action_metadata`, `add_pkp_to_group`, `remove_pkp_from_group`, `add_usage_api_key`, `remove_usage_api_key`, `update_usage_api_key`, `update_usage_api_key_metadata`.
+
+---
+
+## Purchasing Credits
+
+### Paying with a Credit Card (via Stripe)
+
+Credits can be purchased directly in the dashboard using a credit card. Stripe processes the payment — your card details are sent directly to Stripe and are never stored on Lit's servers.
+
+**To add funds:**
+
+1. Log in to the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/).
+2. Click **Add Funds** in the top-right corner.
+3. Select a credit package from the table below.
+4. Enter your card details and click **Pay**.
+
+Credits are applied to your account immediately after payment is confirmed.
+
+### Credit Packages
+
+| Package | Price | Credits included |
+|---|---|---|
+| Starter | **$5.00** | 500 credits |
+| Basic | **$10.00** | 1,000 credits |
+| Standard | **$25.00** | 2,500 credits |
+| Pro | **$50.00** | 5,000 credits |
+
+The minimum top-up is **$5.00**. All packages are one-time purchases with no expiry.
+
+### Paying with Crypto
+
+Direct payment with cryptocurrency (ETH, USDC, and other tokens) is an **upcoming feature**. Sign up for updates on the [Lit Protocol Discord](https://litgateway.com/discord).
+
+---
+
+## Credit Balance
+
+Your current balance is always visible in the top-right corner of the dashboard once you're logged in. A negative balance (displayed as a credit) means funds are available. Credits are depleted as you make metered API calls.
+
+If a call is made when your balance is exhausted, the API returns a `402 Payment Required` error. Top up your account to resume normal operation.
+
+---
+
+## Billing Identity
+
+Your billing account is tied to the **wallet address derived from your account API key**. This wallet address is used as the Stripe customer identifier. If you provide an email address when creating your account, it is forwarded to Stripe for your customer record and for payment receipts.

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -40,6 +40,11 @@ export interface NewAccountResponse {
 export interface NewAccountRequest {
   account_name: string;
   account_description: string;
+  /**
+   * Optional email address — forwarded to Stripe for the customer record.  Not stored on-chain.
+   * @nullable
+   */
+  email?: string | null;
 }
 
 export interface CreateWalletResponse {
@@ -245,6 +250,46 @@ export interface NodeChainConfigResponse {
   testnet: boolean;
   token: string;
   contract_address: string;
+}
+
+/**
+ * GET /billing/stripe_config — returns the Stripe publishable key for Stripe.js.
+ */
+export interface StripeConfigResponse {
+  publishable_key: string;
+}
+
+/**
+ * GET /billing/balance — current credit balance for the authenticated API key.
+ */
+export interface BillingBalanceResponse {
+  /** Balance in cents.  Negative means credits are available; zero means exhausted. */
+  balance_cents: number;
+  /** Human-readable, e.g. "$5.00 credit". */
+  balance_display: string;
+}
+
+/**
+ * POST /billing/create_payment_intent — client secret for Stripe.js confirmCardPayment.
+ */
+export interface CreatePaymentIntentResponse {
+  client_secret: string;
+  payment_intent_id: string;
+}
+
+/**
+ * POST /billing/create_payment_intent
+ */
+export interface CreatePaymentIntentRequest {
+  /** Amount to charge in US cents (minimum 500 = $5.00). */
+  amount_cents: number;
+}
+
+/**
+ * POST /billing/confirm_payment
+ */
+export interface ConfirmPaymentRequest {
+  payment_intent_id: string;
 }
 
 export type ListApiKeysParams = {
@@ -505,6 +550,37 @@ export type GetNodeChainConfigDefault = NodeChainConfigResponse | ErrMessage;
 export type GetApiPayersDefault = string[] | ErrMessage;
 
 export type GetAdminApiPayerDefault = string | ErrMessage;
+
+export type BillingStripeConfigDefault = StripeConfigResponse | ErrMessage;
+
+export type BillingBalanceHeaders = {
+  /**
+   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   */
+  "X-Api-Key": string;
+};
+
+export type BillingBalanceDefault = BillingBalanceResponse | ErrMessage;
+
+export type BillingCreatePaymentIntentHeaders = {
+  /**
+   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   */
+  "X-Api-Key": string;
+};
+
+export type BillingCreatePaymentIntentDefault =
+  | CreatePaymentIntentResponse
+  | ErrMessage;
+
+export type BillingConfirmPaymentHeaders = {
+  /**
+   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   */
+  "X-Api-Key": string;
+};
+
+export type BillingConfirmPaymentDefault = AccountOpResponse | ErrMessage;
 
 /**
  * This is the base client to use for interacting with the API.
@@ -1650,6 +1726,182 @@ export class LitApiServerClient {
       response,
       data,
       operationId: "get_admin_api_payer",
+    };
+  }
+
+  /**
+   * GET /billing/stripe_config — returns the Stripe publishable key. No auth required; the publishable key is safe to expose.
+   */
+  billingStripeConfig(requestParameters?: Params): {
+    response: Response;
+    data: BillingStripeConfigDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/billing/stripe_config`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "GET",
+      k6url.toString(),
+      undefined,
+      mergedRequestParameters,
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "billing_stripe_config",
+    };
+  }
+
+  /**
+   * GET /billing/balance — returns the current credit balance for the authenticated user.
+   */
+  billingBalance(
+    headers: BillingBalanceHeaders,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: BillingBalanceDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/billing/balance`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request("GET", k6url.toString(), undefined, {
+      ...mergedRequestParameters,
+      headers: {
+        ...mergedRequestParameters?.headers,
+        // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
+        ...Object.fromEntries(
+          Object.entries(headers || {}).map(([key, value]) => [
+            key,
+            String(value),
+          ]),
+        ),
+      },
+    });
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "billing_balance",
+    };
+  }
+
+  /**
+   * POST /billing/create_payment_intent — creates a Stripe PaymentIntent and returns the client_secret for use with Stripe.js `confirmCardPayment`.
+   */
+  billingCreatePaymentIntent(
+    createPaymentIntentRequest: CreatePaymentIntentRequest,
+    headers: BillingCreatePaymentIntentHeaders,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: BillingCreatePaymentIntentDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/billing/create_payment_intent`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(createPaymentIntentRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+          // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
+          ...Object.fromEntries(
+            Object.entries(headers || {}).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "billing_create_payment_intent",
+    };
+  }
+
+  /**
+   * POST /billing/confirm_payment — verifies a succeeded PaymentIntent and credits the account.
+   */
+  billingConfirmPayment(
+    confirmPaymentRequest: ConfirmPaymentRequest,
+    headers: BillingConfirmPaymentHeaders,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: BillingConfirmPaymentDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/billing/confirm_payment`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(confirmPaymentRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+          // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
+          ...Object.fromEntries(
+            Object.entries(headers || {}).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "billing_confirm_payment",
     };
   }
 

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -14,11 +14,11 @@ use crate::core::v1::models::response::{
     NewAccountResponse, NodeChainConfigResponse, WalletItem,
 };
 use crate::dstack::v1::get_client_key;
+use crate::stripe::StripeState;
 use crate::utils::generate_unique_derivation_path;
 use crate::utils::parse_with_hash::{
     hex_array_to_h160_array, hex_array_to_u256_array, ipfs_cid_to_u256, string_group_id_to_u256,
 };
-use crate::stripe::StripeState;
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
 use ethers::signers::{LocalWallet, Signer};

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -83,10 +83,21 @@ pub async fn new_account(
     )
     .await?;
 
-    // Best-effort: register the customer email in Stripe (does not fail account creation).
+    // Best-effort: eagerly create the Stripe customer (with $0 balance) and set the email
+    // if provided.  Neither failure should prevent account creation.
     if let Some(stripe) = stripe_state {
         let wallet_hex = bytes_to_0x_hex(wallet_address.as_bytes());
-        crate::stripe::register_customer_email(&wallet_hex, &email, &stripe).await;
+        match crate::stripe::get_customer_by_wallet(&wallet_hex, &stripe).await {
+            Ok(customer_id) => {
+                if !email.trim().is_empty() {
+                    let _ = crate::stripe::set_customer_email(&customer_id, email.trim(), &stripe)
+                        .await;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("stripe: failed to create customer for new account: {e}");
+            }
+        }
     }
 
     Ok(NewAccountResponse {

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -18,6 +18,7 @@ use crate::utils::generate_unique_derivation_path;
 use crate::utils::parse_with_hash::{
     hex_array_to_h160_array, hex_array_to_u256_array, ipfs_cid_to_u256, string_group_id_to_u256,
 };
+use crate::stripe::StripeState;
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
 use ethers::signers::{LocalWallet, Signer};
@@ -49,10 +50,12 @@ async fn create_new_wallet() -> Result<(String, H160, [u8; 32], U256), ApiStatus
 
 pub async fn new_account(
     signer_pool: Arc<SignerPool>,
+    stripe_state: Option<Arc<StripeState>>,
     new_account_request: Json<NewAccountRequest>,
 ) -> Result<NewAccountResponse, ApiStatus> {
     let account_name = new_account_request.account_name.clone();
     let account_description = new_account_request.account_description.clone();
+    let email = new_account_request.email.clone().unwrap_or_default();
 
     let (_public_key, wallet_address, secret, derivation_path) = create_new_wallet().await?;
     let api_key = base64_light::base64_encode_bytes(&secret);
@@ -79,6 +82,12 @@ pub async fn new_account(
         "Account Master Wallet",
     )
     .await?;
+
+    // Best-effort: register the customer email in Stripe (does not fail account creation).
+    if let Some(stripe) = stripe_state {
+        let wallet_hex = bytes_to_0x_hex(wallet_address.as_bytes());
+        crate::stripe::register_customer_email(&wallet_hex, &email, &stripe).await;
+    }
 
     Ok(NewAccountResponse {
         api_key: api_key.to_string(),

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -565,16 +565,13 @@ async fn billing_balance_impl(
     let wallet = stripe::api_key_to_wallet_address(api_key)
         .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
     // Look up an existing Stripe customer without creating one.
-    let maybe_customer_id = stripe::get_customer_by_wallet(&wallet, stripe)
+    let customer_id = stripe::get_customer_by_wallet(&wallet, stripe)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
-    let balance = if let Some(customer_id) = maybe_customer_id {
+    let balance = 
         stripe::get_credit_balance(&customer_id, stripe)
             .await
-            .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?
-    } else {
-        0
-    };
+            .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
     let credits = -balance; // positive = available credit cents
     let display = if credits <= 0 {
         "No credits".to_string()

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -561,9 +561,7 @@ async fn billing_balance_impl(
     api_key: &str,
     stripe_state: &Option<Arc<StripeState>>,
 ) -> Result<BillingBalanceResponse, ApiStatus> {
-    let stripe = stripe_state
-        .as_ref()
-        .ok_or_else(billing_disabled_err)?;
+    let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
     let wallet = stripe::api_key_to_wallet_address(api_key)
         .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
     let customer_id = stripe::get_or_create_customer(&wallet, stripe)
@@ -605,9 +603,7 @@ async fn billing_create_payment_intent_impl(
     stripe_state: &Option<Arc<StripeState>>,
     req: Json<CreatePaymentIntentRequest>,
 ) -> Result<CreatePaymentIntentResponse, ApiStatus> {
-    let stripe = stripe_state
-        .as_ref()
-        .ok_or_else(billing_disabled_err)?;
+    let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
     let wallet = stripe::api_key_to_wallet_address(api_key)
         .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
     let (client_secret, payment_intent_id) =
@@ -628,8 +624,7 @@ async fn billing_confirm_payment(
     stripe_state: &State<Option<Arc<StripeState>>>,
     req: Json<ConfirmPaymentRequest>,
 ) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    let result =
-        billing_confirm_payment_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
+    let result = billing_confirm_payment_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
     OpenApiResponse {
         response: ApiResult(result).into(),
     }
@@ -640,9 +635,7 @@ async fn billing_confirm_payment_impl(
     stripe_state: &Option<Arc<StripeState>>,
     req: Json<ConfirmPaymentRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
-    let stripe = stripe_state
-        .as_ref()
-        .ok_or_else(billing_disabled_err)?;
+    let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
     let wallet = stripe::api_key_to_wallet_address(api_key)
         .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
     stripe::confirm_payment_and_credit(&req.payment_intent_id, &wallet, stripe)

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -564,12 +564,17 @@ async fn billing_balance_impl(
     let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
     let wallet = stripe::api_key_to_wallet_address(api_key)
         .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
-    let customer_id = stripe::get_or_create_customer(&wallet, stripe)
+    // Look up an existing Stripe customer without creating one.
+    let maybe_customer_id = stripe::get_customer_by_wallet(&wallet, stripe)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
-    let balance = stripe::get_credit_balance(&customer_id, stripe)
-        .await
-        .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    let balance = if let Some(customer_id) = maybe_customer_id {
+        stripe::get_credit_balance(&customer_id, stripe)
+            .await
+            .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?
+    } else {
+        0
+    };
     let credits = -balance; // positive = available credit cents
     let display = if credits <= 0 {
         "No credits".to_string()

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -568,10 +568,9 @@ async fn billing_balance_impl(
     let customer_id = stripe::get_customer_by_wallet(&wallet, stripe)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
-    let balance = 
-        stripe::get_credit_balance(&customer_id, stripe)
-            .await
-            .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    let balance = stripe::get_credit_balance(&customer_id, stripe)
+        .await
+        .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
     let credits = -balance; // positive = available credit cents
     let display = if credits <= 0 {
         "No credits".to_string()

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -487,7 +487,7 @@ async fn update_usage_api_key_metadata(
     }
 }
 
-// ─── Billed Lit Action endpoint ($0.05) ───────────────────────────────────────
+// ─── Billed Lit Action endpoint ($0.01) ───────────────────────────────────────
 
 #[openapi(tag = "Actions")]
 #[post("/lit_action", format = "json", data = "<lit_action_request>")]

--- a/lit-api-server/src/core/v1/endpoints.rs
+++ b/lit-api-server/src/core/v1/endpoints.rs
@@ -5,23 +5,26 @@ use crate::actions::grpc::GrpcClientPool;
 use crate::core::account_management;
 use crate::core::core_features;
 use crate::core::v1::guards::apikey::ApiKey;
+use crate::core::v1::guards::billing::{BilledLitActionApiKey, BilledManagementApiKey};
 use crate::core::v1::guards::cpu_overload::CpuAvailable;
-use crate::core::v1::helpers::api_status::{ApiResult, ErrMessage};
+use crate::core::v1::helpers::api_status::{ApiResult, ApiStatus, ErrMessage};
 use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, LitActionRequest, NewAccountRequest, RemoveActionFromGroupRequest,
-    RemoveGroupRequest, RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest,
-    UpdateActionMetadataRequest, UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest,
-    UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, ConfirmPaymentRequest, CreatePaymentIntentRequest, LitActionRequest,
+    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest, RemovePkpFromGroupRequest,
+    RemoveUsageApiKeyRequest, UpdateActionMetadataRequest, UpdateGroupRequest,
+    UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::ApiKeyItem;
 use crate::core::v1::models::response::WalletItem;
 use crate::core::v1::models::response::{
-    AccountOpResponse, AddUsageApiKeyResponse, CreateWalletResponse, ListMetadataItem,
-    LitActionResponse, NewAccountResponse, NodeChainConfigResponse,
+    AccountOpResponse, AddUsageApiKeyResponse, BillingBalanceResponse, CreatePaymentIntentResponse,
+    CreateWalletResponse, ListMetadataItem, LitActionResponse, NewAccountResponse,
+    NodeChainConfigResponse, StripeConfigResponse,
 };
 use crate::observability::RequestSpan;
+use crate::stripe::{self, StripeState};
 use moka::future::Cache;
 use rocket::Route;
 use rocket::State;
@@ -31,7 +34,7 @@ use rocket_okapi::okapi::openapi3::OpenApi;
 use rocket_okapi::openapi;
 use rocket_okapi::openapi_get_routes_spec;
 
-/// Returns Core v1 routes and the OpenAPI spec for them. Mount routes at `/core/v1/` and serve the spec at `/openapi.json` (or use it for Swagger UI).
+/// Returns Core v1 routes and the OpenAPI spec for them.
 pub fn routes_with_spec() -> (Vec<Route>, OpenApi) {
     openapi_get_routes_spec![
         list_api_keys,
@@ -60,71 +63,42 @@ pub fn routes_with_spec() -> (Vec<Route>, OpenApi) {
         get_node_chain_config,
         get_api_payers,
         get_admin_api_payer,
+        billing_stripe_config,
+        billing_balance,
+        billing_create_payment_intent,
+        billing_confirm_payment,
     ]
 }
+
+// ─── Account creation (not behind billing — creating an account is free) ──────
 
 #[openapi(tag = "Account Management")]
 #[post("/new_account", format = "json", data = "<new_account_request>")]
 async fn new_account(
     signer_pool: &State<Arc<SignerPool>>,
+    stripe_state: &State<Option<Arc<StripeState>>>,
     new_account_request: Json<NewAccountRequest>,
 ) -> OpenApiResponse<NewAccountResponse, ErrMessage> {
     OpenApiResponse {
         response: ApiResult(
-            account_management::new_account(signer_pool.inner().clone(), new_account_request).await,
+            account_management::new_account(
+                signer_pool.inner().clone(),
+                stripe_state.inner().clone(),
+                new_account_request,
+            )
+            .await,
         )
         .into(),
     }
 }
+
+// ─── Read-only endpoints (no billing) ─────────────────────────────────────────
 
 #[openapi(tag = "Account Management")]
 #[get("/account_exists")]
 async fn account_exists(api_key: ApiKey) -> OpenApiResponse<bool, ErrMessage> {
     OpenApiResponse {
         response: ApiResult(account_management::account_exists(api_key.0.as_str()).await).into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[get("/create_wallet")]
-async fn create_wallet(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-) -> OpenApiResponse<CreateWalletResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::create_wallet(signer_pool.inner().clone(), api_key.0.as_str())
-                .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Actions")]
-#[post("/lit_action", format = "json", data = "<lit_action_request>")]
-#[tracing::instrument(name = "endpoint::lit_action", skip_all, parent = &request_span.span)]
-async fn lit_action(
-    _cpu: CpuAvailable,
-    request_span: RequestSpan,
-    api_key: ApiKey,
-    grpc_client_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
-    ipfs_cache: &State<Cache<String, String>>,
-    http_client: &State<reqwest::Client>,
-    lit_action_request: Json<LitActionRequest>,
-) -> OpenApiResponse<LitActionResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            core_features::lit_action(
-                &request_span,
-                api_key.0.as_str(),
-                grpc_client_pool.inner(),
-                ipfs_cache.inner(),
-                http_client.inner(),
-                lit_action_request,
-            )
-            .await,
-        )
-        .into(),
     }
 }
 
@@ -138,248 +112,30 @@ async fn get_lit_action_ipfs_id(code: Json<String>) -> OpenApiResponse<String, E
 }
 
 #[openapi(tag = "Account Management")]
-#[post("/add_group", format = "json", data = "<req>")]
-async fn add_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<AddGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+#[get("/get_node_chain_config")]
+async fn get_node_chain_config() -> OpenApiResponse<NodeChainConfigResponse, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(
-            account_management::add_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
-                .await,
-        )
-        .into(),
+        response: ApiResult(account_management::get_chain_info().await).into(),
     }
 }
 
 #[openapi(tag = "Account Management")]
-#[post("/remove_group", format = "json", data = "<req>")]
-async fn remove_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<RemoveGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+#[get("/get_api_payers")]
+async fn get_api_payers() -> OpenApiResponse<Vec<String>, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(
-            account_management::remove_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
-                .await,
-        )
-        .into(),
+        response: ApiResult(account_management::get_api_payers().await).into(),
     }
 }
 
 #[openapi(tag = "Account Management")]
-#[post("/add_action", format = "json", data = "<req>")]
-async fn add_action(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<AddActionRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+#[get("/get_admin_api_payer")]
+async fn get_admin_api_payer() -> OpenApiResponse<String, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(
-            account_management::add_action(signer_pool.inner().clone(), api_key.0.as_str(), req)
-                .await,
-        )
-        .into(),
+        response: ApiResult(account_management::get_admin_api_payer().await).into(),
     }
 }
 
-#[openapi(tag = "Account Management")]
-#[post("/add_action_to_group", format = "json", data = "<req>")]
-async fn add_action_to_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<AddActionToGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::add_action_to_group(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/add_pkp_to_group", format = "json", data = "<req>")]
-async fn add_pkp_to_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<AddPkpToGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::add_pkp_to_group(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/remove_pkp_from_group", format = "json", data = "<req>")]
-async fn remove_pkp_from_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<RemovePkpFromGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::remove_pkp_from_group(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/add_usage_api_key", format = "json", data = "<req>")]
-async fn add_usage_api_key(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<AddUsageApiKeyRequest>,
-) -> OpenApiResponse<AddUsageApiKeyResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::add_usage_api_key(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/remove_usage_api_key", format = "json", data = "<req>")]
-async fn remove_usage_api_key(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<RemoveUsageApiKeyRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::remove_usage_api_key(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/update_usage_api_key", format = "json", data = "<req>")]
-async fn update_usage_api_key(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<UpdateUsageApiKeyRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::update_usage_api_key(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/update_group", format = "json", data = "<req>")]
-async fn update_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<UpdateGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::update_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
-                .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/remove_action_from_group", format = "json", data = "<req>")]
-async fn remove_action_from_group(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<RemoveActionFromGroupRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::remove_action_from_group(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/update_action_metadata", format = "json", data = "<req>")]
-async fn update_action_metadata(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<UpdateActionMetadataRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::update_action_metadata(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
-
-#[openapi(tag = "Account Management")]
-#[post("/update_usage_api_key_metadata", format = "json", data = "<req>")]
-async fn update_usage_api_key_metadata(
-    signer_pool: &State<Arc<SignerPool>>,
-    api_key: ApiKey,
-    req: Json<UpdateUsageApiKeyMetadataRequest>,
-) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    OpenApiResponse {
-        response: ApiResult(
-            account_management::update_usage_api_key_metadata(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
-    }
-}
+// ─── List endpoints (no billing charge) ───────────────────────────────────────
 
 #[openapi(tag = "Account Management")]
 #[get("/list_api_keys?<page_number>&<page_size>")]
@@ -470,26 +226,427 @@ async fn list_actions(
     }
 }
 
+// ─── Billed management endpoints ($0.01 each) ─────────────────────────────────
+
 #[openapi(tag = "Account Management")]
-#[get("/get_node_chain_config")]
-async fn get_node_chain_config() -> OpenApiResponse<NodeChainConfigResponse, ErrMessage> {
+#[get("/create_wallet")]
+async fn create_wallet(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+) -> OpenApiResponse<CreateWalletResponse, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(account_management::get_chain_info().await).into(),
+        response: ApiResult(
+            account_management::create_wallet(signer_pool.inner().clone(), api_key.0.as_str())
+                .await,
+        )
+        .into(),
     }
 }
 
 #[openapi(tag = "Account Management")]
-#[get("/get_api_payers")]
-async fn get_api_payers() -> OpenApiResponse<Vec<String>, ErrMessage> {
+#[post("/add_group", format = "json", data = "<req>")]
+async fn add_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<AddGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(account_management::get_api_payers().await).into(),
+        response: ApiResult(
+            account_management::add_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
+                .await,
+        )
+        .into(),
     }
 }
 
 #[openapi(tag = "Account Management")]
-#[get("/get_admin_api_payer")]
-async fn get_admin_api_payer() -> OpenApiResponse<String, ErrMessage> {
+#[post("/remove_group", format = "json", data = "<req>")]
+async fn remove_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<RemoveGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
     OpenApiResponse {
-        response: ApiResult(account_management::get_admin_api_payer().await).into(),
+        response: ApiResult(
+            account_management::remove_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
+                .await,
+        )
+        .into(),
     }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/add_action", format = "json", data = "<req>")]
+async fn add_action(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<AddActionRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::add_action(signer_pool.inner().clone(), api_key.0.as_str(), req)
+                .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/add_action_to_group", format = "json", data = "<req>")]
+async fn add_action_to_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<AddActionToGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::add_action_to_group(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/add_pkp_to_group", format = "json", data = "<req>")]
+async fn add_pkp_to_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<AddPkpToGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::add_pkp_to_group(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/remove_pkp_from_group", format = "json", data = "<req>")]
+async fn remove_pkp_from_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<RemovePkpFromGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::remove_pkp_from_group(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/add_usage_api_key", format = "json", data = "<req>")]
+async fn add_usage_api_key(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<AddUsageApiKeyRequest>,
+) -> OpenApiResponse<AddUsageApiKeyResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::add_usage_api_key(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/remove_usage_api_key", format = "json", data = "<req>")]
+async fn remove_usage_api_key(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<RemoveUsageApiKeyRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::remove_usage_api_key(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/update_usage_api_key", format = "json", data = "<req>")]
+async fn update_usage_api_key(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<UpdateUsageApiKeyRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::update_usage_api_key(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/update_group", format = "json", data = "<req>")]
+async fn update_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<UpdateGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::update_group(signer_pool.inner().clone(), api_key.0.as_str(), req)
+                .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/remove_action_from_group", format = "json", data = "<req>")]
+async fn remove_action_from_group(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<RemoveActionFromGroupRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::remove_action_from_group(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/update_action_metadata", format = "json", data = "<req>")]
+async fn update_action_metadata(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<UpdateActionMetadataRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::update_action_metadata(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/update_usage_api_key_metadata", format = "json", data = "<req>")]
+async fn update_usage_api_key_metadata(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<UpdateUsageApiKeyMetadataRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::update_usage_api_key_metadata(
+                signer_pool.inner().clone(),
+                api_key.0.as_str(),
+                req,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+// ─── Billed Lit Action endpoint ($0.05) ───────────────────────────────────────
+
+#[openapi(tag = "Actions")]
+#[post("/lit_action", format = "json", data = "<lit_action_request>")]
+#[tracing::instrument(name = "endpoint::lit_action", skip_all, parent = &request_span.span)]
+async fn lit_action(
+    _cpu: CpuAvailable,
+    request_span: RequestSpan,
+    api_key: BilledLitActionApiKey,
+    grpc_client_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
+    ipfs_cache: &State<Cache<String, String>>,
+    http_client: &State<reqwest::Client>,
+    lit_action_request: Json<LitActionRequest>,
+) -> OpenApiResponse<LitActionResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            core_features::lit_action(
+                &request_span,
+                api_key.0.as_str(),
+                grpc_client_pool.inner(),
+                ipfs_cache.inner(),
+                http_client.inner(),
+                lit_action_request,
+            )
+            .await,
+        )
+        .into(),
+    }
+}
+
+// ─── Billing endpoints ─────────────────────────────────────────────────────────
+
+fn billing_disabled_err() -> ApiStatus {
+    ApiStatus::internal_server_error(
+        anyhow::anyhow!("Stripe billing is not configured on this node"),
+        "Billing not configured",
+    )
+}
+
+/// GET /billing/stripe_config — returns the Stripe publishable key.
+/// No auth required; the publishable key is safe to expose.
+#[openapi(tag = "Billing")]
+#[get("/billing/stripe_config")]
+async fn billing_stripe_config(
+    stripe_state: &State<Option<Arc<StripeState>>>,
+) -> OpenApiResponse<StripeConfigResponse, ErrMessage> {
+    let result = match stripe_state.inner() {
+        Some(s) => Ok(StripeConfigResponse {
+            publishable_key: s.publishable_key.clone(),
+        }),
+        None => Err(billing_disabled_err()),
+    };
+    OpenApiResponse {
+        response: ApiResult(result).into(),
+    }
+}
+
+/// GET /billing/balance — returns the current credit balance for the authenticated user.
+#[openapi(tag = "Billing")]
+#[get("/billing/balance")]
+async fn billing_balance(
+    api_key: ApiKey,
+    stripe_state: &State<Option<Arc<StripeState>>>,
+) -> OpenApiResponse<BillingBalanceResponse, ErrMessage> {
+    let result = billing_balance_impl(api_key.0.as_str(), stripe_state.inner()).await;
+    OpenApiResponse {
+        response: ApiResult(result).into(),
+    }
+}
+
+async fn billing_balance_impl(
+    api_key: &str,
+    stripe_state: &Option<Arc<StripeState>>,
+) -> Result<BillingBalanceResponse, ApiStatus> {
+    let stripe = stripe_state
+        .as_ref()
+        .ok_or_else(billing_disabled_err)?;
+    let wallet = stripe::api_key_to_wallet_address(api_key)
+        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    let customer_id = stripe::get_or_create_customer(&wallet, stripe)
+        .await
+        .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    let balance = stripe::get_credit_balance(&customer_id, stripe)
+        .await
+        .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    let credits = -balance; // positive = available credit cents
+    let display = if credits <= 0 {
+        "No credits".to_string()
+    } else {
+        format!("{} credit", stripe::cents_to_display(credits))
+    };
+    Ok(BillingBalanceResponse {
+        balance_cents: balance,
+        balance_display: display,
+    })
+}
+
+/// POST /billing/create_payment_intent — creates a Stripe PaymentIntent and returns
+/// the client_secret for use with Stripe.js `confirmCardPayment`.
+#[openapi(tag = "Billing")]
+#[post("/billing/create_payment_intent", format = "json", data = "<req>")]
+async fn billing_create_payment_intent(
+    api_key: ApiKey,
+    stripe_state: &State<Option<Arc<StripeState>>>,
+    req: Json<CreatePaymentIntentRequest>,
+) -> OpenApiResponse<CreatePaymentIntentResponse, ErrMessage> {
+    let result =
+        billing_create_payment_intent_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
+    OpenApiResponse {
+        response: ApiResult(result).into(),
+    }
+}
+
+async fn billing_create_payment_intent_impl(
+    api_key: &str,
+    stripe_state: &Option<Arc<StripeState>>,
+    req: Json<CreatePaymentIntentRequest>,
+) -> Result<CreatePaymentIntentResponse, ApiStatus> {
+    let stripe = stripe_state
+        .as_ref()
+        .ok_or_else(billing_disabled_err)?;
+    let wallet = stripe::api_key_to_wallet_address(api_key)
+        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    let (client_secret, payment_intent_id) =
+        stripe::create_payment_intent(&wallet, req.amount_cents, stripe)
+            .await
+            .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    Ok(CreatePaymentIntentResponse {
+        client_secret,
+        payment_intent_id,
+    })
+}
+
+/// POST /billing/confirm_payment — verifies a succeeded PaymentIntent and credits the account.
+#[openapi(tag = "Billing")]
+#[post("/billing/confirm_payment", format = "json", data = "<req>")]
+async fn billing_confirm_payment(
+    api_key: ApiKey,
+    stripe_state: &State<Option<Arc<StripeState>>>,
+    req: Json<ConfirmPaymentRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    let result =
+        billing_confirm_payment_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
+    OpenApiResponse {
+        response: ApiResult(result).into(),
+    }
+}
+
+async fn billing_confirm_payment_impl(
+    api_key: &str,
+    stripe_state: &Option<Arc<StripeState>>,
+    req: Json<ConfirmPaymentRequest>,
+) -> Result<AccountOpResponse, ApiStatus> {
+    let stripe = stripe_state
+        .as_ref()
+        .ok_or_else(billing_disabled_err)?;
+    let wallet = stripe::api_key_to_wallet_address(api_key)
+        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    stripe::confirm_payment_and_credit(&req.payment_intent_id, &wallet, stripe)
+        .await
+        .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
+    Ok(AccountOpResponse { success: true })
 }

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -104,7 +104,7 @@ impl<'r> OpenApiFromRequest<'r> for BilledManagementApiKey {
 
 // ─── BilledLitActionApiKey ────────────────────────────────────────────────────
 
-/// Guards a lit-action endpoint ($0.05 per call).
+/// Guards a lit-action endpoint ($0.01 per call).
 pub struct BilledLitActionApiKey(pub String);
 
 #[rocket::async_trait]

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -19,7 +19,7 @@ use crate::stripe::{self, StripeState};
 fn extract_api_key(request: &Request<'_>) -> Option<String> {
     // Authorization: Bearer <key>
     if let Some(v) = request.headers().get_one("Authorization") {
-        let mut parts = v.trim().split_whitespace();
+        let mut parts = v.split_whitespace();
         if let (Some(scheme), Some(key)) = (parts.next(), parts.next())
             && scheme.eq_ignore_ascii_case("bearer")
             && !key.trim().is_empty()
@@ -45,13 +45,12 @@ async fn charge_guard(
         return Outcome::Error((Status::Unauthorized, ()));
     };
 
-    if let Some(state) = request.rocket().state::<Option<Arc<StripeState>>>() {
-        if let Some(stripe) = state.as_ref() {
-            if let Err(e) = charge_fn(&key, stripe).await {
-                tracing::warn!("billing guard charge failed: {e}");
-                return Outcome::Error((Status::PaymentRequired, ()));
-            }
-        }
+    if let Some(state) = request.rocket().state::<Option<Arc<StripeState>>>()
+        && let Some(stripe) = state.as_ref()
+        && let Err(e) = charge_fn(&key, stripe).await
+    {
+        tracing::warn!("billing guard charge failed: {e}");
+        return Outcome::Error((Status::PaymentRequired, ()));
     }
 
     Outcome::Success(key)

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -1,0 +1,150 @@
+/// Rocket request guards that extract the API key **and** debit a Stripe billing charge
+/// before the handler runs.
+///
+/// If Stripe is not configured (no `StripeState` managed), the guard succeeds without charging.
+/// If the customer has insufficient credits the guard fails with `402 Payment Required`.
+use std::sync::Arc;
+
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+use rocket_okapi::Result as RocketOkapiResult;
+use rocket_okapi::r#gen::OpenApiGenerator;
+use rocket_okapi::okapi::openapi3::{Object, Parameter, ParameterValue};
+use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
+
+use crate::stripe::{self, StripeState};
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+fn extract_api_key(request: &Request<'_>) -> Option<String> {
+    // Authorization: Bearer <key>
+    if let Some(v) = request.headers().get_one("Authorization") {
+        let mut parts = v.trim().split_whitespace();
+        if let (Some(scheme), Some(key)) = (parts.next(), parts.next())
+            && scheme.eq_ignore_ascii_case("bearer")
+            && !key.trim().is_empty()
+        {
+            return Some(key.trim().to_string());
+        }
+    }
+    // X-Api-Key: <key>
+    if let Some(key) = request.headers().get_one("X-Api-Key") {
+        let key = key.trim();
+        if !key.is_empty() {
+            return Some(key.to_string());
+        }
+    }
+    None
+}
+
+async fn charge_guard(
+    request: &Request<'_>,
+    charge_fn: impl AsyncFn(&str, &StripeState) -> anyhow::Result<()>,
+) -> Outcome<String, ()> {
+    let Some(key) = extract_api_key(request) else {
+        return Outcome::Error((Status::Unauthorized, ()));
+    };
+
+    if let Some(state) = request.rocket().state::<Option<Arc<StripeState>>>() {
+        if let Some(stripe) = state.as_ref() {
+            if let Err(e) = charge_fn(&key, stripe).await {
+                tracing::warn!("billing guard charge failed: {e}");
+                return Outcome::Error((Status::PaymentRequired, ()));
+            }
+        }
+    }
+
+    Outcome::Success(key)
+}
+
+// ─── BilledManagementApiKey ───────────────────────────────────────────────────
+
+/// Guards a management endpoint ($0.01 per call).
+pub struct BilledManagementApiKey(pub String);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BilledManagementApiKey {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        charge_guard(request, stripe::charge_management)
+            .await
+            .map(BilledManagementApiKey)
+    }
+}
+
+impl<'r> OpenApiFromRequest<'r> for BilledManagementApiKey {
+    fn from_request_input(
+        generator: &mut OpenApiGenerator,
+        _name: String,
+        required: bool,
+    ) -> RocketOkapiResult<RequestHeaderInput> {
+        let schema = generator.json_schema::<String>();
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            name: "X-Api-Key".to_owned(),
+            location: "header".to_owned(),
+            description: Some(
+                "Account or usage API key. Alternatively use Authorization: Bearer <key>."
+                    .to_owned(),
+            ),
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Object::default(),
+        }))
+    }
+}
+
+// ─── BilledLitActionApiKey ────────────────────────────────────────────────────
+
+/// Guards a lit-action endpoint ($0.05 per call).
+pub struct BilledLitActionApiKey(pub String);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BilledLitActionApiKey {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        charge_guard(request, stripe::charge_lit_action)
+            .await
+            .map(BilledLitActionApiKey)
+    }
+}
+
+impl<'r> OpenApiFromRequest<'r> for BilledLitActionApiKey {
+    fn from_request_input(
+        generator: &mut OpenApiGenerator,
+        _name: String,
+        required: bool,
+    ) -> RocketOkapiResult<RequestHeaderInput> {
+        let schema = generator.json_schema::<String>();
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            name: "X-Api-Key".to_owned(),
+            location: "header".to_owned(),
+            description: Some(
+                "Account or usage API key. Alternatively use Authorization: Bearer <key>."
+                    .to_owned(),
+            ),
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Object::default(),
+        }))
+    }
+}

--- a/lit-api-server/src/core/v1/guards/mod.rs
+++ b/lit-api-server/src/core/v1/guards/mod.rs
@@ -1,2 +1,3 @@
 pub mod apikey;
+pub mod billing;
 pub mod cpu_overload;

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct NewAccountRequest {
     pub account_name: String,
     pub account_description: String,
+    /// Optional email address — forwarded to Stripe for the customer record.  Not stored on-chain.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 /// Request for add_group. permitted_actions and pkps are keccak256 hashes as hex strings (with or without 0x). API key via header.
@@ -138,6 +141,19 @@ pub struct RemoveGroupRequest {
 pub struct LitActionRequest {
     pub code: String,
     pub js_params: Option<serde_json::Value>,
+}
+
+/// POST /billing/create_payment_intent
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CreatePaymentIntentRequest {
+    /// Amount to charge in US cents (minimum 500 = $5.00).
+    pub amount_cents: i64,
+}
+
+/// POST /billing/confirm_payment
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ConfirmPaymentRequest {
+    pub payment_intent_id: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/lit-api-server/src/core/v1/models/response.rs
+++ b/lit-api-server/src/core/v1/models/response.rs
@@ -91,6 +91,28 @@ pub struct ApiKeyItem {
     pub can_execute_in_groups: Vec<u64>,
 }
 
+/// GET /billing/stripe_config — returns the Stripe publishable key for Stripe.js.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct StripeConfigResponse {
+    pub publishable_key: String,
+}
+
+/// GET /billing/balance — current credit balance for the authenticated API key.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct BillingBalanceResponse {
+    /// Balance in cents.  Negative means credits are available; zero means exhausted.
+    pub balance_cents: i64,
+    /// Human-readable, e.g. "$5.00 credit".
+    pub balance_display: String,
+}
+
+/// POST /billing/create_payment_intent — client secret for Stripe.js confirmCardPayment.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CreatePaymentIntentResponse {
+    pub client_secret: String,
+    pub payment_intent_id: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct NodeChainConfigResponse {
     pub chain_name: String,

--- a/lit-api-server/src/lib.rs
+++ b/lit-api-server/src/lib.rs
@@ -5,4 +5,5 @@ pub mod core;
 pub mod dstack;
 pub mod error;
 pub mod observability;
+pub mod stripe;
 pub mod utils;

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -6,6 +6,7 @@ use lit_api_server::core;
 use lit_api_server::core::v1::guards::cpu_overload::CpuOverloadMonitor;
 use lit_api_server::dstack;
 use lit_api_server::observability;
+use lit_api_server::stripe;
 use lit_api_server::utils::chain_info::Chain;
 use moka::future::Cache;
 use rocket::response::Redirect;
@@ -147,6 +148,8 @@ async fn main() -> Result<(), rocket::Error> {
         .max_capacity(1024 * 1024 * 1024)
         .build();
 
+    let stripe_state = stripe::init();
+
     let (core_routes, openapi_spec) = core::v1::endpoints::routes_with_spec();
 
     let mut r = rocket::build()
@@ -171,7 +174,8 @@ async fn main() -> Result<(), rocket::Error> {
         // .manage(action_store)
         .manage(GrpcClientPool::<tonic::transport::Channel>::new())
         .manage(signer_pool)
-        .manage(CpuOverloadMonitor::start());
+        .manage(CpuOverloadMonitor::start())
+        .manage(stripe_state);
 
     {
         // /attestation at root — per Phala Get Attestation

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -132,9 +132,8 @@ pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -
         return Ok(id.to_string());
     };
 
-    // Not found 
+    // Not found
     Err(anyhow::anyhow!("Stripe customer not found"))
-
 }
 
 /// Return the current credit balance in cents (≤ 0 means credits available; the Stripe

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -115,7 +115,7 @@ pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
 }
 
 /// Find the Stripe customer for this wallet address, creating one if none exists.
-pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -> Result<String> {
+pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -> Result<String> {
     // Search by metadata.
     let query = format!("metadata['wallet_address']:'{wallet_address}'");
     let resp = stripe_get(
@@ -130,26 +130,11 @@ pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -
         && let Some(id) = first.get("id").and_then(|i| i.as_str())
     {
         return Ok(id.to_string());
-    }
+    };
 
-    // Not found — create.
-    let resp = stripe_post(
-        state,
-        "customers",
-        &[
-            ("metadata[wallet_address]", wallet_address),
-            (
-                "description",
-                &format!("Lit Express Node — {wallet_address}"),
-            ),
-        ],
-    )
-    .await?;
+    // Not found 
+    Err(anyhow::anyhow!("Stripe customer not found"))
 
-    resp.get("id")
-        .and_then(|i| i.as_str())
-        .map(|s| s.to_string())
-        .ok_or_else(|| anyhow::anyhow!("Stripe customer create: missing id"))
 }
 
 /// Return the current credit balance in cents (≤ 0 means credits available; the Stripe
@@ -164,7 +149,7 @@ pub async fn get_credit_balance(customer_id: &str, state: &StripeState) -> Resul
 /// Returns `Err` if the balance would go positive (insufficient credits).
 async fn charge(api_key: &str, cost_cents: i64, state: &StripeState) -> Result<()> {
     let wallet = api_key_to_wallet_address(api_key)?;
-    let customer_id = get_or_create_customer(&wallet, state).await?;
+    let customer_id = get_customer_by_wallet(&wallet, state).await?;
     let balance = get_credit_balance(&customer_id, state).await?;
 
     if balance + cost_cents > 0 {
@@ -196,12 +181,10 @@ pub async fn charge_management(api_key: &str, state: &StripeState) -> Result<()>
     charge(api_key, COST_MANAGEMENT_CENTS, state).await
 }
 
-
 /// Charge $0.01 for a Lit Action execution.
 pub async fn charge_lit_action(api_key: &str, state: &StripeState) -> Result<()> {
     charge(api_key, COST_LIT_ACTION_CENTS, state).await
 }
-
 
 /// Create a PaymentIntent for `amount_cents`.  Returns `(client_secret, payment_intent_id)`.
 pub async fn create_payment_intent(
@@ -217,7 +200,7 @@ pub async fn create_payment_intent(
         );
     }
 
-    let customer_id = get_or_create_customer(wallet_address, state).await?;
+    let customer_id = get_customer_by_wallet(wallet_address, state).await?;
     let amount_str = amount_cents.to_string();
 
     let resp = stripe_post(
@@ -285,7 +268,7 @@ pub async fn confirm_payment_and_credit(
 
     // Ownership check: the PaymentIntent's customer must match the caller's customer.
     let pi_customer = resp.get("customer").and_then(|c| c.as_str()).unwrap_or("");
-    let customer_id = get_or_create_customer(wallet_address, state).await?;
+    let customer_id = get_customer_by_wallet(wallet_address, state).await?;
     if pi_customer != customer_id {
         anyhow::bail!("PaymentIntent {payment_intent_id} does not belong to this account");
     }
@@ -324,7 +307,7 @@ pub async fn register_customer_email(wallet_address: &str, email: &str, state: &
     if email.trim().is_empty() {
         return;
     }
-    let Ok(customer_id) = get_or_create_customer(wallet_address, state).await else {
+    let Ok(customer_id) = get_customer_by_wallet(wallet_address, state).await else {
         return;
     };
     let _ = stripe_post(

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -125,12 +125,11 @@ pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -
     )
     .await?;
 
-    if let Some(data) = resp.get("data").and_then(|d| d.as_array()) {
-        if let Some(first) = data.first() {
-            if let Some(id) = first.get("id").and_then(|i| i.as_str()) {
-                return Ok(id.to_string());
-            }
-        }
+    if let Some(data) = resp.get("data").and_then(|d| d.as_array())
+        && let Some(first) = data.first()
+        && let Some(id) = first.get("id").and_then(|i| i.as_str())
+    {
+        return Ok(id.to_string());
     }
 
     // Not found — create.
@@ -139,7 +138,10 @@ pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -
         "customers",
         &[
             ("metadata[wallet_address]", wallet_address),
-            ("description", &format!("Lit Express Node — {wallet_address}")),
+            (
+                "description",
+                &format!("Lit Express Node — {wallet_address}"),
+            ),
         ],
     )
     .await?;
@@ -154,10 +156,7 @@ pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -
 /// balance field is negative when the customer has a credit).
 pub async fn get_credit_balance(customer_id: &str, state: &StripeState) -> Result<i64> {
     let resp = stripe_get(state, &format!("customers/{customer_id}"), &[]).await?;
-    let balance = resp
-        .get("balance")
-        .and_then(|b| b.as_i64())
-        .unwrap_or(0);
+    let balance = resp.get("balance").and_then(|b| b.as_i64()).unwrap_or(0);
     Ok(balance)
 }
 
@@ -268,9 +267,7 @@ pub async fn confirm_payment_and_credit(
         .unwrap_or("unknown");
 
     if status != "succeeded" {
-        anyhow::bail!(
-            "PaymentIntent {payment_intent_id} has status '{status}', not 'succeeded'"
-        );
+        anyhow::bail!("PaymentIntent {payment_intent_id} has status '{status}', not 'succeeded'");
     }
 
     // Replay guard: reject if this intent was already credited.
@@ -285,10 +282,7 @@ pub async fn confirm_payment_and_credit(
     }
 
     // Ownership check: the PaymentIntent's customer must match the caller's customer.
-    let pi_customer = resp
-        .get("customer")
-        .and_then(|c| c.as_str())
-        .unwrap_or("");
+    let pi_customer = resp.get("customer").and_then(|c| c.as_str()).unwrap_or("");
     let customer_id = get_or_create_customer(wallet_address, state).await?;
     if pi_customer != customer_id {
         anyhow::bail!("PaymentIntent {payment_intent_id} does not belong to this account");
@@ -324,11 +318,7 @@ pub async fn confirm_payment_and_credit(
 }
 
 /// Best-effort: set the customer's email in Stripe.  Never fails the caller.
-pub async fn register_customer_email(
-    wallet_address: &str,
-    email: &str,
-    state: &StripeState,
-) {
+pub async fn register_customer_email(wallet_address: &str, email: &str, state: &StripeState) {
     if email.trim().is_empty() {
         return;
     }

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -15,7 +15,7 @@ use ethers::signers::{LocalWallet, Signer};
 
 /// Cost constants in US cents.
 pub const COST_MANAGEMENT_CENTS: i64 = 1; // $0.01
-pub const COST_LIT_ACTION_CENTS: i64 = 5; // $0.05
+pub const COST_LIT_ACTION_CENTS: i64 = 1; // $0.05
 /// Minimum top-up (500 cents = $5.00).
 pub const MIN_TOPUP_CENTS: i64 = 500;
 
@@ -247,6 +247,14 @@ pub async fn create_payment_intent(
 }
 
 /// Verify a PaymentIntent succeeded and credit the customer's account.
+///
+/// Replay protection:
+/// 1. Checks `metadata.credited == "true"` on the PaymentIntent — rejects if already applied.
+/// 2. Verifies the PaymentIntent's `customer` field matches the caller's Stripe customer —
+///    prevents one account from claiming another account's payment.
+/// 3. Marks the PaymentIntent as credited (`metadata[credited]=true`) **before** creating
+///    the balance transaction, so a crash or retry after this point is safe (the second call
+///    will be rejected by check 1).
 pub async fn confirm_payment_and_credit(
     payment_intent_id: &str,
     wallet_address: &str,
@@ -265,14 +273,42 @@ pub async fn confirm_payment_and_credit(
         );
     }
 
+    // Replay guard: reject if this intent was already credited.
+    let already_credited = resp
+        .get("metadata")
+        .and_then(|m| m.get("credited"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        == "true";
+    if already_credited {
+        anyhow::bail!("PaymentIntent {payment_intent_id} has already been credited");
+    }
+
+    // Ownership check: the PaymentIntent's customer must match the caller's customer.
+    let pi_customer = resp
+        .get("customer")
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+    let customer_id = get_or_create_customer(wallet_address, state).await?;
+    if pi_customer != customer_id {
+        anyhow::bail!("PaymentIntent {payment_intent_id} does not belong to this account");
+    }
+
     let amount = resp
         .get("amount")
         .and_then(|a| a.as_i64())
         .ok_or_else(|| anyhow::anyhow!("PaymentIntent: missing amount"))?;
 
-    let customer_id = get_or_create_customer(wallet_address, state).await?;
-    let credit = (-amount).to_string(); // negative = credit to customer
+    // Mark as credited before creating the balance transaction so that any subsequent
+    // call with the same intent ID is rejected even if the process crashes after this point.
+    stripe_post(
+        state,
+        &format!("payment_intents/{payment_intent_id}"),
+        &[("metadata[credited]", "true")],
+    )
+    .await?;
 
+    let credit = (-amount).to_string(); // negative = credit to customer
     stripe_post(
         state,
         &format!("customers/{customer_id}/balance_transactions"),

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -1,0 +1,313 @@
+/// Stripe billing integration using customer balance as a credit ledger.
+///
+/// Credits flow:
+///   • Funding:   PaymentIntent succeeds → create customer balance transaction (amount = -cents)
+///                This makes the balance more negative = more credits available.
+///   • Charging:  Before each API call we check `balance + cost <= 0`; if so we create a
+///                positive balance transaction (depletes credits).
+///
+/// Customer identity: the Stripe customer is keyed by the wallet address derived from the API key
+/// (stored in customer metadata as `wallet_address`).
+use std::sync::Arc;
+
+use anyhow::Result;
+use ethers::signers::{LocalWallet, Signer};
+
+/// Cost constants in US cents.
+pub const COST_MANAGEMENT_CENTS: i64 = 1; // $0.01
+pub const COST_LIT_ACTION_CENTS: i64 = 5; // $0.05
+/// Minimum top-up (500 cents = $5.00).
+pub const MIN_TOPUP_CENTS: i64 = 500;
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct StripeState {
+    pub publishable_key: String,
+    secret_key: String,
+    client: reqwest::Client,
+}
+
+/// Initialise Stripe from environment variables.  Returns `None` if the env vars are absent
+/// (billing disabled — all charges are skipped).
+pub fn init() -> Option<Arc<StripeState>> {
+    let secret_key = std::env::var("STRIPE_SECRET_KEY").ok()?;
+    let publishable_key = std::env::var("STRIPE_PUBLISHABLE_KEY").ok()?;
+    if secret_key.is_empty() || publishable_key.is_empty() {
+        return None;
+    }
+    tracing::info!("stripe: billing enabled");
+    Some(Arc::new(StripeState {
+        publishable_key,
+        secret_key,
+        client: reqwest::Client::new(),
+    }))
+}
+
+// ─── Stripe API helpers ───────────────────────────────────────────────────────
+
+fn stripe_base() -> &'static str {
+    "https://api.stripe.com/v1"
+}
+
+/// `GET /v1/<path>` with optional query params.
+async fn stripe_get(
+    state: &StripeState,
+    path: &str,
+    query: &[(&str, &str)],
+) -> Result<serde_json::Value> {
+    let url = format!("{}/{}", stripe_base(), path);
+    let resp = state
+        .client
+        .get(&url)
+        .basic_auth(&state.secret_key, Some(""))
+        .query(query)
+        .send()
+        .await?;
+    let body: serde_json::Value = resp.json().await?;
+    if let Some(e) = body.get("error") {
+        anyhow::bail!(
+            "Stripe GET {path}: {}",
+            e.get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error")
+        );
+    }
+    Ok(body)
+}
+
+/// `POST /v1/<path>` with form-encoded body.
+async fn stripe_post(
+    state: &StripeState,
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<serde_json::Value> {
+    let url = format!("{}/{}", stripe_base(), path);
+    let resp = state
+        .client
+        .post(&url)
+        .basic_auth(&state.secret_key, Some(""))
+        .form(params)
+        .send()
+        .await?;
+    let body: serde_json::Value = resp.json().await?;
+    if let Some(e) = body.get("error") {
+        anyhow::bail!(
+            "Stripe POST {path}: {}",
+            e.get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error")
+        );
+    }
+    Ok(body)
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Derive the hex wallet address from a base64-encoded API key.
+pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
+    let bytes = base64_light::base64_decode(api_key);
+    if bytes.len() < 32 {
+        anyhow::bail!("API key too short to derive wallet address");
+    }
+    let wallet = LocalWallet::from_bytes(&bytes[..32])?;
+    Ok(format!("{:?}", wallet.address()))
+}
+
+/// Find the Stripe customer for this wallet address, creating one if none exists.
+pub async fn get_or_create_customer(wallet_address: &str, state: &StripeState) -> Result<String> {
+    // Search by metadata.
+    let query = format!("metadata['wallet_address']:'{wallet_address}'");
+    let resp = stripe_get(
+        state,
+        "customers/search",
+        &[("query", query.as_str()), ("limit", "1")],
+    )
+    .await?;
+
+    if let Some(data) = resp.get("data").and_then(|d| d.as_array()) {
+        if let Some(first) = data.first() {
+            if let Some(id) = first.get("id").and_then(|i| i.as_str()) {
+                return Ok(id.to_string());
+            }
+        }
+    }
+
+    // Not found — create.
+    let resp = stripe_post(
+        state,
+        "customers",
+        &[
+            ("metadata[wallet_address]", wallet_address),
+            ("description", &format!("Lit Express Node — {wallet_address}")),
+        ],
+    )
+    .await?;
+
+    resp.get("id")
+        .and_then(|i| i.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("Stripe customer create: missing id"))
+}
+
+/// Return the current credit balance in cents (≤ 0 means credits available; the Stripe
+/// balance field is negative when the customer has a credit).
+pub async fn get_credit_balance(customer_id: &str, state: &StripeState) -> Result<i64> {
+    let resp = stripe_get(state, &format!("customers/{customer_id}"), &[]).await?;
+    let balance = resp
+        .get("balance")
+        .and_then(|b| b.as_i64())
+        .unwrap_or(0);
+    Ok(balance)
+}
+
+/// Charge `cost_cents` against the customer's credit balance.
+/// Returns `Err` if the balance would go positive (insufficient credits).
+async fn charge(api_key: &str, cost_cents: i64, state: &StripeState) -> Result<()> {
+    let wallet = api_key_to_wallet_address(api_key)?;
+    let customer_id = get_or_create_customer(&wallet, state).await?;
+    let balance = get_credit_balance(&customer_id, state).await?;
+
+    if balance + cost_cents > 0 {
+        anyhow::bail!(
+            "Insufficient credits: balance {} cents, need {} cents",
+            -balance,
+            cost_cents
+        );
+    }
+
+    // Create a positive balance transaction to deduct credits.
+    let cost_str = cost_cents.to_string();
+    stripe_post(
+        state,
+        &format!("customers/{customer_id}/balance_transactions"),
+        &[
+            ("amount", cost_str.as_str()),
+            ("currency", "usd"),
+            ("description", "API call charge"),
+        ],
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Charge $0.01 for a management API call.
+pub async fn charge_management(api_key: &str, state: &StripeState) -> Result<()> {
+    charge(api_key, COST_MANAGEMENT_CENTS, state).await
+}
+
+/// Charge $0.05 for a Lit Action execution.
+pub async fn charge_lit_action(api_key: &str, state: &StripeState) -> Result<()> {
+    charge(api_key, COST_LIT_ACTION_CENTS, state).await
+}
+
+/// Create a PaymentIntent for `amount_cents`.  Returns `(client_secret, payment_intent_id)`.
+pub async fn create_payment_intent(
+    wallet_address: &str,
+    amount_cents: i64,
+    state: &StripeState,
+) -> Result<(String, String)> {
+    if amount_cents < MIN_TOPUP_CENTS {
+        anyhow::bail!(
+            "Minimum top-up is {} ({})",
+            cents_to_display(MIN_TOPUP_CENTS),
+            MIN_TOPUP_CENTS
+        );
+    }
+
+    let customer_id = get_or_create_customer(wallet_address, state).await?;
+    let amount_str = amount_cents.to_string();
+
+    let resp = stripe_post(
+        state,
+        "payment_intents",
+        &[
+            ("amount", amount_str.as_str()),
+            ("currency", "usd"),
+            ("customer", &customer_id),
+            ("payment_method_types[]", "card"),
+        ],
+    )
+    .await?;
+
+    let pi_id = resp
+        .get("id")
+        .and_then(|i| i.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe PaymentIntent: missing id"))?
+        .to_string();
+
+    let client_secret = resp
+        .get("client_secret")
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe PaymentIntent: missing client_secret"))?
+        .to_string();
+
+    Ok((client_secret, pi_id))
+}
+
+/// Verify a PaymentIntent succeeded and credit the customer's account.
+pub async fn confirm_payment_and_credit(
+    payment_intent_id: &str,
+    wallet_address: &str,
+    state: &StripeState,
+) -> Result<()> {
+    let resp = stripe_get(state, &format!("payment_intents/{payment_intent_id}"), &[]).await?;
+
+    let status = resp
+        .get("status")
+        .and_then(|s| s.as_str())
+        .unwrap_or("unknown");
+
+    if status != "succeeded" {
+        anyhow::bail!(
+            "PaymentIntent {payment_intent_id} has status '{status}', not 'succeeded'"
+        );
+    }
+
+    let amount = resp
+        .get("amount")
+        .and_then(|a| a.as_i64())
+        .ok_or_else(|| anyhow::anyhow!("PaymentIntent: missing amount"))?;
+
+    let customer_id = get_or_create_customer(wallet_address, state).await?;
+    let credit = (-amount).to_string(); // negative = credit to customer
+
+    stripe_post(
+        state,
+        &format!("customers/{customer_id}/balance_transactions"),
+        &[
+            ("amount", credit.as_str()),
+            ("currency", "usd"),
+            ("description", &format!("Top-up via {payment_intent_id}")),
+        ],
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Best-effort: set the customer's email in Stripe.  Never fails the caller.
+pub async fn register_customer_email(
+    wallet_address: &str,
+    email: &str,
+    state: &StripeState,
+) {
+    if email.trim().is_empty() {
+        return;
+    }
+    let Ok(customer_id) = get_or_create_customer(wallet_address, state).await else {
+        return;
+    };
+    let _ = stripe_post(
+        state,
+        &format!("customers/{customer_id}"),
+        &[("email", email.trim())],
+    )
+    .await;
+}
+
+/// Format cents as a display string, e.g. 500 → "$5.00".
+pub fn cents_to_display(cents: i64) -> String {
+    format!("${}.{:02}", cents / 100, cents.abs() % 100)
+}

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -15,7 +15,7 @@ use ethers::signers::{LocalWallet, Signer};
 
 /// Cost constants in US cents.
 pub const COST_MANAGEMENT_CENTS: i64 = 1; // $0.01
-pub const COST_LIT_ACTION_CENTS: i64 = 1; // $0.05
+pub const COST_LIT_ACTION_CENTS: i64 = 1; // $0.01
 /// Minimum top-up (500 cents = $5.00).
 pub const MIN_TOPUP_CENTS: i64 = 500;
 

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -114,6 +114,7 @@ pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
     Ok(format!("{:?}", wallet.address()))
 }
 
+
 /// Find the Stripe customer for this wallet address, creating one if none exists.
 pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -> Result<String> {
     // Search by metadata.
@@ -132,9 +133,20 @@ pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -
         return Ok(id.to_string());
     };
 
-    // Not found
-    Err(anyhow::anyhow!("Stripe customer not found"))
+    // Not found, create a new customer
+    let resp = stripe_post(
+        state,
+        "customers",
+        &[("metadata[wallet_address]", wallet_address)],
+    )
+    .await?;
+    let id = resp
+        .get("id")
+        .and_then(|i| i.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe: missing customer id"))?;
+    Ok(id.to_string())
 }
+
 
 /// Return the current credit balance in cents (≤ 0 means credits available; the Stripe
 /// balance field is negative when the customer has a credit).

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -196,10 +196,12 @@ pub async fn charge_management(api_key: &str, state: &StripeState) -> Result<()>
     charge(api_key, COST_MANAGEMENT_CENTS, state).await
 }
 
-/// Charge $0.05 for a Lit Action execution.
+
+/// Charge $0.01 for a Lit Action execution.
 pub async fn charge_lit_action(api_key: &str, state: &StripeState) -> Result<()> {
     charge(api_key, COST_LIT_ACTION_CENTS, state).await
 }
+
 
 /// Create a PaymentIntent for `amount_cents`.  Returns `(client_secret, payment_intent_id)`.
 pub async fn create_payment_intent(

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -114,7 +114,6 @@ pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
     Ok(format!("{:?}", wallet.address()))
 }
 
-
 /// Find the Stripe customer for this wallet address, creating one if none exists.
 pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -> Result<String> {
     // Search by metadata.
@@ -146,7 +145,6 @@ pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -
         .ok_or_else(|| anyhow::anyhow!("Stripe: missing customer id"))?;
     Ok(id.to_string())
 }
-
 
 /// Return the current credit balance in cents (≤ 0 means credits available; the Stripe
 /// balance field is negative when the customer has a credit).
@@ -313,6 +311,17 @@ pub async fn confirm_payment_and_credit(
     Ok(())
 }
 
+/// Set (or update) the email on an existing Stripe customer.
+pub async fn set_customer_email(customer_id: &str, email: &str, state: &StripeState) -> Result<()> {
+    stripe_post(
+        state,
+        &format!("customers/{customer_id}"),
+        &[("email", email.trim())],
+    )
+    .await?;
+    Ok(())
+}
+
 /// Best-effort: set the customer's email in Stripe.  Never fails the caller.
 pub async fn register_customer_email(wallet_address: &str, email: &str, state: &StripeState) {
     if email.trim().is_empty() {
@@ -321,12 +330,7 @@ pub async fn register_customer_email(wallet_address: &str, email: &str, state: &
     let Ok(customer_id) = get_customer_by_wallet(wallet_address, state).await else {
         return;
     };
-    let _ = stripe_post(
-        state,
-        &format!("customers/{customer_id}"),
-        &[("email", email.trim())],
-    )
-    .await;
+    let _ = set_customer_email(&customer_id, email.trim(), state).await;
 }
 
 /// Format cents as a display string, e.g. 500 → "$5.00".

--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -12,6 +12,7 @@
  * @typedef {Object} NewAccountOptions
  * @property {string} accountName - Name for the account
  * @property {string} accountDescription - Description for the account
+ * @property {string} [email] - Optional email address for Stripe billing
  */
 
 /**

--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -319,11 +319,12 @@ export class LitNodeSimpleApiClient {
    * @param {NewAccountOptions} options
    * @returns {Promise<NewAccountResponse>}
    */
-  async newAccount({ accountName, accountDescription }) {
+  async newAccount({ accountName, accountDescription, email }) {
     const body = {
       account_name: accountName,
       account_description: accountDescription ?? '',
     };
+    if (email) body.email = email;
     const res = await fetch(`${this.baseUrl}/new_account`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -795,6 +796,63 @@ export class LitNodeSimpleApiClient {
   async getAdminApiPayer() {
     const res = await fetch(`${this.baseUrl}/get_admin_api_payer`);
     return parseResponse(res, 'get_admin_api_payer');
+  }
+
+  // ─── Billing ─────────────────────────────────────────────────────────────
+
+  /**
+   * GET /core/v1/billing/stripe_config
+   * Returns the Stripe publishable key for Stripe.js initialisation.
+   * @returns {Promise<{publishable_key: string}>}
+   */
+  async getStripeConfig() {
+    const res = await fetch(`${this.baseUrl}/billing/stripe_config`);
+    return parseResponse(res, 'billing/stripe_config');
+  }
+
+  /**
+   * GET /core/v1/billing/balance
+   * Returns the current credit balance for the authenticated API key.
+   * @param {string} apiKey
+   * @returns {Promise<{balance_cents: number, balance_display: string}>}
+   */
+  async getBillingBalance(apiKey) {
+    const res = await fetch(`${this.baseUrl}/billing/balance`, {
+      headers: headersWithApiKey(apiKey),
+    });
+    return parseResponse(res, 'billing/balance');
+  }
+
+  /**
+   * POST /core/v1/billing/create_payment_intent
+   * Creates a Stripe PaymentIntent; returns client_secret and payment_intent_id.
+   * @param {string} apiKey
+   * @param {number} amountCents - Amount in US cents (minimum 500)
+   * @returns {Promise<{client_secret: string, payment_intent_id: string}>}
+   */
+  async createPaymentIntent(apiKey, amountCents) {
+    const res = await fetch(`${this.baseUrl}/billing/create_payment_intent`, {
+      method: 'POST',
+      headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ amount_cents: amountCents }),
+    });
+    return parseResponse(res, 'billing/create_payment_intent');
+  }
+
+  /**
+   * POST /core/v1/billing/confirm_payment
+   * Verifies a succeeded PaymentIntent and credits the account.
+   * @param {string} apiKey
+   * @param {string} paymentIntentId
+   * @returns {Promise<void>}
+   */
+  async confirmPayment(apiKey, paymentIntentId) {
+    const res = await fetch(`${this.baseUrl}/billing/confirm_payment`, {
+      method: 'POST',
+      headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ payment_intent_id: paymentIntentId }),
+    });
+    return parseResponse(res, 'billing/confirm_payment');
   }
 }
 

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -29,10 +29,15 @@ function getBaseUrl() {
 function updateAuthUI() {
   const hasKey = !!getApiKey();
   document.body.classList.toggle('has-api-key', hasKey);
+  const balanceEl = document.getElementById('billing-balance-display');
+  const addFundsBtn = document.getElementById('btn-add-funds');
+  if (balanceEl) balanceEl.style.display = hasKey ? '' : 'none';
+  if (addFundsBtn) addFundsBtn.style.display = hasKey ? '' : 'none';
   if (hasKey) {
     refreshOverviewAccount();
     updateStatCards();
     preloadAllTables();
+    loadBillingBalance();
   }
 }
 
@@ -152,6 +157,7 @@ function initLogin() {
   document.getElementById('btn-create-account').addEventListener('click', async () => {
     const name = document.getElementById('new-account-name').value.trim();
     const desc = document.getElementById('new-account-desc').value.trim();
+    const email = document.getElementById('new-account-email').value.trim();
     hideStatus('login-status');
     if (!name) {
       showStatus('login-status', 'Enter an account name.', 'error');
@@ -165,7 +171,7 @@ function initLogin() {
         'Creating a new Lit Express account and returning an API key.'
       );
       const client = await getClient();
-      const res = await client.newAccount({ accountName: name, accountDescription: desc });
+      const res = await client.newAccount({ accountName: name, accountDescription: desc, email: email || undefined });
       setApiKey(res.api_key);
       showNewAccountBanner(res.api_key);
       document.getElementById('new-account-name').value = '';
@@ -193,6 +199,112 @@ function keyPreview(key) {
 
 function refreshOverviewAccount() {
   // Overview no longer displays API key or status; kept for any future use.
+}
+
+// ----- Billing -----
+async function loadBillingBalance() {
+  const apiKey = getApiKey();
+  if (!apiKey) return;
+  const el = document.getElementById('billing-balance-display');
+  if (!el) return;
+  try {
+    const client = await getClient();
+    const data = await client.getBillingBalance(apiKey);
+    el.textContent = data.balance_display || '';
+  } catch (_) {
+    el.textContent = '';
+  }
+}
+
+// Stripe card element singleton
+let _stripe = null;
+let _stripeCard = null;
+
+async function openAddFundsModal() {
+  const overlay = document.getElementById('billing-modal-overlay');
+  if (!overlay) return;
+  overlay.setAttribute('aria-hidden', 'false');
+  overlay.style.display = 'flex';
+
+  const statusEl = document.getElementById('billing-modal-status');
+  if (statusEl) { statusEl.style.display = 'none'; }
+
+  // Initialise Stripe.js if not already done
+  if (!_stripe) {
+    try {
+      const client = await getClient();
+      const cfg = await client.getStripeConfig();
+      _stripe = Stripe(cfg.publishable_key); // eslint-disable-line no-undef
+      const elements = _stripe.elements();
+      _stripeCard = elements.create('card');
+      _stripeCard.mount('#stripe-card-element');
+    } catch (e) {
+      if (statusEl) {
+        statusEl.textContent = 'Billing not available: ' + (e && e.message ? e.message : String(e));
+        statusEl.className = 'status error';
+        statusEl.style.display = 'block';
+      }
+      const payBtn = document.getElementById('billing-pay-btn');
+      if (payBtn) payBtn.disabled = true;
+    }
+  }
+}
+
+function closeBillingModal() {
+  const overlay = document.getElementById('billing-modal-overlay');
+  if (overlay) {
+    overlay.setAttribute('aria-hidden', 'true');
+    overlay.style.display = '';
+  }
+}
+
+function initBilling() {
+  const addFundsBtn = document.getElementById('btn-add-funds');
+  const closeBtn = document.getElementById('billing-modal-close-btn');
+  const cancelBtn = document.getElementById('billing-cancel-btn');
+  const payBtn = document.getElementById('billing-pay-btn');
+
+  if (addFundsBtn) addFundsBtn.addEventListener('click', openAddFundsModal);
+  if (closeBtn) closeBtn.addEventListener('click', closeBillingModal);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeBillingModal);
+
+  if (payBtn) {
+    payBtn.addEventListener('click', async () => {
+      const apiKey = getApiKey();
+      if (!apiKey || !_stripe || !_stripeCard) return;
+
+      const amountCents = parseInt(document.getElementById('billing-amount').value, 10);
+      const statusEl = document.getElementById('billing-modal-status');
+
+      payBtn.disabled = true;
+      if (statusEl) { statusEl.style.display = 'none'; }
+
+      try {
+        const client = await getClient();
+        const intent = await client.createPaymentIntent(apiKey, amountCents);
+
+        const result = await _stripe.confirmCardPayment(intent.client_secret, {
+          payment_method: { card: _stripeCard },
+        });
+
+        if (result.error) {
+          throw new Error(result.error.message);
+        }
+
+        await client.confirmPayment(apiKey, intent.payment_intent_id);
+        closeBillingModal();
+        await loadBillingBalance();
+      } catch (e) {
+        if (statusEl) {
+          statusEl.textContent = 'Payment failed: ' + (e && e.message ? e.message : String(e));
+          statusEl.className = 'status error';
+          statusEl.style.display = 'block';
+        }
+      } finally {
+        payBtn.disabled = false;
+      }
+    });
+  }
 }
 
 function showNewAccountBanner(apiKey) {
@@ -1432,6 +1544,7 @@ function init() {
   initActionRunner(); // async; CodeJar loads lazily on first use
   initSidebar();
   initHeader();
+  initBilling();
 }
 
 init();

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -350,9 +350,10 @@ function initOverview() {
   document.getElementById('btn-add-usage-key')?.addEventListener('click', () => openUsageKeyModal());
 }
 
-// ----- Icons (pencil, trash) -----
+// ----- Icons (pencil, trash, copy) -----
 const ICON_PENCIL = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>';
 const ICON_TRASH = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
+const ICON_COPY = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>';
 
 // ----- Modal (Add / Edit) -----
 function openModal(title, bodyHTML, footerHTML) {
@@ -659,6 +660,31 @@ function renderUsageKeysTable() {
       '<td class="mono">' + escapeHtml(balance) + '</td>' +
       '<td class="cell-actions"></td>';
     const actionsCell = tr.querySelector('.cell-actions');
+    const fullKey = item.api_key || (!item.api_key_hash ? item.usage_api_key : null);
+    const copyBtn = document.createElement('button');
+    copyBtn.type = 'button';
+    copyBtn.className = 'btn-icon';
+    copyBtn.title = fullKey ? 'Copy usage API key' : 'Key only available when first created';
+    copyBtn.innerHTML = ICON_COPY;
+    if (!fullKey) copyBtn.disabled = true;
+    copyBtn.addEventListener('click', async () => {
+      if (!fullKey) return;
+      try {
+        await navigator.clipboard.writeText(fullKey);
+      } catch (_) {
+        const ta = document.createElement('textarea');
+        ta.value = fullKey;
+        ta.style.cssText = 'position:fixed;opacity:0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      const origTitle = copyBtn.title;
+      copyBtn.title = 'Copied!';
+      setTimeout(() => { copyBtn.title = origTitle; }, 1500);
+    });
+    actionsCell.appendChild(copyBtn);
     const canEdit = !!(item.usage_api_key ?? item.api_key);
     const editBtn = document.createElement('button');
     editBtn.type = 'button';

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -223,8 +223,8 @@ let _stripeCard = null;
 async function openAddFundsModal() {
   const overlay = document.getElementById('billing-modal-overlay');
   if (!overlay) return;
+  overlay.classList.add('is-open');
   overlay.setAttribute('aria-hidden', 'false');
-  overlay.style.display = 'flex';
 
   const statusEl = document.getElementById('billing-modal-status');
   if (statusEl) { statusEl.style.display = 'none'; }
@@ -253,8 +253,8 @@ async function openAddFundsModal() {
 function closeBillingModal() {
   const overlay = document.getElementById('billing-modal-overlay');
   if (overlay) {
+    overlay.classList.remove('is-open');
     overlay.setAttribute('aria-hidden', 'true');
-    overlay.style.display = '';
   }
 }
 

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -229,6 +229,11 @@ async function openAddFundsModal() {
   const statusEl = document.getElementById('billing-modal-status');
   if (statusEl) { statusEl.style.display = 'none'; }
 
+  // Reset pay button to enabled state each time the modal is opened so that
+  // a previous Stripe init failure does not permanently disable it.
+  const payBtn = document.getElementById('billing-pay-btn');
+  if (payBtn) payBtn.disabled = true; // disabled until Stripe is ready
+
   // Initialise Stripe.js if not already done
   if (!_stripe) {
     try {
@@ -244,10 +249,13 @@ async function openAddFundsModal() {
         statusEl.className = 'status error';
         statusEl.style.display = 'block';
       }
-      const payBtn = document.getElementById('billing-pay-btn');
-      if (payBtn) payBtn.disabled = true;
+      // payBtn stays disabled (already set above)
+      return;
     }
   }
+
+  // Stripe is ready – allow the user to pay
+  if (payBtn) payBtn.disabled = false;
 }
 
 function closeBillingModal() {

--- a/lit-static/static/dapps/dashboard/index.html
+++ b/lit-static/static/dapps/dashboard/index.html
@@ -43,6 +43,10 @@
               <label for="new-account-desc">Account description</label>
               <input type="text" id="new-account-desc" class="input" placeholder="Optional">
             </div>
+            <div class="form-group">
+              <label for="new-account-email">Email (optional)</label>
+              <input type="email" id="new-account-email" class="input" placeholder="you@example.com">
+            </div>
             <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
           </div>
         </div>
@@ -92,6 +96,8 @@
           </div>
           <div class="topbar-right">
             <button type="button" class="btn btn-topbar btn-theme-toggle" id="theme-toggle" aria-label="Switch to dark mode"><span class="theme-icon" aria-hidden="true"></span></button>
+            <span id="billing-balance-display" class="billing-balance" style="display:none;"></span>
+            <button type="button" class="btn btn-primary btn-sm" id="btn-add-funds" style="display:none;">Add Funds</button>
             <div class="account-dropdown" id="account-dropdown">
               <button type="button" class="btn btn-topbar account-dropdown-trigger" id="account-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-label="Account menu">
                 Account
@@ -345,6 +351,38 @@
     </div>
   </div>
 
+  <!-- Billing modal -->
+  <div id="billing-modal-overlay" class="modal-overlay" aria-hidden="true">
+    <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="billing-modal-title">
+      <div class="modal-header">
+        <h3 id="billing-modal-title" class="modal-title">Add Funds</h3>
+        <button type="button" class="modal-close" id="billing-modal-close-btn" aria-label="Close">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.05 per Lit Action).</p>
+        <div class="form-group">
+          <label for="billing-amount">Amount (USD)</label>
+          <select id="billing-amount" class="input">
+            <option value="500">$5.00</option>
+            <option value="1000">$10.00</option>
+            <option value="2500">$25.00</option>
+            <option value="5000">$50.00</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Card details</label>
+          <div id="stripe-card-element" style="padding:0.625rem 0.75rem;border:1px solid var(--border,#e5e7eb);border-radius:0.375rem;background:var(--input-bg,#fff);"></div>
+        </div>
+        <div id="billing-modal-status" class="status" style="display:none;"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline" id="billing-cancel-btn">Cancel</button>
+        <button type="button" class="btn btn-primary" id="billing-pay-btn">Pay</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://js.stripe.com/v3/"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>

--- a/lit-static/static/dapps/dashboard/index.html
+++ b/lit-static/static/dapps/dashboard/index.html
@@ -359,7 +359,7 @@
         <button type="button" class="modal-close" id="billing-modal-close-btn" aria-label="Close">&times;</button>
       </div>
       <div class="modal-body">
-        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.05 per Lit Action).</p>
+        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.01 per Lit Action).</p>
         <div class="form-group">
           <label for="billing-amount">Amount (USD)</label>
           <select id="billing-amount" class="input">

--- a/lit-static/static/dapps/dashboard/styles.css
+++ b/lit-static/static/dapps/dashboard/styles.css
@@ -285,6 +285,14 @@ body.has-api-key .dashboard-wrap {
   margin-left: auto;
 }
 
+/* Billing balance chip */
+.billing-balance {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 /* Account dropdown */
 .account-dropdown {
   position: relative;


### PR DESCRIPTION
## Pull request overview

This PR introduces Stripe-based credit billing for the Lit Express (Chipotle) API and dashboard, including UI for viewing balance and adding funds, plus server-side enforcement of credit charges on metered endpoints.

**Changes:**
- Add dashboard UI (balance chip + “Add Funds” modal) and Stripe.js card flow to purchase credits.
- Add Core v1 billing endpoints (`/billing/*`) and Stripe integration module on the API server.
- Introduce Rocket request guards that debit credits for management and Lit Action execution endpoints.