### PR TITLE
Fix getLitActionWalletAddress returning ellipsed address

### DIFF
--- a/lit-api-server/src/actions/client/op_code_helpers/private_keys.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/private_keys.rs
@@ -43,6 +43,6 @@ pub async fn get_lit_action_wallet_address(ipfs_id: &str) -> Result<String> {
     let local_wallet = LocalWallet::from_bytes(&secret_bytes)
         .map_err(|e| anyhow::anyhow!("Unable to convert secret bytes to local wallet: {e}"))?;
     let wallet_address = local_wallet.address();
-    let wallet_address = wallet_address.to_string();
+    let wallet_address = format!("{wallet_address:?}");
     Ok(wallet_address)
 }

--- a/lit-api-server/src/actions/client/op_code_helpers/private_keys.rs
+++ b/lit-api-server/src/actions/client/op_code_helpers/private_keys.rs
@@ -43,6 +43,6 @@ pub async fn get_lit_action_wallet_address(ipfs_id: &str) -> Result<String> {
     let local_wallet = LocalWallet::from_bytes(&secret_bytes)
         .map_err(|e| anyhow::anyhow!("Unable to convert secret bytes to local wallet: {e}"))?;
     let wallet_address = local_wallet.address();
-    let wallet_address = format!("{wallet_address:?}");
+    let wallet_address = bytes_to_0x_hex(wallet_address.as_bytes());
     Ok(wallet_address)
 }


### PR DESCRIPTION
## Summary
- `getLitActionWalletAddress` was returning a truncated/ellipsed wallet address (e.g. `0x1234…abcd`) because `H160::to_string()` uses a shortened Display format
- Changed to `format!("{wallet_address:?}")` (Debug formatting) which returns the full 42-character hex address, matching the existing pattern in `stripe.rs`

## Test plan
- [ ] Verify `getLitActionWalletAddress` returns a full 42-char `0x`-prefixed address
- [ ] Confirm no regression in wallet address usage downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)