### PR TITLE
docs: add chain connectivity and RPC URL security to migration guide (CPL-170)

### DIFF
--- a/docs/lit-actions/migration/changes.mdx
+++ b/docs/lit-actions/migration/changes.mdx
@@ -59,6 +59,31 @@ async function main() {
 
 ---
 
+## Connecting to Chains
+
+In Datil and Naga, blockchain connectivity was managed by node operators. The network maintained a list of supported chains and their RPC endpoints, and developers used `Lit.Actions.getRpcUrl` to retrieve the URL for a given chain. If you needed support for a chain that wasn't already available, you had to contact Lit to have it added.
+
+**In Chipotle, this restriction no longer exists.** Connection information is now provided entirely by the client — you supply your own RPC URLs directly in your Lit Actions. This means **all EVM-compatible chains are available** without any configuration from Lit or node operators.
+
+**Before (Datil / Naga):**
+```js
+// Limited to chains pre-configured by node operators
+const rpcUrl = await Lit.Actions.getRpcUrl({ chain: "ethereum" });
+const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+```
+
+**After (Chipotle):**
+```js
+// Any chain — just supply your own RPC URL
+const provider = new ethers.providers.JsonRpcProvider("https://your-rpc-url");
+```
+
+<Note>
+If your RPC URL contains an API key, you can encrypt the key and have the Lit Action decrypt it at runtime — keeping the secret hidden while still verifiably targeting a specific chain. See [Securing RPC URLs](/lit-actions/patterns#securing-rpc-urls--hiding-api-keys-with-encryption) in the Patterns guide.
+</Note>
+
+You can connect to any chain by passing in the appropriate RPC endpoint — Ethereum, Polygon, Arbitrum, Base, or any other EVM-compatible network. There is no need to contact Lit to "add" chain support.
+
 ---
 
 ## Current Actions

--- a/docs/lit-actions/patterns.mdx
+++ b/docs/lit-actions/patterns.mdx
@@ -206,6 +206,58 @@ async function main({ pkpId, ciphertext, holderAddress, nftContractAddress }) {
 }
 ```
 
+---
+
+## Securing RPC URLs — Hiding API Keys with Encryption
+
+Many RPC providers require an API key appended to the endpoint URL (e.g. `https://mainnet.infura.io/v3/YOUR_API_KEY`). Passing the full URL as a `js_param` would expose the key to anyone who can inspect the action call. Instead, you can **encrypt the secret portion** of the URL and let the Lit Action decrypt and reassemble it at runtime inside the TEE.
+
+This pattern provides two guarantees:
+
+1. **The API key is never visible** to the caller or in the transaction parameters — it only exists in plaintext inside the TEE during execution.
+2. **The action is verifiably calling a specific chain** — the base URL is passed in the clear (or hardcoded), so observers can confirm which network the action targets, while the confidential key portion stays hidden.
+
+### Setup: Encrypt the API key
+
+Use a dedicated "secrets" PKP to encrypt the API key once. Store the resulting ciphertext alongside the action or in your configuration.
+
+```javascript
+// Encrypt the API key portion once and store the ciphertext.
+// js_params: { pkpId, apiKey }
+async function main({ pkpId, apiKey }) {
+  const ciphertext = await Lit.Actions.Encrypt({ pkpId, message: apiKey });
+  return { ciphertext };
+}
+```
+
+### Usage: Decrypt and connect at runtime
+
+The production action receives the base URL and the encrypted API key, decrypts the key inside the TEE, and assembles the full RPC URL.
+
+```javascript
+// js_params: { pkpId, encryptedApiKey, targetAddress }
+async function main({ pkpId, encryptedApiKey, targetAddress }) {
+  // Decrypt the API key inside the TEE — it never leaves the node.
+  const apiKey = await Lit.Actions.Decrypt({ pkpId, ciphertext: encryptedApiKey });
+
+  // Assemble the full RPC URL.
+  const provider = new ethers.providers.JsonRpcProvider(
+    `https://sepolia.infura.io/v3/${apiKey}`
+  );
+
+  // Use the provider as normal.
+  const balance = await provider.getBalance(targetAddress);
+
+  return { balance: ethers.utils.formatEther(balance) };
+}
+```
+
+<Note>
+You should hard-code the base URL directly in the action code rather than passing it as a parameter. Because the action is pinned to IPFS, hardcoding makes the target chain immutable — verifiable by anyone who inspects the action's CID.
+</Note>
+
+---
+
 ### Why this is safe to expose
 
 Sharing a PKP ID (the wallet address) with users is safe because:


### PR DESCRIPTION
## Summary

Addresses [CPL-170](https://linear.app/litprotocol/issue/CPL-170/update-migration-section-of-docs): the migration guide was missing documentation about the chain connectivity model change.

- **Migration guide** (`docs/lit-actions/migration/changes.mdx`): New "Connecting to Chains" section explaining that in Chipotle, clients supply their own RPC URLs, making all EVM-compatible chains available without contacting Lit. Includes before/after code examples and a note linking to the security pattern.
- **Patterns guide** (`docs/lit-actions/patterns.mdx`): New "Securing RPC URLs" section showing how to encrypt API keys with PKP encryption so they're decrypted inside the TEE at runtime, keeping secrets hidden while verifiably targeting a specific chain.

## Pre-Landing Review

No issues found. Docs-only change, no application code.

## Test plan
- [x] Docs-only change — no application code modified
- [x] Pre-landing review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)