### PR TITLE
fix: replace stale Phala gateway URLs with custom domains (CPL-161)

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -20,9 +20,9 @@ jobs:
         id: target
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "api_url=https://f8fce543471dc9f5f5643aa217422398c36e5edc-8000.dstack-base-prod5.phala.network" >> "$GITHUB_OUTPUT"
+            echo "api_url=https://api.dev.litprotocol.com" >> "$GITHUB_OUTPUT"
           else
-            echo "api_url=https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network" >> "$GITHUB_OUTPUT"
+            echo "api_url=https://test.chipotle.litprotocol.com" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Inject API URL

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ app_name       := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main
 instance_type  := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo tdx.small || echo tdx.small'`
 gcp_project_id := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo chipotle-dev || echo chipotle-next'`
 node_config    := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo NodeConfig.main.toml || echo NodeConfig.next.toml'`
+domain         := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo api.dev.litprotocol.com || echo test.chipotle.litprotocol.com'`
 
 import "justfile.deploy"
 import "justfile.sim"

--- a/justfile.deploy
+++ b/justfile.deploy
@@ -57,14 +57,19 @@ deploy name=(app_name): docker-push _check_phala
     [ -n "$DIGEST_LIT_ACTIONS" ]    || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
     [ -n "$DIGEST_LIT_API_SERVER" ] || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
     [ -n "$DIGEST_OTEL_COLLECTOR" ] || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
         -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
         -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|{{image_base}}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
         -e "s|\${GCP_PROJECT_ID}|{{gcp_project_id}}|g" \
+        -e "s|\${CERTBOT_DOMAIN}|{{domain}}|g" \
+        -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${CERTBOT_AWS_ACCESS_KEY_ID}|g" \
+        -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${CERTBOT_AWS_SECRET_ACCESS_KEY}|g" \
+        -e "s|\${CERTBOT_AWS_ROLE_ARN}|${CERTBOT_AWS_ROLE_ARN}|g" \
+        -e "s|\${CERTBOT_AWS_REGION}|${CERTBOT_AWS_REGION}|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
     cat docker-compose.deploy.yml
-    if [ -f .env ]; then set -a && . ./.env && set +a; fi
     [ -n "${PHALA_PRIVATE_KEY}" ] || { echo "error: PHALA_PRIVATE_KEY not set. Copy .env.example to .env and set your DstackApp key."; exit 1; }
     phala deploy -c docker-compose.deploy.yml --cvm-id {{app_name}} --private-key "${PHALA_PRIVATE_KEY}"
 
@@ -85,14 +90,19 @@ deploy-new name=(app_name): docker-push _check_phala
     [ -n "$DIGEST_LIT_ACTIONS" ]    || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
     [ -n "$DIGEST_LIT_API_SERVER" ] || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
     [ -n "$DIGEST_OTEL_COLLECTOR" ] || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
         -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
         -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|{{image_base}}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
         -e "s|\${GCP_PROJECT_ID}|{{gcp_project_id}}|g" \
+        -e "s|\${CERTBOT_DOMAIN}|{{domain}}|g" \
+        -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${CERTBOT_AWS_ACCESS_KEY_ID}|g" \
+        -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${CERTBOT_AWS_SECRET_ACCESS_KEY}|g" \
+        -e "s|\${CERTBOT_AWS_ROLE_ARN}|${CERTBOT_AWS_ROLE_ARN}|g" \
+        -e "s|\${CERTBOT_AWS_REGION}|${CERTBOT_AWS_REGION}|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
     cat docker-compose.deploy.yml
-    if [ -f .env ]; then set -a && . ./.env && set +a; fi
     [ -n "${PHALA_PRIVATE_KEY}" ] || { echo "error: PHALA_PRIVATE_KEY not set. Copy .env.example to .env and set your DstackApp key."; exit 1; }
     phala deploy -c docker-compose.deploy.yml -n "$APP_NAME" --instance-type {{instance_type}} \
         --image dstack-0.5.6 \

--- a/k6/README.md
+++ b/k6/README.md
@@ -11,7 +11,7 @@ Auto-generated from the OpenAPI spec using [@grafana/openapi-to-k6](https://gith
 
 ```bash
 npm install -g @grafana/openapi-to-k6
-openapi-to-k6 https://f8fce543471dc9f5f5643aa217422398c36e5edc-8000.dstack-base-prod5.phala.network/openapi.json \ ./k6
+openapi-to-k6 https://api.dev.litprotocol.com/openapi.json \ ./k6
 
 # Note: The OpenAPI spec paths omit the /core/v1 prefix. Set BASE_URL with /core/v1
 # when running against the Phala deployment, e.g. BASE_URL=.../core/v1

--- a/k6/justfile
+++ b/k6/justfile
@@ -16,7 +16,7 @@
 
 NETWORK := 'main'
 _base_url_main := 'https://api.dev.litprotocol.com/core/v1'
-_base_url_next := 'https://969a8c14c9e13420705b19c7246aeed27897e7ea-8000.dstack-base-prod5.phala.network/core/v1'
+_base_url_next := 'https://test.chipotle.litprotocol.com/core/v1'
 _accounts_file_main := './data/accounts.dev.json'
 _accounts_file_next := './data/accounts.next.json'
 BASE_URL := if NETWORK == 'next' { _base_url_next } else { _base_url_main }


### PR DESCRIPTION
## Summary
- Replace all remaining hardcoded `dstack-base-prod5.phala.network` URLs with the new custom domains:
  - **dev** (main) → `api.dev.litprotocol.com`
  - **next** → `test.chipotle.litprotocol.com`
- Add CERTBOT_* variable substitution to `justfile.deploy` so local `just deploy` configures `dstack-ingress` TLS correctly
- Add branch-derived `domain` variable to root `justfile`

## Files changed
| File | Change |
|------|--------|
| `.github/workflows/deploy-static.yml` | Old Phala URLs → custom domains |
| `k6/justfile` | `_base_url_next` → `test.chipotle.litprotocol.com` |
| `k6/README.md` | Example URL → `api.dev.litprotocol.com` |
| `justfile` | Add `domain` variable (branch-derived) |
| `justfile.deploy` | Add CERTBOT_* sed substitutions to `deploy` and `deploy-new` |

## Test plan
- [ ] `grep -rn 'dstack-base-prod5'` returns no hits in modified files
- [ ] `just deploy` generates `docker-compose.deploy.yml` with correct `DOMAIN` for `dstack-ingress`
- [ ] After merge to main, `https://api.dev.litprotocol.com/core/v1` serves with valid Let's Encrypt cert

Closes CPL-161

🤖 Generated with [Claude Code](https://claude.com/claude-code)