### PR TITLE
fix: truncate expected SHA to match /version short SHA

### DIFF
--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -105,6 +105,8 @@ jobs:
           BASE_URL="${{ steps.resolve-url.outputs.api_root_url }}"
           TIMEOUT="${{ inputs.timeout }}"
           EXPECTED_SHA="${{ inputs.expected_sha }}"
+          # /version returns a short (7-char) SHA, so truncate to match
+          EXPECTED_SHA="${EXPECTED_SHA:0:7}"
           VERSION_URL="${BASE_URL}/version"
           HEALTH_URL="${BASE_URL%/core/v1}/health"
 


### PR DESCRIPTION
## Summary
- The `/version` endpoint returns a 7-character short SHA (e.g. `80e3b71`), but the deploy wait workflow compared against the full 40-character SHA from `github.sha` / `source_sha`, so the version check could never match and always timed out.
- Truncates `EXPECTED_SHA` to 7 characters before comparing.

## Test plan
- [ ] Deploy to staging and verify the wait step matches the short SHA and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)