### PR TITLE
fix: start dstack-ingress before other services (CPL-152)

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -68,6 +68,8 @@ services:
       # Optional overide for NodeConfig.toml (chain, contract_address).
       # - ./NodeConfig.toml:/app/NodeConfig.toml:ro
     depends_on:
+      dstack-ingress:
+        condition: service_healthy
       lit-actions:
         condition: service_started
       otel-collector:
@@ -125,9 +127,12 @@ services:
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
       - cert-data:/etc/letsencrypt
-    depends_on:
-      lit-api-server:
-        condition: service_started
+    healthcheck:
+      test: ["CMD", "test", "-f", "/etc/letsencrypt/live/${CERTBOT_DOMAIN}/fullchain.pem"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- dstack-ingress must finish obtaining the TLS certificate before lit-api-server starts accepting traffic
- Removes `depends_on: lit-api-server` from dstack-ingress (it was backwards)
- Adds healthcheck on dstack-ingress that waits for the Let's Encrypt cert file
- Makes lit-api-server depend on `dstack-ingress: condition: service_healthy`

## Startup order
1. `otel-collector` + `dstack-ingress` start in parallel
2. dstack-ingress provisions DNS records + TLS cert (healthcheck passes when cert exists)
3. `lit-actions` starts
4. `lit-api-server` starts (after dstack-ingress healthy + lit-actions started)

## Related
- CPL-152

## Test plan
- [x] `docker compose config` validates
- [ ] Deploy to `next` — verify dstack-ingress gets cert before API server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)