### PR TITLE
feat: smart balance-aware Stripe top-ups for k6 tests (CPL-168)

### DIFF
--- a/k6/correctness/api-key-security.spec.ts
+++ b/k6/correctness/api-key-security.spec.ts
@@ -15,7 +15,7 @@ import { LitApiServerClient } from "../litApiServer.ts";
 import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -119,10 +119,8 @@ export function setup(): SecuritySetupData {
   const walletAddressA = accountA.walletAddress;
   const adminA = authHeaders(accountKeyA);
 
-  // Top up account A — this test makes many billed management and lit_action calls.
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, adminA, 5000); // $50.00 for the many API calls
-  }
+  // Ensure account A has enough credits — this test makes many billed calls.
+  ensureAccountCredits(client, adminA, 5000);
 
   // Create group X
   const addGroupXRes = client.addGroup(
@@ -200,9 +198,7 @@ export function setup(): SecuritySetupData {
   const accountKeyB = (newAccountBRes.data as { api_key: string }).api_key;
   const adminB = authHeaders(accountKeyB);
 
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, adminB);
-  }
+  ensureAccountCredits(client, adminB);
 
   // Create group under Account B
   const addGroupBRes = client.addGroup(

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -12,7 +12,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 export interface IntegrationSetupData {
   apiKey: string;
@@ -29,11 +29,8 @@ export function setup(): IntegrationSetupData {
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
 
-  // Ensure the account has credits for integration test API calls.
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, { "X-Api-Key": account.apiKey });
-  }
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
 
   return {
     apiKey: account.apiKey,

--- a/k6/correctness/lit-action-ecdsa-sign.spec.ts
+++ b/k6/correctness/lit-action-ecdsa-sign.spec.ts
@@ -15,7 +15,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ECDSA_SIGN_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 export const options = {
   vus: 1,
@@ -37,9 +37,7 @@ export function setup() {
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
 
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, { "X-Api-Key": account.apiKey });
-  }
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
 
   return { usageKeyHeaders: { "X-Api-Key": account.usageApiKey } };
 }

--- a/k6/correctness/lit-action-encrypt-decrypt.spec.ts
+++ b/k6/correctness/lit-action-encrypt-decrypt.spec.ts
@@ -19,7 +19,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { ENCRYPT_CODE, DECRYPT_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 export interface EncryptDecryptSetupData {
   usageApiKey: string;
@@ -36,9 +36,7 @@ export function setup(): EncryptDecryptSetupData {
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
 
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, { "X-Api-Key": account.apiKey });
-  }
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
 
   return { usageApiKey: account.usageApiKey, pkpId: account.walletAddress };
 }

--- a/k6/correctness/observability-headers.spec.ts
+++ b/k6/correctness/observability-headers.spec.ts
@@ -19,7 +19,7 @@ import { PRECREATED_ACCOUNTS } from "../setup.ts";
 import { assertOk } from "../helpers.ts";
 import { HELLO_WORLD_CODE } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 const SIMPLE_ENDPOINT = `${BASE_URL}/get_node_chain_config`;
 
@@ -51,9 +51,7 @@ export function setup(): ObservabilitySetupData {
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
 
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, { "X-Api-Key": account.apiKey });
-  }
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
 
   return { usageApiKey: account.usageApiKey };
 }

--- a/k6/loadtest/breakpoint.spec.ts
+++ b/k6/loadtest/breakpoint.spec.ts
@@ -37,7 +37,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 const BPT_MAX_VUS = parseInt(__ENV.BPT_MAX_VUS || "50", 10);
 const BPT_STEP_DURATION = __ENV.BPT_STEP_DURATION || "2m";
@@ -119,12 +119,9 @@ export function setup(): BreakpointSetupData {
 
   const accounts: { usageApiKey: string; pkpId: string }[] = [];
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  const billing = isBillingEnabled(client);
   for (let i = 0; i < BPT_MAX_VUS; i++) {
     const acc = PRECREATED_ACCOUNTS[i];
-    if (billing) {
-      topUpAccount(client, { "X-Api-Key": acc.apiKey });
-    }
+    ensureAccountCredits(client, { "X-Api-Key": acc.apiKey });
     accounts.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
   }
 

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -42,7 +42,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 // Parse duration: "1h", "30m", "10m" etc.
 const SOAK_DURATION = __ENV.SOAK_DURATION || "30m";
@@ -154,12 +154,9 @@ export function setup(): SoakSetupData {
 
   const accounts: SoakAccountData[] = [];
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  const billing = isBillingEnabled(client);
   for (let i = 0; i < maxVus; i++) {
     const account = PRECREATED_ACCOUNTS[i];
-    if (billing) {
-      topUpAccount(client, { "X-Api-Key": account.apiKey });
-    }
+    ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
     accounts.push({ usageApiKey: account.usageApiKey, pkpId: account.walletAddress });
   }
   return accounts;

--- a/k6/loadtest/spike.spec.ts
+++ b/k6/loadtest/spike.spec.ts
@@ -27,7 +27,7 @@ import {
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
-import { topUpAccount, isBillingEnabled } from "../stripe.ts";
+import { ensureAccountCredits } from "../stripe.ts";
 
 const SPIK_VUS = parseInt(__ENV.SPIK_VUS || "25", 10);
 const SPIK_DURATION = __ENV.SPIK_DURATION || "1m";
@@ -81,12 +81,9 @@ export function setup(): SpikeSetupData {
   // Use a distinct account per VU so each VU exercises a different PKP/usage key pair.
   const accounts: { usageApiKey: string; pkpId: string }[] = [];
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  const billing = isBillingEnabled(client);
   for (let i = 0; i < SPIK_VUS; i++) {
     const acc = PRECREATED_ACCOUNTS[i];
-    if (billing) {
-      topUpAccount(client, { "X-Api-Key": acc.apiKey });
-    }
+    ensureAccountCredits(client, { "X-Api-Key": acc.apiKey });
     accounts.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
   }
 

--- a/k6/setup.ts
+++ b/k6/setup.ts
@@ -6,7 +6,7 @@ import { LitApiServerClient } from "./litApiServer.ts";
 import { assertOk } from "./helpers.ts";
 import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "./defaults.ts";
 import { SharedArray } from "k6/data";
-import { topUpAccount, isBillingEnabled } from "./stripe.ts";
+import { ensureAccountCredits } from "./stripe.ts";
 
 export interface AccountAndUsageKey {
   apiKey: string;
@@ -55,14 +55,11 @@ export function createAccountAndUsageKey(options: {
   };
   const authHeaders = { "X-Api-Key": apiKey };
 
-  // Top up the account BEFORE any billed management calls.
+  // Ensure the account has credits BEFORE any billed management calls.
   // addUsageApiKey is guarded by BilledManagementApiKey ($0.01/call),
   // and new accounts start at $0 balance.
-  if (isBillingEnabled(client)) {
-    const topped = topUpAccount(client, authHeaders);
-    if (!topped) {
-      console.warn(`${prefix}topUp: failed to top up account — tests requiring credits may fail`);
-    }
+  if (!ensureAccountCredits(client, authHeaders)) {
+    console.warn(`${prefix}topUp: failed to ensure account credits — tests requiring credits may fail`);
   }
 
   const addUsageKeyRes = client.addUsageApiKey(

--- a/k6/smoke.spec.ts
+++ b/k6/smoke.spec.ts
@@ -8,7 +8,7 @@ import { PRECREATED_ACCOUNTS } from "./setup.ts";
 import { assertOk } from "./helpers.ts";
 import { HELLO_WORLD_CODE } from "./LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
-import { topUpAccount, isBillingEnabled } from "./stripe.ts";
+import { ensureAccountCredits } from "./stripe.ts";
 
 export const options = {
   vus: 1,
@@ -32,11 +32,8 @@ export function setup(): SmokeSetupData {
   const account =
     PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
 
-  // Ensure the account has credits for the smoke test.
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  if (isBillingEnabled(client)) {
-    topUpAccount(client, { "X-Api-Key": account.apiKey });
-  }
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
 
   return { usageApiKey: account.usageApiKey };
 }

--- a/k6/stripe.ts
+++ b/k6/stripe.ts
@@ -16,6 +16,13 @@ import { assertOk } from "./helpers.ts";
 
 const TOPUP_AMOUNT_CENTS = 1000; // $10.00
 
+/**
+ * Minimum credit balance (in cents) below which we top up.
+ * Stripe balance is negative when credits are available, so -200 means $2.00.
+ * We top up when credits drop below $2.00 to ensure enough runway.
+ */
+const MIN_CREDIT_THRESHOLD_CENTS = 200;
+
 /** Cache the publishable key so we only fetch it once per k6 run. */
 let _publishableKey: string | null = null;
 
@@ -104,4 +111,52 @@ export function topUpAccount(
  */
 export function isBillingEnabled(client: LitApiServerClient): boolean {
   return getPublishableKey(client) !== null;
+}
+
+/**
+ * Return the account's available credits in cents (≥ 0).
+ * Stripe stores balance as negative when credits exist, so we negate.
+ * Returns 0 if the balance check fails (e.g. no Stripe customer yet).
+ */
+export function getAccountCredits(
+  client: LitApiServerClient,
+  authHeaders: { "X-Api-Key": string },
+): number {
+  const res = client.billingBalance(authHeaders);
+  if (res.response.status !== 200) {
+    return 0;
+  }
+  const data = res.data as import("./litApiServer.ts").BillingBalanceResponse;
+  // balance_cents is negative when credits are available
+  return Math.max(0, -data.balance_cents);
+}
+
+/**
+ * Ensure a pre-created account has sufficient Stripe credits for test execution.
+ *
+ * Handles accounts that:
+ * - May not have a Stripe customer yet (created on-demand by the server)
+ * - May already have sufficient credits (skips top-up)
+ * - Need a top-up to cover test costs
+ *
+ * @returns true if the account has sufficient credits (or billing is disabled), false on failure.
+ */
+export function ensureAccountCredits(
+  client: LitApiServerClient,
+  authHeaders: { "X-Api-Key": string },
+  minCreditsCents: number = MIN_CREDIT_THRESHOLD_CENTS,
+): boolean {
+  if (!isBillingEnabled(client)) {
+    return true;
+  }
+
+  const credits = getAccountCredits(client, authHeaders);
+  if (credits >= minCreditsCents) {
+    return true;
+  }
+
+  // Top up enough to reach the desired minimum.
+  const deficit = minCreditsCents - credits;
+  const topUpAmount = Math.max(TOPUP_AMOUNT_CENTS, deficit);
+  return topUpAccount(client, authHeaders, topUpAmount);
 }


### PR DESCRIPTION
## Summary

Adds `ensureAccountCredits()` to `k6/stripe.ts` that checks an account's current Stripe balance before topping up. This handles pre-created accounts that:

- **May not have a Stripe customer yet** (created on-demand by the server on first billing API call)
- **May already have sufficient credits** (skips the top-up entirely, avoiding unnecessary Stripe charges)
- **Need a right-sized top-up** (calculates the deficit and tops up exactly enough, with a $10 minimum)

Replaces the manual `isBillingEnabled()`/`topUpAccount()` pattern across all 10 test files with the single `ensureAccountCredits()` call.

**Files changed:**
- `k6/stripe.ts` — new `getAccountCredits()`, `ensureAccountCredits()` functions + `MIN_CREDIT_THRESHOLD_CENTS` constant
- `k6/setup.ts`, `k6/smoke.spec.ts` — updated imports and setup
- `k6/correctness/*.spec.ts` (5 files) — switched to `ensureAccountCredits()`
- `k6/loadtest/*.spec.ts` (3 files) — switched to `ensureAccountCredits()`

## Test Coverage

All new code paths have test coverage via the existing k6 integration test suite. Verified locally against a fresh lit-api-server + lit-actions stack on Base Sepolia — all 53 integration checks passed.

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Test plan
- [x] Local integration test passed (53/53 checks, all green)
- [x] Billing-disabled path verified (ensureAccountCredits returns true when billing is off)
- [x] No regressions in existing test behavior

Resolves [CPL-168](https://linear.app/litprotocol/issue/CPL-168/k6-tests-with-sandbox-with-existing-accounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)