### PR TITLE
fix: add AWS_ROLE_ARN and AWS_REGION for dstack-ingress STS (CPL-152)

### DIFF
--- a/.github/workflows/deploy-phala.yml
+++ b/.github/workflows/deploy-phala.yml
@@ -27,6 +27,9 @@
 #                    ${DOCKER_IMAGE}-lit-api-server
 #                    ${DOCKER_IMAGE}-otel-collector
 #   DOCKERHUB_USERNAME - Docker Hub username
+#   CERTBOT_AWS_ACCESS_KEY_ID - Route 53 IAM access key for DNS-01 challenge
+#   CERTBOT_AWS_ROLE_ARN      - IAM role ARN for STS assumption (required by dstack-ingress)
+#   CERTBOT_AWS_REGION        - AWS region for STS endpoint (e.g. "us-east-1")
 
 name: Deploy to Phala CVM
 
@@ -156,6 +159,8 @@ jobs:
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
             -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ vars.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
             -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}|g" \
+            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ vars.CERTBOT_AWS_ROLE_ARN }}|g" \
+            -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
           cat docker-compose.deploy.yml
 

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -14,8 +14,10 @@
 #   GCP_SERVICE_ACCOUNT_JSON  - GCP service account key (raw JSON or base64-encoded)
 #   GCP_PROJECT_ID            - GCP project ID (e.g. "my-gcp-project")
 #   CERTBOT_DOMAIN            - Custom domain for TLS (e.g. "api.chipotle.litprotocol.com")
-#   CERTBOT_AWS_ACCESS_KEY_ID     - Route 53 IAM credentials for DNS-01 challenge
-#   CERTBOT_AWS_SECRET_ACCESS_KEY - Route 53 IAM credentials for DNS-01 challenge
+#   CERTBOT_AWS_ACCESS_KEY_ID     - Route 53 IAM access key for DNS-01 challenge
+#   CERTBOT_AWS_SECRET_ACCESS_KEY - Route 53 IAM secret key for DNS-01 challenge
+#   CERTBOT_AWS_ROLE_ARN          - IAM role ARN for STS assumption (required by dstack-ingress)
+#   CERTBOT_AWS_REGION            - AWS region for STS endpoint (e.g. "us-east-1")
 
 # RUST_LOG filter shared by lit-actions and lit-api-server.
 # App code stays at trace; per-module overrides suppress low-value internals:
@@ -114,9 +116,10 @@ services:
       SET_CAA: "true"
       AWS_ACCESS_KEY_ID: "${CERTBOT_AWS_ACCESS_KEY_ID}"
       AWS_SECRET_ACCESS_KEY: "${CERTBOT_AWS_SECRET_ACCESS_KEY}"
-      # Optional: for STS role assumption instead of direct IAM keys
-      # AWS_ROLE_ARN: "${CERTBOT_AWS_ROLE_ARN}"
-      # AWS_REGION: "${CERTBOT_AWS_REGION}"
+      # STS role assumption — required by dstack-ingress for Route 53 access.
+      # The IAM user (AWS_ACCESS_KEY_ID) assumes this role to modify DNS records.
+      AWS_ROLE_ARN: "${CERTBOT_AWS_ROLE_ARN}"
+      AWS_REGION: "${CERTBOT_AWS_REGION}"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
       - cert-data:/etc/letsencrypt


### PR DESCRIPTION
## Summary
- dstack-ingress requires STS role assumption — direct IAM keys cause `Invalid length for parameter RoleArn` validation errors
- Uncomments `AWS_ROLE_ARN` and `AWS_REGION` in `docker-compose.phala.yml` and wires them through the deploy workflow as GitHub variables

Follows up on #181.

## Changes
**`docker-compose.phala.yml`**
- `AWS_ROLE_ARN` and `AWS_REGION` are now required env vars (were commented out as "optional")
- Updated header docs to list `CERTBOT_AWS_ROLE_ARN` and `CERTBOT_AWS_REGION`

**`.github/workflows/deploy-phala.yml`**
- Added sed substitutions for `CERTBOT_AWS_ROLE_ARN` and `CERTBOT_AWS_REGION` (both GitHub variables)
- Updated header docs listing required vars

## Required GitHub configuration
After merging, set these before deploying:
- **Variable**: `CERTBOT_AWS_ROLE_ARN` — IAM role ARN with Route 53 permissions (e.g. `arn:aws:iam::<ACCOUNT>:role/certbot-route53-dns-challenge`)
- **Variable**: `CERTBOT_AWS_REGION` — AWS region for STS endpoint (e.g. `us-east-1`)

## Test plan
- [x] `docker-compose.phala.yml` validates with `docker compose config`
- [ ] CI passes
- [ ] After setting vars, deploy to `next` and verify `https://test.chipotle.litprotocol.com/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)