### PR TITLE
fix: align docs with actual API params, deduplicate index.mdx, add Gr…

### DIFF
--- a/docs/api_direct.mdx
+++ b/docs/api_direct.mdx
@@ -135,18 +135,17 @@ Create a group (with optional permitted actions and PKPs). Then add an action (I
     
     // Register action metadata (name/description) with the IPFS CID
     await client.addAction({
-
-    // Add an IPFS action (CID) to the group
-    await client.addActionToGroup({
       apiKey: accountApiKey,
       actionIpfsCid: 'QmYourIpfsCidHere',
+      name: 'My Action',
+      description: 'Optional description',
     });
 
     // Add the action (IPFS CID) to the group
     await client.addActionToGroup({
       apiKey: accountApiKey,
       groupId,
-      actionIpfsCid: 'QmYourIpfsCidHere'
+      actionIpfsCid: 'QmYourIpfsCidHere',
     });
     ```
   </Tab>
@@ -235,27 +234,33 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 
 ### Other useful endpoints
 
+<Info>
+**Raw CID vs hashed CID:** Some endpoints accept a raw IPFS CID (`action_ipfs_cid`, e.g. `"QmYour..."`) — the server hashes it for you. Other endpoints require the already-hashed CID (`hashed_cid`, e.g. `"0xabc..."`) — a keccak256 hex string you get back from `list_actions`. As a rule: **creation endpoints** (`add_action`, `add_action_to_group`) take the raw CID; **update/delete endpoints** (`delete_action`, `remove_action_from_group`, `update_action_metadata`) take the hashed CID.
+</Info>
+
 - **list_api_keys** — List usage API keys (paginated).
 - **list_groups** — List groups.
 - **list_wallets** — List wallets.
 - **list_actions** — List actions in a group (by `group_id`).
 - **list_wallets_in_group** — List wallets in a group.
 - **update_group** — Update group name, description, and permission flags.
-- **delete_action** — Delete an action (IPFS CID) and its metadata from the account.
-- **remove_action_from_group** / **remove_pkp_from_group** — Remove action or PKP from a group.
+- **delete_action** — Delete an action and its metadata from the account. Body: `{"hashed_cid": "0x..."}` (already-hashed CID).
+- **remove_action_from_group** — Remove an action from a group. Body: `{"group_id": 1, "hashed_cid": "0x..."}` (already-hashed CID).
+- **remove_pkp_from_group** — Remove a PKP from a group.
 - **get_node_chain_config** — Get node chain config - a quick way to find the location of contracts within the system.
 
 ---
 
 ### Add action
 
-Register a standalone action entry (name and description only). To make it executable, add its IPFS CID to a group with `add_action_to_group`.
+Register a standalone action entry (IPFS CID, name, and description). The CID is keccak256-hashed on the server. To make it executable, add its IPFS CID to a group with `add_action_to_group`.
 
 <Tabs>
   <Tab title="JavaScript (Core SDK)">
     ```javascript
     await client.addAction({
       apiKey: accountApiKey,
+      actionIpfsCid: 'QmYourIpfsCidHere',
       name: 'Price Oracle',
       description: 'Fetches and signs ETH/USD price',
     });
@@ -266,7 +271,7 @@ Register a standalone action entry (name and description only). To make it execu
     curl -s -X POST "http://localhost:8000/core/v1/add_action" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: KEY" \
-      -d '{"name":"Price Oracle","description":"Fetches and signs ETH/USD price"}'
+      -d '{"action_ipfs_cid":"QmYourIpfsCidHere","name":"Price Oracle","description":"Fetches and signs ETH/USD price"}'
     ```
   </Tab>
 </Tabs>
@@ -361,15 +366,14 @@ Update only the name and description of a usage API key without changing its per
 
 ### Update action metadata
 
-Update the name and description of an action that is already registered in a group.
+Update the name and description of a registered action. The action is identified by its already-hashed CID (`0x`-prefixed keccak256 hex string), which you can obtain from `list_actions`.
 
 <Tabs>
   <Tab title="JavaScript (Core SDK)">
     ```javascript
     await client.updateActionMetadata({
       apiKey: accountApiKey,
-      groupId: 1,
-      actionIpfsCid: 'QmYourIpfsCidHere',
+      hashedCid: '0xabc123...',  // already-hashed CID from list_actions
       name: 'Updated Action Name',
       description: 'Updated description',
     });
@@ -380,7 +384,7 @@ Update the name and description of an action that is already registered in a gro
     curl -s -X POST "http://localhost:8000/core/v1/update_action_metadata" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: KEY" \
-      -d '{"group_id":1,"action_ipfs_cid":"QmYourIpfsCidHere","name":"Updated Action Name","description":"Updated description"}'
+      -d '{"hashed_cid":"0xabc123...","name":"Updated Action Name","description":"Updated description"}'
     ```
   </Tab>
 </Tabs>

--- a/docs/architecture/groups.mdx
+++ b/docs/architecture/groups.mdx
@@ -1,0 +1,93 @@
+---
+title: "Groups"
+description: "How groups organize wallets, actions, and usage keys in Lit Chipotle."
+---
+
+## What is a Group?
+
+A **group** is the core organizing unit in Lit Chipotle. It binds together three things:
+
+1. **Wallets (PKPs)** — which wallets can be used
+2. **IPFS Actions** — which lit-actions can be executed
+3. **Usage API Keys** — which keys have access (via their permission arrays)
+
+Think of a group as an access-control boundary: a usage API key can only run actions and use wallets that belong to groups it has been granted access to.
+
+```
+                        ┌─────────────────────────┐
+                        │        Group 1           │
+                        │                          │
+  Usage Key A ─────────►│  Wallet X    Action CID  │
+  (execute_in: [1])     │  Wallet Y    Action CID  │
+                        │                          │
+                        └─────────────────────────┘
+
+                        ┌─────────────────────────┐
+                        │        Group 2           │
+                        │                          │
+  Usage Key B ─────────►│  Wallet Z    Action CID  │
+  (execute_in: [1,2])   │                          │
+                        │                          │
+                        └─────────────────────────┘
+```
+
+In this example, Key A can only use Group 1's wallets and actions. Key B can use both groups. The account key always has full access to all groups.
+
+## Why Groups Exist
+
+Without groups, every usage key would have access to every wallet and every action in your account. Groups let you:
+
+- **Scope a key to a single dApp** — give your price-oracle service a key that can only execute the price-oracle action using a specific wallet.
+- **Isolate environments** — separate staging actions from production actions.
+- **Rotate access safely** — revoke a usage key without affecting other keys or groups.
+
+## How Groups Connect to Everything
+
+| Resource | Relationship to Group |
+|---|---|
+| **Wallet (PKP)** | Added via `add_pkp_to_group`. A wallet can belong to multiple groups. |
+| **IPFS Action** | Added via `add_action_to_group` (raw CID, server hashes it). An action can belong to multiple groups. |
+| **Usage API Key** | Granted access at creation via permission arrays (e.g., `execute_in_groups: [1, 2]`). Use `[0]` as a wildcard for all groups. |
+| **Account Key** | Always has full access to all groups — no group scoping needed. |
+
+## Common Patterns
+
+### One group per dApp
+
+```
+Group "Price Oracle"     → wallet-A, action-QmPriceOracle
+Group "NFT Minter"       → wallet-B, action-QmMintNFT
+```
+
+Give each dApp its own usage key scoped to its group. If the price-oracle key leaks, the minter is unaffected.
+
+### All-access key for development
+
+Create a usage key with `execute_in_groups: [0]` (wildcard). This key can run any action in any group — useful for local development, but never deploy it.
+
+### Shared wallets across groups
+
+A single wallet can belong to multiple groups. This is useful when multiple dApps need to sign with the same address but run different actions.
+
+## Group Lifecycle
+
+1. **Create** — `POST /core/v1/add_group` with a name and optional pre-permitted PKPs and CID hashes.
+2. **Configure** — Add wallets (`add_pkp_to_group`) and actions (`add_action_to_group`).
+3. **Grant access** — Create or update usage keys with the group ID in their permission arrays.
+4. **Update** — `POST /core/v1/update_group` to change name, description, or permission lists.
+5. **Delete** — `POST /core/v1/remove_group` to remove the group. Usage keys that referenced it lose that access.
+
+## Permission Flags on Groups
+
+When creating a group, two convenience flags control default access:
+
+- **All wallets permitted** — any wallet in the account can be used via this group (no need to add individually).
+- **All actions permitted** — any registered action can be run via this group.
+
+These are set in the Dashboard's group creation form or via the `pkp_ids_permitted` and `cid_hashes_permitted` arrays in the API.
+
+## Further Reading
+
+- [API Reference](/management/api_direct) — Full endpoint docs for group management
+- [API Keys](/management/api_keys) — How usage keys connect to groups
+- [Architecture](/architecture/index) — System design overview

--- a/docs/architecture/groups.mdx
+++ b/docs/architecture/groups.mdx
@@ -84,8 +84,14 @@ When creating a group, two convenience flags control default access:
 - **All wallets permitted** — any wallet in the account can be used via this group (no need to add individually).
 - **All actions permitted** — any registered action can be run via this group.
 
-These are set in the Dashboard's group creation form or via the `pkp_ids_permitted` and `cid_hashes_permitted` arrays in the API.
+These are set in the Dashboard's group creation form or via the `pkp_ids_permitted` and `cid_hashes_permitted` arrays in the API. On-chain, these flags are *not* separate booleans: they are encoded using wildcard values in the arrays:
 
+- To permit **all wallets**, include the zero PKP ID in `pkp_ids_permitted`:
+  - `pkp_ids_permitted: ["0x0000000000000000000000000000000000000000000000000000000000000000"]`
+- To permit **all actions**, include `0` in `cid_hashes_permitted`:
+  - `cid_hashes_permitted: [0]`
+
+Leaving these arrays empty or omitting them does **not** mean "all" — it means no wallets/actions are automatically permitted by default.
 ## Further Reading
 
 - [API Reference](/management/api_direct) — Full endpoint docs for group management

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,7 @@
             "group": "Architecture",
             "pages": [
               "architecture/index",
+              "architecture/groups",
               "architecture/authModel",
               "architecture/diagram"
             ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,12 +7,12 @@ This guide introduces the [**Lit Chipotle API**](https://api.dev.litprotocol.com
 
 ## Zero to LitAction
 
-1. [Create an account via the Dashboard](/dashboard#1-request-a-new-account-or-log-in), note down your API key
+1. [Create an account via the Dashboard](/management/dashboard#1-request-a-new-account-or-log-in), note down your API key
 2. Add a usage API key - set its permissions by clicking "All Options"
 3. Run a LitAction
-   1. [From the Dashboard](/dashboard#6-run-lit-actions)
-   2. [Programmatically via cURL/JavaScript](/api_direct#6-run-lit-action)
-   3. or build your own SDK from the [OpenAPI spec](/api_direct#open-api-specification)
+   1. [From the Dashboard](/management/dashboard#6-run-lit-actions)
+   2. [Programmatically via cURL/JavaScript](/management/api_direct#6-run-lit-action)
+   3. or build your own SDK from the [OpenAPI spec](/management/api_direct#open-api-specification)
 
 ## Overview
 
@@ -39,65 +39,29 @@ It supports light/dark theme for your convenience and provides simple management
 
 **Dashboard workflow (recommended order):**
 
-1. [Request a new account (or log in)](/dashboard#1-request-a-new-account-or-log-in)
-2. [Request usage API keys](/dashboard#2-request-usage-api-keys)
-3. [Request new PKPs (wallets)](/dashboard#3-request-new-pkps-wallets)
-4. [Register IPFS CIDs (actions)](/dashboard#4-register-ipfs-cids-actions)
-5. [Create groups](/dashboard#5-create-groups)
-6. [Run lit-actions](/dashboard#6-run-lit-actions)
+1. [Request a new account (or log in)](/management/dashboard#1-request-a-new-account-or-log-in)
+2. [Request usage API keys](/management/dashboard#2-request-usage-api-keys)
+3. [Request new PKPs (wallets)](/management/dashboard#3-request-new-pkps-wallets)
+4. [Register IPFS CIDs (actions)](/management/dashboard#4-register-ipfs-cids-actions)
+5. [Create groups](/management/dashboard#5-create-groups)
+6. [Run lit-actions](/management/dashboard#6-run-lit-actions)
 
-### 1. Request a new account (or log in)
+For detailed step-by-step instructions with screenshots, see [Using the Dashboard](/management/dashboard).
 
-On the login page you have two tabs:
+## Using the API directly
 
-- **Existing User** — Paste your account API key and click **Log in**. The server checks that the account exists and is mutable.
-- **New User** — Enter an account name and an optional description, then click **Create account**. The server creates the account and displays your new API key and wallet address in a one-time success message. **Copy and store the API key immediately**; it is shown only once and you'll need it to manage the account.
+The same workflows can be done via the REST API under `/core/v1/`. All endpoints that require authentication expect the API key in a header (`X-Api-Key` or `Authorization: Bearer`).
 
-After login, the dashboard shows Overview, Usage API Keys, Groups, IPFS Actions, Wallets, and Action Runner.\
-You'll notice a single wallet in your account - it represents your master account API key, and can be used like a standard EVM wallet, or you can safely skip its web3 properties and use the APIs directly.
+**API workflow:**
 
-### 2. Request usage API keys
+1. [New account or verify account (login)](/management/api_direct#1-new-account-or-verify-account-login)
+2. [Add usage API key](/management/api_direct#2-add-usage-api-key)
+3. [Create wallet (PKP)](/management/api_direct#3-create-a-wallet-pkp)
+4. [Add group and register IPFS action](/management/api_direct#4-add-group-and-register-ipfs-action)
+5. [Add PKP to group (optional)](/management/api_direct#5-add-pkp-to-group-optional)
+6. [Run lit-action](/management/api_direct#6-run-lit-action)
 
-Usage API keys are scoped keys you can give to clients or dApps to run specific lit-actions or to deploy. They can be rotated or removed without changing the main account.
-
-In the **Usage API Keys** section, click **Add**. Set an optional name and description, then click _Confirm_. The server generates a new usage key and displays it in a one-time success message — **copy and store it immediately**, as it will not be shown again. \
-\
-Use this key in the `X-Api-Key` (or `Authorization: Bearer`) header when calling the node so that usage is attributed to this key.
-
-### 3. Request new PKPs (wallets)
-
-PKPs (Programmable Key Pairs) are wallets the lit-nodes can use for signing. In the **Wallets** section, click **Add** to create a new wallet to assign to one of your users, or for use in running a lit-action. The server generates a new PKP and returns its address and public key.
-
-You can add existing PKPs to groups (see step 5) via **Add PKP to group** in the Groups section.
-
-### 4. Register IPFS CIDs (actions)
-
-To scope which usage API keys can run which code, you register **IPFS CIDs** as permitted actions. In the **IPFS Actions** section, pick a group from the dropdown, then **Add** an action: enter the IPFS CID of the lit-action and optional name/description. The server hashes the CID and stores it in the group. Only keys that are allowed to use that group can run that action.
-
-### 5. Create groups
-
-Groups logically combine PKPs, IPFS actions, and (indirectly) usage API keys. You can use any combination: e.g., a group with only permitted actions, or only permitted wallets, or both.
-
-In the **Groups** section, click **Add** to create a group (name, description, optional permitted actions and PKPs, and flags for "all wallets permitted" / "all actions permitted"). Then:
-
-- Use **IPFS Actions** to add CIDs to the group.
-- Use **Add PKP to group** / **Remove PKP from group** to allow which wallets can be used in that group.
-
-Usage API keys (and the account key) are validated against the account's groups and permitted actions/wallets when you run a lit-action.
-
-### 6. Run lit-actions
-
-In the **Action Runner** section, paste some Lit Action JavaScript code and optional JSON parameters. For example
-```javascript
-async function main() {
-  const wallet = new ethers.Wallet(
-    await Lit.Actions.getPrivateKey({ pkpId })
-  );
-  const sig = await wallet.signMessage("Hello from Lit Action");
-  return { sig };
-}
-```
- Choose the API key (account or usage key) to use for the request, then click **Execute**. The node runs the action and returns the response and logs. The key you use must be allowed to run that action (via the group and IPFS CID configuration).
+For full code examples (JavaScript Core SDK and cURL), see the [API Reference](/management/api_direct).
 
 ## Daily Usage
 
@@ -105,383 +69,10 @@ The dashboard is just your human-friendly configuration tool. Once your account 
 
 1. Call the API with your usage key, action-code ( or IPFS CID ) and any parameters that you need
 
-## Using the API directly
+## Further Reading
 
-The same workflows can be done via the REST API. The API itself is under `/core/v1/`. All endpoints _that require authentication_ expect the API key in a header:
-
-- `X-Api-Key: your-api-key`
-- or `Authorization: Bearer your-api-key`
-
-Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=http://localhost:8000` (local dev node) and JavaScript snippets use `BASE=https://api.dev.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
-
-**API workflow:**
-
-1. [New account or verify account (login)](/api_direct#1-new-account-or-verify-account-login)
-2. [Add usage API key](/api_direct#2-add-usage-api-key)
-3. [Create wallet (PKP)](/api_direct#3-create-a-wallet-pkp)
-4. [Add group and register IPFS action](/api_direct#4-add-group-and-register-ipfs-action)
-5. [Add PKP to group (optional)](/api_direct#5-add-pkp-to-group-optional)
-6. [Run lit-action](/api_direct#6-run-lit-action)
-
-### 1. New account or verify account (login)
-
-Create a new account (returns API key and wallet address). Or verify an existing key with the `account_exists` function.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    import { createClient } from './core_sdk.js';
-    
-    const client = createClient('https://api.dev.litprotocol.com');
-    
-    // New account
-    const res = await client.newAccount({
-      accountName: 'My App',
-      accountDescription: 'Optional description',
-      email: 'you@example.com'  // optional, forwarded to Stripe
-    });
-    console.log('API key:', res.api_key);
-    console.log('Wallet:', res.wallet_address);
-    // Store res.api_key securely.
-    
-    // Or verify existing key (login)
-    const exists = await client.accountExists(res.api_key);
-    console.log('Account exists:', exists);
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    # New account
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/new_account" \
-      -H "Content-Type: application/json" \
-      -d '{"account_name":"My App","account_description":"Optional","email":"you@example.com"}'
-    
-    # Verify account (replace KEY with your API key)
-    curl -s "http://localhost:8000/core/v1/account_exists" \
-      -H "X-Api-Key: KEY"
-    ```
-  </Tab>
-</Tabs>
-
-### 2. Add usage API key
-
-Create a scoped usage API key. The response includes the new key only once — store it. Permissions are defined by boolean flags and group ID arrays (use `0` as a wildcard for "all groups").
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    const res = await client.addUsageApiKey({
-      apiKey: accountApiKey,
-      name: 'My dApp Key',
-      description: 'Execute-only key for group 1',
-      canCreateGroups: false,
-      canDeleteGroups: false,
-      canCreatePkps: false,
-      manageIpfsIdsInGroups: [],
-      addPkpToGroups: [],
-      removePkpFromGroups: [],
-      executeInGroups: [1],     // grant execute in group 1; use [0] for all groups
-    });
-    console.log('New usage API key (store it now):', res.usage_api_key);
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    # Replace KEY with account API key
-    curl -s -X POST "http://localhost:8000/core/v1/add_usage_api_key" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"name":"My dApp Key","description":"Execute-only key for group 1","can_create_groups":false,"can_delete_groups":false,"can_create_pkps":false,"manage_ipfs_ids_in_groups":[],"add_pkp_to_groups":[],"remove_pkp_from_groups":[],"execute_in_groups":[1]}'
-    ```
-  </Tab>
-</Tabs>
-
-### 3. Create a wallet (PKP)
-
-Request a new wallet (PKP) for the account. The server returns the wallet address and registers it.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    const res = await client.createWallet(accountApiKey);
-    console.log('Wallet address:', res.wallet_address);
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s "http://localhost:8000/core/v1/create_wallet" \
-      -H "X-Api-Key: KEY"
-    ```
-  </Tab>
-</Tabs>
-
-### 4. Add group and register IPFS action
-
-Create a group (with optional permitted actions and PKPs). Then add an action (IPFS CID) to the group to scope which keys can run it.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    // Create group (pkpIdsPermitted and cidHashesPermitted can be empty arrays)
-    await client.addGroup({
-      apiKey: accountApiKey,
-      groupName: 'My Group',
-      groupDescription: 'Optional',
-      pkpIdsPermitted: [],
-      cidHashesPermitted: [],
-    });
-
-    // List groups to get the new group ID
-    const groups = await client.listGroups({ apiKey: accountApiKey, pageNumber: '0', pageSize: '10' });
-    const groupId = groups[groups.length - 1].id;
-
-    // Add an IPFS action (CID) to the group
-    await client.addActionToGroup({
-      apiKey: accountApiKey,
-      groupId,
-      actionIpfsCid: 'QmYourIpfsCidHere',
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    # Create group
-    curl -s -X POST "http://localhost:8000/core/v1/add_group" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"group_name":"My Group","group_description":"","pkp_ids_permitted":[],"cid_hashes_permitted":[]}'
-    
-    # List groups to get group_id (use the "id" from the response)
-    curl -s "http://localhost:8000/core/v1/list_groups?page_number=0&page_size=10" \
-      -H "X-Api-Key: KEY"
-    
-    # Add action to group (replace GROUP_ID and IPFS_CID)
-    curl -s -X POST "http://localhost:8000/core/v1/add_action_to_group" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"group_id":"GROUP_ID","action_ipfs_cid":"QmYourIpfsCidHere"}'
-    ```
-  </Tab>
-</Tabs>
-
-### 5. Add PKP to group (optional)
-
-Restrict which wallets (PKPs) can be used in the group by adding their public keys (or wallet addresses) to the group.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.addPkpToGroup({
-      apiKey: accountApiKey,
-      groupId,
-      pkpId: walletId,  // from listWallets or createWallet flow
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/add_pkp_to_group" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"group_id":"GROUP_ID","pkp_id":"YOUR_PKP_ID"}'
-    ```
-  </Tab>
-</Tabs>
-
-### 6. Run lit-action
-
-Execute a lit-action by sending JavaScript code and optional params. Use a usage API key in the header.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    const result = await client.litAction({
-      apiKey: accountApiKey,  // or usageApiKey
-      code: `
-        async function main() {
-          const wallet = new ethers.Wallet(await Lit.Actions.getPrivateKey({ pkpId }));
-          const sig = await wallet.signMessage("Hello from Lit Action");
-          return { sig };
-        }
-      `,
-      jsParams: { pkpId: '0x...' }
-    });
-    console.log(result.response, result.logs);
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    # Replace KEY with account or usage API key. Include the code and js_params in the request body.
-    curl -s -X POST "http://localhost:8000/core/v1/lit_action" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"code":"async function main() { return \"hello\"; }","js_params":null}'
-    ```
-  </Tab>
-</Tabs>
-
-### Other useful endpoints
-
-- **list_api_keys** — List usage API keys (paginated).
-- **list_groups** — List groups.
-- **list_wallets** — List wallets.
-- **list_actions** — List actions in a group (by `group_id`).
-- **list_wallets_in_group** — List wallets in a group.
-- **update_group** — Update group name, description, and permission flags.
-- **remove_action_from_group** / **remove_pkp_from_group** — Remove action or PKP from a group.
-- **get_node_chain_config** — Get node chain config - a quick way to find the location of contracts within the system.
-
----
-
-### Add action
-
-Register a standalone action entry (name and description only). To make it executable, add its IPFS CID to a group with `add_action_to_group`.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.addAction({
-      apiKey: accountApiKey,
-      name: 'Price Oracle',
-      description: 'Fetches and signs ETH/USD price',
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/add_action" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"name":"Price Oracle","description":"Fetches and signs ETH/USD price"}'
-    ```
-  </Tab>
-</Tabs>
-
----
-
-### Remove usage API key
-
-Permanently remove a usage API key from the account. Any clients using this key will immediately lose access.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.removeUsageApiKey({
-      apiKey: accountApiKey,
-      usageApiKey: 'the-key-to-remove',
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/remove_usage_api_key" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"usage_api_key":"the-key-to-remove"}'
-    ```
-  </Tab>
-</Tabs>
-
----
-
-### Update usage API key
-
-Replace all permissions on an existing usage API key. This is a full overwrite — include every field, not just the ones you want to change.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.updateUsageApiKey({
-      apiKey: accountApiKey,
-      usageApiKey: 'the-key-to-update',
-      name: 'Updated Key',
-      description: 'Now also has PKP-create permission',
-      canCreateGroups: false,
-      canDeleteGroups: false,
-      canCreatePkps: true,
-      manageIpfsIdsInGroups: [],
-      addPkpToGroups: [],
-      removePkpFromGroups: [],
-      executeInGroups: [1],
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/update_usage_api_key" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"usage_api_key":"the-key-to-update","name":"Updated Key","description":"Now also has PKP-create permission","can_create_groups":false,"can_delete_groups":false,"can_create_pkps":true,"manage_ipfs_ids_in_groups":[],"add_pkp_to_groups":[],"remove_pkp_from_groups":[],"execute_in_groups":[1]}'
-    ```
-  </Tab>
-</Tabs>
-
----
-
-### Update usage API key metadata
-
-Update only the name and description of a usage API key without changing its permissions.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.updateUsageApiKeyMetadata({
-      apiKey: accountApiKey,
-      usageApiKey: 'the-key-to-update',
-      name: 'Renamed Key',
-      description: 'New description',
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/update_usage_api_key_metadata" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"usage_api_key":"the-key-to-update","name":"Renamed Key","description":"New description"}'
-    ```
-  </Tab>
-</Tabs>
-
----
-
-### Update action metadata
-
-Update the name and description of an action that is already registered in a group.
-
-<Tabs>
-  <Tab title="JavaScript (Core SDK)">
-    ```javascript
-    await client.updateActionMetadata({
-      apiKey: accountApiKey,
-      groupId: 1,
-      actionIpfsCid: 'QmYourIpfsCidHere',
-      name: 'Updated Action Name',
-      description: 'Updated description',
-    });
-    ```
-  </Tab>
-  <Tab title="cURL">
-    ```bash
-    curl -s -X POST "http://localhost:8000/core/v1/update_action_metadata" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: KEY" \
-      -d '{"group_id":1,"action_ipfs_cid":"QmYourIpfsCidHere","name":"Updated Action Name","description":"Updated description"}'
-    ```
-  </Tab>
-</Tabs>
-
----
-
-Both request/response shapes and OpenAPI spec are available directly in the dev system. For a Swagger UI implementation of the OpenAPI spec, please browse to:\
-\
-https://api.dev.litprotocol.com/swagger-ui/
-
-
-### Open API Specification
-
-The OpenAPI spec itself can be found at:\
-\
-[https://api.dev.litprotocol.com/core/v1/openapi.json](https://api.dev.litprotocol.com/core/v1/openapi.json)
-
-Note that these specs are subject to minor changes and will always be available with the dev server endpoints.
+- [API Keys](/management/api_keys) — Understanding account keys vs usage keys
+- [Pricing](/management/pricing) — Credit-based billing model
+- [Lit Actions](/lit-actions/index) — Writing and deploying Lit Actions
+- [Architecture](/architecture/index) — System design and auth model
+- [OpenAPI Spec](https://api.dev.litprotocol.com/core/v1/openapi.json) / [Swagger UI](https://api.dev.litprotocol.com/swagger-ui/)

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -244,6 +244,10 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 
 ### Other useful endpoints
 
+<Info>
+**Raw CID vs hashed CID:** Some endpoints accept a raw IPFS CID (`action_ipfs_cid`, e.g. `"QmYour..."`) — the server hashes it for you. Other endpoints require the already-hashed CID (`hashed_cid`, e.g. `"0xabc..."`) — a keccak256 hex string you get back from `list_actions`. As a rule: **creation endpoints** (`add_action`, `add_action_to_group`) take the raw CID; **update/delete endpoints** (`delete_action`, `remove_action_from_group`, `update_action_metadata`) take the hashed CID.
+</Info>
+
 **Read / list (no billing charge):**
 
 - **`GET /list_api_keys?page_number&page_size`** — List usage API keys (paginated). Returns metadata only — key values are not returned.
@@ -263,9 +267,10 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 - **`POST /update_usage_api_key_metadata`** — Update only the name/description of a usage key. Body: `{"usage_api_key": "...", "name": "...", "description": "..."}`.
 - **`POST /remove_group`** — Delete a group. Body: `{"group_id": "..."}`.
 - **`POST /update_group`** — Update group name, description, and permitted PKP IDs / CID hashes. Body: `{"group_id": 1, "name": "...", "description": "...", "pkp_ids_permitted": [], "cid_hashes_permitted": []}`.
-- **`POST /add_action`** — Register a standalone action (name + description). Body: `{"name": "...", "description": "..."}`.
-- **`POST /remove_action_from_group`** — Remove an IPFS action from a group. Body: `{"group_id": 1, "action_ipfs_cid": "Qm..."}`.
-- **`POST /update_action_metadata`** — Update the name/description of a registered action. Body: `{"group_id": 1, "action_ipfs_cid": "Qm...", "name": "...", "description": "..."}`.
+- **`POST /add_action`** — Register a standalone action (name + description + IPFS CID). Body: `{"action_ipfs_cid": "Qm...", "name": "...", "description": "..."}`.
+- **`POST /delete_action`** — Delete an action and its metadata from the account. Body: `{"hashed_cid": "0x..."}` (already-hashed CID).
+- **`POST /remove_action_from_group`** — Remove an IPFS action from a group. Body: `{"group_id": 1, "hashed_cid": "0x..."}` (already-hashed CID).
+- **`POST /update_action_metadata`** — Update the name/description of a registered action. Body: `{"hashed_cid": "0x...", "name": "...", "description": "..."}`.
 - **`POST /remove_pkp_from_group`** — Remove a PKP from a group. Body: `{"group_id": 1, "pkp_id": "..."}`.
 
 **Billing:**


### PR DESCRIPTION
## Summary

- **Fix wrong API parameter names** across docs that caused runtime errors: `update_action_metadata` now uses `hashed_cid` (not `group_id`/`action_ipfs_cid`), `remove_action_from_group` uses `hashed_cid`, `add_action` includes required `action_ipfs_cid` field
- **Fix broken JavaScript example** in Section 4 — incomplete `addAction({` call and duplicate `addActionToGroup` replaced with clean, working code
- **Deduplicate index.mdx** — reduced from ~500 lines (full copies of dashboard + API content) to a concise Quick Start (~60 lines) with links to canonical pages
- **Add Groups architecture page** — new `docs/architecture/groups.mdx` explaining the group access-control model with diagrams and common patterns
- **Add CID vs hashed CID explainer** — Info box clarifying when to use raw IPFS CIDs vs already-hashed CIDs

## Pre-Landing Review

No issues found. (Docs-only change — no SQL, application code, or LLM output.)

## Adversarial Review

3-pass review (Claude structured, Claude adversarial subagent, Codex adversarial). Findings are all informational — pre-existing issues or API design observations, not regressions:

- groups.mdx "Permission Flags" section wording could be more precise about API vs Dashboard capabilities (pre-existing API design limitation)
- `list_groups` returns hex string IDs while mutating endpoints expect u64 (pre-existing; SDK handles via `Number()`)
- Root-level `docs/api_direct.mdx` is orphaned from navigation (pre-existing, not introduced by this PR)

## Plan Completion

All 7 plan items DONE. 1 item explicitly deferred (OpenAPI auto-gen).

## Test plan

- [x] All parameter fixes verified against `request.rs` structs
- [x] SDK examples verified against `core_sdk.js` method signatures
- [x] Mintlify syntax (Tabs, Tab, Info components) verified
- [x] `docs.json` navigation updated with new Groups page

🤖 Generated with [Claude Code](https://claude.com/claude-code)