### PR TITLE
Rename action_ipfs_cid to hashed_cid and stop re-hashing in delete/re…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .cursor
 .claude
+.agents
 .env
 docker-compose.deploy.yml
 .digest-*.txt

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -425,7 +425,7 @@ export default function (data: IntegrationSetupData) {
 
   // ── 21. removeActionFromGroup ─────────────────────────────────────────────
   const removeActionRes = client.removeActionFromGroup(
-    { group_id: parseInt(groupId) , action_ipfs_cid: ipfsId },
+    { group_id: parseInt(groupId) , hashed_cid: ipfsId },
     authHeaders,
   );
   assertOk("removeActionFromGroup", "POST /remove_action_from_group", removeActionRes);
@@ -441,7 +441,7 @@ export default function (data: IntegrationSetupData) {
 
   // ── 21b. deleteAction ────────────────────────────────────────────────────
   const deleteActionRes = client.deleteAction(
-    { action_ipfs_cid: ipfsId },
+    { hashed_cid: ipfsId },
     authHeaders,
   );
   assertOk("deleteAction", "POST /delete_action", deleteActionRes);

--- a/k6/k6-script.sample.ts
+++ b/k6/k6-script.sample.ts
@@ -214,7 +214,7 @@ export default function () {
    */
   removeActionFromGroupRequest = {
     group_id: "jaywalk",
-    action_ipfs_cid: "vice",
+    hashed_cid: "vice",
   };
   headers = {
     "X-Api-Key": "after",

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -104,11 +104,11 @@ export interface AddActionRequest {
 }
 
 /**
- * Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
+ * Request for delete_action. hashed_cid is already a keccak256 hash (hex string). API key via header.
  */
 export interface DeleteActionRequest {
-  /** IPFS CID for the action (keccak256-hashed on server). */
-  action_ipfs_cid: string;
+  /** Already-hashed CID for the action (0x-prefixed hex string). */
+  hashed_cid: string;
 }
 
 export interface AddActionToGroupRequest {
@@ -203,13 +203,13 @@ export interface UpdateGroupRequest {
 }
 
 /**
- * Request for remove_action_from_group. action_ipfs_cid is keccak256-hashed on server. API key via header.
+ * Request for remove_action_from_group. hashed_cid is already a keccak256 hash (hex string). API key via header.
  */
 export interface RemoveActionFromGroupRequest {
   /** @minimum 0 */
   group_id: number;
-  /** IPFS CID for the action (keccak256-hashed on server). */
-  action_ipfs_cid: string;
+  /** Already-hashed CID for the action (0x-prefixed hex string). */
+  hashed_cid: string;
 }
 
 /**

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -213,13 +213,13 @@ export interface RemoveActionFromGroupRequest {
 }
 
 /**
- * Request for update_action_metadata. action_ipfs_cid is keccak256-hashed on server. API key via header.
+ * Request for update_action_metadata. hashed_cid is already a keccak256 hash (hex string). API key via header.
  */
 export interface UpdateActionMetadataRequest {
   /** @minimum 0 */
   group_id: number;
-  /** IPFS CID for the action (keccak256-hashed on server). */
-  action_ipfs_cid: string;
+  /** Already-hashed CID for the action (0x-prefixed hex string). */
+  hashed_cid: string;
   name: string;
   description: string;
 }

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -285,15 +285,13 @@ contract WritesFacet {
         string memory name,
         string memory description
     ) public {
-        SecurityLib.revertIfActionDoesNotExist(
-            accountApiKeyHash,
-            groupId,
-            actionHash,
-            msg.sender
-        );
+        SecurityLib.revertIfNoAccountAccess(accountApiKeyHash, msg.sender);
         SecurityLib.revertIfNotMasterAccount(accountApiKeyHash);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         AppStorage.Account storage account = s.accounts[accountApiKeyHash];
+        if (!account.actionHashesList.contains(actionHash)) {
+            revert AppStorage.ActionDoesNotExist(accountApiKeyHash, groupId, actionHash);
+        }
         account.actionMetadata[actionHash].name = name;
         account.actionMetadata[actionHash].description = description;
     }

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -393,7 +393,7 @@ pub async fn update_action_metadata(
     req: Json<UpdateActionMetadataRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
     let group_id = U256::from(req.group_id);
-    let action_hash = ipfs_cid_to_u256(&req.action_ipfs_cid)?;
+    let action_hash = hashed_cid_to_u256(&req.hashed_cid)?;
     accounts::update_action_metadata(
         signer_pool,
         api_key,

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -20,7 +20,8 @@ use crate::dstack::v1::get_client_key;
 use crate::stripe::StripeState;
 use crate::utils::generate_unique_derivation_path;
 use crate::utils::parse_with_hash::{
-    hex_array_to_h160_array, hex_array_to_u256_array, ipfs_cid_to_u256, string_group_id_to_u256,
+    hashed_cid_to_u256, hex_array_to_h160_array, hex_array_to_u256_array, ipfs_cid_to_u256,
+    string_group_id_to_u256,
 };
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
@@ -184,7 +185,7 @@ pub async fn delete_action(
     api_key: &str,
     req: Json<DeleteActionRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
-    let action_hash = ipfs_cid_to_u256(&req.action_ipfs_cid)?;
+    let action_hash = hashed_cid_to_u256(&req.hashed_cid)?;
     accounts::remove_action(signer_pool, api_key, action_hash)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "delete_action failed"))?;
@@ -379,7 +380,8 @@ pub async fn remove_action_from_group(
     req: Json<RemoveActionFromGroupRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
     let group_id = U256::from(req.group_id);
-    accounts::remove_action_from_group_by_cid(signer_pool, api_key, group_id, &req.action_ipfs_cid)
+    let action_hash = hashed_cid_to_u256(&req.hashed_cid)?;
+    accounts::remove_action_from_group(signer_pool, api_key, group_id, action_hash)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "remove_action_from_group failed"))?;
     Ok(AccountOpResponse { success: true })

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -64,19 +64,19 @@ pub struct UpdateGroupRequest {
     pub cid_hashes_permitted: Vec<String>,
 }
 
-/// Request for delete_action. action_ipfs_cid is keccak256-hashed on server. API key via header.
+/// Request for delete_action. hashed_cid is already a keccak256 hash (hex string). API key via header.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct DeleteActionRequest {
-    /// IPFS CID for the action (keccak256-hashed on server).
-    pub action_ipfs_cid: String,
+    /// Already-hashed CID for the action (0x-prefixed hex string).
+    pub hashed_cid: String,
 }
 
-/// Request for remove_action_from_group. action_ipfs_cid is keccak256-hashed on server. API key via header.
+/// Request for remove_action_from_group. hashed_cid is already a keccak256 hash (hex string). API key via header.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RemoveActionFromGroupRequest {
     pub group_id: u64,
-    /// IPFS CID for the action (keccak256-hashed on server).
-    pub action_ipfs_cid: String,
+    /// Already-hashed CID for the action (0x-prefixed hex string).
+    pub hashed_cid: String,
 }
 
 /// Request for update_action_metadata. action_ipfs_cid is keccak256-hashed on server. API key via header.

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -79,12 +79,12 @@ pub struct RemoveActionFromGroupRequest {
     pub hashed_cid: String,
 }
 
-/// Request for update_action_metadata. action_ipfs_cid is keccak256-hashed on server. API key via header.
+/// Request for update_action_metadata. hashed_cid is already a keccak256 hash (hex string). API key via header.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UpdateActionMetadataRequest {
     pub group_id: u64,
-    /// IPFS CID for the action (keccak256-hashed on server).
-    pub action_ipfs_cid: String,
+    /// Already-hashed CID for the action (0x-prefixed hex string).
+    pub hashed_cid: String,
     pub name: String,
     pub description: String,
 }

--- a/lit-api-server/src/utils/parse_with_hash.rs
+++ b/lit-api-server/src/utils/parse_with_hash.rs
@@ -74,6 +74,17 @@ pub fn string_group_id_to_u256(group_id: &str) -> Result<U256, ApiStatus> {
     })
 }
 
+/// Parse an already-hashed CID (0x-prefixed hex or decimal string) into U256.
+/// Unlike `ipfs_cid_to_u256`, this does NOT keccak256-hash the input.
+pub fn hashed_cid_to_u256(hashed_cid: &str) -> Result<U256, ApiStatus> {
+    parse_u256(hashed_cid).map_err(|e| {
+        ApiStatus::bad_request(
+            anyhow::anyhow!("Unable to parse hashed CID: {}", e),
+            "Unable to parse hashed CID",
+        )
+    })
+}
+
 fn string_to_bytes_to_hash_to_u256(s: &str) -> Result<U256, ApiStatus> {
     let bytes = keccak256(s.as_bytes());
     Ok(U256::from_big_endian(&bytes))

--- a/lit-static/static/core_sdk.js
+++ b/lit-static/static/core_sdk.js
@@ -108,21 +108,21 @@
 /**
  * @typedef {Object} DeleteActionOptions
  * @property {string} apiKey - Account API key
- * @property {string} actionIpfsCid - IPFS CID for the action (keccak256-hashed on server)
+ * @property {string} hashedCid - Already-hashed CID for the action (0x-prefixed keccak256 hex string)
  */
 
 /**
  * @typedef {Object} RemoveActionFromGroupOptions
  * @property {string} apiKey - Account API key
  * @property {string} groupId - Group ID (decimal or hex string)
- * @property {string} actionIpfsCid - IPFS CID for the action (keccak256-hashed on server)
+ * @property {string} hashedCid - Already-hashed CID for the action (0x-prefixed keccak256 hex string)
  */
 
 /**
  * @typedef {Object} UpdateActionMetadataOptions
  * @property {string} apiKey - Account API key
  * @property {string} groupId - Group ID (decimal or hex string)
- * @property {string} actionIpfsCid - IPFS CID for the action (keccak256-hashed on server)
+ * @property {string} hashedCid - Already-hashed CID for the action (0x-prefixed keccak256 hex string)
  * @property {string} name - Action name
  * @property {string} description - Action description
  */
@@ -625,12 +625,12 @@ export class LitNodeSimpleApiClient {
 
   /**
    * POST /core/v1/delete_action
-   * Delete an action (IPFS CID) and its metadata from the account.
+   * Delete an action and its metadata from the account.
    * @param {DeleteActionOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async deleteAction({ apiKey, actionIpfsCid }) {
-    const body = { action_ipfs_cid: actionIpfsCid };
+  async deleteAction({ apiKey, hashedCid }) {
+    const body = { hashed_cid: hashedCid };
     const res = await fetch(`${this.baseUrl}/delete_action`, {
       method: 'POST',
       headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
@@ -641,14 +641,14 @@ export class LitNodeSimpleApiClient {
 
   /**
    * POST /core/v1/remove_action_from_group
-   * Remove an action from a group by IPFS CID (keccak256-hashed on server).
+   * Remove an action from a group by already-hashed CID.
    * @param {RemoveActionFromGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async removeActionFromGroup({ apiKey, groupId, actionIpfsCid }) {
+  async removeActionFromGroup({ apiKey, groupId, hashedCid }) {
     const body = {
       group_id: Number(groupId),
-      action_ipfs_cid: actionIpfsCid,
+      hashed_cid: hashedCid,
     };
     const res = await fetch(`${this.baseUrl}/remove_action_from_group`, {
       method: 'POST',
@@ -660,14 +660,14 @@ export class LitNodeSimpleApiClient {
 
   /**
    * POST /core/v1/update_action_metadata
-   * Update action metadata (name, description) for an action in a group.
+   * Update action metadata (name, description) for an action.
    * @param {UpdateActionMetadataOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async updateActionMetadata({ apiKey, groupId, actionIpfsCid, name, description }) {
+  async updateActionMetadata({ apiKey, groupId, hashedCid, name, description }) {
     const body = {
       group_id: Number(groupId),
-      action_ipfs_cid: actionIpfsCid,
+      hashed_cid: hashedCid,
       name: name ?? '',
       description: description ?? '',
     };

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -973,7 +973,7 @@ function openAddActionModal() {
 }
 
 function openEditActionModal(item) {
-  const cid = item.ipfs_cid || item.cid || '';
+  const cid = item.ipfs_cid || item.cid || String(item.id ?? '');
   const body =
     '<div class="form-group"><label>Hashed CID</label><div class="mono">' + escapeHtml(cid) + '</div></div>' +
     '<div class="form-group"><label for="modal-edit-action-name">Name</label><input type="text" id="modal-edit-action-name" class="input" value="' + escapeHtml(item.name || '') + '"></div>' +
@@ -996,7 +996,7 @@ function openEditActionModal(item) {
     try {
       showActionProgress('Updating action', `Updating action metadata for CID "${cid}".`);
       const client = await getClient();
-      await client.updateActionMetadata({ apiKey, groupId: '0', actionIpfsCid: cid, name, description: desc });
+      await client.updateActionMetadata({ apiKey, groupId: '0', hashedCid: cid, name, description: desc });
       await loadActions();
       showStatus('actions-status', 'Action updated.', 'success');
     } catch (e) {
@@ -1019,7 +1019,7 @@ async function confirmAndRemoveAction(item) {
   try {
     showActionProgress('Deleting action', `Deleting action CID "${cid}".`);
     const client = await getClient();
-    await client.deleteAction({ apiKey, actionIpfsCid: cid });
+    await client.deleteAction({ apiKey, hashedCid: cid });
     await loadActions();
     showStatus('actions-status', 'Action deleted.', 'success');
   } catch (e) {

--- a/lit-static/static/dapps/dashboard/app.js
+++ b/lit-static/static/dapps/dashboard/app.js
@@ -46,12 +46,10 @@ async function preloadAllTables() {
   const apiKey = getApiKey();
   if (!apiKey) return;
   try {
-    const groups = await loadGroups();
+    await loadGroups();
     await loadWallets();
     await loadUsageKeys();
-    const groupIdEl = document.getElementById('actions-group-id');
-    const groupId = (groupIdEl && groupIdEl.value.trim()) || (groups && groups.length > 0 ? String(groups[0].id) : '0');
-    await loadActions(groupId);
+    await loadActions();
   } catch (_) { /* ignore */ }
 }
 
@@ -540,7 +538,7 @@ async function confirmAndRemoveGroup(item) {
   }
 }
 
-function renderActionsTable(items, groupId) {
+function renderActionsTable(items) {
   const tbody = document.getElementById('actions-tbody');
   const empty = document.getElementById('actions-empty');
   if (!tbody) return;
@@ -564,14 +562,14 @@ function renderActionsTable(items, groupId) {
     editBtn.className = 'btn-icon';
     editBtn.title = 'Edit';
     editBtn.innerHTML = ICON_PENCIL;
-    editBtn.addEventListener('click', () => openEditActionModal(item, groupId));
+    editBtn.addEventListener('click', () => openEditActionModal(item));
     actionsCell.appendChild(editBtn);
     const delBtn = document.createElement('button');
     delBtn.type = 'button';
     delBtn.className = 'btn-icon btn-icon-danger';
     delBtn.title = 'Delete';
     delBtn.innerHTML = ICON_TRASH;
-    delBtn.addEventListener('click', () => confirmAndRemoveAction(item, groupId));
+    delBtn.addEventListener('click', () => confirmAndRemoveAction(item));
     actionsCell.appendChild(delBtn);
     tbody.appendChild(tr);
   });
@@ -784,17 +782,6 @@ async function loadUsageKeys() {
 }
 
 // ----- Load table data (used by preload and refresh buttons) -----
-function populateActionsGroupDropdown(groups) {
-  const sel = document.getElementById('actions-group-id');
-  if (!sel) return;
-  const current = sel.value;
-  sel.innerHTML = groups.length === 0
-    ? '<option value="" disabled selected>No groups</option>'
-    : groups.map(g => `<option value="${g.id}">${escapeHtml(g.name || String(g.id))}</option>`).join('');
-  // Restore previous selection if still valid, otherwise pick first.
-  if (current && [...sel.options].some(o => o.value === current)) sel.value = current;
-  else if (sel.options.length > 0) sel.selectedIndex = 0;
-}
 
 async function loadGroups() {
   const apiKey = getApiKey();
@@ -807,7 +794,6 @@ async function loadGroups() {
     const items = await client.listGroups({ apiKey, pageNumber: '0', pageSize: LIST_PAGE_SIZE });
     window._groups = items;
     renderGroupsTable(items);
-    populateActionsGroupDropdown(items);
     window._statGroups = items.length;
     updateStatCards();
     return items;
@@ -841,17 +827,17 @@ async function loadWallets() {
   }
 }
 
-async function loadActions(groupId) {
+async function loadActions() {
   const apiKey = getApiKey();
-  if (!apiKey || !groupId) return;
+  if (!apiKey) return;
   hideStatus('actions-status');
   const btn = document.getElementById('btn-load-actions');
   if (btn) btn.disabled = true;
   try {
     const client = await getClient();
-    const items = await client.listActions({ apiKey, groupId, pageNumber: '0', pageSize: LIST_PAGE_SIZE });
+    const items = await client.listActions({ apiKey, groupId: '0', pageNumber: '0', pageSize: LIST_PAGE_SIZE });
     window._actions = items;
-    renderActionsTable(items, groupId);
+    renderActionsTable(items);
     window._statActions = items.length;
     updateStatCards();
     return items;
@@ -952,12 +938,7 @@ function openEditGroupModal(item) { openGroupModal(item); }
 
 // ----- Action modals -----
 function openAddActionModal() {
-  const groupIdEl = document.getElementById('actions-group-id');
-  const groupId = (groupIdEl && groupIdEl.value.trim()) || '0';
-  const selectedOption = groupIdEl && groupIdEl.options[groupIdEl.selectedIndex];
-  const groupLabel = selectedOption ? selectedOption.textContent : groupId;
   const body =
-    '<div class="form-group"><label>Group</label><div class="input" style="background:var(--input-bg,#f3f4f6);color:var(--text-muted,#6b7280);cursor:default;" id="modal-action-group-id">' + escapeHtml(groupLabel) + '</div></div>' +
     '<div class="form-group"><label for="modal-action-cid">IPFS CID</label><input type="text" id="modal-action-cid" class="input" placeholder="Qm... or bafy..."></div>' +
     '<div class="form-group"><label for="modal-action-name">Name (optional)</label><input type="text" id="modal-action-name" class="input" placeholder="Action name"></div>' +
     '<div class="form-group"><label for="modal-action-desc">Description (optional)</label><input type="text" id="modal-action-desc" class="input" placeholder="Optional"></div>';
@@ -967,24 +948,21 @@ function openAddActionModal() {
   openModal('Add action', body, footer);
   document.getElementById('modal-cancel-btn').addEventListener('click', closeModal);
   document.getElementById('modal-add-btn').addEventListener('click', async () => {
-    const gid = groupId;
     const cid = document.getElementById('modal-action-cid').value.trim();
     const name = document.getElementById('modal-action-name').value.trim() || undefined;
     const desc = document.getElementById('modal-action-desc').value.trim() || undefined;
     const apiKey = getApiKey();
-    if (!apiKey || !gid || !cid) {
+    if (!apiKey || !cid) {
       showStatus('actions-status', 'Fill in the IPFS CID.', 'error');
       return;
     }
     closeModal();
     hideStatus('actions-status');
     try {
-      showActionProgress('Adding action', `Adding action CID "${cid}" to group ${gid}.`);
+      showActionProgress('Adding action', `Adding action CID "${cid}".`);
       const client = await getClient();
       await client.addAction({ apiKey, actionIpfsCid: cid, name: name || '', description: desc || '' });
-      await client.addActionToGroup({ apiKey, groupId: gid, actionIpfsCid: cid });
-      if (groupIdEl) groupIdEl.value = gid;
-      await loadActions(gid);
+      await loadActions();
       showStatus('actions-status', 'Action added.', 'success');
     } catch (e) {
       showStatus('actions-status', 'Error: ' + (e && e.message ? e.message : String(e)), 'error');
@@ -994,13 +972,10 @@ function openAddActionModal() {
   });
 }
 
-function openEditActionModal(item, groupId) {
+function openEditActionModal(item) {
   const cid = item.ipfs_cid || item.cid || '';
-  const group = getGroupsStore().find((g) => String(g.id) === String(groupId));
-  const groupLabel = group ? (group.name || String(groupId)) : String(groupId);
   const body =
-    '<div class="form-group"><label>Group</label><div class="input" style="background:var(--input-bg,#f3f4f6);color:var(--text-muted,#6b7280);cursor:default;">' + escapeHtml(groupLabel) + '</div></div>' +
-    '<div class="form-group"><label>IPFS CID</label><div class="mono">' + escapeHtml(cid) + '</div></div>' +
+    '<div class="form-group"><label>Hashed CID</label><div class="mono">' + escapeHtml(cid) + '</div></div>' +
     '<div class="form-group"><label for="modal-edit-action-name">Name</label><input type="text" id="modal-edit-action-name" class="input" value="' + escapeHtml(item.name || '') + '"></div>' +
     '<div class="form-group"><label for="modal-edit-action-desc">Description</label><input type="text" id="modal-edit-action-desc" class="input" value="' + escapeHtml(item.description || '') + '"></div>';
   const footer =
@@ -1012,7 +987,7 @@ function openEditActionModal(item, groupId) {
     const name = document.getElementById('modal-edit-action-name').value.trim();
     const desc = document.getElementById('modal-edit-action-desc').value.trim();
     const apiKey = getApiKey();
-    if (!apiKey || !groupId || !cid || !name) {
+    if (!apiKey || !cid || !name) {
       showStatus('actions-status', 'Fill Name.', 'error');
       return;
     }
@@ -1021,8 +996,8 @@ function openEditActionModal(item, groupId) {
     try {
       showActionProgress('Updating action', `Updating action metadata for CID "${cid}".`);
       const client = await getClient();
-      await client.updateActionMetadata({ apiKey, groupId, actionIpfsCid: cid, name, description: desc });
-      await loadActions(groupId);
+      await client.updateActionMetadata({ apiKey, groupId: '0', actionIpfsCid: cid, name, description: desc });
+      await loadActions();
       showStatus('actions-status', 'Action updated.', 'success');
     } catch (e) {
       showStatus('actions-status', 'Error: ' + (e && e.message ? e.message : String(e)), 'error');
@@ -1032,21 +1007,20 @@ function openEditActionModal(item, groupId) {
   });
 }
 
-async function confirmAndRemoveAction(item, groupId) {
+async function confirmAndRemoveAction(item) {
   const cid = item.ipfs_cid || item.cid || String(item.id ?? '');
   const name = item.name || cid;
-  const msg = 'Delete action "' + escapeHtml(name) + '" from this group and account? This cannot be undone.';
+  const msg = 'Delete action "' + escapeHtml(name) + '"? This cannot be undone.';
   const confirmed = await confirmDelete(msg);
   if (!confirmed) return;
   const apiKey = getApiKey();
   if (!apiKey) return;
   hideStatus('actions-status');
   try {
-    showActionProgress('Deleting action', `Deleting action CID "${cid}" from group ${groupId}.`);
+    showActionProgress('Deleting action', `Deleting action CID "${cid}".`);
     const client = await getClient();
-    await client.removeActionFromGroup({ apiKey, groupId, actionIpfsCid: cid });
     await client.deleteAction({ apiKey, actionIpfsCid: cid });
-    await loadActions(groupId);
+    await loadActions();
     showStatus('actions-status', 'Action deleted.', 'success');
   } catch (e) {
     showStatus('actions-status', 'Error: ' + (e && e.message ? e.message : String(e)), 'error');
@@ -1348,15 +1322,7 @@ function initGroups() {
 
 // ----- IPFS Actions -----
 function initActions() {
-  document.getElementById('btn-load-actions')?.addEventListener('click', () => {
-    const groupId = document.getElementById('actions-group-id').value.trim();
-    if (groupId) loadActions(groupId);
-    else showStatus('actions-status', 'Select a group.', 'error');
-  });
-  document.getElementById('actions-group-id')?.addEventListener('change', () => {
-    const groupId = document.getElementById('actions-group-id').value.trim();
-    if (groupId) loadActions(groupId);
-  });
+  document.getElementById('btn-load-actions')?.addEventListener('click', () => loadActions());
   document.getElementById('btn-add-action')?.addEventListener('click', () => openAddActionModal());
 }
 

--- a/lit-static/static/dapps/dashboard/index.html
+++ b/lit-static/static/dapps/dashboard/index.html
@@ -223,21 +223,18 @@
             <div id="actions-status" class="status" style="display: none;"></div>
             <div class="card">
               <div class="card-header">
-                <h3 class="card-title">Actions in group</h3>
+                <h3 class="card-title">Actions</h3>
                 <div class="card-header-actions">
-                  <select id="actions-group-id" class="input input-sm" style="width: 12rem;">
-                    <option value="" disabled selected>Loading groups…</option>
-                  </select>
                   <button type="button" id="btn-load-actions" class="btn btn-sm btn-outline">Refresh</button>
                 </div>
               </div>
               <div class="card-body">
                 <div class="table-wrap">
                   <table class="data-table" id="actions-table">
-                    <thead><tr><th>Name</th><th>CID</th><th>Description</th><th class="th-actions"></th></tr></thead>
+                    <thead><tr><th>Name</th><th>Hashed CID</th><th>Description</th><th class="th-actions"></th></tr></thead>
                     <tbody id="actions-tbody"></tbody>
                   </table>
-                  <p id="actions-empty" class="empty-state" style="display: none;">No actions in this group.</p>
+                  <p id="actions-empty" class="empty-state" style="display: none;">No actions found.</p>
                 </div>
                 <div class="table-add-row">
                   <button type="button" id="btn-add-action" class="btn btn-primary">Add</button>


### PR DESCRIPTION
…move endpoints

The DeleteActionRequest and RemoveActionFromGroupRequest now accept hashed_cid (an already-hashed hex string) instead of action_ipfs_cid, and the server no longer keccak256-hashes the value again. Dashboard actions section simplified: group filter removed, header renamed to "Actions", CID column renamed to "Hashed CID", and group references removed from create/edit modals.