### PR TITLE
fix: cache Stripe customer lookups to prevent duplicate creation

### DIFF
--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use ethers::signers::{LocalWallet, Signer};
+use moka::future::Cache;
 use reqwest::StatusCode;
 
 /// Cost constants in US cents.
@@ -28,6 +29,9 @@ pub struct StripeState {
     pub publishable_key: String,
     secret_key: String,
     client: reqwest::Client,
+    /// wallet_address → Stripe customer ID cache.
+    /// Avoids duplicate customer creation caused by Stripe Search API indexing lag.
+    customer_cache: Cache<String, String>,
 }
 
 /// Initialise Stripe from environment variables.  Returns `None` if the env vars are absent
@@ -43,11 +47,16 @@ pub fn init() -> Option<Arc<StripeState>> {
         .build()
         .map_err(|e| tracing::error!("stripe: failed to build HTTP client: {e}"))
         .ok()?;
+    let customer_cache = Cache::builder()
+        .max_capacity(10_000)
+        .time_to_idle(Duration::from_secs(3600))
+        .build();
     tracing::info!("stripe: billing enabled");
     Some(Arc::new(StripeState {
         publishable_key,
         secret_key,
         client,
+        customer_cache,
     }))
 }
 
@@ -134,36 +143,51 @@ pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
 }
 
 /// Find the Stripe customer for this wallet address, creating one if none exists.
+///
+/// Results are cached in memory to avoid duplicate customer creation caused by
+/// Stripe Search API indexing lag (newly created customers may not appear in
+/// search results for several seconds).
+///
+/// Uses `try_get_with` to coalesce concurrent requests for the same wallet,
+/// preventing duplicate Stripe customer creation under concurrent load.
 pub async fn get_customer_by_wallet(wallet_address: &str, state: &StripeState) -> Result<String> {
-    // Search by metadata.
-    let query = format!("metadata['wallet_address']:'{wallet_address}'");
-    let resp = stripe_get(
-        state,
-        "customers/search",
-        &[("query", query.as_str()), ("limit", "1")],
-    )
-    .await?;
+    let state = state.clone();
+    let wallet = wallet_address.to_string();
+    state
+        .customer_cache
+        .try_get_with(wallet.clone(), async {
+            // Search by metadata.
+            let query = format!("metadata['wallet_address']:'{wallet}'");
+            let resp = stripe_get(
+                &state,
+                "customers/search",
+                &[("query", query.as_str()), ("limit", "1")],
+            )
+            .await?;
 
-    if let Some(data) = resp.body.get("data").and_then(|d| d.as_array())
-        && let Some(first) = data.first()
-        && let Some(id) = first.get("id").and_then(|i| i.as_str())
-    {
-        return Ok(id.to_string());
-    };
+            if let Some(data) = resp.body.get("data").and_then(|d| d.as_array())
+                && let Some(first) = data.first()
+                && let Some(id) = first.get("id").and_then(|i| i.as_str())
+            {
+                return Ok(id.to_string());
+            };
 
-    // Not found, create a new customer
-    let resp = stripe_post(
-        state,
-        "customers",
-        &[("metadata[wallet_address]", wallet_address)],
-    )
-    .await?;
-    let id = resp
-        .body
-        .get("id")
-        .and_then(|i| i.as_str())
-        .ok_or_else(|| anyhow::anyhow!("Stripe: missing customer id"))?;
-    Ok(id.to_string())
+            // Not found, create a new customer
+            let resp = stripe_post(
+                &state,
+                "customers",
+                &[("metadata[wallet_address]", &wallet)],
+            )
+            .await?;
+            let id = resp
+                .body
+                .get("id")
+                .and_then(|i| i.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Stripe: missing customer id"))?;
+            Ok(id.to_string())
+        })
+        .await
+        .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{e}"))
 }
 
 /// Return the current credit balance in cents (≤ 0 means credits available; the Stripe


### PR DESCRIPTION
## Summary

Fixes the 500 error on `POST /billing/confirm_payment` caused by Stripe Search API indexing lag.

**Root cause:** `get_customer_by_wallet` uses Stripe's Search API to find customers by wallet address metadata. When a customer is just created, the search index hasn't caught up yet, so a second call creates a duplicate customer. The PaymentIntent belongs to customer A, but the ownership check in `confirm_payment_and_credit` resolves to customer B, causing "PaymentIntent does not belong to this account."

**Fix:** Add an in-memory `moka` cache (`Cache<String, String>`) to `StripeState` that maps `wallet_address → customer_id`. Uses `try_get_with` to coalesce concurrent requests for the same wallet, preventing both the indexing lag race and concurrent duplicate creation within a single process.

- Cache: 10,000 entries max, 1 hour time-to-idle
- `moka` was already a dependency (used elsewhere in the project)

**Known limitations (pre-existing, not introduced by this change):**
- Cache is in-process only. Multi-replica deployments can still create duplicates across instances. A distributed fix (Redis/DB/Stripe idempotency keys) would address this but is a larger effort.
- Deleted or merged Stripe customers remain cached until TTL expires (1 hour idle). This is an ops edge case, not a normal user flow.

## Test Coverage

```
CODE PATH COVERAGE
===========================
[+] lit-api-server/src/stripe.rs — get_customer_by_wallet()
    │
    ├── Cache hit (try_get_with returns cached value) — [GAP]
    ├── Cache miss → Stripe search finds customer — [GAP]
    ├── Cache miss → search empty → create customer — [GAP]
    └── Cache miss → Stripe API error — [GAP]

COVERAGE: 0/4 new paths tested (0%)
```

All paths require HTTP mocking infrastructure that doesn't exist in this codebase. Existing tests cover `parse_stripe_response` only (pure function). Adding mock HTTP would require refactoring `stripe_get`/`stripe_post` to accept injectable clients.

## Pre-Landing Review

No issues found.

## Adversarial Review (Codex)

Three findings, all pre-existing architectural limitations, not regressions:
1. Stale cache if Stripe customer is deleted (mitigated by 1h TTI)
2. Multi-replica duplicate creation (in-memory cache only)
3. Cross-node ledger split consequence of #2

This change is a net improvement over the previous no-cache behavior.

## TODOS

No TODO items completed in this PR. Existing "Startup Stripe key validation" TODO is separate work.

## Test plan
- [x] All Rust tests pass (34 passed, 2 pre-existing Linux-only failures on macOS)
- [x] `cargo check` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)