### PR TITLE
fix: use vars for CLOUDFLARE_ACCOUNT_ID and rename project to lit-static-next

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -19,7 +19,7 @@ jobs:
             echo "project=lit-static-prod" >> "$GITHUB_OUTPUT"
             echo "api_url=https://f8fce543471dc9f5f5643aa217422398c36e5edc-8000.dstack-base-prod5.phala.network" >> "$GITHUB_OUTPUT"
           else
-            echo "project=lit-static-staging" >> "$GITHUB_OUTPUT"
+            echo "project=lit-static-next" >> "$GITHUB_OUTPUT"
             echo "api_url=https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network" >> "$GITHUB_OUTPUT"
           fi
 
@@ -30,5 +30,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy lit-static/static --project-name=${{ steps.target.outputs.project }}


### PR DESCRIPTION
## Summary
- Fix `deploy-static.yml` to read `CLOUDFLARE_ACCOUNT_ID` from `vars` (repository variable) instead of `secrets` — the value was configured as a variable, causing auth failure
- Rename Cloudflare Pages project from `lit-static-staging` to `lit-static-next` to match the branch name

## Context
PR #177 deployed with `secrets.CLOUDFLARE_ACCOUNT_ID` but the value was added as a GitHub repository variable, resulting in [this CI failure](https://github.com/LIT-Protocol/lit-node-express/actions/runs/23615627490/job/68782188311).

## Test plan
- [ ] Merge to `next` triggers `deploy-static.yml`
- [ ] Cloudflare Pages deploy succeeds (no more auth error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)