### PR TITLE
fix: stop sed substitution for encrypted vars

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -161,9 +161,6 @@ jobs:
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|chipotle-prod|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
-            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
-            -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}|g" \
-            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ secrets.CERTBOT_AWS_ROLE_ARN }}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,8 +21,8 @@
 #   DOCKERHUB_TOKEN - Docker Hub PAT (Account Settings > Security > Access Tokens)
 #   PHALA_CLOUD_API_KEY - From Phala Cloud Dashboard > API Tokens
 #   PHALA_DSTACKAPP_PRIVATE_KEY - Private key for DstackApp on-chain KMS
-#   STRIPE_SECRET_KEY - Stripe API secret key (test sandbox for next, live for main)
-#   STRIPE_PUBLISHABLE_KEY - Stripe API publishable key (test sandbox for next, live for main)
+#   STRIPE_SANDBOX_SECRET_KEY - Stripe sandbox/test secret key
+#   STRIPE_SANDBOX_PUBLISHABLE_KEY - Stripe sandbox/test publishable key
 #   GCP_SERVICE_ACCOUNT_JSON - GCP service account key (raw JSON or base64-encoded)
 #   BASE_CHAIN_RPC - RPC endpoint for Base blockchain
 #   CERTBOT_AWS_SECRET_ACCESS_KEY - Route 53 IAM secret key for DNS-01 challenge
@@ -196,9 +196,6 @@ jobs:
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|${{ needs.determine-target.outputs.gcp_project_id }}|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
-            -e "s|\${CERTBOT_AWS_ACCESS_KEY_ID}|${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}|g" \
-            -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}|g" \
-            -e "s|\${CERTBOT_AWS_ROLE_ARN}|${{ secrets.CERTBOT_AWS_ROLE_ARN }}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -13,8 +13,8 @@
 # Required secrets (set as encrypted Phala CVM environment variables):
 #   GCP_SERVICE_ACCOUNT_JSON  - GCP service account key (raw JSON or base64-encoded)
 #   GCP_PROJECT_ID            - GCP project ID (e.g. "my-gcp-project")
-#   STRIPE_SECRET_KEY         - Stripe API secret key (test sandbox for staging, live for prod)
-#   STRIPE_PUBLISHABLE_KEY    - Stripe API publishable key (test sandbox for staging, live for prod)
+#   STRIPE_SECRET_KEY         - Stripe API secret key (sandbox for dev, live for prod)
+#   STRIPE_PUBLISHABLE_KEY    - Stripe API publishable key (sandbox for dev, live for prod)
 #   CERTBOT_DOMAIN            - Custom domain for TLS (e.g. "api.chipotle.litprotocol.com")
 #   CERTBOT_AWS_ACCESS_KEY_ID     - Route 53 IAM access key for DNS-01 challenge
 #   CERTBOT_AWS_SECRET_ACCESS_KEY - Route 53 IAM secret key for DNS-01 challenge
@@ -65,7 +65,7 @@ services:
       # BASE_CHAIN_RPC is populated via an encrypted secret passed in through the Phala CLI/UI
       BASE_CHAIN_RPC: ${BASE_CHAIN_RPC}
       # Stripe billing keys — resolved by Phala CVM at container startup from encrypted env vars.
-      # Use test sandbox keys for chipotle-next (staging), live keys for chipotle-dev (production).
+      # Use sandbox keys for dev/next, live keys for prod.
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
       STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY}
     volumes:


### PR DESCRIPTION
## Summary

- **Remove secret-leaking `sed` substitutions** from both staging and prod deploy workflows. AWS credentials (`CERTBOT_AWS_ACCESS_KEY_ID`, `CERTBOT_AWS_SECRET_ACCESS_KEY`, `CERTBOT_AWS_ROLE_ARN`) and Stripe keys were being baked as plaintext into `docker-compose.deploy.yml`, which is uploaded to Phala Cloud. These secrets are already passed via encrypted CVM env vars (`-e` flags / `encrypted_env` API payload), making the `sed` lines both redundant and a security risk.
- Correct staging workflow comments to reference actual GitHub secret names (`STRIPE_SANDBOX_SECRET_KEY`, `STRIPE_SANDBOX_PUBLISHABLE_KEY`)
- Minor docker-compose comment wording cleanup

## Test plan

- [ ] Deploy to chipotle-next from `next` branch and verify `/health` still returns `billing_keys_present: true`
- [ ] Verify dstack-ingress TLS still works (AWS Route 53 creds resolve from encrypted env vars)
- [ ] Verify Stripe billing endpoints still function on staging