### PR TITLE
feat: Stripe sandbox top-up for K6 tests (CPL-166)

### DIFF
--- a/k6/correctness/api-key-security.spec.ts
+++ b/k6/correctness/api-key-security.spec.ts
@@ -15,6 +15,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -119,6 +120,11 @@ export function setup(): SecuritySetupData {
   const walletAddressA = accountA.walletAddress;
   const adminA = authHeaders(accountKeyA);
 
+  // Top up account A — this test makes many billed management and lit_action calls.
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, adminA, 5000); // $50.00 for the many API calls
+  }
+
   // Create group X
   const addGroupXRes = client.addGroup(
     { group_name: `k6-sec-groupX-${K6_RUN_ID}`, group_description: "Security test group X", pkp_ids_permitted: [], cid_hashes_permitted: [] },
@@ -202,6 +208,10 @@ export function setup(): SecuritySetupData {
   if (!assertOk("setup/newAccountB", "POST /new_account", newAccountBRes)) throw new Error("setup failed: newAccountB");
   const accountKeyB = (newAccountBRes.data as { api_key: string }).api_key;
   const adminB = authHeaders(accountKeyB);
+
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, adminB);
+  }
 
   // Create group under Account B
   const addGroupBRes = client.addGroup(

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -12,6 +12,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 export interface IntegrationSetupData {
   apiKey: string;
@@ -27,6 +28,13 @@ export function setup(): IntegrationSetupData {
   }
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  // Ensure the account has credits for integration test API calls.
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, { "X-Api-Key": account.apiKey });
+  }
+
   return {
     apiKey: account.apiKey,
     walletAddress: account.walletAddress,

--- a/k6/correctness/lit-action-ecdsa-sign.spec.ts
+++ b/k6/correctness/lit-action-ecdsa-sign.spec.ts
@@ -15,6 +15,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ECDSA_SIGN_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 export const options = {
   vus: 1,
@@ -35,6 +36,12 @@ export function setup() {
   }
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, { "X-Api-Key": account.apiKey });
+  }
+
   return { usageKeyHeaders: { "X-Api-Key": account.usageApiKey } };
 }
 

--- a/k6/correctness/lit-action-encrypt-decrypt.spec.ts
+++ b/k6/correctness/lit-action-encrypt-decrypt.spec.ts
@@ -19,6 +19,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ENCRYPT_CODE, DECRYPT_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 export interface EncryptDecryptSetupData {
   usageApiKey: string;
@@ -33,6 +34,12 @@ export function setup(): EncryptDecryptSetupData {
   }
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, { "X-Api-Key": account.apiKey });
+  }
+
   return { usageApiKey: account.usageApiKey, pkpId: account.walletAddress };
 }
 

--- a/k6/correctness/observability-headers.spec.ts
+++ b/k6/correctness/observability-headers.spec.ts
@@ -19,6 +19,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 const SIMPLE_ENDPOINT = `${BASE_URL}/get_node_chain_config`;
 
@@ -49,6 +50,12 @@ export function setup(): ObservabilitySetupData {
   }
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, { "X-Api-Key": account.apiKey });
+  }
+
   return { usageApiKey: account.usageApiKey };
 }
 

--- a/k6/loadtest/breakpoint.spec.ts
+++ b/k6/loadtest/breakpoint.spec.ts
@@ -37,6 +37,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 const BPT_MAX_VUS = parseInt(__ENV.BPT_MAX_VUS || "50", 10);
 const BPT_STEP_DURATION = __ENV.BPT_STEP_DURATION || "2m";
@@ -120,8 +121,13 @@ export function setup(): BreakpointSetupData {
   }
 
   const accounts: { usageApiKey: string; pkpId: string }[] = [];
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  const billing = isBillingEnabled(client);
   for (let i = 0; i < BPT_MAX_VUS; i++) {
     const acc = PRECREATED_ACCOUNTS[i];
+    if (billing) {
+      topUpAccount(client, { "X-Api-Key": acc.apiKey });
+    }
     accounts.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
   }
 

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -42,6 +42,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 // Parse duration: "1h", "30m", "10m" etc.
 const SOAK_DURATION = __ENV.SOAK_DURATION || "30m";
@@ -157,8 +158,13 @@ export function setup(): SoakSetupData {
   }
 
   const accounts: SoakAccountData[] = [];
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  const billing = isBillingEnabled(client);
   for (let i = 0; i < maxVus; i++) {
     const account = PRECREATED_ACCOUNTS[i];
+    if (billing) {
+      topUpAccount(client, { "X-Api-Key": account.apiKey });
+    }
     accounts.push({ usageApiKey: account.usageApiKey, pkpId: account.walletAddress });
   }
   return accounts;

--- a/k6/loadtest/spike.spec.ts
+++ b/k6/loadtest/spike.spec.ts
@@ -27,6 +27,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { topUpAccount, isBillingEnabled } from "../stripe.ts";
 
 const SPIK_VUS = parseInt(__ENV.SPIK_VUS || "25", 10);
 const SPIK_DURATION = __ENV.SPIK_DURATION || "1m";
@@ -82,8 +83,13 @@ export function setup(): SpikeSetupData {
 
   // Use a distinct account per VU so each VU exercises a different PKP/usage key pair.
   const accounts: { usageApiKey: string; pkpId: string }[] = [];
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  const billing = isBillingEnabled(client);
   for (let i = 0; i < SPIK_VUS; i++) {
     const acc = PRECREATED_ACCOUNTS[i];
+    if (billing) {
+      topUpAccount(client, { "X-Api-Key": acc.apiKey });
+    }
     accounts.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
   }
 

--- a/k6/setup.ts
+++ b/k6/setup.ts
@@ -6,6 +6,7 @@ import { LitApiServerClient } from "./litApiServer.ts";
 import { assertOk } from "./helpers.ts";
 import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "./defaults.ts";
 import { SharedArray } from "k6/data";
+import { topUpAccount, isBillingEnabled } from "./stripe.ts";
 
 export interface AccountAndUsageKey {
   apiKey: string;
@@ -53,6 +54,16 @@ export function createAccountAndUsageKey(options: {
     wallet_address: string;
   };
   const authHeaders = { "X-Api-Key": apiKey };
+
+  // Top up the account BEFORE any billed management calls.
+  // addUsageApiKey is guarded by BilledManagementApiKey ($0.01/call),
+  // and new accounts start at $0 balance.
+  if (isBillingEnabled(client)) {
+    const topped = topUpAccount(client, authHeaders);
+    if (!topped) {
+      console.warn(`${prefix}topUp: failed to top up account — tests requiring credits may fail`);
+    }
+  }
 
   const addUsageKeyRes = client.addUsageApiKey(
     {

--- a/k6/smoke.spec.ts
+++ b/k6/smoke.spec.ts
@@ -8,6 +8,7 @@ import { PRECREATED_ACCOUNTS } from "./setup.ts";
 import { assertOk } from "./helpers.ts";
 import { HELLO_WORLD_CODE } from "./LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
+import { topUpAccount, isBillingEnabled } from "./stripe.ts";
 
 export const options = {
   vus: 1,
@@ -31,6 +32,13 @@ export function setup(): SmokeSetupData {
   }
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  // Ensure the account has credits for the smoke test.
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  if (isBillingEnabled(client)) {
+    topUpAccount(client, { "X-Api-Key": account.apiKey });
+  }
+
   return { usageApiKey: account.usageApiKey };
 }
 

--- a/k6/stripe.ts
+++ b/k6/stripe.ts
@@ -1,0 +1,107 @@
+/**
+ * Stripe sandbox helpers for K6 tests.
+ *
+ * Fetches the publishable key from the server's /billing/stripe_config endpoint
+ * and uses it to confirm PaymentIntents with a test card token. No secret key
+ * needed — the publishable key is sufficient for client-side confirmation in
+ * Stripe test mode.
+ */
+import http from "k6/http";
+import { LitApiServerClient } from "./litApiServer.ts";
+import type {
+  CreatePaymentIntentResponse,
+  StripeConfigResponse,
+} from "./litApiServer.ts";
+import { assertOk } from "./helpers.ts";
+
+const TOPUP_AMOUNT_CENTS = 1000; // $10.00
+
+/** Cache the publishable key so we only fetch it once per k6 run. */
+let _publishableKey: string | null = null;
+
+/**
+ * Fetch the Stripe publishable key from the server. Returns null if billing
+ * is not configured on the server (stripe_config returns non-200 or no key).
+ */
+function getPublishableKey(client: LitApiServerClient): string | null {
+  if (_publishableKey !== null) return _publishableKey;
+
+  const res = client.billingStripeConfig();
+  if (res.response.status !== 200) {
+    _publishableKey = "";
+    return null;
+  }
+  const data = res.data as StripeConfigResponse;
+  _publishableKey = data.publishable_key ?? "";
+  return _publishableKey || null;
+}
+
+/**
+ * Top up an account's credit balance via Stripe sandbox.
+ *
+ * 1. Fetches the publishable key from /billing/stripe_config.
+ * 2. Creates a PaymentIntent through the lit-api-server billing API.
+ * 3. Confirms the PaymentIntent directly with Stripe using the publishable
+ *    key and the test card `pm_card_visa`.
+ * 4. Tells lit-api-server to verify the payment and credit the account.
+ *
+ * @returns true if top-up succeeded, false otherwise.
+ */
+export function topUpAccount(
+  client: LitApiServerClient,
+  authHeaders: { "X-Api-Key": string },
+  amountCents: number = TOPUP_AMOUNT_CENTS,
+): boolean {
+  const pk = getPublishableKey(client);
+  if (!pk) {
+    console.warn("stripe: billing not enabled on server — skipping top-up");
+    return false;
+  }
+
+  // 1. Create PaymentIntent via our API
+  const createRes = client.billingCreatePaymentIntent(
+    { amount_cents: amountCents },
+    authHeaders,
+  );
+  if (!assertOk("topUp/createPaymentIntent", "POST /billing/create_payment_intent", createRes)) {
+    return false;
+  }
+  const { client_secret, payment_intent_id } = createRes.data as CreatePaymentIntentResponse;
+
+  // 2. Confirm the PaymentIntent with Stripe using the publishable key and
+  //    a test payment method. In test mode, pm_card_visa always succeeds.
+  const confirmStripeRes = http.post(
+    `https://api.stripe.com/v1/payment_intents/${payment_intent_id}/confirm`,
+    { payment_method: "pm_card_visa", client_secret },
+    {
+      headers: {
+        Authorization: `Bearer ${pk}`,
+      },
+    },
+  );
+  if (confirmStripeRes.status !== 200) {
+    console.error(
+      `stripe: confirm failed (${confirmStripeRes.status}): ${confirmStripeRes.body}`,
+    );
+    return false;
+  }
+
+  // 3. Tell our server to verify the payment and credit the account
+  const confirmRes = client.billingConfirmPayment(
+    { payment_intent_id },
+    authHeaders,
+  );
+  if (!assertOk("topUp/confirmPayment", "POST /billing/confirm_payment", confirmRes)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check whether Stripe billing is enabled on the server.
+ * Makes a single HTTP call on first invocation, then caches the result.
+ */
+export function isBillingEnabled(client: LitApiServerClient): boolean {
+  return getPublishableKey(client) !== null;
+}


### PR DESCRIPTION
## Summary

K6 tests now require payment for state-mutating API calls (management endpoints at $0.01/call, lit action execution at $0.01/call). This adds automatic account top-up via Stripe sandbox so tests have credits.

**How it works:**
- New `k6/stripe.ts` fetches the publishable key from `GET /billing/stripe_config` (already public)
- Confirms PaymentIntents with Stripe's test card `pm_card_visa` using the publishable key
- No secret key needed, no CI workflow changes needed
- Graceful no-op when billing is not configured on the server

**Files changed:**
- **`k6/stripe.ts`** (new): `topUpAccount()` and `isBillingEnabled()` helpers
- **`k6/setup.ts`**: top up before first billed call (`addUsageApiKey`) in `createAccountAndUsageKey()`
- **Correctness tests**: integration, ecdsa-sign, encrypt-decrypt, observability-headers, api-key-security
- **Load tests**: spike, breakpoint, soak
- **`k6/smoke.spec.ts`**: top up before smoke test lit action

## Test Coverage

No new application code paths to audit. All changes are K6 test infrastructure.

## Pre-Landing Review

No issues found. Prior /review caught a critical ordering bug (top-up after first billed call instead of before) which was fixed before this PR.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan
- [ ] Deploy to staging (next branch) and run `k6 run k6/smoke.spec.ts` against a billing-enabled instance
- [ ] Verify top-up succeeds (check k6 output for `topUp/createPaymentIntent 2xx` and `topUp/confirmPayment 2xx`)
- [ ] Verify tests still pass when billing is disabled (no Stripe keys on server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)