### PR TITLE
docs: add Stripe payment step to quick start guides (CPL-169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ curl -s -X POST https://api.dev.litprotocol.com/core/v1/new_account \
 }
 ```
 
-### 2. Create a wallet (PKP)
+### 2. Add funds
+
+Running Lit Actions and management calls require credits. Add funds via credit card in the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) — click **Add Funds** in the top-right corner and select a credit package (minimum $5.00). See [Pricing](https://docs.dev.litprotocol.com/management/pricing) for details.
+
+### 3. Create a wallet (PKP)
 
 ```bash
 curl -s https://api.dev.litprotocol.com/core/v1/create_wallet \
@@ -87,7 +91,7 @@ curl -s https://api.dev.litprotocol.com/core/v1/create_wallet \
 }
 ```
 
-### 3. Run a Lit Action
+### 4. Run a Lit Action
 
 ```bash
 curl -s -X POST https://api.dev.litprotocol.com/core/v1/lit_action \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ curl -s -X POST https://api.dev.litprotocol.com/core/v1/new_account \
 
 ### 2. Add funds
 
-Running Lit Actions and management calls require credits. Add funds via credit card in the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) — click **Add Funds** in the top-right corner and select a credit package (minimum $5.00). See [Pricing](https://docs.dev.litprotocol.com/management/pricing) for details.
+Lit Action execution and write/metered management operations require credits. Add funds via credit card in the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) — click **Add Funds** in the top-right corner and select a credit package (minimum $5.00). See [Pricing](https://docs.dev.litprotocol.com/management/pricing) for details.
 
 ### 3. Create a wallet (PKP)
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,9 +8,10 @@ This guide introduces the [**Lit Chipotle API**](https://api.dev.litprotocol.com
 ## Zero to LitAction
 
 1. [Create an account via the Dashboard](/management/dashboard#1-request-a-new-account-or-log-in), note down your API key
-2. Add a usage API key - set its permissions by clicking "All Options"
-3. Run a LitAction
-   1. [From the Dashboard](/management/dashboard#6-run-lit-actions)
+2. [Add funds](/management/pricing#paying-with-a-credit-card-via-stripe) — click **Add Funds** in the Dashboard and pay with a credit card (minimum $5.00). Running Lit Actions and management calls cost credits.
+3. Add a usage API key - set its permissions by clicking "All Options"
+4. Run a LitAction
+   1. [From the Dashboard](/management/dashboard#7-run-lit-actions)
    2. [Programmatically via cURL/JavaScript](/management/api_direct#6-run-lit-action)
    3. or build your own SDK from the [OpenAPI spec](/management/api_direct#open-api-specification)
 
@@ -40,11 +41,12 @@ It supports light/dark theme for your convenience and provides simple management
 **Dashboard workflow (recommended order):**
 
 1. [Request a new account (or log in)](/management/dashboard#1-request-a-new-account-or-log-in)
-2. [Request usage API keys](/management/dashboard#2-request-usage-api-keys)
-3. [Request new PKPs (wallets)](/management/dashboard#3-request-new-pkps-wallets)
-4. [Register IPFS CIDs (actions)](/management/dashboard#4-register-ipfs-cids-actions)
-5. [Create groups](/management/dashboard#5-create-groups)
-6. [Run lit-actions](/management/dashboard#6-run-lit-actions)
+2. [Add funds via credit card](/management/dashboard#2-add-funds)
+3. [Request usage API keys](/management/dashboard#3-request-usage-api-keys)
+4. [Request new PKPs (wallets)](/management/dashboard#4-request-new-pkps-wallets)
+5. [Register IPFS CIDs (actions)](/management/dashboard#5-register-ipfs-cids-actions)
+6. [Create groups](/management/dashboard#6-create-groups)
+7. [Run lit-actions](/management/dashboard#7-run-lit-actions)
 
 For detailed step-by-step instructions with screenshots, see [Using the Dashboard](/management/dashboard).
 
@@ -55,11 +57,12 @@ The same workflows can be done via the REST API under `/core/v1/`. All endpoints
 **API workflow:**
 
 1. [New account or verify account (login)](/management/api_direct#1-new-account-or-verify-account-login)
-2. [Add usage API key](/management/api_direct#2-add-usage-api-key)
-3. [Create wallet (PKP)](/management/api_direct#3-create-a-wallet-pkp)
-4. [Add group and register IPFS action](/management/api_direct#4-add-group-and-register-ipfs-action)
-5. [Add PKP to group (optional)](/management/api_direct#5-add-pkp-to-group-optional)
-6. [Run lit-action](/management/api_direct#6-run-lit-action)
+2. [Add funds via credit card](/management/pricing#paying-with-a-credit-card-via-stripe) (or [via the billing API](/management/api_direct#billing))
+3. [Add usage API key](/management/api_direct#2-add-usage-api-key)
+4. [Create wallet (PKP)](/management/api_direct#3-create-a-wallet-pkp)
+5. [Add group and register IPFS action](/management/api_direct#4-add-group-and-register-ipfs-action)
+6. [Add PKP to group (optional)](/management/api_direct#5-add-pkp-to-group-optional)
+7. [Run lit-action](/management/api_direct#6-run-lit-action)
 
 For full code examples (JavaScript Core SDK and cURL), see the [API Reference](/management/api_direct).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,7 +8,7 @@ This guide introduces the [**Lit Chipotle API**](https://api.dev.litprotocol.com
 ## Zero to LitAction
 
 1. [Create an account via the Dashboard](/management/dashboard#1-request-a-new-account-or-log-in), note down your API key
-2. [Add funds](/management/pricing#paying-with-a-credit-card-via-stripe) — click **Add Funds** in the Dashboard and pay with a credit card (minimum $5.00). Running Lit Actions and management calls cost credits.
+2. [Add funds](/management/pricing#paying-with-a-credit-card-via-stripe) — click **Add Funds** in the Dashboard and pay with a credit card (minimum $5.00). Running Lit Actions and metered/write management operations consume credits, while read-only management calls (for example listing resources or checking your balance) are free.
 3. Add a usage API key - set its permissions by clicking "All Options"
 4. Run a LitAction
    1. [From the Dashboard](/management/dashboard#7-run-lit-actions)

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -270,7 +270,7 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 - **`POST /update_action_metadata`** — Update the name/description of a registered action. Body: `{"hashed_cid": "0x...", "name": "...", "description": "..."}`.
 - **`POST /remove_pkp_from_group`** — Remove a PKP from a group. Body: `{"group_id": 1, "pkp_id": "..."}`.
 
-**Billing:**
+#### Billing
 
 - **`GET /billing/stripe_config`** — Returns the Stripe publishable key. No auth required.
 - **`GET /billing/balance`** — Returns the current credit balance for the authenticated account.

--- a/docs/management/api_keys.mdx
+++ b/docs/management/api_keys.mdx
@@ -55,7 +55,7 @@ In the **Usage API Keys** section of the [Dashboard](https://dashboard.dev.litpr
 - **Add** — Click **Add**, optionally set a name and description, then confirm. The new key is displayed once — copy it immediately.
 - **Delete** — Select a key and delete it. This takes effect immediately; any service still using the key will receive authentication errors.
 
-For a full walkthrough of the dashboard workflow, see [Using the Dashboard](/management/dashboard#2-request-usage-api-keys).
+For a full walkthrough of the dashboard workflow, see [Using the Dashboard](/management/dashboard#3-request-usage-api-keys).
 
 #### Via the API
 

--- a/docs/management/dashboard.mdx
+++ b/docs/management/dashboard.mdx
@@ -29,7 +29,7 @@ You'll notice a single wallet in your account - it represents your master accoun
 
 ### 2. Add funds
 
-Running Lit Actions and management calls require credits. Click **Add Funds** in the top-right corner of the Dashboard to purchase credits with a credit card via Stripe. Select a credit package (minimum $5.00), enter your card details, and click **Pay**. Credits are applied to your account immediately.
+Running Lit Actions and metered/write management operations (such as creating, updating, or deleting keys, PKPs, groups, or IPFS actions) requires credits. Read-only dashboard and API operations (for example, viewing keys, balances, or usage) are free. Click **Add Funds** in the top-right corner of the Dashboard to purchase credits with a credit card via Stripe. Select a credit package (minimum $5.00), enter your card details, and click **Pay**. Credits are applied to your account immediately.
 
 See [Pricing](/management/pricing) for credit packages and cost details.
 

--- a/docs/management/dashboard.mdx
+++ b/docs/management/dashboard.mdx
@@ -10,11 +10,12 @@ It supports light/dark theme for your convenience and provides simple management
 **Dashboard workflow (recommended order):**
 
 1. [Request a new account (or log in)](#1-request-a-new-account-or-log-in)
-2. [Request usage API keys](#2-request-usage-api-keys)
-3. [Request new PKPs (wallets)](#3-request-new-pkps-wallets)
-4. [Register IPFS CIDs (actions)](#4-register-ipfs-cids-actions)
-5. [Create groups](#5-create-groups)
-6. [Run lit-actions](#6-run-lit-actions)
+2. [Add funds](#2-add-funds)
+3. [Request usage API keys](#3-request-usage-api-keys)
+4. [Request new PKPs (wallets)](#4-request-new-pkps-wallets)
+5. [Register IPFS CIDs (actions)](#5-register-ipfs-cids-actions)
+6. [Create groups](#6-create-groups)
+7. [Run lit-actions](#7-run-lit-actions)
 
 ### 1. Request a new account (or log in)
 
@@ -26,7 +27,13 @@ On the login page you have two tabs:
 After login, the dashboard shows Overview, Usage API Keys, Groups, IPFS Actions, Wallets, and Action Runner.\
 You'll notice a single wallet in your account - it represents your master account API key, and can be used like a standard EVM wallet, or you can safely skip its web3 properties and use the APIs directly.
 
-### 2. Request usage API keys
+### 2. Add funds
+
+Running Lit Actions and management calls require credits. Click **Add Funds** in the top-right corner of the Dashboard to purchase credits with a credit card via Stripe. Select a credit package (minimum $5.00), enter your card details, and click **Pay**. Credits are applied to your account immediately.
+
+See [Pricing](/management/pricing) for credit packages and cost details.
+
+### 3. Request usage API keys
 
 Usage API keys are scoped keys you can give to clients or dApps to run specific lit-actions or to deploy. They can be rotated or removed without changing the main account.
 
@@ -34,17 +41,17 @@ In the **Usage API Keys** section, click **Add**. Set an optional name and descr
 \
 Use this key in the `X-Api-Key` (or `Authorization: Bearer`) header when calling the node so that usage is attributed to this key.
 
-### 3. Request new PKPs (wallets)
+### 4. Request new PKPs (wallets)
 
 PKPs (Programmable Key Pairs) are wallets the lit-nodes can use for signing. In the **Wallets** section, click **Add** to create a new wallet to assign to one of your users, or for use in running a lit-action. The server generates a new PKP and returns its address and public key.
 
-You can add existing PKPs to groups (see step 5) via **Add PKP to group** in the Groups section.
+You can add existing PKPs to groups (see step 6) via **Add PKP to group** in the Groups section.
 
-### 4. Register IPFS CIDs (actions)
+### 5. Register IPFS CIDs (actions)
 
 To scope which usage API keys can run which code, you register **IPFS CIDs** as permitted actions. In the **IPFS Actions** section, pick a group from the dropdown, then **Add** an action: enter the IPFS CID of the lit-action and optional name/description. The server hashes the CID and stores it in the group. Only keys that are allowed to use that group can run that action.
 
-### 5. Create groups
+### 6. Create groups
 
 Groups logically combine PKPs, IPFS actions, and (indirectly) usage API keys. You can use any combination: e.g., a group with only permitted actions, or only permitted wallets, or both.
 
@@ -55,7 +62,7 @@ In the **Groups** section, click **Add** to create a group (name, description, o
 
 Usage API keys (and the account key) are validated against the account's groups and permitted actions/wallets when you run a lit-action.
 
-### 6. Run lit-actions
+### 7. Run lit-actions
 
 In the **Action Runner** section, paste some Lit Action JavaScript code and optional JSON parameters. For example
 ```


### PR DESCRIPTION
## Summary

- **Add funds step to all quick start guides** — README.md, docs/index.mdx, and docs/management/dashboard.mdx now include "Add funds via Stripe credit card" as step 2 in the onboarding workflow, before any billed operations
- **Fix broken cross-references** — updated anchor links in api_keys.mdx and index.mdx to match renumbered dashboard sections
- **Promote Billing to proper heading** — changed bold text to `#### Billing` in api_direct.mdx so `#billing` anchor links resolve correctly

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed — design review skipped.

## Adversarial Review
Codex adversarial (medium tier, 66 lines): 2 findings, both auto-fixed:
- Broken `#billing` anchor (bold text, not heading) → promoted to `#### Billing`
- Stale `#2-request-usage-api-keys` cross-ref in api_keys.mdx → updated to `#3-request-usage-api-keys`

## Test plan
- [x] Docs-only change — no application code modified
- [x] All internal cross-references verified consistent across files
- [x] Adversarial review findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)