### PR TITLE
CPL-147: Add action_ipfs_cid to actions, add delete_action endpoint

### DIFF
--- a/docs/api_direct.mdx
+++ b/docs/api_direct.mdx
@@ -132,13 +132,19 @@ Create a group (with optional permitted actions and PKPs). Then add an action (I
     const groups = await client.listGroups({ apiKey: accountApiKey, pageNumber: '0', pageSize: '10' });
     const groupId = groups[groups.length - 1].id;
     
-    // Add an IPFS action (CID) to the group
-    await client.addActionToGroup({
+    // Register action metadata (name/description) with the IPFS CID
+    await client.addAction({
       apiKey: accountApiKey,
-      groupId,
       actionIpfsCid: 'QmYourIpfsCidHere',
       name: 'My Action',
       description: 'Optional'
+    });
+
+    // Add the action (IPFS CID) to the group
+    await client.addActionToGroup({
+      apiKey: accountApiKey,
+      groupId,
+      actionIpfsCid: 'QmYourIpfsCidHere'
     });
     ```
   </Tab>
@@ -154,11 +160,17 @@ Create a group (with optional permitted actions and PKPs). Then add an action (I
     curl -s "http://localhost:8000/core/v1/list_groups?page_number=0&page_size=10" \
       -H "X-Api-Key: KEY"
     
+    # Register action metadata (replace IPFS_CID)
+    curl -s -X POST "http://localhost:8000/core/v1/add_action" \
+      -H "Content-Type: application/json" \
+      -H "X-Api-Key: KEY" \
+      -d '{"action_ipfs_cid":"QmYourIpfsCidHere","name":"My Action","description":""}'
+
     # Add action to group (replace GROUP_ID and IPFS_CID)
     curl -s -X POST "http://localhost:8000/core/v1/add_action_to_group" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: KEY" \
-      -d '{"group_id":"GROUP_ID","action_ipfs_cid":"QmYourIpfsCidHere","name":"My Action","description":""}'
+      -d '{"group_id":"GROUP_ID","action_ipfs_cid":"QmYourIpfsCidHere"}'
     ```
   </Tab>
 </Tabs>
@@ -227,6 +239,7 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 - **list_actions** — List actions in a group (by `group_id`).
 - **list_wallets_in_group** — List wallets in a group.
 - **update_group** — Update group name, description, and permission flags.
+- **delete_action** — Delete an action (IPFS CID) and its metadata from the account.
 - **remove_action_from_group** / **remove_pkp_from_group** — Remove action or PKP from a group.
 - **get_node_chain_config** — Get node chain config - a quick way to find the location of contracts within the system.
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -30,7 +30,7 @@ The following operations consume credits each time they are called:
 | Management call (create/update/delete group, wallet, action, usage key, etc.) | **$0.01** |
 | Lit Action execution | **$0.01** |
 
-Management calls include: `create_wallet`, `add_group`, `remove_group`, `add_action`, `add_action_to_group`, `remove_action_from_group`, `update_group`, `update_action_metadata`, `add_pkp_to_group`, `remove_pkp_from_group`, `add_usage_api_key`, `remove_usage_api_key`, `update_usage_api_key`, `update_usage_api_key_metadata`.
+Management calls include: `create_wallet`, `add_group`, `remove_group`, `add_action`, `delete_action`, `add_action_to_group`, `remove_action_from_group`, `update_group`, `update_action_metadata`, `add_pkp_to_group`, `remove_pkp_from_group`, `add_usage_api_key`, `remove_usage_api_key`, `update_usage_api_key`, `update_usage_api_key_metadata`.
 
 ---
 

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -176,7 +176,7 @@ export default function (data: IntegrationSetupData) {
 
   // ── 9. addAction + addActionToGroup ──────────────────────────────────────
   const addActionMetaRes = client.addAction(
-    { name: "hello-world", description: "Hello World lit action" },
+    { action_ipfs_cid: ipfsId, name: "hello-world", description: "Hello World lit action" },
     authHeaders,
   );
   if (!assertOk("addAction", "POST /add_action", addActionMetaRes)) return;
@@ -438,6 +438,22 @@ export default function (data: IntegrationSetupData) {
       }
     },
   }, "removeActionFromGroup");
+
+  // ── 21b. deleteAction ────────────────────────────────────────────────────
+  const deleteActionRes = client.deleteAction(
+    { action_ipfs_cid: ipfsId },
+    authHeaders,
+  );
+  assertOk("deleteAction", "POST /delete_action", deleteActionRes);
+  checkAndLog(deleteActionRes.response, {
+    "deleteAction success": (r) => {
+      try {
+        return JSON.parse(r.body as string).success === true;
+      } catch {
+        return false;
+      }
+    },
+  }, "deleteAction");
 
   // ── 22. removeGroup ───────────────────────────────────────────────────────
   const removeGroupRes = client.removeGroup(

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -103,6 +103,14 @@ export interface AddActionRequest {
   description: string;
 }
 
+/**
+ * Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
+ */
+export interface DeleteActionRequest {
+  /** IPFS CID for the action (keccak256-hashed on server). */
+  action_ipfs_cid: string;
+}
+
 export interface AddActionToGroupRequest {
   /** @minimum 0 */
   group_id: number;
@@ -192,14 +200,6 @@ export interface UpdateGroupRequest {
   description: string;
   pkp_ids_permitted?: string[];
   cid_hashes_permitted?: string[];
-}
-
-/**
- * Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
- */
-export interface DeleteActionRequest {
-  /** IPFS CID for the action (keccak256-hashed on server). */
-  action_ipfs_cid: string;
 }
 
 /**
@@ -418,6 +418,15 @@ export type AddActionHeaders = {
 
 export type AddActionDefault = AccountOpResponse | ErrMessage;
 
+export type DeleteActionHeaders = {
+  /**
+   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   */
+  "X-Api-Key": string;
+};
+
+export type DeleteActionDefault = AccountOpResponse | ErrMessage;
+
 export type AddActionToGroupHeaders = {
   /**
    * Account or usage API key. Alternatively use Authorization: Bearer <key>.
@@ -480,15 +489,6 @@ export type UpdateGroupHeaders = {
 };
 
 export type UpdateGroupDefault = AccountOpResponse | ErrMessage;
-
-export type DeleteActionHeaders = {
-  /**
-   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
-   */
-  "X-Api-Key": string;
-};
-
-export type DeleteActionDefault = AccountOpResponse | ErrMessage;
 
 export type RemoveActionFromGroupHeaders = {
   /**
@@ -1054,6 +1054,53 @@ export class LitApiServerClient {
     };
   }
 
+  deleteAction(
+    deleteActionRequest: DeleteActionRequest,
+    headers: DeleteActionHeaders,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: DeleteActionDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/delete_action`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(deleteActionRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+          // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
+          ...Object.fromEntries(
+            Object.entries(headers || {}).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "delete_action",
+    };
+  }
+
   addActionToGroup(
     addActionToGroupRequest: AddActionToGroupRequest,
     headers: AddActionToGroupHeaders,
@@ -1380,52 +1427,6 @@ export class LitApiServerClient {
       response,
       data,
       operationId: "update_group",
-    };
-  }
-
-  deleteAction(
-    deleteActionRequest: DeleteActionRequest,
-    headers: DeleteActionHeaders,
-    requestParameters?: Params,
-  ): {
-    response: Response;
-    data: DeleteActionDefault;
-    operationId: string;
-  } {
-    const k6url = new URL(this.cleanBaseUrl + `/delete_action`);
-    const mergedRequestParameters = this._mergeRequestParameters(
-      requestParameters || {},
-      this.commonRequestParameters,
-    );
-    const response = http.request(
-      "POST",
-      k6url.toString(),
-      JSON.stringify(deleteActionRequest),
-      {
-        ...mergedRequestParameters,
-        headers: {
-          ...mergedRequestParameters?.headers,
-          "Content-Type": "application/json",
-          ...Object.fromEntries(
-            Object.entries(headers || {}).map(([key, value]) => [
-              key,
-              String(value),
-            ]),
-          ),
-        },
-      },
-    );
-    let data;
-
-    try {
-      data = response.json();
-    } catch {
-      data = response.body;
-    }
-    return {
-      response,
-      data,
-      operationId: "delete_action",
     };
   }
 

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -97,6 +97,8 @@ export interface RemoveGroupRequest {
 }
 
 export interface AddActionRequest {
+  /** IPFS CID for the action (keccak256-hashed on server). */
+  action_ipfs_cid: string;
   name: string;
   description: string;
 }
@@ -190,6 +192,14 @@ export interface UpdateGroupRequest {
   description: string;
   pkp_ids_permitted?: string[];
   cid_hashes_permitted?: string[];
+}
+
+/**
+ * Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
+ */
+export interface DeleteActionRequest {
+  /** IPFS CID for the action (keccak256-hashed on server). */
+  action_ipfs_cid: string;
 }
 
 /**
@@ -470,6 +480,15 @@ export type UpdateGroupHeaders = {
 };
 
 export type UpdateGroupDefault = AccountOpResponse | ErrMessage;
+
+export type DeleteActionHeaders = {
+  /**
+   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   */
+  "X-Api-Key": string;
+};
+
+export type DeleteActionDefault = AccountOpResponse | ErrMessage;
 
 export type RemoveActionFromGroupHeaders = {
   /**
@@ -1361,6 +1380,52 @@ export class LitApiServerClient {
       response,
       data,
       operationId: "update_group",
+    };
+  }
+
+  deleteAction(
+    deleteActionRequest: DeleteActionRequest,
+    headers: DeleteActionHeaders,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: DeleteActionDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/delete_action`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(deleteActionRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+          ...Object.fromEntries(
+            Object.entries(headers || {}).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "delete_action",
     };
   }
 

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
@@ -95,7 +95,7 @@ library AppStorage {
         mapping(address => Metadata) pkpData; // mapping from a wallet address to it's metadata.  the ID is the derivationPath.
         bool managed; // whether the LIT-node can help manage the key.
         uint256 pkpCount; // counter for creating unique pkp ids
-        uint256 actionCount; // counter for creating unique action ids
+        uint256 actionCount; // count of unique actions registered to this account
         uint256 groupCount; // counter for creating unique group ids
     }
 

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
@@ -260,6 +260,32 @@ contract ViewsFacet {
 
     function listActions(
         uint256 accountApiKeyHash,
+        uint256 pageNumber,
+        uint256 pageSize
+    ) public view returns (AppStorage.Metadata[] memory) {
+        AppStorage.Account storage account = getReadOnlyAccount(
+            accountApiKeyHash
+        );
+        (uint256 startIndex, uint256 pageLength) = getPageStartAndLength(
+            account.actionHashesList.length(),
+            pageNumber,
+            pageSize
+        );
+
+        AppStorage.Metadata[] memory pageMetadata = new AppStorage.Metadata[](
+            pageLength
+        );
+
+        for (uint256 i = 0; i < pageLength; i++) {
+            pageMetadata[i] = account.actionMetadata[
+                account.actionHashesList.at(startIndex + i)
+            ];
+        }
+        return pageMetadata;
+    }
+
+    function listActionsInGroup(
+        uint256 accountApiKeyHash,
         uint256 groupId,
         uint256 pageNumber,
         uint256 pageSize

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -246,6 +246,13 @@ contract WritesFacet {
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
+
+        // Remove the action from all groups that may reference it to avoid stale cidHash entries.
+        uint256 groupCount = account.groupList.length();
+        for (uint256 i = 0; i < groupCount; i++) {
+            uint256 groupId = account.groupList.at(i);
+            account.groups[groupId].cidHash.remove(actionHash);
+        }
         account.actionHashesList.remove(actionHash);
         delete account.actionMetadata[actionHash];
     }

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -261,8 +261,6 @@ contract WritesFacet {
             account.groups[groupId].cidHash.remove(actionHash);
         }
         delete account.actionMetadata[actionHash];
-
-        delete account.actionMetadata[actionHash];
     }
 
     function addActionToGroup(

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -224,17 +224,30 @@ contract WritesFacet {
     function addAction(
         uint256 accountApiKeyHash,
         string memory name,
-        string memory description
+        string memory description,
+        uint256 actionHash
     ) public {
         SecurityLib.revertIfNoAccountAccess(accountApiKeyHash, msg.sender);
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
         account.actionCount++;
-        uint256 actionId = account.actionCount;
-        account.actionMetadata[actionId].id = actionId;
-        account.actionMetadata[actionId].name = name;
-        account.actionMetadata[actionId].description = description;
+        account.actionHashesList.add(actionHash);
+        account.actionMetadata[actionHash].id = actionHash;
+        account.actionMetadata[actionHash].name = name;
+        account.actionMetadata[actionHash].description = description;
+    }
+
+    function removeAction(
+        uint256 accountApiKeyHash,
+        uint256 actionHash
+    ) public {
+        SecurityLib.revertIfNoAccountAccess(accountApiKeyHash, msg.sender);
+        SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
+        AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
+        AppStorage.Account storage account = s.accounts[accountApiKeyHash];
+        account.actionHashesList.remove(actionHash);
+        delete account.actionMetadata[actionHash];
     }
 
     function addActionToGroup(

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -248,6 +248,7 @@ contract WritesFacet {
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
+
         bool removed = account.actionHashesList.remove(actionHash);
         if (removed) {
             account.actionCount--;
@@ -259,7 +260,8 @@ contract WritesFacet {
             uint256 groupId = account.groupList.at(i);
             account.groups[groupId].cidHash.remove(actionHash);
         }
-        account.actionHashesList.remove(actionHash);
+        delete account.actionMetadata[actionHash];
+
         delete account.actionMetadata[actionHash];
     }
 

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -231,8 +231,10 @@ contract WritesFacet {
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
-        account.actionCount++;
-        account.actionHashesList.add(actionHash);
+        bool added = account.actionHashesList.add(actionHash);
+        if (added) {
+            account.actionCount++;
+        }
         account.actionMetadata[actionHash].id = actionHash;
         account.actionMetadata[actionHash].name = name;
         account.actionMetadata[actionHash].description = description;
@@ -246,6 +248,10 @@ contract WritesFacet {
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
+        bool removed = account.actionHashesList.remove(actionHash);
+        if (removed) {
+            account.actionCount--;
+        }
 
         // Remove the action from all groups that may reference it to avoid stale cidHash entries.
         uint256 groupCount = account.groupList.length();

--- a/lit-api-server/src/accounts/contracts/AccountConfig.json
+++ b/lit-api-server/src/accounts/contracts/AccountConfig.json
@@ -151,6 +151,11 @@
           "internalType": "string",
           "name": "description",
           "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actionHash",
+          "type": "uint256"
         }
       ],
       "name": "addAction",
@@ -299,6 +304,24 @@
         }
       ],
       "name": "registerWalletDerivation",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "accountApiKeyHash",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actionHash",
+          "type": "uint256"
+        }
+      ],
+      "name": "removeAction",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -973,6 +996,52 @@
         },
         {
           "internalType": "uint256",
+          "name": "pageNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "pageSize",
+          "type": "uint256"
+        }
+      ],
+      "name": "listActions",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "id",
+              "type": "uint256"
+            },
+            {
+              "internalType": "string",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct AppStorage.Metadata[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "accountApiKeyHash",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
           "name": "groupId",
           "type": "uint256"
         },
@@ -987,7 +1056,7 @@
           "type": "uint256"
         }
       ],
-      "name": "listActions",
+      "name": "listActionsInGroup",
       "outputs": [
         {
           "components": [

--- a/lit-api-server/src/accounts/contracts/account_config_contract.rs
+++ b/lit-api-server/src/accounts/contracts/account_config_contract.rs
@@ -82,6 +82,13 @@ pub mod account_config {
                                     ::std::borrow::ToOwned::to_owned("string"),
                                 ),
                             },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("actionHash"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
                         ],
                         outputs: ::std::vec![],
                         constant: ::core::option::Option::None,
@@ -715,6 +722,52 @@ pub mod account_config {
                                 ),
                             },
                             ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pageNumber"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("pageSize"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Array(
+                                ::std::boxed::Box::new(
+                                    ::ethers::core::abi::ethabi::ParamType::Tuple(::std::vec![
+                                        ::ethers::core::abi::ethabi::ParamType::Uint(256usize),
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                        ::ethers::core::abi::ethabi::ParamType::String,
+                                    ],),
+                                ),
+                            ),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("struct AppStorage.Metadata[]",),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("listActionsInGroup"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("listActionsInGroup"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("accountApiKeyHash"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
                                 name: ::std::borrow::ToOwned::to_owned("groupId"),
                                 kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
                                 internal_type: ::core::option::Option::Some(
@@ -1254,6 +1307,31 @@ pub mod account_config {
                                 kind: ::ethers::core::abi::ethabi::ParamType::String,
                                 internal_type: ::core::option::Option::Some(
                                     ::std::borrow::ToOwned::to_owned("string"),
+                                ),
+                            },
+                        ],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
+                ),
+                (
+                    ::std::borrow::ToOwned::to_owned("removeAction"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("removeAction"),
+                        inputs: ::std::vec![
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("accountApiKeyHash"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
+                                ),
+                            },
+                            ::ethers::core::abi::ethabi::Param {
+                                name: ::std::borrow::ToOwned::to_owned("actionHash"),
+                                kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                                internal_type: ::core::option::Option::Some(
+                                    ::std::borrow::ToOwned::to_owned("uint256"),
                                 ),
                             },
                         ],
@@ -2118,17 +2196,31 @@ pub mod account_config {
                 .method_hash([113, 159, 172, 67], api_key_hash)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `addAction` (0x0c6d7fbd) function
+        ///Calls the contract's `addAction` (0xb49b8b89) function
         pub fn add_action(
             &self,
             account_api_key_hash: ::ethers::core::types::U256,
             name: ::std::string::String,
             description: ::std::string::String,
+            action_hash: ::ethers::core::types::U256,
         ) -> ::ethers::contract::builders::ContractCall<M, ()> {
             self.0
                 .method_hash(
-                    [12, 109, 127, 189],
-                    (account_api_key_hash, name, description),
+                    [180, 155, 139, 137],
+                    (account_api_key_hash, name, description, action_hash),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `removeAction` (0x40d4411b) function
+        pub fn remove_action(
+            &self,
+            account_api_key_hash: ::ethers::core::types::U256,
+            action_hash: ::ethers::core::types::U256,
+        ) -> ::ethers::contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash(
+                    [64, 212, 65, 27],
+                    (account_api_key_hash, action_hash),
                 )
                 .expect("method not found (this should never happen)")
         }
@@ -2350,8 +2442,22 @@ pub mod account_config {
                 .method_hash([111, 225, 251, 132], index)
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `listActions` (0x542970ed) function
+        ///Calls the contract's `listActions` (0xc9176804) function
         pub fn list_actions(
+            &self,
+            account_api_key_hash: ::ethers::core::types::U256,
+            page_number: ::ethers::core::types::U256,
+            page_size: ::ethers::core::types::U256,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::std::vec::Vec<Metadata>> {
+            self.0
+                .method_hash(
+                    [201, 23, 104, 4],
+                    (account_api_key_hash, page_number, page_size),
+                )
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `listActionsInGroup` (0xea79e095) function
+        pub fn list_actions_in_group(
             &self,
             account_api_key_hash: ::ethers::core::types::U256,
             group_id: ::ethers::core::types::U256,
@@ -2360,7 +2466,7 @@ pub mod account_config {
         ) -> ::ethers::contract::builders::ContractCall<M, ::std::vec::Vec<Metadata>> {
             self.0
                 .method_hash(
-                    [84, 41, 112, 237],
+                    [234, 121, 224, 149],
                     (account_api_key_hash, group_id, page_number, page_size),
                 )
                 .expect("method not found (this should never happen)")
@@ -3307,7 +3413,7 @@ pub mod account_config {
     pub struct AccountExistsAndIsMutableCall {
         pub api_key_hash: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `addAction` function with signature `addAction(uint256,string,string)` and selector `0x0c6d7fbd`
+    ///Container type for all input parameters for the `addAction` function with signature `addAction(uint256,string,string,uint256)` and selector `0xb49b8b89`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -3320,11 +3426,30 @@ pub mod account_config {
         Eq,
         Hash,
     )]
-    #[ethcall(name = "addAction", abi = "addAction(uint256,string,string)")]
+    #[ethcall(name = "addAction", abi = "addAction(uint256,string,string,uint256)")]
     pub struct AddActionCall {
         pub account_api_key_hash: ::ethers::core::types::U256,
         pub name: ::std::string::String,
         pub description: ::std::string::String,
+        pub action_hash: ::ethers::core::types::U256,
+    }
+    ///Container type for all input parameters for the `removeAction` function with signature `removeAction(uint256,uint256)` and selector `0x40d4411b`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(name = "removeAction", abi = "removeAction(uint256,uint256)")]
+    pub struct RemoveActionCall {
+        pub account_api_key_hash: ::ethers::core::types::U256,
+        pub action_hash: ::ethers::core::types::U256,
     }
     ///Container type for all input parameters for the `addActionToGroup` function with signature `addActionToGroup(uint256,uint256,uint256)` and selector `0x1f52aa42`
     #[derive(
@@ -3710,7 +3835,7 @@ pub mod account_config {
     pub struct IndexToAccountHashAtCall {
         pub index: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `listActions` function with signature `listActions(uint256,uint256,uint256,uint256)` and selector `0x542970ed`
+    ///Container type for all input parameters for the `listActions` function with signature `listActions(uint256,uint256,uint256)` and selector `0xc9176804`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -3725,9 +3850,31 @@ pub mod account_config {
     )]
     #[ethcall(
         name = "listActions",
-        abi = "listActions(uint256,uint256,uint256,uint256)"
+        abi = "listActions(uint256,uint256,uint256)"
     )]
     pub struct ListActionsCall {
+        pub account_api_key_hash: ::ethers::core::types::U256,
+        pub page_number: ::ethers::core::types::U256,
+        pub page_size: ::ethers::core::types::U256,
+    }
+    ///Container type for all input parameters for the `listActionsInGroup` function with signature `listActionsInGroup(uint256,uint256,uint256,uint256)` and selector `0xea79e095`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(
+        name = "listActionsInGroup",
+        abi = "listActionsInGroup(uint256,uint256,uint256,uint256)"
+    )]
+    pub struct ListActionsInGroupCall {
         pub account_api_key_hash: ::ethers::core::types::U256,
         pub group_id: ::ethers::core::types::U256,
         pub page_number: ::ethers::core::types::U256,
@@ -4379,6 +4526,7 @@ pub mod account_config {
         GroupIdsForActionAndWallet(GroupIdsForActionAndWalletCall),
         IndexToAccountHashAt(IndexToAccountHashAtCall),
         ListActions(ListActionsCall),
+        ListActionsInGroup(ListActionsInGroupCall),
         ListApiKeys(ListApiKeysCall),
         ListGroupContents(ListGroupContentsCall),
         ListGroups(ListGroupsCall),
@@ -4393,6 +4541,7 @@ pub mod account_config {
         PricingOperator(PricingOperatorCall),
         RebalanceAmount(RebalanceAmountCall),
         RegisterWalletDerivation(RegisterWalletDerivationCall),
+        RemoveAction(RemoveActionCall),
         RemoveActionFromGroup(RemoveActionFromGroupCall),
         RemoveGroup(RemoveGroupCall),
         RemovePkpFromGroup(RemovePkpFromGroupCall),
@@ -4518,6 +4667,11 @@ pub mod account_config {
             if let Ok(decoded) = <ListActionsCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ListActions(decoded));
             }
+            if let Ok(decoded) =
+                <ListActionsInGroupCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::ListActionsInGroup(decoded));
+            }
             if let Ok(decoded) = <ListApiKeysCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::ListApiKeys(decoded));
             }
@@ -4575,6 +4729,11 @@ pub mod account_config {
                 <RegisterWalletDerivationCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
                 return Ok(Self::RegisterWalletDerivation(decoded));
+            }
+            if let Ok(decoded) =
+                <RemoveActionCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::RemoveAction(decoded));
             }
             if let Ok(decoded) =
                 <RemoveActionFromGroupCall as ::ethers::core::abi::AbiDecode>::decode(data)
@@ -4704,6 +4863,9 @@ pub mod account_config {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
                 Self::ListActions(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::ListActionsInGroup(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::ListApiKeys(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ListGroupContents(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::ListGroups(element) => ::ethers::core::abi::AbiEncode::encode(element),
@@ -4728,6 +4890,7 @@ pub mod account_config {
                 Self::RegisterWalletDerivation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
+                Self::RemoveAction(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::RemoveActionFromGroup(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
@@ -4799,6 +4962,7 @@ pub mod account_config {
                 Self::GroupIdsForActionAndWallet(element) => ::core::fmt::Display::fmt(element, f),
                 Self::IndexToAccountHashAt(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ListActions(element) => ::core::fmt::Display::fmt(element, f),
+                Self::ListActionsInGroup(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ListApiKeys(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ListGroupContents(element) => ::core::fmt::Display::fmt(element, f),
                 Self::ListGroups(element) => ::core::fmt::Display::fmt(element, f),
@@ -4813,6 +4977,7 @@ pub mod account_config {
                 Self::PricingOperator(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RebalanceAmount(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RegisterWalletDerivation(element) => ::core::fmt::Display::fmt(element, f),
+                Self::RemoveAction(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RemoveActionFromGroup(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RemoveGroup(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RemovePkpFromGroup(element) => ::core::fmt::Display::fmt(element, f),
@@ -4953,6 +5118,11 @@ pub mod account_config {
             Self::ListActions(value)
         }
     }
+    impl ::core::convert::From<ListActionsInGroupCall> for AccountConfigCalls {
+        fn from(value: ListActionsInGroupCall) -> Self {
+            Self::ListActionsInGroup(value)
+        }
+    }
     impl ::core::convert::From<ListApiKeysCall> for AccountConfigCalls {
         fn from(value: ListApiKeysCall) -> Self {
             Self::ListApiKeys(value)
@@ -5021,6 +5191,11 @@ pub mod account_config {
     impl ::core::convert::From<RegisterWalletDerivationCall> for AccountConfigCalls {
         fn from(value: RegisterWalletDerivationCall) -> Self {
             Self::RegisterWalletDerivation(value)
+        }
+    }
+    impl ::core::convert::From<RemoveActionCall> for AccountConfigCalls {
+        fn from(value: RemoveActionCall) -> Self {
+            Self::RemoveAction(value)
         }
     }
     impl ::core::convert::From<RemoveActionFromGroupCall> for AccountConfigCalls {
@@ -5349,7 +5524,7 @@ pub mod account_config {
         Hash,
     )]
     pub struct IndexToAccountHashAtReturn(pub ::ethers::core::types::U256);
-    ///Container type for all return fields from the `listActions` function with signature `listActions(uint256,uint256,uint256,uint256)` and selector `0x542970ed`
+    ///Container type for all return fields from the `listActions` function with signature `listActions(uint256,uint256,uint256)` and selector `0xc9176804`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -5363,6 +5538,20 @@ pub mod account_config {
         Hash,
     )]
     pub struct ListActionsReturn(pub ::std::vec::Vec<Metadata>);
+    ///Container type for all return fields from the `listActionsInGroup` function with signature `listActionsInGroup(uint256,uint256,uint256,uint256)` and selector `0xea79e095`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct ListActionsInGroupReturn(pub ::std::vec::Vec<Metadata>);
     ///Container type for all return fields from the `listApiKeys` function with signature `listApiKeys(uint256,uint256,uint256)` and selector `0xc704668c`
     #[derive(
         Clone,

--- a/lit-api-server/src/accounts/contracts/account_config_contract.rs
+++ b/lit-api-server/src/accounts/contracts/account_config_contract.rs
@@ -2211,19 +2211,6 @@ pub mod account_config {
                 )
                 .expect("method not found (this should never happen)")
         }
-        ///Calls the contract's `removeAction` (0x40d4411b) function
-        pub fn remove_action(
-            &self,
-            account_api_key_hash: ::ethers::core::types::U256,
-            action_hash: ::ethers::core::types::U256,
-        ) -> ::ethers::contract::builders::ContractCall<M, ()> {
-            self.0
-                .method_hash(
-                    [64, 212, 65, 27],
-                    (account_api_key_hash, action_hash),
-                )
-                .expect("method not found (this should never happen)")
-        }
         ///Calls the contract's `addActionToGroup` (0x1f52aa42) function
         pub fn add_action_to_group(
             &self,
@@ -2641,6 +2628,16 @@ pub mod account_config {
                         description,
                     ),
                 )
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `removeAction` (0x40d4411b) function
+        pub fn remove_action(
+            &self,
+            account_api_key_hash: ::ethers::core::types::U256,
+            action_hash: ::ethers::core::types::U256,
+        ) -> ::ethers::contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([64, 212, 65, 27], (account_api_key_hash, action_hash))
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `removeActionFromGroup` (0x5d861c72) function
@@ -3433,24 +3430,6 @@ pub mod account_config {
         pub description: ::std::string::String,
         pub action_hash: ::ethers::core::types::U256,
     }
-    ///Container type for all input parameters for the `removeAction` function with signature `removeAction(uint256,uint256)` and selector `0x40d4411b`
-    #[derive(
-        Clone,
-        ::ethers::contract::EthCall,
-        ::ethers::contract::EthDisplay,
-        serde::Serialize,
-        serde::Deserialize,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-    )]
-    #[ethcall(name = "removeAction", abi = "removeAction(uint256,uint256)")]
-    pub struct RemoveActionCall {
-        pub account_api_key_hash: ::ethers::core::types::U256,
-        pub action_hash: ::ethers::core::types::U256,
-    }
     ///Container type for all input parameters for the `addActionToGroup` function with signature `addActionToGroup(uint256,uint256,uint256)` and selector `0x1f52aa42`
     #[derive(
         Clone,
@@ -3848,10 +3827,7 @@ pub mod account_config {
         Eq,
         Hash,
     )]
-    #[ethcall(
-        name = "listActions",
-        abi = "listActions(uint256,uint256,uint256)"
-    )]
+    #[ethcall(name = "listActions", abi = "listActions(uint256,uint256,uint256)")]
     pub struct ListActionsCall {
         pub account_api_key_hash: ::ethers::core::types::U256,
         pub page_number: ::ethers::core::types::U256,
@@ -4137,6 +4113,24 @@ pub mod account_config {
         pub derivation_path: ::ethers::core::types::U256,
         pub name: ::std::string::String,
         pub description: ::std::string::String,
+    }
+    ///Container type for all input parameters for the `removeAction` function with signature `removeAction(uint256,uint256)` and selector `0x40d4411b`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(name = "removeAction", abi = "removeAction(uint256,uint256)")]
+    pub struct RemoveActionCall {
+        pub account_api_key_hash: ::ethers::core::types::U256,
+        pub action_hash: ::ethers::core::types::U256,
     }
     ///Container type for all input parameters for the `removeActionFromGroup` function with signature `removeActionFromGroup(uint256,uint256,uint256)` and selector `0x5d861c72`
     #[derive(
@@ -4730,8 +4724,7 @@ pub mod account_config {
             {
                 return Ok(Self::RegisterWalletDerivation(decoded));
             }
-            if let Ok(decoded) =
-                <RemoveActionCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            if let Ok(decoded) = <RemoveActionCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
                 return Ok(Self::RemoveAction(decoded));
             }

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -87,16 +87,31 @@ pub async fn add_group(
     send_transaction(function_call, signer_pool, signer_address, client).await
 }
 
-/// Create a new action entry with name and description in the account's actionMetadata mapping.
+/// Create a new action entry with name, description, and IPFS CID hash in the account's actionMetadata mapping.
 pub async fn add_action(
     signer_pool: Arc<SignerPool>,
     api_key: &str,
+    action_hash: U256,
     req: AddActionRequest,
 ) -> Result<bool> {
     let (contract, signer_address, client) =
         get_signable_account_config_contract(signer_pool.clone()).await?;
     let account_api_key_hash = api_key_hash(api_key);
-    let function_call = contract.add_action(account_api_key_hash, req.name, req.description);
+    let function_call =
+        contract.add_action(account_api_key_hash, req.name, req.description, action_hash);
+    send_transaction(function_call, signer_pool, signer_address, client).await
+}
+
+/// Remove an action from the account by its hash (AccountConfig.removeAction).
+pub async fn remove_action(
+    signer_pool: Arc<SignerPool>,
+    api_key: &str,
+    action_hash: U256,
+) -> Result<bool> {
+    let (contract, signer_address, client) =
+        get_signable_account_config_contract(signer_pool.clone()).await?;
+    let account_api_key_hash = api_key_hash(api_key);
+    let function_call = contract.remove_action(account_api_key_hash, action_hash);
     send_transaction(function_call, signer_pool, signer_address, client).await
 }
 
@@ -449,7 +464,7 @@ pub async fn list_actions(
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
     let page = contract
-        .list_actions(account_api_key_hash, group_id, page_number, page_size)
+        .list_actions_in_group(account_api_key_hash, group_id, page_number, page_size)
         .call()
         .await?;
     Ok(page)

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -6,9 +6,10 @@ use crate::config::GLOBAL_NODE_CONFIG;
 use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest,
+    RemoveGroupRequest, RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest,
+    UpdateActionMetadataRequest, UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest,
+    UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddUsageApiKeyResponse, ApiKeyItem, ChainConfigKeysResponse,
@@ -171,9 +172,22 @@ pub async fn add_action(
     api_key: &str,
     req: Json<AddActionRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
-    accounts::add_action(signer_pool, api_key, req.into_inner())
+    let action_hash = ipfs_cid_to_u256(&req.action_ipfs_cid)?;
+    accounts::add_action(signer_pool, api_key, action_hash, req.into_inner())
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "add_action failed"))?;
+    Ok(AccountOpResponse { success: true })
+}
+
+pub async fn delete_action(
+    signer_pool: Arc<SignerPool>,
+    api_key: &str,
+    req: Json<DeleteActionRequest>,
+) -> Result<AccountOpResponse, ApiStatus> {
+    let action_hash = ipfs_cid_to_u256(&req.action_ipfs_cid)?;
+    accounts::remove_action(signer_pool, api_key, action_hash)
+        .await
+        .map_err(|e| ApiStatus::internal_server_error(e, "delete_action failed"))?;
     Ok(AccountOpResponse { success: true })
 }
 

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -8,9 +8,10 @@ use crate::core::v1::helpers::api_status::{ApiResult, ErrMessage};
 use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest,
+    RemoveGroupRequest, RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest,
+    UpdateActionMetadataRequest, UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest,
+    UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddUsageApiKeyResponse, ApiKeyItem, ChainConfigKeysResponse,
@@ -226,6 +227,22 @@ pub(super) async fn add_action(
     OpenApiResponse {
         response: ApiResult(
             account_management::add_action(signer_pool.inner().clone(), api_key.0.as_str(), req)
+                .await,
+        )
+        .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/delete_action", format = "json", data = "<req>")]
+pub(super) async fn delete_action(
+    signer_pool: &State<Arc<SignerPool>>,
+    api_key: BilledManagementApiKey,
+    req: Json<DeleteActionRequest>,
+) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(
+            account_management::delete_action(signer_pool.inner().clone(), api_key.0.as_str(), req)
                 .await,
         )
         .into(),

--- a/lit-api-server/src/core/v1/endpoints/mod.rs
+++ b/lit-api-server/src/core/v1/endpoints/mod.rs
@@ -24,6 +24,7 @@ pub fn routes_with_spec() -> (Vec<Route>, OpenApi) {
         add_group,
         remove_group,
         add_action,
+        delete_action,
         add_action_to_group,
         add_pkp_to_group,
         remove_pkp_from_group,

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -25,6 +25,8 @@ pub struct AddGroupRequest {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AddActionRequest {
+    /// IPFS CID for the action (keccak256-hashed on server).
+    pub action_ipfs_cid: String,
     pub name: String,
     pub description: String,
 }
@@ -60,6 +62,13 @@ pub struct UpdateGroupRequest {
     pub pkp_ids_permitted: Vec<String>,
     #[serde(default)]
     pub cid_hashes_permitted: Vec<String>,
+}
+
+/// Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DeleteActionRequest {
+    /// IPFS CID for the action (keccak256-hashed on server).
+    pub action_ipfs_cid: String,
 }
 
 /// Request for remove_action_from_group. action_ipfs_cid is keccak256-hashed on server. API key via header.

--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -34,6 +34,7 @@
 /**
  * @typedef {Object} AddActionOptions
  * @property {string} apiKey - Account API key
+ * @property {string} actionIpfsCid - IPFS CID for the action (keccak256-hashed on server)
  * @property {string} name - Name for the action (stored in contract actionMetadata)
  * @property {string} description - Description for the action
  */
@@ -102,6 +103,12 @@
  * @property {string} description - Group description
  * @property {string[]} [pkpIdsPermitted=[]] - PKP IDs permitted to use the group
  * @property {string[]} [cidHashesPermitted=[]] - Keccak256 hashes of permitted action IPFS CIDs
+ */
+
+/**
+ * @typedef {Object} DeleteActionOptions
+ * @property {string} apiKey - Account API key
+ * @property {string} actionIpfsCid - IPFS CID for the action (keccak256-hashed on server)
  */
 
 /**
@@ -423,8 +430,8 @@ export class LitNodeSimpleApiClient {
    * @param {AddActionOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async addAction({ apiKey, name, description }) {
-    const body = { name: name ?? '', description: description ?? '' };
+  async addAction({ apiKey, actionIpfsCid, name, description }) {
+    const body = { action_ipfs_cid: actionIpfsCid, name: name ?? '', description: description ?? '' };
     const res = await fetch(`${this.baseUrl}/add_action`, {
       method: 'POST',
       headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
@@ -614,6 +621,22 @@ export class LitNodeSimpleApiClient {
       body: JSON.stringify(body),
     });
     return parseResponse(res, 'update_group');
+  }
+
+  /**
+   * POST /core/v1/delete_action
+   * Delete an action (IPFS CID) and its metadata from the account.
+   * @param {DeleteActionOptions} options
+   * @returns {Promise<AccountOpResponse>}
+   */
+  async deleteAction({ apiKey, actionIpfsCid }) {
+    const body = { action_ipfs_cid: actionIpfsCid };
+    const res = await fetch(`${this.baseUrl}/delete_action`, {
+      method: 'POST',
+      headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    return parseResponse(res, 'delete_action');
   }
 
   /**

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -982,7 +982,7 @@ function openAddActionModal() {
       showActionProgress('Adding action', `Adding action CID "${cid}" to group ${gid}.`);
       const client = await getClient();
       if (name || desc) {
-        await client.addAction({ apiKey, name: name || '', description: desc || '' });
+        await client.addAction({ apiKey, actionIpfsCid: cid, name: name || '', description: desc || '' });
       }
       await client.addActionToGroup({ apiKey, groupId: gid, actionIpfsCid: cid });
       if (groupIdEl) groupIdEl.value = gid;
@@ -1037,18 +1037,19 @@ function openEditActionModal(item, groupId) {
 async function confirmAndRemoveAction(item, groupId) {
   const cid = item.ipfs_cid || item.cid || String(item.id ?? '');
   const name = item.name || cid;
-  const msg = 'Remove action "' + escapeHtml(name) + '" from this group? This cannot be undone.';
+  const msg = 'Delete action "' + escapeHtml(name) + '" from this group and account? This cannot be undone.';
   const confirmed = await confirmDelete(msg);
   if (!confirmed) return;
   const apiKey = getApiKey();
   if (!apiKey) return;
   hideStatus('actions-status');
   try {
-    showActionProgress('Removing action', `Removing action CID "${cid}" from group ${groupId}.`);
+    showActionProgress('Deleting action', `Deleting action CID "${cid}" from group ${groupId}.`);
     const client = await getClient();
     await client.removeActionFromGroup({ apiKey, groupId, actionIpfsCid: cid });
+    await client.deleteAction({ apiKey, actionIpfsCid: cid });
     await loadActions(groupId);
-    showStatus('actions-status', 'Action removed.', 'success');
+    showStatus('actions-status', 'Action deleted.', 'success');
   } catch (e) {
     showStatus('actions-status', 'Error: ' + (e && e.message ? e.message : String(e)), 'error');
   } finally {

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -981,9 +981,7 @@ function openAddActionModal() {
     try {
       showActionProgress('Adding action', `Adding action CID "${cid}" to group ${gid}.`);
       const client = await getClient();
-      if (name || desc) {
-        await client.addAction({ apiKey, actionIpfsCid: cid, name: name || '', description: desc || '' });
-      }
+      await client.addAction({ apiKey, actionIpfsCid: cid, name: name || '', description: desc || '' });
       await client.addActionToGroup({ apiKey, groupId: gid, actionIpfsCid: cid });
       if (groupIdEl) groupIdEl.value = gid;
       await loadActions(gid);


### PR DESCRIPTION
## Summary
- Add `action_ipfs_cid` field to `AddActionRequest` and wire it through all Rust layers (request → endpoint → business logic → accounts → contract binding)
- Add new `POST /delete_action` endpoint to remove an action and its metadata from the account entirely
- Update `WritesFacet.sol`: `addAction` now accepts `actionHash` param, new `removeAction` function
- Update `ViewsFacet.sol`: new account-level `listActions` (no groupId), rename old to `listActionsInGroup`
- Update Rust contract bindings with correct selectors for all changed/new Solidity functions
- Update core SDK (`core_sdk.js`), dashboard app, k6 types/tests, and docs

## Test plan
- [ ] Verify `POST /add_action` accepts `action_ipfs_cid` and stores metadata keyed by hash
- [ ] Verify `POST /delete_action` removes action metadata from account
- [ ] Verify `listActions` returns account-level actions, `listActionsInGroup` returns group-scoped actions
- [ ] Run k6 integration tests (`integration.spec.ts`)
- [ ] Verify dashboard add/delete action flows work end-to-end
- [ ] Deploy updated Solidity contracts and verify ABI selectors match

🤖 Generated with [Claude Code](https://claude.com/claude-code)