### PR TITLE
fix: use auto-populated DSTACK_GATEWAY_DOMAIN (CPL-152)

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -109,7 +109,9 @@ services:
       # Route 53 provider docs (env vars, optional role assumption):
       # https://github.com/Dstack-TEE/dstack-examples/blob/main/custom-domain/dstack-ingress/DNS_PROVIDERS.md
       DOMAIN: "${CERTBOT_DOMAIN}"
-      GATEWAY_DOMAIN: "_.dstack-base-prod5.phala.network"
+      # DSTACK_GATEWAY_DOMAIN is auto-populated by Phala Cloud into the CVM.
+      # https://docs.phala.com/phala-cloud/networking/specifications
+      GATEWAY_DOMAIN: "_.${DSTACK_GATEWAY_DOMAIN}"
       DNS_PROVIDER: "route53"
       TARGET_ENDPOINT: "http://lit-api-server:8000"
       CERTBOT_EMAIL: "admin@litprotocol.com"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `GATEWAY_DOMAIN: "_.dstack-base-prod5.phala.network"` with `_.${DSTACK_GATEWAY_DOMAIN}`
- `DSTACK_GATEWAY_DOMAIN` is [auto-populated by Phala Cloud](https://docs.phala.com/phala-cloud/networking/specifications) into the CVM environment — no external config needed

## Why
The previous deployment failed to proxy HTTPS requests. dstack-ingress was creating DNS records pointing to the gateway but the hardcoded gateway domain didn't match the actual gateway routing expectations. Using the auto-populated variable ensures the value is always correct for the deployment region.

## Related
- Fixes proxy failure in #181
- CPL-152

## Test plan
- [ ] Deploy to `next` and verify `https://test.chipotle.litprotocol.com/` returns a response from lit-api-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)