### PR TITLE
fix: resolve usage API keys to parent account for Stripe billing (CPL-171)

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
@@ -108,6 +108,17 @@ contract ViewsFacet {
         return AppStorage.accountExistsAndIsMutable(apiKeyHash, msg.sender);
     }
 
+    /// @notice Return the creator wallet address for the account that owns the given API key.
+    /// @dev Works with both master and usage API key hashes (resolves via allApiKeyHashesToMaster).
+    /// @param apiKeyHash keccak256 of a master or usage API key (base64-encoded).
+    /// @return The creator wallet address stored on the resolved master account.
+    function getAccountWalletAddress(
+        uint256 apiKeyHash
+    ) public view returns (address) {
+        AppStorage.Account storage account = getReadOnlyAccount(apiKeyHash);
+        return account.creatorWalletAddress;
+    }
+
     function getWalletDerivation(
         uint256 apiKeyHash,
         address walletAddress

--- a/lit-api-server/src/accounts/contracts/AccountConfig.json
+++ b/lit-api-server/src/accounts/contracts/AccountConfig.json
@@ -903,6 +903,25 @@
           "internalType": "uint256",
           "name": "apiKeyHash",
           "type": "uint256"
+        }
+      ],
+      "name": "getAccountWalletAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "apiKeyHash",
+          "type": "uint256"
         },
         {
           "internalType": "address",

--- a/lit-api-server/src/accounts/contracts/account_config_contract.rs
+++ b/lit-api-server/src/accounts/contracts/account_config_contract.rs
@@ -564,6 +564,28 @@ pub mod account_config {
                     },],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("getAccountWalletAddress"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("getAccountWalletAddress",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("apiKeyHash"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("getPricing"),
                     ::std::vec![::ethers::core::abi::ethabi::Function {
                         name: ::std::borrow::ToOwned::to_owned("getPricing"),
@@ -2377,6 +2399,15 @@ pub mod account_config {
                 .method_hash([64, 180, 212, 83], (api_key_hash, amount))
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `getAccountWalletAddress` (0x50ed5bb8) function
+        pub fn get_account_wallet_address(
+            &self,
+            api_key_hash: ::ethers::core::types::U256,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+            self.0
+                .method_hash([80, 237, 91, 184], api_key_hash)
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `getPricing` (0xc12f1a42) function
         pub fn get_pricing(
             &self,
@@ -3725,6 +3756,26 @@ pub mod account_config {
         pub api_key_hash: ::ethers::core::types::U256,
         pub amount: ::ethers::core::types::U256,
     }
+    ///Container type for all input parameters for the `getAccountWalletAddress` function with signature `getAccountWalletAddress(uint256)` and selector `0x50ed5bb8`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(
+        name = "getAccountWalletAddress",
+        abi = "getAccountWalletAddress(uint256)"
+    )]
+    pub struct GetAccountWalletAddressCall {
+        pub api_key_hash: ::ethers::core::types::U256,
+    }
     ///Container type for all input parameters for the `getPricing` function with signature `getPricing(uint256)` and selector `0xc12f1a42`
     #[derive(
         Clone,
@@ -4520,6 +4571,7 @@ pub mod account_config {
         CanUseWalletInActionFast(CanUseWalletInActionFastCall),
         CreditApiKey(CreditApiKeyCall),
         DebitApiKey(DebitApiKeyCall),
+        GetAccountWalletAddress(GetAccountWalletAddressCall),
         GetPricing(GetPricingCall),
         GetWalletDerivation(GetWalletDerivationCall),
         GroupIdsForAction(GroupIdsForActionCall),
@@ -4640,6 +4692,11 @@ pub mod account_config {
             }
             if let Ok(decoded) = <DebitApiKeyCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::DebitApiKey(decoded));
+            }
+            if let Ok(decoded) =
+                <GetAccountWalletAddressCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::GetAccountWalletAddress(decoded));
             }
             if let Ok(decoded) = <GetPricingCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::GetPricing(decoded));
@@ -4850,6 +4907,9 @@ pub mod account_config {
                 }
                 Self::CreditApiKey(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::DebitApiKey(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::GetAccountWalletAddress(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::GetPricing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetWalletDerivation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
@@ -4955,6 +5015,7 @@ pub mod account_config {
                 Self::CanUseWalletInActionFast(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CreditApiKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DebitApiKey(element) => ::core::fmt::Display::fmt(element, f),
+                Self::GetAccountWalletAddress(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetPricing(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetWalletDerivation(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GroupIdsForAction(element) => ::core::fmt::Display::fmt(element, f),
@@ -5085,6 +5146,11 @@ pub mod account_config {
     impl ::core::convert::From<DebitApiKeyCall> for AccountConfigCalls {
         fn from(value: DebitApiKeyCall) -> Self {
             Self::DebitApiKey(value)
+        }
+    }
+    impl ::core::convert::From<GetAccountWalletAddressCall> for AccountConfigCalls {
+        fn from(value: GetAccountWalletAddressCall) -> Self {
+            Self::GetAccountWalletAddress(value)
         }
     }
     impl ::core::convert::From<GetPricingCall> for AccountConfigCalls {
@@ -5467,6 +5533,20 @@ pub mod account_config {
         Hash,
     )]
     pub struct CanUseWalletInActionFastReturn(pub bool);
+    ///Container type for all return fields from the `getAccountWalletAddress` function with signature `getAccountWalletAddress(uint256)` and selector `0x50ed5bb8`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct GetAccountWalletAddressReturn(pub ::ethers::core::types::Address);
     ///Container type for all return fields from the `getPricing` function with signature `getPricing(uint256)` and selector `0xc12f1a42`
     #[derive(
         Clone,

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -613,6 +613,26 @@ pub async fn can_execute_action_and_use_wallet(
     Ok(result)
 }
 
+/// Resolve any API key (master or usage) to the creator wallet address of its parent account.
+///
+/// This is the authoritative wallet address for billing: both master and usage keys resolve
+/// to the same account wallet, ensuring charges hit the correct Stripe customer.
+#[instrument(
+    name = "accounts::get_account_wallet_address",
+    level = "debug",
+    skip_all,
+    err
+)]
+pub async fn get_account_wallet_address(api_key: &str) -> Result<String> {
+    let contract = get_read_only_account_config_contract().await?;
+    let key_hash = api_key_hash(api_key);
+    let wallet_address = contract.get_account_wallet_address(key_hash).call().await?;
+    if wallet_address == H160::zero() {
+        anyhow::bail!("account has no wallet address");
+    }
+    Ok(format!("{:?}", wallet_address))
+}
+
 pub async fn get_node_configuration_values() -> Result<Vec<KeyValueReturn>> {
     let contract = get_read_only_account_config_contract().await?;
     let values = contract.node_configuration_values().call().await?;

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -347,10 +347,10 @@ pub(super) async fn remove_usage_api_key(
 
     // Evict the deleted usage key from the billing wallet cache so stale
     // mappings are never served after the key is removed on-chain.
-    if result.is_ok() {
-        if let Some(stripe) = stripe_state.as_ref() {
-            crate::stripe::invalidate_wallet_cache(&usage_key, stripe).await;
-        }
+    if result.is_ok()
+        && let Some(stripe) = stripe_state.as_ref()
+    {
+        crate::stripe::invalidate_wallet_cache(&usage_key, stripe).await;
     }
 
     OpenApiResponse {

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -334,18 +334,27 @@ pub(super) async fn add_usage_api_key(
 pub(super) async fn remove_usage_api_key(
     signer_pool: &State<Arc<SignerPool>>,
     api_key: BilledManagementApiKey,
+    stripe_state: &State<Option<Arc<StripeState>>>,
     req: Json<RemoveUsageApiKeyRequest>,
 ) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
+    let usage_key = req.usage_api_key.clone();
+    let result = account_management::remove_usage_api_key(
+        signer_pool.inner().clone(),
+        api_key.0.as_str(),
+        req,
+    )
+    .await;
+
+    // Evict the deleted usage key from the billing wallet cache so stale
+    // mappings are never served after the key is removed on-chain.
+    if result.is_ok() {
+        if let Some(stripe) = stripe_state.as_ref() {
+            crate::stripe::invalidate_wallet_cache(&usage_key, stripe).await;
+        }
+    }
+
     OpenApiResponse {
-        response: ApiResult(
-            account_management::remove_usage_api_key(
-                signer_pool.inner().clone(),
-                api_key.0.as_str(),
-                req,
-            )
-            .await,
-        )
-        .into(),
+        response: ApiResult(result).into(),
     }
 }
 

--- a/lit-api-server/src/core/v1/endpoints/billing.rs
+++ b/lit-api-server/src/core/v1/endpoints/billing.rs
@@ -32,7 +32,12 @@ fn wallet_resolution_err(e: anyhow::Error) -> ApiStatus {
             "Invalid API key",
         )
     } else {
-        ApiStatus::internal_server_error(e, "Billing lookup failed")
+        // Log the underlying error for internal diagnostics without exposing details to clients.
+        eprintln!("wallet_resolution_err internal failure: {e:?}");
+        ApiStatus::internal_server_error(
+            anyhow::anyhow!("internal billing lookup error"),
+            "Billing lookup failed",
+        )
     }
 }
 

--- a/lit-api-server/src/core/v1/endpoints/billing.rs
+++ b/lit-api-server/src/core/v1/endpoints/billing.rs
@@ -20,6 +20,22 @@ pub(super) fn billing_disabled_err() -> ApiStatus {
     )
 }
 
+/// Map wallet resolution errors to the correct HTTP status.
+///
+/// "account has no wallet address" and contract reverts for missing accounts → 400.
+/// Everything else (RPC failures, timeouts) → 500.
+fn wallet_resolution_err(e: anyhow::Error) -> ApiStatus {
+    let msg = e.to_string();
+    if msg.contains("account has no wallet address") || msg.contains("AccountDoesNotExist") {
+        ApiStatus::bad_request(
+            anyhow::anyhow!("account not found for API key"),
+            "Invalid API key",
+        )
+    } else {
+        ApiStatus::internal_server_error(e, "Billing lookup failed")
+    }
+}
+
 /// GET /billing/stripe_config — returns the Stripe publishable key.
 /// No auth required; the publishable key is safe to expose.
 #[openapi(tag = "Billing")]
@@ -56,8 +72,9 @@ async fn billing_balance_impl(
     stripe_state: &Option<Arc<StripeState>>,
 ) -> Result<BillingBalanceResponse, ApiStatus> {
     let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
-    let wallet = stripe::api_key_to_wallet_address(api_key)
-        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    let wallet = stripe::resolve_wallet_address(api_key, stripe)
+        .await
+        .map_err(wallet_resolution_err)?;
     let customer_id = stripe::get_customer_by_wallet(&wallet, stripe)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;
@@ -98,8 +115,9 @@ async fn billing_create_payment_intent_impl(
     req: Json<CreatePaymentIntentRequest>,
 ) -> Result<CreatePaymentIntentResponse, ApiStatus> {
     let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
-    let wallet = stripe::api_key_to_wallet_address(api_key)
-        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    let wallet = stripe::resolve_wallet_address(api_key, stripe)
+        .await
+        .map_err(wallet_resolution_err)?;
     let (client_secret, payment_intent_id) =
         stripe::create_payment_intent(&wallet, req.amount_cents, stripe)
             .await
@@ -130,8 +148,9 @@ async fn billing_confirm_payment_impl(
     req: Json<ConfirmPaymentRequest>,
 ) -> Result<AccountOpResponse, ApiStatus> {
     let stripe = stripe_state.as_ref().ok_or_else(billing_disabled_err)?;
-    let wallet = stripe::api_key_to_wallet_address(api_key)
-        .map_err(|e| ApiStatus::bad_request(e, "Invalid API key"))?;
+    let wallet = stripe::resolve_wallet_address(api_key, stripe)
+        .await
+        .map_err(wallet_resolution_err)?;
     stripe::confirm_payment_and_credit(&req.payment_intent_id, &wallet, stripe)
         .await
         .map_err(|e| ApiStatus::internal_server_error(e, "Stripe error"))?;

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -140,11 +140,20 @@ async fn stripe_post(
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/// Compute a non-sensitive cache key from a raw API key string.
+///
+/// Uses the same keccak256 hash that the contract uses, so no secret material
+/// is held in the cache's key set.  Avoids leaking raw API keys via memory
+/// dumps, debug tooling, or telemetry.
+fn cache_key(api_key: &str) -> String {
+    crate::utils::parse_with_hash::api_key_hash(api_key).to_string()
+}
+
 /// Remove an API key from the wallet address cache.
 ///
 /// Call this when a usage API key is deleted so that stale mappings are not served.
 pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
-    state.wallet_cache.invalidate(api_key).await;
+    state.wallet_cache.invalidate(&cache_key(api_key)).await;
 }
 
 /// Resolve any API key (master or usage) to the account's creator wallet address.
@@ -152,8 +161,11 @@ pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
 /// Uses the on-chain `allApiKeyHashesToMaster` mapping so that usage API keys
 /// resolve to the same wallet (and therefore same Stripe customer) as their
 /// parent account key.  Results are cached for 1 hour.
+///
+/// The cache is keyed by the keccak256 hash of the API key (not the raw key)
+/// to avoid holding secret material in memory.
 pub async fn resolve_wallet_address(api_key: &str, state: &StripeState) -> Result<String> {
-    let key = api_key.to_string();
+    let key = cache_key(api_key);
     state
         .wallet_cache
         .try_get_with(key, async {

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use ethers::signers::{LocalWallet, Signer};
 use moka::future::Cache;
 use reqwest::StatusCode;
 
@@ -32,6 +31,10 @@ pub struct StripeState {
     /// wallet_address → Stripe customer ID cache.
     /// Avoids duplicate customer creation caused by Stripe Search API indexing lag.
     customer_cache: Cache<String, String>,
+    /// api_key → wallet_address cache.
+    /// Resolves both master and usage API keys to the account's creator wallet address
+    /// via the on-chain `allApiKeyHashesToMaster` mapping, avoiding a contract call per charge.
+    wallet_cache: Cache<String, String>,
 }
 
 /// Initialise Stripe from environment variables.  Returns `None` if the env vars are absent
@@ -51,12 +54,17 @@ pub fn init() -> Option<Arc<StripeState>> {
         .max_capacity(10_000)
         .time_to_idle(Duration::from_secs(3600))
         .build();
+    let wallet_cache = Cache::builder()
+        .max_capacity(10_000)
+        .time_to_idle(Duration::from_secs(3600))
+        .build();
     tracing::info!("stripe: billing enabled");
     Some(Arc::new(StripeState {
         publishable_key,
         secret_key,
         client,
         customer_cache,
+        wallet_cache,
     }))
 }
 
@@ -132,14 +140,27 @@ async fn stripe_post(
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-/// Derive the hex wallet address from a base64-encoded API key.
-pub fn api_key_to_wallet_address(api_key: &str) -> Result<String> {
-    let bytes = base64_light::base64_decode(api_key);
-    if bytes.len() < 32 {
-        anyhow::bail!("API key too short to derive wallet address");
-    }
-    let wallet = LocalWallet::from_bytes(&bytes[..32])?;
-    Ok(format!("{:?}", wallet.address()))
+/// Remove an API key from the wallet address cache.
+///
+/// Call this when a usage API key is deleted so that stale mappings are not served.
+pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
+    state.wallet_cache.invalidate(api_key).await;
+}
+
+/// Resolve any API key (master or usage) to the account's creator wallet address.
+///
+/// Uses the on-chain `allApiKeyHashesToMaster` mapping so that usage API keys
+/// resolve to the same wallet (and therefore same Stripe customer) as their
+/// parent account key.  Results are cached for 1 hour.
+pub async fn resolve_wallet_address(api_key: &str, state: &StripeState) -> Result<String> {
+    let key = api_key.to_string();
+    state
+        .wallet_cache
+        .try_get_with(key, async {
+            crate::accounts::get_account_wallet_address(api_key).await
+        })
+        .await
+        .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{e}"))
 }
 
 /// Find the Stripe customer for this wallet address, creating one if none exists.
@@ -205,7 +226,7 @@ pub async fn get_credit_balance(customer_id: &str, state: &StripeState) -> Resul
 /// Charge `cost_cents` against the customer's credit balance.
 /// Returns `Err` if the balance would go positive (insufficient credits).
 async fn charge(api_key: &str, cost_cents: i64, state: &StripeState) -> Result<()> {
-    let wallet = api_key_to_wallet_address(api_key)?;
+    let wallet = resolve_wallet_address(api_key, state).await?;
     let customer_id = get_customer_by_wallet(&wallet, state).await?;
     let balance = get_credit_balance(&customer_id, state).await?;
 


### PR DESCRIPTION
## Summary

Fixes HTTP 402 "Payment Required" errors on smoke tests and all billed endpoints when using usage API keys.

**Root cause:** Usage API keys derived to a different wallet address than their parent account key. Credits topped up on the account key went to Stripe Customer A, but charges via the usage key hit Stripe Customer B (with $0 balance).

**Fix:** Replace local key-to-wallet derivation with on-chain resolution via `allApiKeyHashesToMaster`. Both master and usage keys now resolve to the same Stripe customer.

### Changes

**Smart contract (ViewsFacet.sol):**
- Add `getAccountWalletAddress(uint256 apiKeyHash)` public view function
- Resolves any key hash (master or usage) to the account's `creatorWalletAddress`

**Server (stripe.rs, billing.rs, account_management.rs):**
- Replace `api_key_to_wallet_address()` with `resolve_wallet_address()` backed by contract call
- Add `wallet_cache` (moka, 1h TTL) to avoid contract call per charge
- Fix error classification: RPC failures return 500, not 400
- Sanitize contract revert reasons from API responses
- Evict deleted usage keys from `wallet_cache` on `remove_usage_api_key`
- Add zero-address guard to prevent billing cross-contamination

## Pre-Landing Review

Pre-Landing Review: 2 informational issues found, both fixed.
- [AUTO-FIXED] `billing.rs:22-33` — Error classification + info disclosure for contract failures
- [AUTO-FIXED] `accounts/mod.rs:630` — Zero-address defensive guard on wallet resolution

## Test Coverage

Rust unit tests: 33 passed, 3 pre-existing failures (Linux-specific CPU overload tests + health socket test, unrelated to this branch).

K6 smoke tests exercise the full billing flow end-to-end but require a running server.

## Deployment Note

This change requires a **diamond cut** to deploy the new `getAccountWalletAddress` facet function to the on-chain contract before the server fix takes effect.

## Test plan
- [ ] Deploy updated ViewsFacet via diamond cut
- [ ] Verify smoke tests pass without 402 errors
- [ ] Verify billing balance/top-up works with both master and usage API keys
- [ ] Verify `remove_usage_api_key` evicts from wallet cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)