### PR TITLE
docs: E2E verification guide for attested TLS

### DIFF
--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -32,3 +32,4 @@ There are no modes. Whether you operate in a self-sovereign or SaaS posture is a
 
 - [Auth Model & Permission Matrix](/architecture/authModel) — detailed entity boundaries, execution flow, and the full permission matrix
 - [System Diagram](/architecture/diagram) — entity relationships, on-chain vs TEE boundaries, and management paths
+- [Security & Verification](/architecture/verification) — Zero-Trust TLS, attestation verification, and the full chain of trust

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -32,4 +32,4 @@ There are no modes. Whether you operate in a self-sovereign or SaaS posture is a
 
 - [Auth Model & Permission Matrix](/architecture/authModel) — detailed entity boundaries, execution flow, and the full permission matrix
 - [System Diagram](/architecture/diagram) — entity relationships, on-chain vs TEE boundaries, and management paths
-- [Security & Verification](/architecture/verification) — Zero-Trust TLS, attestation verification, and the full chain of trust
+- [Security & Verification](/architecture/verification/index) — Zero-Trust TLS, attestation verification, and the full chain of trust

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -55,9 +55,15 @@ The sections below walk through Phala's [Complete Chain of Trust](https://docs.p
 
 This is a complete, end-to-end how-to. It mirrors the CI workflow that runs on every Lit Chipotle deployment and covers all layers of the chain of trust.
 
-**Prerequisites:** `python3`, `docker`, `openssl`, `dig`, and optionally [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) and [`cast`](https://book.getfoundry.sh/getting-started/installation) (from Foundry).
+<Tip>
+**New to TEE verification?** You don't need to understand every cryptographic detail. Each step below is a self-contained check you can copy-paste into your terminal. The commands will output PASS or FAIL. If all steps pass, you have cryptographic proof that your connection terminates in genuine, unmodified TEE hardware running authorized code.
+</Tip>
+
+**Prerequisites:** `python3` (3.8+), `docker`, `openssl`, `dig`, and optionally [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) and [`cast`](https://book.getfoundry.sh/getting-started/installation) (from Foundry).
 
 #### 1. Verify the TDX attestation quote (Platform)
+
+**What this checks:** Is the server running on real Intel TDX hardware? The TDX attestation quote is like a hardware-signed certificate of authenticity — Intel's chips sign a statement about what software is running, and this step verifies that signature is genuine.
 
 Fetch the attestation from the live API and run the official dstack verifier. This validates the Intel TDX quote signature (proving genuine hardware), replays the RTMR3 event log (proving no events were tampered with), and checks OS measurements.
 
@@ -148,7 +154,7 @@ curl -X POST https://cloud-api.phala.network/api/v1/attestations/verify \
 
 #### 2. Verify the application code (Application)
 
-Confirm that the running CVM is executing the exact code you expect.
+**What this checks:** Is the TEE running the exact code you expect, with no modifications? This step verifies the Docker images and their configuration match what was built in CI from the public GitHub repository.
 
 ```bash
 # Fetch app info (compose hash + full app-compose config)
@@ -176,7 +182,8 @@ compose = yaml.safe_load(json.loads(info["tcb_info"]["app_compose"])["docker_com
 for name, svc in compose.get("services", {}).items():
     img = svc.get("image", "")
     pinned = "@sha256:" in img
-    print(f"  {name}: {img[:80]}... {"OK" if pinned else "NOT PINNED"}")
+    status = "OK" if pinned else "NOT PINNED"
+    print(f"  {name}: {img[:80]}... {status}")
     assert pinned, f"{name} is not digest-pinned"
 print("All images digest-pinned OK")
 '
@@ -195,34 +202,71 @@ cosign verify \
 
 #### 3. Verify TLS terminates in the TEE (Network)
 
-Confirm that the TLS certificate served to your browser was generated inside the TEE.
+**What this checks:** Was the TLS certificate generated inside the TEE? This confirms your encrypted connection goes directly into the secure hardware — no proxy or intermediary can see your traffic. The TEE records the certificate's hash in the attestation quote, so you can compare it against the certificate you actually received.
 
 ```bash
-# 3a. Get the certificate fingerprint from the live TLS connection
-openssl s_client -connect api.chipotle.litprotocol.com:443 \
+# 3a. Compute the SHA-256 hash of the live TLS certificate (DER-encoded)
+LIVE_CERT_HASH=$(openssl s_client -connect api.chipotle.litprotocol.com:443 \
   -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
-  | openssl x509 -noout -fingerprint -sha256
+  | openssl x509 -outform DER 2>/dev/null \
+  | openssl dgst -sha256 -hex 2>/dev/null | awk '{print $NF}')
+echo "Live TLS cert hash: $LIVE_CERT_HASH"
 
-# The /evidences/ endpoint on the CVM gateway serves cert.pem,
-# sha256sum.txt, and quote.json. The SHA-256 hash of the certificate
-# is embedded in the quote's reportData field — compare it with
-# the fingerprint above to confirm they match.
+# 3b. Extract the attested cert hash from the TDX quote
+# The TDX quote's reportData field (at byte offset 568 in the quote binary)
+# contains the SHA-256 hash of the certificate that was generated inside the TEE.
+# We already fetched attestation.json in Step 1 — reuse it here.
+ATTESTED_CERT_HASH=$(python3 -c '
+import json
+att = json.load(open("attestation.json"))
+q = att["quote"]
+if q.startswith("0x"):
+    q = q[2:]
+# TDX quote v4 format: reportData starts at byte 568 (hex char 1136)
+# First 32 bytes of reportData = SHA-256 of the TLS certificate
+report_data = q[1136:1136+128]
+cert_hash = report_data[:64]
+print(cert_hash)
+')
+echo "Attested cert hash:  $ATTESTED_CERT_HASH"
 
-# 3b. Verify CAA DNS records restrict issuance to Let's Encrypt
+# 3c. Compare — if they match, the certificate was generated inside the TEE
+if [ "$LIVE_CERT_HASH" = "$ATTESTED_CERT_HASH" ]; then
+  echo "TLS certificate matches attestation — OK"
+else
+  echo "MISMATCH: the served certificate does not match the attested hash"
+  echo "This could indicate a proxy or man-in-the-middle between you and the TEE"
+fi
+
+# 3d. Verify CAA DNS records restrict certificate issuance to Let's Encrypt only
+# This ensures only the TEE-controlled ACME flow can obtain a certificate for this domain.
 dig CAA api.chipotle.litprotocol.com
 ```
 
 #### 4. Verify on-chain governance (Governance)
 
-Confirm that the compose-hash running in the CVM was authorized on-chain.
+**What this checks:** Was the code running in the TEE authorized through on-chain governance? The compose-hash (a fingerprint of the entire application configuration) must be registered in a smart contract on Base before the CVM will accept it. This means deploying new code requires an on-chain transaction — you can audit the full history on Basescan.
 
 The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **DstackKms** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
 
+**Finding the DstackApp contract address:** The DstackApp contract is the on-chain governance contract that authorizes what code the CVM can run. To find the correct address for a given CVM:
+
+1. Go to the [Phala Cloud dashboard](https://cloud.phala.network) and look up the application by its `app_id` (available from `GET /info`). The dashboard shows the associated DstackApp contract address.
+2. Verify the contract is the one your CVM is attached to by checking the `app_id` in the `/info` response matches the app registered in the contract on Basescan.
+
+For Lit Chipotle production, the DstackApp contract is [`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C).
+
 ```bash
 # Requires `cast` from Foundry (https://book.getfoundry.sh)
+DSTACK_APP="0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C"
+
 # Check if the compose-hash is whitelisted in DstackApp
 COMPOSE_HASH=$(python3 -c 'import json; print("0x" + json.load(open("info.json"))["compose_hash"])')
-cast call <DSTACK_APP_ADDRESS> "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-url https://mainnet.base.org
+echo "Compose hash: $COMPOSE_HASH"
+cast call "$DSTACK_APP" "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-url https://mainnet.base.org
+
+# A return value of 0x...01 (true) means the compose-hash is whitelisted.
+# If it returns 0x...00 (false), the CVM is running unauthorized code.
 ```
 
 The **AccountConfig** contract ([`0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24`](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24)) on Base governs Lit Chipotle's permission model — account ownership, API key scopes, PKP registries, and action groups. Inspect it on Basescan to verify ownership and permissions.

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -9,11 +9,10 @@ description: "How to verify that your connection to Lit Chipotle terminates insi
 
 **How it works for Lit Chipotle:**
 
-1. The dstack DeRoT (Decentralized Root of Trust) running inside the CVM generates a x.509 certificate using the RootKey — a key derived from the dstack-KMS, which itself runs in a TEE.
-2. The certificate is sent to Let's Encrypt for signing. Authentication uses API access only (no HTTP challenge on ports 80/443), which can be fully controlled by the TEE.
-3. DNS [CAA records](https://letsencrypt.org/docs/caa/) for the domain restrict which CAs can issue certificates, ensuring only the TEE-controlled ACME flow can obtain a cert.
-4. The certificate, key, and their SHA-256 hashes are recorded as evidence files. These hashes are embedded in the Intel TDX attestation quote's `reportData` field.
-5. Because the quote is signed by Intel's TDX hardware root of trust and bound to these hashes, anyone can cryptographically prove the certificate was generated inside this specific enclave.
+1. The [dstack-ingress](https://github.com/Dstack-TEE/dstack-examples/tree/main/custom-domain/dstack-ingress) container, running inside the CVM, generates a private key and requests a TLS certificate from Let's Encrypt via DNS-01 challenge (Route 53). The private key never leaves the TEE.
+2. DNS [CAA records](https://letsencrypt.org/docs/caa/) for the domain restrict which CAs can issue certificates and require DNS-01 validation with a specific ACME account URI, ensuring only the TEE-controlled ACME flow can obtain a cert.
+4. The certificate and ACME account are recorded as evidence files. Their SHA-256 checksums are hashed into a single digest that is embedded in a TDX attestation quote's `reportData` field.
+5. Because the quote is signed by Intel's TDX hardware root of trust and bound to this digest, anyone can cryptographically prove the certificate was generated inside this specific TEE.
 
 **What this means:** When you connect to `api.chipotle.litprotocol.com` over HTTPS, the TLS handshake completes **inside the TEE**. No proxy, load balancer, or CDN can intercept the traffic. If the TLS handshake succeeds and the certificate is valid, you are provably talking to the TEE — not to any intermediary.
 
@@ -204,45 +203,75 @@ cosign verify \
 
 #### 3. Verify TLS terminates in the TEE (Network)
 
-**What this checks:** Was the TLS certificate generated inside the TEE? This confirms your encrypted connection goes directly into the secure hardware — no proxy or intermediary can see your traffic. The TEE records the certificate's hash in the attestation quote, so you can compare it against the certificate you actually received.
+**What this checks:** Was the TLS certificate generated inside the TEE? This confirms your encrypted connection goes directly into the secure hardware — no proxy or intermediary can see your traffic.
+
+Lit Chipotle uses [dstack-ingress](https://github.com/Dstack-TEE/dstack-examples/tree/main/custom-domain/dstack-ingress) for custom-domain TLS. Unlike the default dstack gateway (which embeds cert hashes directly in the CVM's boot-time TDX quote via `reportData`), dstack-ingress runs as an application container and generates a **separate** TDX evidence quote after obtaining the Let's Encrypt certificate. This evidence quote binds the certificate to TDX hardware through a checksum chain:
+
+1. dstack-ingress obtains a Let's Encrypt cert via DNS-01 inside the TEE
+2. It computes `SHA-256` of each evidence file (cert PEM, ACME account) → `sha256sum.txt`
+3. It computes `SHA-256(sha256sum.txt)` and requests a TDX quote with this hash as `reportData`
+4. The evidence files and quote are served at `/evidences/` on the custom domain
 
 ```bash
-# 3a. Compute the SHA-256 hash of the live TLS certificate (DER-encoded)
+# 3a. Download evidence files from the dstack-ingress container
+curl -sf https://api.chipotle.litprotocol.com/evidences/sha256sum.txt > evidences-sha256sum.txt
+curl -sf https://api.chipotle.litprotocol.com/evidences/quote.json > evidences-quote.json
+
+# Download the attested cert PEM (filename includes the domain)
+CERT_FILE=$(curl -sf https://api.chipotle.litprotocol.com/evidences/ \
+  | grep -o 'href="cert-[^"]*\.pem"' | sed 's/href="//;s/"//')
+curl -sf "https://api.chipotle.litprotocol.com/evidences/$CERT_FILE" > evidences-cert.pem
+
+# 3b. Verify the evidence checksum chain
+# The quote's reportData must equal SHA-256(sha256sum.txt)
+python3 -c '
+import hashlib, json
+
+# Compute SHA-256 of the sha256sum.txt file
+with open("evidences-sha256sum.txt", "rb") as f:
+    computed = hashlib.sha256(f.read()).hexdigest()
+
+# Extract reportData from the evidence quote
+eq = json.load(open("evidences-quote.json"))
+report_data = eq.get("report_data", "")
+# reportData is the hash zero-padded to 64 bytes (128 hex chars)
+attested = report_data[:64]
+
+print(f"SHA-256(sha256sum.txt): {computed}")
+print(f"Evidence reportData:    {attested}")
+assert computed == attested, "MISMATCH — evidence checksum chain broken"
+print("Evidence checksum chain OK")
+'
+
+# 3c. Verify the live TLS cert matches the attested cert
+# Extract the leaf cert (DER) fingerprint from what your TLS handshake received
 LIVE_CERT_HASH=$(openssl s_client -connect api.chipotle.litprotocol.com:443 \
   -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
   | openssl x509 -outform DER 2>/dev/null \
   | openssl dgst -sha256 -hex 2>/dev/null | awk '{print $NF}')
-echo "Live TLS cert hash: $LIVE_CERT_HASH"
 
-# 3b. Extract the attested cert hash from the TDX quote
-# The TDX quote's reportData field (at byte offset 568 in the quote binary)
-# contains the SHA-256 hash of the certificate that was generated inside the TEE.
-# We already fetched attestation.json in Step 1 — reuse it here.
-ATTESTED_CERT_HASH=$(python3 -c '
-import json
-att = json.load(open("attestation.json"))
-q = att["quote"]
-if q.startswith("0x"):
-    q = q[2:]
-# TDX quote v4 format: reportData starts at byte 568 (hex char 1136)
-# First 32 bytes of reportData = SHA-256 of the TLS certificate
-report_data = q[1136:1136+128]
-cert_hash = report_data[:64]
-print(cert_hash)
-')
-echo "Attested cert hash:  $ATTESTED_CERT_HASH"
+# Extract the leaf cert (DER) fingerprint from the evidence PEM
+EVIDENCE_CERT_HASH=$(openssl x509 -in evidences-cert.pem -outform DER 2>/dev/null \
+  | openssl dgst -sha256 -hex 2>/dev/null | awk '{print $NF}')
 
-# 3c. Compare — if they match, the certificate was generated inside the TEE
-if [ "$LIVE_CERT_HASH" = "$ATTESTED_CERT_HASH" ]; then
-  echo "TLS certificate matches attestation — OK"
+echo "Live TLS cert hash:     $LIVE_CERT_HASH"
+echo "Evidence cert hash:     $EVIDENCE_CERT_HASH"
+
+if [ "$LIVE_CERT_HASH" = "$EVIDENCE_CERT_HASH" ]; then
+  echo "TLS certificate matches evidence — OK"
 else
-  echo "MISMATCH: the served certificate does not match the attested hash"
-  echo "This could indicate a proxy or man-in-the-middle between you and the TEE"
+  echo "MISMATCH: the served certificate does not match the attested evidence"
 fi
 
-# 3d. Verify CAA DNS records restrict certificate issuance to Let's Encrypt only
-# This ensures only the TEE-controlled ACME flow can obtain a certificate for this domain.
-dig CAA api.chipotle.litprotocol.com
+# 3d. Verify CAA DNS records restrict certificate issuance
+# dstack-ingress sets a CAA CNAME alias on the custom domain pointing to the
+# gateway domain, which holds the actual CAA records restricting issuance to
+# Let's Encrypt with DNS-01 validation and a specific ACME account URI.
+echo ""
+echo "CAA alias on custom domain:"
+dig CAA api.chipotle.litprotocol.com +short
+echo "Resolved CAA policy:"
+dig CAA dstack-base-prod5.phala.network +short
 ```
 
 #### 4. Verify on-chain governance (Governance)
@@ -282,7 +311,7 @@ The sections below explain what each verification step is actually checking and 
 | Check | What it proves |
 |-------|----------------|
 | **compose-hash** | The SHA-256 of the `app-compose.json` config (which includes `docker-compose.yaml` plus metadata) is recorded as an event in RTMR3. Recomputing the hash from `/info` and comparing it to the attested value proves the CVM is running the declared configuration. |
-| **Docker image digests** | All 4 images (lit-actions, lit-api-server, lit-static, otel-collector) use `@sha256:` digest pinning. Mutable tags like `:latest` would allow silent image substitution. |
+| **Docker image digests** | All images (lit-actions, lit-api-server, otel-collector, dstack-ingress) use `@sha256:` digest pinning. Mutable tags like `:latest` would allow silent image substitution. |
 | **Image provenance (Sigstore)** | Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verification proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository and recorded in the public Rekor transparency log. |
 | **RTMR3 event log replay** | Each event extends RTMR3 via a hash chain: `RTMR3_new = SHA384(RTMR3_old ‖ SHA384(event))`. The dstack-verifier replays all events from the initial value (48 zero bytes) and confirms the final value matches the RTMR3 in the TDX quote. This ensures no events were added, removed, or modified. |
 
@@ -309,9 +338,10 @@ The TDX quote contains hardware-measured registers that attest the entire boot c
 
 | Check | What it proves |
 |-------|----------------|
-| **Evidence files** | The CVM gateway's `/evidences/` endpoint serves `cert.pem`, `sha256sum.txt`, and `quote.json`. The SHA-256 hash of the certificate is embedded in the quote's `reportData`. |
-| **Certificate fingerprint match** | Comparing what `openssl s_client` returns against the attested cert hash proves TLS terminates inside the TEE, not at an intermediary. |
-| **CAA DNS records** | `dig CAA api.chipotle.litprotocol.com` should restrict certificate issuance to Let's Encrypt only, through the TEE-controlled ACME flow. |
+| **Evidence files** | dstack-ingress serves `/evidences/` with `cert-<domain>.pem`, `sha256sum.txt`, `acme-account.json`, and `quote.json`. The SHA-256 of `sha256sum.txt` is embedded in the evidence quote's `reportData`, creating a checksum chain from the TDX hardware root of trust to the certificate files. |
+| **Evidence checksum chain** | `SHA-256(sha256sum.txt)` must match `reportData` in `/evidences/quote.json`. This proves the evidence files were generated inside the TEE that produced the quote. |
+| **Certificate fingerprint match** | The leaf cert DER fingerprint from `openssl s_client` must match the leaf cert extracted from the evidence PEM. This proves the live TLS connection uses the same certificate attested by the TEE. |
+| **CAA DNS records** | The custom domain has a CAA CNAME alias pointing to the gateway domain (`_.dstack-base-prod5.phala.network`), which restricts certificate issuance to Let's Encrypt via DNS-01 with a specific ACME account URI — ensuring only the TEE-controlled ACME flow can obtain certificates. |
 
 #### Governance Layer
 

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -9,11 +9,11 @@ description: "How to verify that your connection to Lit Chipotle terminates insi
 
 **How it works for Lit Chipotle:**
 
-1. The dstack gateway running inside the CVM generates a private key using secrets derived from the dstack-KMS (itself a TEE).
-2. It requests a TLS certificate from Let's Encrypt via ACME DNS-01 challenge — no ports 80/443 are exposed during verification.
-3. DNS CAA records for the domain restrict which CAs can issue certificates, ensuring only TEE-controlled ACME can obtain a cert.
+1. The dstack DeRoT (Decentralized Root of Trust) running inside the CVM generates a x.509 certificate using the RootKey — a key derived from the dstack-KMS, which itself runs in a TEE.
+2. The certificate is sent to Let's Encrypt for signing. Authentication uses API access only (no HTTP challenge on ports 80/443), which can be fully controlled by the TEE.
+3. DNS [CAA records](https://letsencrypt.org/docs/caa/) for the domain restrict which CAs can issue certificates, ensuring only the TEE-controlled ACME flow can obtain a cert.
 4. The certificate, key, and their SHA-256 hashes are recorded as evidence files. These hashes are embedded in the Intel TDX attestation quote's `reportData` field.
-5. Because the quote is signed by Intel's TDX Attestation Key and bound to the hash chain, anyone can cryptographically prove the certificate was generated inside this specific enclave.
+5. Because the quote is signed by Intel's TDX hardware root of trust and bound to these hashes, anyone can cryptographically prove the certificate was generated inside this specific enclave.
 
 **What this means:** When you connect to `api.chipotle.litprotocol.com` over HTTPS, the TLS handshake completes **inside the TEE**. No proxy, load balancer, or CDN can intercept the traffic. If the TLS handshake succeeds and the certificate is valid, you are provably talking to the TEE — not to any intermediary.
 
@@ -49,11 +49,19 @@ openssl s_client -connect api.chipotle.litprotocol.com:443 \
 - Whether the code was **authorized** by on-chain governance
 - Whether the **OS** and **KMS** are unmodified
 
-This section covers all 4 layers per the [Phala Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust).
+The sections below walk through Phala's [Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust), organized into the application layer (your code), the platform layer (hardware, OS, KMS, and network), and the governance layer (on-chain authorization).
 
-### Step 0: Quick Automated Verification
+### Run a Full Verification
 
-This mirrors the CI workflow that runs on every deployment. Save the Python script below as `fix-attestation-event-log.py`, then run the verification commands.
+This is a complete, end-to-end how-to. It mirrors the CI workflow that runs on every Lit Chipotle deployment and covers all layers of the chain of trust.
+
+**Prerequisites:** `python3`, `docker`, `openssl`, `dig`, and optionally [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) and [`cast`](https://book.getfoundry.sh/getting-started/installation) (from Foundry).
+
+#### 1. Verify the TDX attestation quote (Platform)
+
+Fetch the attestation from the live API and run the official dstack verifier. This validates the Intel TDX quote signature (proving genuine hardware), replays the RTMR3 event log (proving no events were tampered with), and checks OS measurements.
+
+Save the Python script below as `fix-attestation-event-log.py`, then run the verification commands.
 
 <CodeGroup>
 ```python fix-attestation-event-log.py
@@ -127,87 +135,147 @@ print("VALID" if v.get("is_valid") else "INVALID")
 The dstack guest-agent strips digests from RTMR3 runtime events to reduce response size. The fix script recomputes them as `SHA384(event_type || ":" || event || ":" || payload)`. The Docker verifier's parser rejects empty digests, so this preprocessing step is necessary.
 </Note>
 
-### Layer 1: Application — Is This the Right Code?
-
-**compose-hash** — The SHA-256 of the docker-compose config is recorded in RTMR3. Fetch `/info` to get `compose_hash` and `tcb_info.app_compose`. To verify manually:
+If you prefer not to run the Docker verifier locally, you can verify the TDX quote signature via the Phala Cloud API:
 
 ```bash
-curl -sf https://api.chipotle.litprotocol.com/info | python3 -c '
-import sys, json
-info = json.load(sys.stdin)
-print("compose_hash:", info["compose_hash"])
-print("app_compose:", info["tcb_info"]["app_compose"][:200], "...")
+# Extract the raw quote hex and verify via Phala Cloud
+QUOTE=$(python3 -c 'import json; q=json.load(open("attestation.json"))["quote"]; print(q[2:] if q.startswith("0x") else q)')
+
+curl -X POST https://cloud-api.phala.network/api/v1/attestations/verify \
+  -H "Content-Type: application/json" \
+  -d "{\"hex\": \"$QUOTE\"}"
+```
+
+#### 2. Verify the application code (Application)
+
+Confirm that the running CVM is executing the exact code you expect.
+
+```bash
+# Fetch app info (compose hash + full app-compose config)
+curl -sf https://api.chipotle.litprotocol.com/info > info.json
+
+# 2a. Verify compose-hash: the SHA-256 of the app-compose.json config
+#     (which includes docker-compose.yaml + metadata) is recorded in RTMR3.
+python3 -c '
+import json, hashlib
+info = json.load(open("info.json"))
+app_compose = info["tcb_info"]["app_compose"]
+computed = hashlib.sha256(app_compose.encode()).hexdigest()
+recorded = info["compose_hash"]
+print(f"Computed:  {computed}")
+print(f"Recorded:  {recorded}")
+assert computed == recorded, "MISMATCH"
+print("compose-hash OK")
+'
+
+# 2b. Verify all images use @sha256: digest pinning (no mutable tags)
+python3 -c '
+import json, yaml
+info = json.load(open("info.json"))
+compose = yaml.safe_load(json.loads(info["tcb_info"]["app_compose"])["docker_compose_file"])
+for name, svc in compose.get("services", {}).items():
+    img = svc.get("image", "")
+    pinned = "@sha256:" in img
+    print(f"  {name}: {img[:80]}... {"OK" if pinned else "NOT PINNED"}")
+    assert pinned, f"{name} is not digest-pinned"
+print("All images digest-pinned OK")
 '
 ```
 
-```bash
-# Recompute the hash from app_compose
-echo -n '<app_compose value>' | sha256sum
-```
-
-**Docker image digests** — All 4 images (lit-actions, lit-api-server, lit-static, otel-collector) must use `@sha256:` digest pinning (no mutable tags like `:latest`). Inspect the `app_compose` from `/info` to confirm.
-
-**Image provenance (Sigstore)** — Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verify that an image was built by GitHub Actions from the LIT-Protocol/lit-node-express repo:
+**Verify image provenance with Sigstore** — Each image is signed with cosign (keyless, GitHub OIDC) during CI. This proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repo:
 
 ```bash
+# Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/
+# Verify each image digest extracted from the compose config above
 cosign verify \
   --certificate-identity-regexp "https://github.com/LIT-Protocol/lit-node-express/.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   <image>@<digest>
 ```
 
-This proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository.
+#### 3. Verify TLS terminates in the TEE (Network)
 
-**RTMR3 event log replay** — Each event extends RTMR3: `RTMR3_new = SHA384(RTMR3_old || SHA384(event))`. The dstack-verifier replays all events and confirms the final value matches the quoted RTMR3. This ensures no events were added, removed, or modified.
-
-### Layer 2: Platform — Is the Hardware Genuine?
-
-**TDX quote signature** — Verified against Intel root CA. Proves genuine TDX hardware. The dstack-verifier handles this automatically. Alternatively, use the Phala Cloud API:
+Confirm that the TLS certificate served to your browser was generated inside the TEE.
 
 ```bash
-# Extract the quote hex and verify via Phala Cloud
-curl -sf https://api.chipotle.litprotocol.com/attestation \
-  | python3 -c 'import sys,json; q=json.load(sys.stdin)["quote"]; print(q[2:] if q.startswith("0x") else q)' \
-  > quote.hex
-
-curl -X POST https://cloud-api.phala.network/api/v1/attestations/verify \
-  -H "Content-Type: application/json" \
-  -d "{\"hex\": \"$(cat quote.hex)\"}"
-```
-
-**OS measurements (MRTD, RTMR0-2)** — Firmware, kernel, and boot parameters are measured into these registers. They must match known-good values from the dstack release.
-
-**KMS identity** — The `key-provider` event in RTMR3 records the KMS root CA public key hash. This binds the CVM to a specific trusted KMS — if someone substituted a rogue KMS, this hash would change and RTMR3 verification would fail.
-
-**KMS attestation** — The KMS itself runs in a TEE with its own attestation quote. Phala's Trust Center verifies this independently.
-
-### Layer 3: Network — Does TLS Terminate in the TEE?
-
-**Evidence files** — The `/evidences/` endpoint on the CVM serves `cert.pem`, `sha256sum.txt`, and `quote.json`. The SHA-256 hash of the certificate is embedded in the quote's `reportData`.
-
-**Certificate fingerprint match** — Compare what `openssl s_client` shows with the attested cert hash from the evidence files:
-
-```bash
-# Get the certificate fingerprint from the live connection
+# 3a. Get the certificate fingerprint from the live TLS connection
 openssl s_client -connect api.chipotle.litprotocol.com:443 \
   -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
   | openssl x509 -noout -fingerprint -sha256
 
-# Compare with the attested hash from evidence files
-# The sha256sum.txt in /evidences/ should contain a matching hash
-```
+# The /evidences/ endpoint on the CVM gateway serves cert.pem,
+# sha256sum.txt, and quote.json. The SHA-256 hash of the certificate
+# is embedded in the quote's reportData field — compare it with
+# the fingerprint above to confirm they match.
 
-**CAA DNS records** — Verify that certificate issuance is restricted to Let's Encrypt only, through TEE-controlled ACME:
-
-```bash
+# 3b. Verify CAA DNS records restrict issuance to Let's Encrypt
 dig CAA api.chipotle.litprotocol.com
 ```
 
-### Layer 4: Governance — Who Authorized This Code?
+#### 4. Verify on-chain governance (Governance)
 
-**On-chain whitelisting** — The compose-hash must be registered in the DstackApp smart contract on Base before the CVM will accept it. This is controlled by the deployer key.
+Confirm that the compose-hash running in the CVM was authorized on-chain.
 
-**AccountConfig contract** — [`0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24`](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24) on Base governs Lit Chipotle's permission model — account ownership, API key scopes, PKP registries, and action groups are all managed here. Inspect the contract on [Basescan](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24) to verify ownership and permissions.
+The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **DstackKms** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
+
+```bash
+# Requires `cast` from Foundry (https://book.getfoundry.sh)
+# Check if the compose-hash is whitelisted in DstackApp
+COMPOSE_HASH=$(python3 -c 'import json; print("0x" + json.load(open("info.json"))["compose_hash"])')
+cast call <DSTACK_APP_ADDRESS> "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-url https://mainnet.base.org
+```
+
+The **AccountConfig** contract ([`0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24`](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24)) on Base governs Lit Chipotle's permission model — account ownership, API key scopes, PKP registries, and action groups. Inspect it on Basescan to verify ownership and permissions.
+
+### Understanding the Layers
+
+The sections below explain what each verification step is actually checking and why it matters. Refer to the [Phala Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust) for the canonical reference.
+
+#### Application Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **compose-hash** | The SHA-256 of the `app-compose.json` config (which includes `docker-compose.yaml` plus metadata) is recorded as an event in RTMR3. Recomputing the hash from `/info` and comparing it to the attested value proves the CVM is running the declared configuration. |
+| **Docker image digests** | All 4 images (lit-actions, lit-api-server, lit-static, otel-collector) use `@sha256:` digest pinning. Mutable tags like `:latest` would allow silent image substitution. |
+| **Image provenance (Sigstore)** | Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verification proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository and recorded in the public Rekor transparency log. |
+| **RTMR3 event log replay** | Each event extends RTMR3 via a hash chain: `RTMR3_new = SHA384(RTMR3_old ‖ SHA384(event))`. The dstack-verifier replays all events from the initial value (48 zero bytes) and confirms the final value matches the RTMR3 in the TDX quote. This ensures no events were added, removed, or modified. |
+
+#### Platform Layer
+
+The TDX quote contains hardware-measured registers that attest the entire boot chain:
+
+| Register | What it measures |
+|----------|-----------------|
+| **MRTD** | Virtual firmware hash |
+| **RTMR0** | Hardware configuration |
+| **RTMR1** | Kernel measurements |
+| **RTMR2** | Boot parameters |
+| **RTMR3** | Application events (compose-hash, key-provider, etc.) |
+
+| Check | What it proves |
+|-------|----------------|
+| **TDX quote signature** | Intel signs the TDX quote with the hardware root of trust. Verification against the Intel root CA proves the quote came from genuine TDX hardware. The dstack-verifier and the Phala Cloud API both handle this. |
+| **OS measurements** | MRTD, RTMR0–2 values must match known-good values from the dstack release. The **DstackKms** contract on-chain whitelists allowed OS images via `allowedOsImages(bytes32)`. |
+| **KMS identity** | The `key-provider` event in RTMR3 records the KMS root CA public key hash. This binds the CVM to a specific trusted KMS — if someone substituted a rogue KMS, this hash would change and RTMR3 verification would fail. The DstackKms contract also whitelists KMS instances via `kmsAllowedAggregatedMrs(bytes32)`. |
+| **KMS attestation** | The KMS itself runs in a TEE with its own attestation quote. [Phala's Trust Center](https://github.com/Phala-Network/trust-center) verifies this independently. |
+
+#### Network Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **Evidence files** | The CVM gateway's `/evidences/` endpoint serves `cert.pem`, `sha256sum.txt`, and `quote.json`. The SHA-256 hash of the certificate is embedded in the quote's `reportData`. |
+| **Certificate fingerprint match** | Comparing what `openssl s_client` returns against the attested cert hash proves TLS terminates inside the TEE, not at an intermediary. |
+| **CAA DNS records** | `dig CAA api.chipotle.litprotocol.com` should restrict certificate issuance to Let's Encrypt only, through the TEE-controlled ACME flow. |
+
+#### Governance Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. Only the deployer key can add hashes. |
+| **DstackKms contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
+| **AccountConfig contract** | Governs Lit Chipotle's permission model on Base — account ownership, API key scopes, PKP registries, and action groups. |
+
+If all checks pass, the CVM is running your exact code on genuine TEE hardware with no security gaps.
 
 ## After Verification — Certificate Pinning
 
@@ -223,4 +291,7 @@ Once full verification passes, pin the TLS certificate fingerprint:
 - [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust)
 - [Phala: Verify Your Application](https://docs.phala.com/phala-cloud/attestation/verify-your-application)
 - [Phala: Get Attestation](https://docs.phala.com/phala-cloud/attestation/get-attestation)
+- [RTMR3 Calculator](https://rtmr3-calculator.vercel.app/) — web tool for computing compose hashes
+- [dstack Verification Script](https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py) — reference Python implementation
+- [Phala Trust Center](https://github.com/Phala-Network/trust-center) — reference verification implementation
 - [Sigstore cosign](https://docs.sigstore.dev/cosign/overview/)

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -176,15 +176,17 @@ print("compose-hash OK")
 
 # 2b. Verify all images use @sha256: digest pinning (no mutable tags)
 python3 -c '
-import json, yaml
+import json, re
 info = json.load(open("info.json"))
-compose = yaml.safe_load(json.loads(info["tcb_info"]["app_compose"])["docker_compose_file"])
-for name, svc in compose.get("services", {}).items():
-    img = svc.get("image", "")
+compose_yaml = json.loads(info["tcb_info"]["app_compose"])["docker_compose_file"]
+images = re.findall(r"image:\s*(.+)", compose_yaml)
+assert images, "No image directives found"
+for img in images:
+    img = img.strip()
     pinned = "@sha256:" in img
     status = "OK" if pinned else "NOT PINNED"
-    print(f"  {name}: {img[:80]}... {status}")
-    assert pinned, f"{name} is not digest-pinned"
+    print(f"  {img[:80]}  {status}")
+    assert pinned, f"Image is not digest-pinned: {img}"
 print("All images digest-pinned OK")
 '
 ```

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -285,7 +285,7 @@ The compose-hash must be registered in the **DstackApp** smart contract on Base 
 1. Go to the [Phala Cloud dashboard](https://cloud.phala.network) and look up the application by its `app_id` (available from `GET /info`). The dashboard shows the associated DstackApp contract address.
 2. Verify the contract is the one your CVM is attached to by checking the `app_id` in the `/info` response matches the app registered in the contract on Basescan.
 
-For Lit Chipotle production, the DstackApp contract is [`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C).
+For Lit Chipotle production, the DstackApp contract is [`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C). The KMS Phala app contract is [`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC).
 
 ```bash
 # Requires `cast` from Foundry (https://book.getfoundry.sh)
@@ -300,7 +300,13 @@ cast call "$DSTACK_APP" "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-ur
 # If it returns 0x...00 (false), the CVM is running unauthorized code.
 ```
 
-The **AccountConfig** contract ([`0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24`](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24)) on Base governs Lit Chipotle's permission model — account ownership, API key scopes, PKP registries, and action groups. Inspect it on Basescan to verify ownership and permissions.
+**Governance via Safe multisig:** All on-chain governance actions are controlled by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. This Safe administers:
+
+- **DstackApp** ([`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C)) — compose-hash whitelisting for the Lit Chipotle CVM
+- **KMS Phala app** ([`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC)) — KMS configuration and allowed OS images
+- **AccountConfig** — _details coming soon_
+
+Any governance action (e.g., whitelisting a new compose-hash, updating allowed OS images, or upgrading the AccountConfig Diamond) requires at least 2 of 3 signers. Production deployments use a two-phase workflow: CI proposes the transaction to the Safe, and signers approve it through the Safe UI before the deployment can proceed.
 
 ### Understanding the Layers
 
@@ -347,9 +353,10 @@ The TDX quote contains hardware-measured registers that attest the entire boot c
 
 | Check | What it proves |
 |-------|----------------|
-| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. Only the deployer key can add hashes. |
-| **DstackKms contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
+| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. |
+| **KMS Phala app contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
 | **AccountConfig contract** | Governs Lit Chipotle's permission model on Base — account ownership, API key scopes, PKP registries, and action groups. |
+| **Safe multisig** | All three contracts above are administered by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. Production deployments use a two-phase CI workflow: propose → approve via Safe UI → execute. |
 
 If all checks pass, the CVM is running your exact code on genuine TEE hardware with no security gaps.
 

--- a/docs/architecture/verification.mdx
+++ b/docs/architecture/verification.mdx
@@ -1,0 +1,226 @@
+---
+title: "Security & Verification"
+description: "How to verify that your connection to Lit Chipotle terminates inside a genuine TEE running unmodified code."
+---
+
+## Zero-Trust TLS
+
+**What is Zero-Trust TLS?** In traditional web hosting, you trust the server operator not to inspect or tamper with your traffic. Zero-Trust TLS (ZT-TLS) eliminates this trust assumption entirely. The TLS private key is generated **inside** the Trusted Execution Environment (TEE) and **never leaves it** — not even the cloud provider, OS administrator, or Lit Protocol team can extract it.
+
+**How it works for Lit Chipotle:**
+
+1. The dstack gateway running inside the CVM generates a private key using secrets derived from the dstack-KMS (itself a TEE).
+2. It requests a TLS certificate from Let's Encrypt via ACME DNS-01 challenge — no ports 80/443 are exposed during verification.
+3. DNS CAA records for the domain restrict which CAs can issue certificates, ensuring only TEE-controlled ACME can obtain a cert.
+4. The certificate, key, and their SHA-256 hashes are recorded as evidence files. These hashes are embedded in the Intel TDX attestation quote's `reportData` field.
+5. Because the quote is signed by Intel's TDX Attestation Key and bound to the hash chain, anyone can cryptographically prove the certificate was generated inside this specific enclave.
+
+**What this means:** When you connect to `api.chipotle.litprotocol.com` over HTTPS, the TLS handshake completes **inside the TEE**. No proxy, load balancer, or CDN can intercept the traffic. If the TLS handshake succeeds and the certificate is valid, you are provably talking to the TEE — not to any intermediary.
+
+**Contrast with traditional TLS:** Traditional TLS proves identity (the server holds the private key for this domain) but says nothing about *where* the key lives or *what code* uses it. ZT-TLS closes that gap: the key can only exist inside attested TEE hardware.
+
+<Note>
+Zero-Trust TLS means the encryption endpoint is the trust boundary. Once you verify the certificate was issued to the TEE, the HTTPS connection itself becomes your proof of confidentiality.
+</Note>
+
+For the full design, see [Phala: TEE-Controlled Domain Certificates](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates).
+
+## Quick TLS Verification
+
+Given Zero-Trust TLS, simple certificate validation already gives strong guarantees. This is sufficient for most users.
+
+```bash
+# Inspect the TLS certificate
+openssl s_client -connect api.chipotle.litprotocol.com:443 \
+  -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 -dates -subject
+```
+
+- The certificate is issued by **Let's Encrypt** (a public CA) to the exact domain.
+- Because ZT-TLS guarantees the private key lives only in the TEE, a valid TLS handshake = connection to the TEE.
+- For programmatic clients: **pin the certificate fingerprint** after initial verification (see [Certificate Pinning](#after-verification--certificate-pinning) below).
+
+## Full Chain of Trust Verification
+
+**Why go further?** TLS validation proves your connection is secure, but not:
+
+- What **code** is running inside the TEE
+- Whether the **hardware** is genuine Intel TDX
+- Whether the code was **authorized** by on-chain governance
+- Whether the **OS** and **KMS** are unmodified
+
+This section covers all 4 layers per the [Phala Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust).
+
+### Step 0: Quick Automated Verification
+
+This mirrors the CI workflow that runs on every deployment. Save the Python script below as `fix-attestation-event-log.py`, then run the verification commands.
+
+<CodeGroup>
+```python fix-attestation-event-log.py
+#!/usr/bin/env python3
+"""Fix event log for dstack verifier: compute digests for runtime events with empty digest.
+
+The dstack guest-agent strips digests from runtime events (RTMR3, event_type 0x08000001)
+to reduce response size. The digest is deterministically derived as
+SHA384(event_type || ":" || event || ":" || payload), so it can be recomputed.
+The Docker verifier's serde parser rejects digest="", so we fill in the computed digest
+before calling the verifier.
+"""
+import hashlib
+import json
+import struct
+import sys
+
+DSTACK_RUNTIME = 0x08000001
+
+
+def hex_to_bytes(s: str) -> bytes:
+    return bytes.fromhex(s) if s else b""
+
+
+def compute_digest(event: str, payload_hex: str) -> str:
+    payload = hex_to_bytes(payload_hex)
+    data = struct.pack("<I", DSTACK_RUNTIME) + b":" + event.encode() + b":" + payload
+    return hashlib.sha384(data).hexdigest()
+
+
+def main() -> None:
+    attest_path = sys.argv[1]
+    with open(attest_path) as f:
+        d = json.load(f)
+    events = json.loads(d["event_log"])
+    for e in events:
+        if e.get("digest") == "" and e.get("event_type") == DSTACK_RUNTIME:
+            e["digest"] = compute_digest(e.get("event", ""), e.get("event_payload", ""))
+    d["event_log"] = json.dumps(events)
+    q = d["quote"]
+    q = q[2:] if isinstance(q, str) and q.startswith("0x") else q
+    out = {"quote": q, "event_log": d["event_log"], "vm_config": d["vm_config"], "attestation": None}
+    json.dump(out, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+```bash Verification commands
+# 1. Fetch attestation from the live API
+curl -sf https://api.chipotle.litprotocol.com/attestation > attestation.json
+
+# 2. Fix empty digests in runtime events (see note below)
+python3 fix-attestation-event-log.py attestation.json > verify-request.json
+
+# 3. Run the official dstack verifier
+docker run --rm -v $(pwd):/verify -w /verify --platform linux/amd64 \
+  dstacktee/dstack-verifier:latest --verify /verify/verify-request.json
+
+# 4. Check result
+python3 -c '
+import json
+v = json.load(open("verify-request.json.verification.json"))
+print("VALID" if v.get("is_valid") else "INVALID")
+'
+```
+</CodeGroup>
+
+<Note>
+The dstack guest-agent strips digests from RTMR3 runtime events to reduce response size. The fix script recomputes them as `SHA384(event_type || ":" || event || ":" || payload)`. The Docker verifier's parser rejects empty digests, so this preprocessing step is necessary.
+</Note>
+
+### Layer 1: Application — Is This the Right Code?
+
+**compose-hash** — The SHA-256 of the docker-compose config is recorded in RTMR3. Fetch `/info` to get `compose_hash` and `tcb_info.app_compose`. To verify manually:
+
+```bash
+curl -sf https://api.chipotle.litprotocol.com/info | python3 -c '
+import sys, json
+info = json.load(sys.stdin)
+print("compose_hash:", info["compose_hash"])
+print("app_compose:", info["tcb_info"]["app_compose"][:200], "...")
+'
+```
+
+```bash
+# Recompute the hash from app_compose
+echo -n '<app_compose value>' | sha256sum
+```
+
+**Docker image digests** — All 4 images (lit-actions, lit-api-server, lit-static, otel-collector) must use `@sha256:` digest pinning (no mutable tags like `:latest`). Inspect the `app_compose` from `/info` to confirm.
+
+**Image provenance (Sigstore)** — Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verify that an image was built by GitHub Actions from the LIT-Protocol/lit-node-express repo:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "https://github.com/LIT-Protocol/lit-node-express/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  <image>@<digest>
+```
+
+This proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository.
+
+**RTMR3 event log replay** — Each event extends RTMR3: `RTMR3_new = SHA384(RTMR3_old || SHA384(event))`. The dstack-verifier replays all events and confirms the final value matches the quoted RTMR3. This ensures no events were added, removed, or modified.
+
+### Layer 2: Platform — Is the Hardware Genuine?
+
+**TDX quote signature** — Verified against Intel root CA. Proves genuine TDX hardware. The dstack-verifier handles this automatically. Alternatively, use the Phala Cloud API:
+
+```bash
+# Extract the quote hex and verify via Phala Cloud
+curl -sf https://api.chipotle.litprotocol.com/attestation \
+  | python3 -c 'import sys,json; q=json.load(sys.stdin)["quote"]; print(q[2:] if q.startswith("0x") else q)' \
+  > quote.hex
+
+curl -X POST https://cloud-api.phala.network/api/v1/attestations/verify \
+  -H "Content-Type: application/json" \
+  -d "{\"hex\": \"$(cat quote.hex)\"}"
+```
+
+**OS measurements (MRTD, RTMR0-2)** — Firmware, kernel, and boot parameters are measured into these registers. They must match known-good values from the dstack release.
+
+**KMS identity** — The `key-provider` event in RTMR3 records the KMS root CA public key hash. This binds the CVM to a specific trusted KMS — if someone substituted a rogue KMS, this hash would change and RTMR3 verification would fail.
+
+**KMS attestation** — The KMS itself runs in a TEE with its own attestation quote. Phala's Trust Center verifies this independently.
+
+### Layer 3: Network — Does TLS Terminate in the TEE?
+
+**Evidence files** — The `/evidences/` endpoint on the CVM serves `cert.pem`, `sha256sum.txt`, and `quote.json`. The SHA-256 hash of the certificate is embedded in the quote's `reportData`.
+
+**Certificate fingerprint match** — Compare what `openssl s_client` shows with the attested cert hash from the evidence files:
+
+```bash
+# Get the certificate fingerprint from the live connection
+openssl s_client -connect api.chipotle.litprotocol.com:443 \
+  -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256
+
+# Compare with the attested hash from evidence files
+# The sha256sum.txt in /evidences/ should contain a matching hash
+```
+
+**CAA DNS records** — Verify that certificate issuance is restricted to Let's Encrypt only, through TEE-controlled ACME:
+
+```bash
+dig CAA api.chipotle.litprotocol.com
+```
+
+### Layer 4: Governance — Who Authorized This Code?
+
+**On-chain whitelisting** — The compose-hash must be registered in the DstackApp smart contract on Base before the CVM will accept it. This is controlled by the deployer key.
+
+**AccountConfig contract** — [`0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24`](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24) on Base governs Lit Chipotle's permission model — account ownership, API key scopes, PKP registries, and action groups are all managed here. Inspect the contract on [Basescan](https://basescan.org/address/0x4c8eb9f329ebfdb369f0c90954875ef8f568ad24) to verify ownership and permissions.
+
+## After Verification — Certificate Pinning
+
+Once full verification passes, pin the TLS certificate fingerprint:
+
+1. Record the SHA-256 fingerprint from the verification above.
+2. On subsequent connections, validate the cert matches the pinned fingerprint — this is fast and doesn't require re-running attestation.
+3. **When to re-verify**: After any CVM redeployment, a new TLS cert is generated inside the TEE. Re-run the full verification and update your pinned fingerprint.
+
+## Further Reading
+
+- [Phala: Zero-Trust TLS (TEE-Controlled Domain Certificates)](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates)
+- [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust)
+- [Phala: Verify Your Application](https://docs.phala.com/phala-cloud/attestation/verify-your-application)
+- [Phala: Get Attestation](https://docs.phala.com/phala-cloud/attestation/get-attestation)
+- [Sigstore cosign](https://docs.sigstore.dev/cosign/overview/)

--- a/docs/architecture/verification/chain-of-trust.mdx
+++ b/docs/architecture/verification/chain-of-trust.mdx
@@ -1,0 +1,52 @@
+---
+title: "Chain of Trust Reference"
+description: "What each verification layer checks and why it matters — application, platform, network, and governance."
+---
+
+The sections below explain what each verification step is actually checking and why it matters. For the step-by-step commands, see the [Full Verification Guide](/architecture/verification/full-verification). For the canonical reference, see [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust).
+
+## Application Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **compose-hash** | The SHA-256 of the `app-compose.json` config (which includes `docker-compose.yaml` plus metadata) is recorded as an event in RTMR3. Recomputing the hash from `/info` and comparing it to the attested value proves the CVM is running the declared configuration. |
+| **Docker image digests** | All images (lit-actions, lit-api-server, otel-collector, dstack-ingress) use `@sha256:` digest pinning. Mutable tags like `:latest` would allow silent image substitution. |
+| **Image provenance (Sigstore)** | Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verification proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository and recorded in the public Rekor transparency log. |
+| **RTMR3 event log replay** | Each event extends RTMR3 via a hash chain: `RTMR3_new = SHA384(RTMR3_old ‖ SHA384(event))`. The dstack-verifier replays all events from the initial value (48 zero bytes) and confirms the final value matches the RTMR3 in the TDX quote. This ensures no events were added, removed, or modified. |
+
+## Platform Layer
+
+The TDX quote contains hardware-measured registers that attest the entire boot chain:
+
+| Register | What it measures |
+|----------|-----------------|
+| **MRTD** | Virtual firmware hash |
+| **RTMR0** | Hardware configuration |
+| **RTMR1** | Kernel measurements |
+| **RTMR2** | Boot parameters |
+| **RTMR3** | Application events (compose-hash, key-provider, etc.) |
+
+| Check | What it proves |
+|-------|----------------|
+| **TDX quote signature** | Intel signs the TDX quote with the hardware root of trust. Verification against the Intel root CA proves the quote came from genuine TDX hardware. The dstack-verifier and the Phala Cloud API both handle this. |
+| **OS measurements** | MRTD, RTMR0–2 values must match known-good values from the dstack release. The **DstackKms** contract on-chain whitelists allowed OS images via `allowedOsImages(bytes32)`. |
+| **KMS identity** | The `key-provider` event in RTMR3 records the KMS root CA public key hash. This binds the CVM to a specific trusted KMS — if someone substituted a rogue KMS, this hash would change and RTMR3 verification would fail. The DstackKms contract also whitelists KMS instances via `kmsAllowedAggregatedMrs(bytes32)`. |
+| **KMS attestation** | The KMS itself runs in a TEE with its own attestation quote. [Phala's Trust Center](https://github.com/Phala-Network/trust-center) verifies this independently. |
+
+## Network Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **Evidence files** | dstack-ingress serves `/evidences/` with `cert-<domain>.pem`, `sha256sum.txt`, `acme-account.json`, and `quote.json`. The SHA-256 of `sha256sum.txt` is embedded in the evidence quote's `reportData`, creating a checksum chain from the TDX hardware root of trust to the certificate files. |
+| **Evidence checksum chain** | `SHA-256(sha256sum.txt)` must match `reportData` in `/evidences/quote.json`. This proves the evidence files were generated inside the TEE that produced the quote. |
+| **Certificate fingerprint match** | The leaf cert DER fingerprint from `openssl s_client` must match the leaf cert extracted from the evidence PEM. This proves the live TLS connection uses the same certificate attested by the TEE. |
+| **CAA DNS records** | The custom domain has a CAA CNAME alias pointing to the gateway domain (`_.dstack-base-prod5.phala.network`), which restricts certificate issuance to Let's Encrypt via DNS-01 with a specific ACME account URI — ensuring only the TEE-controlled ACME flow can obtain certificates. |
+
+## Governance Layer
+
+| Check | What it proves |
+|-------|----------------|
+| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. |
+| **KMS Phala app contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
+| **AccountConfig contract** | Governs Lit Chipotle's permission model on Base — account ownership, API key scopes, PKP registries, and action groups. |
+| **Safe multisig** | All three contracts above are administered by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. Production deployments use a two-phase CI workflow: propose → approve via Safe UI → execute. |

--- a/docs/architecture/verification/full-verification.mdx
+++ b/docs/architecture/verification/full-verification.mdx
@@ -1,56 +1,7 @@
 ---
-title: "Security & Verification"
-description: "How to verify that your connection to Lit Chipotle terminates inside a genuine TEE running unmodified code."
+title: "Full Verification Guide"
+description: "Step-by-step commands to verify every layer of the Lit Chipotle chain of trust: hardware attestation, application code, TLS certificates, and on-chain governance."
 ---
-
-## Zero-Trust TLS
-
-**What is Zero-Trust TLS?** In traditional web hosting, you trust the server operator not to inspect or tamper with your traffic. Zero-Trust TLS (ZT-TLS) eliminates this trust assumption entirely. The TLS private key is generated **inside** the Trusted Execution Environment (TEE) and **never leaves it** — not even the cloud provider, OS administrator, or Lit Protocol team can extract it.
-
-**How it works for Lit Chipotle:**
-
-1. The [dstack-ingress](https://github.com/Dstack-TEE/dstack-examples/tree/main/custom-domain/dstack-ingress) container, running inside the CVM, generates a private key and requests a TLS certificate from Let's Encrypt via DNS-01 challenge (Route 53). The private key never leaves the TEE.
-2. DNS [CAA records](https://letsencrypt.org/docs/caa/) for the domain restrict which CAs can issue certificates and require DNS-01 validation with a specific ACME account URI, ensuring only the TEE-controlled ACME flow can obtain a cert.
-4. The certificate and ACME account are recorded as evidence files. Their SHA-256 checksums are hashed into a single digest that is embedded in a TDX attestation quote's `reportData` field.
-5. Because the quote is signed by Intel's TDX hardware root of trust and bound to this digest, anyone can cryptographically prove the certificate was generated inside this specific TEE.
-
-**What this means:** When you connect to `api.chipotle.litprotocol.com` over HTTPS, the TLS handshake completes **inside the TEE**. No proxy, load balancer, or CDN can intercept the traffic. If the TLS handshake succeeds and the certificate is valid, you are provably talking to the TEE — not to any intermediary.
-
-**Contrast with traditional TLS:** Traditional TLS proves identity (the server holds the private key for this domain) but says nothing about *where* the key lives or *what code* uses it. ZT-TLS closes that gap: the key can only exist inside attested TEE hardware.
-
-<Note>
-Zero-Trust TLS means the encryption endpoint is the trust boundary. Once you verify the certificate was issued to the TEE, the HTTPS connection itself becomes your proof of confidentiality.
-</Note>
-
-For the full design, see [Phala: TEE-Controlled Domain Certificates](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates).
-
-## Quick TLS Verification
-
-Given Zero-Trust TLS, simple certificate validation already gives strong guarantees. This is sufficient for most users.
-
-```bash
-# Inspect the TLS certificate
-openssl s_client -connect api.chipotle.litprotocol.com:443 \
-  -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
-  | openssl x509 -noout -fingerprint -sha256 -dates -subject
-```
-
-- The certificate is issued by **Let's Encrypt** (a public CA) to the exact domain.
-- Because ZT-TLS guarantees the private key lives only in the TEE, a valid TLS handshake = connection to the TEE.
-- For programmatic clients: **pin the certificate fingerprint** after initial verification (see [Certificate Pinning](#after-verification--certificate-pinning) below).
-
-## Full Chain of Trust Verification
-
-**Why go further?** TLS validation proves your connection is secure, but not:
-
-- What **code** is running inside the TEE
-- Whether the **hardware** is genuine Intel TDX
-- Whether the code was **authorized** by on-chain governance
-- Whether the **OS** and **KMS** are unmodified
-
-The sections below walk through Phala's [Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust), organized into the application layer (your code), the platform layer (hardware, OS, KMS, and network), and the governance layer (on-chain authorization).
-
-### Run a Full Verification
 
 This is a complete, end-to-end how-to. It mirrors the CI workflow that runs on every Lit Chipotle deployment and covers all layers of the chain of trust.
 
@@ -60,7 +11,7 @@ This is a complete, end-to-end how-to. It mirrors the CI workflow that runs on e
 
 **Prerequisites:** `python3` (3.8+), `docker`, `openssl`, `dig`, and optionally [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) and [`cast`](https://book.getfoundry.sh/getting-started/installation) (from Foundry).
 
-#### 1. Verify the TDX attestation quote (Platform)
+## 1. Verify the TDX attestation quote (Platform)
 
 **What this checks:** Is the server running on real Intel TDX hardware? The TDX attestation quote is like a hardware-signed certificate of authenticity — Intel's chips sign a statement about what software is running, and this step verifies that signature is genuine.
 
@@ -151,7 +102,7 @@ curl -X POST https://cloud-api.phala.network/api/v1/attestations/verify \
   -d "{\"hex\": \"$QUOTE\"}"
 ```
 
-#### 2. Verify the application code (Application)
+## 2. Verify the application code (Application)
 
 **What this checks:** Is the TEE running the exact code you expect, with no modifications? This step verifies the Docker images and their configuration match what was built in CI from the public GitHub repository.
 
@@ -201,7 +152,7 @@ cosign verify \
   <image>@<digest>
 ```
 
-#### 3. Verify TLS terminates in the TEE (Network)
+## 3. Verify TLS terminates in the TEE (Network)
 
 **What this checks:** Was the TLS certificate generated inside the TEE? This confirms your encrypted connection goes directly into the secure hardware — no proxy or intermediary can see your traffic.
 
@@ -274,11 +225,11 @@ echo "Resolved CAA policy:"
 dig CAA dstack-base-prod5.phala.network +short
 ```
 
-#### 4. Verify on-chain governance (Governance)
+## 4. Verify on-chain governance (Governance)
 
 **What this checks:** Was the code running in the TEE authorized through on-chain governance? The compose-hash (a fingerprint of the entire application configuration) must be registered in a smart contract on Base before the CVM will accept it. This means deploying new code requires an on-chain transaction — you can audit the full history on Basescan.
 
-The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **DstackKms** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
+The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **KMS Phala app** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
 
 **Finding the DstackApp contract address:** The DstackApp contract is the on-chain governance contract that authorizes what code the CVM can run. To find the correct address for a given CVM:
 
@@ -307,74 +258,3 @@ cast call "$DSTACK_APP" "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-ur
 - **AccountConfig** — _details coming soon_
 
 Any governance action (e.g., whitelisting a new compose-hash, updating allowed OS images, or upgrading the AccountConfig Diamond) requires at least 2 of 3 signers. Production deployments use a two-phase workflow: CI proposes the transaction to the Safe, and signers approve it through the Safe UI before the deployment can proceed.
-
-### Understanding the Layers
-
-The sections below explain what each verification step is actually checking and why it matters. Refer to the [Phala Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust) for the canonical reference.
-
-#### Application Layer
-
-| Check | What it proves |
-|-------|----------------|
-| **compose-hash** | The SHA-256 of the `app-compose.json` config (which includes `docker-compose.yaml` plus metadata) is recorded as an event in RTMR3. Recomputing the hash from `/info` and comparing it to the attested value proves the CVM is running the declared configuration. |
-| **Docker image digests** | All images (lit-actions, lit-api-server, otel-collector, dstack-ingress) use `@sha256:` digest pinning. Mutable tags like `:latest` would allow silent image substitution. |
-| **Image provenance (Sigstore)** | Each image is signed with Sigstore cosign (keyless, GitHub OIDC). Verification proves the image was built by GitHub Actions from the `LIT-Protocol/lit-node-express` repository and recorded in the public Rekor transparency log. |
-| **RTMR3 event log replay** | Each event extends RTMR3 via a hash chain: `RTMR3_new = SHA384(RTMR3_old ‖ SHA384(event))`. The dstack-verifier replays all events from the initial value (48 zero bytes) and confirms the final value matches the RTMR3 in the TDX quote. This ensures no events were added, removed, or modified. |
-
-#### Platform Layer
-
-The TDX quote contains hardware-measured registers that attest the entire boot chain:
-
-| Register | What it measures |
-|----------|-----------------|
-| **MRTD** | Virtual firmware hash |
-| **RTMR0** | Hardware configuration |
-| **RTMR1** | Kernel measurements |
-| **RTMR2** | Boot parameters |
-| **RTMR3** | Application events (compose-hash, key-provider, etc.) |
-
-| Check | What it proves |
-|-------|----------------|
-| **TDX quote signature** | Intel signs the TDX quote with the hardware root of trust. Verification against the Intel root CA proves the quote came from genuine TDX hardware. The dstack-verifier and the Phala Cloud API both handle this. |
-| **OS measurements** | MRTD, RTMR0–2 values must match known-good values from the dstack release. The **DstackKms** contract on-chain whitelists allowed OS images via `allowedOsImages(bytes32)`. |
-| **KMS identity** | The `key-provider` event in RTMR3 records the KMS root CA public key hash. This binds the CVM to a specific trusted KMS — if someone substituted a rogue KMS, this hash would change and RTMR3 verification would fail. The DstackKms contract also whitelists KMS instances via `kmsAllowedAggregatedMrs(bytes32)`. |
-| **KMS attestation** | The KMS itself runs in a TEE with its own attestation quote. [Phala's Trust Center](https://github.com/Phala-Network/trust-center) verifies this independently. |
-
-#### Network Layer
-
-| Check | What it proves |
-|-------|----------------|
-| **Evidence files** | dstack-ingress serves `/evidences/` with `cert-<domain>.pem`, `sha256sum.txt`, `acme-account.json`, and `quote.json`. The SHA-256 of `sha256sum.txt` is embedded in the evidence quote's `reportData`, creating a checksum chain from the TDX hardware root of trust to the certificate files. |
-| **Evidence checksum chain** | `SHA-256(sha256sum.txt)` must match `reportData` in `/evidences/quote.json`. This proves the evidence files were generated inside the TEE that produced the quote. |
-| **Certificate fingerprint match** | The leaf cert DER fingerprint from `openssl s_client` must match the leaf cert extracted from the evidence PEM. This proves the live TLS connection uses the same certificate attested by the TEE. |
-| **CAA DNS records** | The custom domain has a CAA CNAME alias pointing to the gateway domain (`_.dstack-base-prod5.phala.network`), which restricts certificate issuance to Let's Encrypt via DNS-01 with a specific ACME account URI — ensuring only the TEE-controlled ACME flow can obtain certificates. |
-
-#### Governance Layer
-
-| Check | What it proves |
-|-------|----------------|
-| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. |
-| **KMS Phala app contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
-| **AccountConfig contract** | Governs Lit Chipotle's permission model on Base — account ownership, API key scopes, PKP registries, and action groups. |
-| **Safe multisig** | All three contracts above are administered by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. Production deployments use a two-phase CI workflow: propose → approve via Safe UI → execute. |
-
-If all checks pass, the CVM is running your exact code on genuine TEE hardware with no security gaps.
-
-## After Verification — Certificate Pinning
-
-Once full verification passes, pin the TLS certificate fingerprint:
-
-1. Record the SHA-256 fingerprint from the verification above.
-2. On subsequent connections, validate the cert matches the pinned fingerprint — this is fast and doesn't require re-running attestation.
-3. **When to re-verify**: After any CVM redeployment, a new TLS cert is generated inside the TEE. Re-run the full verification and update your pinned fingerprint.
-
-## Further Reading
-
-- [Phala: Zero-Trust TLS (TEE-Controlled Domain Certificates)](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates)
-- [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust)
-- [Phala: Verify Your Application](https://docs.phala.com/phala-cloud/attestation/verify-your-application)
-- [Phala: Get Attestation](https://docs.phala.com/phala-cloud/attestation/get-attestation)
-- [RTMR3 Calculator](https://rtmr3-calculator.vercel.app/) — web tool for computing compose hashes
-- [dstack Verification Script](https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py) — reference Python implementation
-- [Phala Trust Center](https://github.com/Phala-Network/trust-center) — reference verification implementation
-- [Sigstore cosign](https://docs.sigstore.dev/cosign/overview/)

--- a/docs/architecture/verification/index.mdx
+++ b/docs/architecture/verification/index.mdx
@@ -1,0 +1,64 @@
+---
+title: "Security & Verification"
+description: "How to verify that your connection to Lit Chipotle terminates inside a genuine TEE running unmodified code."
+---
+
+## Zero-Trust TLS
+
+**What is Zero-Trust TLS?** In traditional web hosting, you trust the server operator not to inspect or tamper with your traffic. Zero-Trust TLS (ZT-TLS) eliminates this trust assumption entirely. The TLS private key is generated **inside** the Trusted Execution Environment (TEE) and **never leaves it** — not even the cloud provider, OS administrator, or Lit Protocol team can extract it.
+
+**How it works for Lit Chipotle:**
+
+1. The [dstack-ingress](https://github.com/Dstack-TEE/dstack-examples/tree/main/custom-domain/dstack-ingress) container, running inside the CVM, generates a private key and requests a TLS certificate from Let's Encrypt via DNS-01 challenge (Route 53). The private key never leaves the TEE.
+2. DNS [CAA records](https://letsencrypt.org/docs/caa/) for the domain restrict which CAs can issue certificates and require DNS-01 validation with a specific ACME account URI, ensuring only the TEE-controlled ACME flow can obtain a cert.
+3. The certificate and ACME account are recorded as evidence files. Their SHA-256 checksums are hashed into a single digest that is embedded in a TDX attestation quote's `reportData` field.
+4. Because the quote is signed by Intel's TDX hardware root of trust and bound to this digest, anyone can cryptographically prove the certificate was generated inside this specific TEE.
+
+**What this means:** When you connect to `api.chipotle.litprotocol.com` over HTTPS, the TLS handshake completes **inside the TEE**. No proxy, load balancer, or CDN can intercept the traffic. If the TLS handshake succeeds and the certificate is valid, you are provably talking to the TEE — not to any intermediary.
+
+**Contrast with traditional TLS:** Traditional TLS proves identity (the server holds the private key for this domain) but says nothing about *where* the key lives or *what code* uses it. ZT-TLS closes that gap: the key can only exist inside attested TEE hardware.
+
+<Note>
+Zero-Trust TLS means the encryption endpoint is the trust boundary. Once you verify the certificate was issued to the TEE, the HTTPS connection itself becomes your proof of confidentiality.
+</Note>
+
+For the full design, see [Phala: TEE-Controlled Domain Certificates](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates).
+
+## Quick TLS Verification
+
+Given Zero-Trust TLS, simple certificate validation already gives strong guarantees. This is sufficient for most users.
+
+```bash
+# Inspect the TLS certificate
+openssl s_client -connect api.chipotle.litprotocol.com:443 \
+  -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 -dates -subject
+```
+
+- The certificate is issued by **Let's Encrypt** (a public CA) to the exact domain.
+- Because ZT-TLS guarantees the private key lives only in the TEE, a valid TLS handshake = connection to the TEE.
+- For programmatic clients: **pin the certificate fingerprint** after initial verification (see [Certificate Pinning](#certificate-pinning) below).
+
+## Certificate Pinning
+
+Once full verification passes, pin the TLS certificate fingerprint:
+
+1. Record the SHA-256 fingerprint from the verification above.
+2. On subsequent connections, validate the cert matches the pinned fingerprint — this is fast and doesn't require re-running attestation.
+3. **When to re-verify**: After any CVM redeployment, a new TLS cert is generated inside the TEE. Re-run the [full verification](/architecture/verification/full-verification) and update your pinned fingerprint.
+
+## What's Next
+
+- [Full Verification Guide](/architecture/verification/full-verification) — step-by-step commands to verify every layer of the chain of trust
+- [Chain of Trust Reference](/architecture/verification/chain-of-trust) — detailed explanation of what each verification step checks and why it matters
+
+## Further Reading
+
+- [Phala: Zero-Trust TLS (TEE-Controlled Domain Certificates)](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates)
+- [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust)
+- [Phala: Verify Your Application](https://docs.phala.com/phala-cloud/attestation/verify-your-application)
+- [Phala: Get Attestation](https://docs.phala.com/phala-cloud/attestation/get-attestation)
+- [RTMR3 Calculator](https://rtmr3-calculator.vercel.app/) — web tool for computing compose hashes
+- [dstack Verification Script](https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py) — reference Python implementation
+- [Phala Trust Center](https://github.com/Phala-Network/trust-center) — reference verification implementation
+- [Sigstore cosign](https://docs.sigstore.dev/cosign/overview/)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,7 +44,8 @@
               "architecture/index",
               "architecture/groups",
               "architecture/authModel",
-              "architecture/diagram"
+              "architecture/diagram",
+              "architecture/verification"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,7 +45,14 @@
               "architecture/groups",
               "architecture/authModel",
               "architecture/diagram",
-              "architecture/verification"
+              {
+                "group": "Security & Verification",
+                "pages": [
+                  "architecture/verification/index",
+                  "architecture/verification/full-verification",
+                  "architecture/verification/chain-of-trust"
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/verification.mdx` — a comprehensive guide for end users to verify the integrity of `api.chipotle.litprotocol.com`
- Covers Zero-Trust TLS concept, quick TLS verification (sufficient for most users), and full Phala chain-of-trust verification across all 4 layers (application, platform, network, governance)
- Includes inline `fix-attestation-event-log.py` script and shell commands mirroring the CI attestation workflow
- Adds the page to docs navigation and links from the architecture overview

## Test plan

- [ ] Verify `docs.json` is valid JSON and the page appears in Mintlify nav
- [ ] Read the `.mdx` end-to-end for coherence and accuracy
- [ ] Spot-check shell commands against `.github/workflows/verify-attestation.yml`
- [ ] Confirm cosign verify command matches `deploy-phala.yml` lines 13-16
- [ ] Verify the AccountConfig contract address matches `NodeConfig.main.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)