### PR TITLE
Move AWS credentials from vars to secrets

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -130,9 +130,9 @@ jobs:
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|chipotle-prod|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
-            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ vars.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
+            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
             -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}|g" \
-            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ vars.CERTBOT_AWS_ROLE_ARN }}|g" \
+            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ secrets.CERTBOT_AWS_ROLE_ARN }}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -159,9 +159,9 @@ jobs:
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|${{ needs.determine-target.outputs.gcp_project_id }}|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
-            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ vars.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
+            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
             -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}|g" \
-            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ vars.CERTBOT_AWS_ROLE_ARN }}|g" \
+            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ secrets.CERTBOT_AWS_ROLE_ARN }}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 


### PR DESCRIPTION
## Summary

- Move `CERTBOT_AWS_ACCESS_KEY_ID` from `vars` to `secrets` in deploy workflows
- Move `CERTBOT_AWS_ROLE_ARN` from `vars` to `secrets` in deploy workflows

These values were stored as GitHub variables (not secrets), so they appeared unmasked in workflow logs. With the repo going public, the full CI run history — including these values — would be visible.

## Action required before merging

1. Add `CERTBOT_AWS_ACCESS_KEY_ID` as a **repository secret** (copy value from the existing var)
2. Add `CERTBOT_AWS_ROLE_ARN` as a **repository secret** (copy value from the existing var)
3. After confirming deploys work, delete the old vars

## Test plan

- [x] Add secrets to repo settings
- [ ] Run a staging deploy and verify the compose file is generated correctly
- [ ] Confirm the values are masked (`***`) in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)