### PR TITLE
fix: compute compose hash client-side (provision hash ≠ deploy hash)

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -238,19 +238,16 @@ jobs:
           echo "kms_slug=$KMS_SLUG" >> "$GITHUB_OUTPUT"
           echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
 
-          # Extract the AppAuth (dstack_app) address from the CVM's KMS info.
+          # The CVM's DstackApp contract address IS the app_id (with 0x prefix).
           # This is the per-app contract that controls compose-hash whitelisting.
-          CVM_INFO=$(phala api /cvms/chipotle-prod --json 2>&1) || true
-          echo "CVM info (kms): $(echo "$CVM_INFO" | jq '.kms_info // .detail' 2>/dev/null)"
-          APP_AUTH=$(echo "$CVM_INFO" | jq -r '.kms_info.dstack_app_address // empty')
-          if [ -z "$APP_AUTH" ]; then
-            echo "::warning::Could not extract dstack_app_address from CVM info, falling back to APP_AUTH_ADDRESS_CHIPOTLE_PROD variable"
-            APP_AUTH="${{ vars.APP_AUTH_ADDRESS_CHIPOTLE_PROD }}"
-          fi
-          if [ -z "$APP_AUTH" ]; then
-            echo "::error::No AppAuth address available (neither from CVM info nor APP_AUTH_ADDRESS_CHIPOTLE_PROD variable)"
+          # NOTE: Do NOT use kms_info.dstack_app_address — that is the KMS's own
+          # DstackApp contract, not the CVM's. Using it would whitelist the hash
+          # on the wrong contract and cause "Compose hash not allowed" at boot.
+          if [ -z "$APP_ID" ]; then
+            echo "::error::app_id not available from provision response"
             exit 1
           fi
+          APP_AUTH="0x${APP_ID}"
           echo "app_auth_address=$APP_AUTH" >> "$GITHUB_OUTPUT"
 
       - name: Fetch CVM encryption public key
@@ -389,10 +386,11 @@ jobs:
             --arg base_url "https://api.chipotle.litprotocol.com" \
             --arg api_root_url "https://api.chipotle.litprotocol.com/core/v1" \
             --arg safe_address "${{ vars.SAFE_ADDRESS_CHIPOTLE_PROD }}" \
+            --arg app_auth_address "${{ needs.prepare-deploy.outputs.app_auth_address }}" \
             --arg version_tag "${{ github.ref_name }}" \
             --arg source_sha "${{ github.sha }}" \
             --arg encrypted_env "${{ needs.prepare-deploy.outputs.encrypted_env }}" \
-            '{compose_hash: $compose_hash, safe_tx_hash: $safe_tx_hash, phala_app_name: $phala_app_name, base_url: $base_url, api_root_url: $api_root_url, safe_address: $safe_address, version_tag: $version_tag, source_sha: $source_sha, encrypted_env: $encrypted_env}' \
+            '{compose_hash: $compose_hash, safe_tx_hash: $safe_tx_hash, phala_app_name: $phala_app_name, base_url: $base_url, api_root_url: $api_root_url, safe_address: $safe_address, app_auth_address: $app_auth_address, version_tag: $version_tag, source_sha: $source_sha, encrypted_env: $encrypted_env}' \
             > deploy-context.json
           echo "Deployment context:"
           cat deploy-context.json

--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -141,6 +141,7 @@ jobs:
     runs-on: self-hosted
     outputs:
       compose_hash: ${{ steps.prepare.outputs.compose_hash }}
+      provision_hash: ${{ steps.prepare.outputs.provision_hash }}
       app_auth_address: ${{ steps.prepare.outputs.app_auth_address }}
       encrypted_env: ${{ steps.encrypt-env.outputs.encrypted_env }}
     steps:
@@ -219,12 +220,12 @@ jobs:
             exit 1
           }
           echo "API response: $OUTPUT"
-          COMPOSE_HASH=$(echo "$OUTPUT" | jq -r '.compose_hash')
-          if [ -z "$COMPOSE_HASH" ] || [ "$COMPOSE_HASH" = "null" ]; then
+          PROVISION_HASH=$(echo "$OUTPUT" | jq -r '.compose_hash')
+          if [ -z "$PROVISION_HASH" ] || [ "$PROVISION_HASH" = "null" ]; then
             echo "::error::Failed to extract compose_hash from provision response"
             exit 1
           fi
-          echo "compose_hash=$COMPOSE_HASH" >> "$GITHUB_OUTPUT"
+          echo "provision_hash=$PROVISION_HASH" >> "$GITHUB_OUTPUT"
 
           # Extract the KMS slug from the provision response. The provision
           # endpoint returns a richer kms_info (with slug/id) than the CVM
@@ -238,17 +239,64 @@ jobs:
           echo "kms_slug=$KMS_SLUG" >> "$GITHUB_OUTPUT"
           echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
 
-          # The CVM's DstackApp contract address IS the app_id (with 0x prefix).
+          # Extract the AppAuth (dstack_app) address from the CVM's KMS info.
           # This is the per-app contract that controls compose-hash whitelisting.
-          # NOTE: Do NOT use kms_info.dstack_app_address — that is the KMS's own
-          # DstackApp contract, not the CVM's. Using it would whitelist the hash
-          # on the wrong contract and cause "Compose hash not allowed" at boot.
-          if [ -z "$APP_ID" ]; then
-            echo "::error::app_id not available from provision response"
+          CVM_INFO=$(phala api /cvms/chipotle-prod --json 2>&1) || true
+          echo "CVM info (kms): $(echo "$CVM_INFO" | jq '.kms_info // .detail' 2>/dev/null)"
+          APP_AUTH=$(echo "$CVM_INFO" | jq -r '.kms_info.dstack_app_address // empty')
+          if [ -z "$APP_AUTH" ]; then
+            echo "::warning::Could not extract dstack_app_address from CVM info, falling back to APP_AUTH_ADDRESS_CHIPOTLE_PROD variable"
+            APP_AUTH="${{ vars.APP_AUTH_ADDRESS_CHIPOTLE_PROD }}"
+          fi
+          if [ -z "$APP_AUTH" ]; then
+            echo "::error::No AppAuth address available (neither from CVM info nor APP_AUTH_ADDRESS_CHIPOTLE_PROD variable)"
             exit 1
           fi
-          APP_AUTH="0x${APP_ID}"
           echo "app_auth_address=$APP_AUTH" >> "$GITHUB_OUTPUT"
+
+          # The provision API's compose_hash is a reference key for the
+          # PATCH/commit call — it does not match the hash the CVM computes
+          # at boot (SHA-256 of the full app-compose.json including server-
+          # managed fields like pre_launch_script, features, etc.).
+          # We fetch the full compose and compute the deploy hash client-side
+          # using the @phala/cloud SDK so the Safe proposal uses the correct
+          # value that the KMS will check via allowedComposeHashes.
+          echo "Fetching full app_compose from Phala API..."
+          FULL_COMPOSE=$(phala api /cvms/chipotle-prod/compose_file --json 2>&1) || {
+            echo "::error::Failed to fetch compose file: $FULL_COMPOSE"
+            exit 1
+          }
+
+          # Sanity check: the fetched compose's docker_compose_file should
+          # match what we just provisioned (if provision updated the server).
+          FETCHED_DC=$(echo "$FULL_COMPOSE" | jq -r '.docker_compose_file')
+          if [ "$FETCHED_DC" != "$COMPOSE_CONTENT" ]; then
+            echo "::warning::Fetched docker_compose_file does not match provisioned content. The provision may not have updated the compose file yet."
+            echo "Constructing full app_compose by merging server defaults with our compose..."
+            FULL_COMPOSE=$(echo "$FULL_COMPOSE" | jq --arg dc "$COMPOSE_CONTENT" '.docker_compose_file = $dc')
+          fi
+
+          # Compute the correct compose hash using the @phala/cloud SDK.
+          COMPOSE_HASH=$(echo "$FULL_COMPOSE" | node -e '
+            const path = require("path");
+            const prefix = require("child_process").execSync("npm prefix -g").toString().trim();
+            const { getComposeHash } = require(
+              require.resolve("@phala/cloud", { paths: [path.join(prefix, "lib/node_modules/phala")] })
+            );
+            let data = "";
+            process.stdin.on("data", chunk => data += chunk);
+            process.stdin.on("end", () => {
+              const appCompose = JSON.parse(data);
+              process.stdout.write(getComposeHash(appCompose));
+            });
+          ')
+          if [ -z "$COMPOSE_HASH" ]; then
+            echo "::error::Failed to compute compose hash client-side"
+            exit 1
+          fi
+          echo "Provision hash (API reference): $PROVISION_HASH"
+          echo "Compose hash (deploy/on-chain): $COMPOSE_HASH"
+          echo "compose_hash=$COMPOSE_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Fetch CVM encryption public key
         id: fetch-pubkey
@@ -390,7 +438,8 @@ jobs:
             --arg version_tag "${{ github.ref_name }}" \
             --arg source_sha "${{ github.sha }}" \
             --arg encrypted_env "${{ needs.prepare-deploy.outputs.encrypted_env }}" \
-            '{compose_hash: $compose_hash, safe_tx_hash: $safe_tx_hash, phala_app_name: $phala_app_name, base_url: $base_url, api_root_url: $api_root_url, safe_address: $safe_address, app_auth_address: $app_auth_address, version_tag: $version_tag, source_sha: $source_sha, encrypted_env: $encrypted_env}' \
+            --arg provision_hash "${{ needs.prepare-deploy.outputs.provision_hash }}" \
+            '{compose_hash: $compose_hash, provision_hash: $provision_hash, safe_tx_hash: $safe_tx_hash, phala_app_name: $phala_app_name, base_url: $base_url, api_root_url: $api_root_url, safe_address: $safe_address, app_auth_address: $app_auth_address, version_tag: $version_tag, source_sha: $source_sha, encrypted_env: $encrypted_env}' \
             > deploy-context.json
           echo "Deployment context:"
           cat deploy-context.json

--- a/.github/workflows/deploy-prod-2-execute.yml
+++ b/.github/workflows/deploy-prod-2-execute.yml
@@ -42,6 +42,7 @@ jobs:
       version_tag: ${{ steps.read.outputs.version_tag }}
       source_sha: ${{ steps.read.outputs.source_sha }}
       encrypted_env: ${{ steps.read.outputs.encrypted_env }}
+      app_auth_address: ${{ steps.read.outputs.app_auth_address }}
     steps:
       - name: Download deployment context from Phase 1 release
         env:
@@ -55,7 +56,7 @@ jobs:
         id: read
         run: |
           cat deploy-context.json
-          for key in compose_hash safe_tx_hash phala_app_name base_url api_root_url safe_address version_tag source_sha encrypted_env; do
+          for key in compose_hash safe_tx_hash phala_app_name base_url api_root_url safe_address app_auth_address version_tag source_sha encrypted_env; do
             val=$(jq -r ".$key" deploy-context.json)
             echo "$key=$val" >> "$GITHUB_OUTPUT"
           done
@@ -104,8 +105,34 @@ jobs:
           fi
           echo "tx_hash=$TX_HASH" >> "$GITHUB_OUTPUT"
 
-  commit-deploy:
+  verify-compose-hash-onchain:
     needs: [download-context, execute-safe-tx]
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install contract dependencies
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npx hardhat compile
+
+      - name: Verify compose hash is whitelisted on-chain
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: |
+          npx hardhat verify-compose-hash \
+            --network base \
+            --app-auth "${{ needs.download-context.outputs.app_auth_address }}" \
+            --compose-hash "${{ needs.download-context.outputs.compose_hash }}"
+
+  commit-deploy:
+    needs: [download-context, verify-compose-hash-onchain]
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-prod-2-execute.yml
+++ b/.github/workflows/deploy-prod-2-execute.yml
@@ -43,6 +43,7 @@ jobs:
       source_sha: ${{ steps.read.outputs.source_sha }}
       encrypted_env: ${{ steps.read.outputs.encrypted_env }}
       app_auth_address: ${{ steps.read.outputs.app_auth_address }}
+      provision_hash: ${{ steps.read.outputs.provision_hash }}
     steps:
       - name: Download deployment context from Phase 1 release
         env:
@@ -56,7 +57,7 @@ jobs:
         id: read
         run: |
           cat deploy-context.json
-          for key in compose_hash safe_tx_hash phala_app_name base_url api_root_url safe_address app_auth_address version_tag source_sha encrypted_env; do
+          for key in compose_hash provision_hash safe_tx_hash phala_app_name base_url api_root_url safe_address app_auth_address version_tag source_sha encrypted_env; do
             val=$(jq -r ".$key" deploy-context.json)
             echo "$key=$val" >> "$GITHUB_OUTPUT"
           done
@@ -148,24 +149,26 @@ jobs:
       - name: Commit deployment to Phala (phase 2)
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
-          COMPOSE_HASH: ${{ needs.download-context.outputs.compose_hash }}
+          PROVISION_HASH: ${{ needs.download-context.outputs.provision_hash }}
           ENCRYPTED_ENV: ${{ needs.download-context.outputs.encrypted_env }}
           PHALA_APP_NAME: ${{ needs.download-context.outputs.phala_app_name }}
         run: |
-          # Commit the provisioned compose file update using the compose hash
-          # from Phase 1. The Safe multisig has already approved and executed
-          # the addComposeHash transaction on-chain.
+          # Commit the provisioned compose file update using the PROVISION hash
+          # (not the client-side compose_hash). The provision_hash is the value
+          # returned by the Phala provision API and serves as a reference key
+          # for the PATCH call. The client-side compose_hash (which matches
+          # what the CVM will compute) was used for the Safe proposal.
           #
           # The encrypted_env (hex blob, sealed to the CVM's X25519 key) and
-          # env_keys are sent alongside compose_hash so that the CVM's
-          # encrypted environment is updated atomically with the compose file.
+          # env_keys are sent alongside the hash so that the CVM's encrypted
+          # environment is updated atomically with the compose file.
           COMMIT_PAYLOAD=$(mktemp)
           trap 'rm -f "$COMMIT_PAYLOAD"' EXIT
 
           ENV_KEYS='["STRIPE_SECRET_KEY","STRIPE_PUBLISHABLE_KEY","GCP_SERVICE_ACCOUNT_JSON","GCP_PROJECT_ID","BASE_CHAIN_RPC","CERTBOT_DOMAIN","CERTBOT_AWS_ACCESS_KEY_ID","CERTBOT_AWS_SECRET_ACCESS_KEY","CERTBOT_AWS_ROLE_ARN","CERTBOT_AWS_REGION"]'
 
           jq -n \
-            --arg hash "$COMPOSE_HASH" \
+            --arg hash "$PROVISION_HASH" \
             --arg env "$ENCRYPTED_ENV" \
             --argjson keys "$ENV_KEYS" \
             '{

--- a/lit-api-server/blockchain/lit_node_express/hardhat.config.ts
+++ b/lit-api-server/blockchain/lit_node_express/hardhat.config.ts
@@ -7,6 +7,7 @@ import "./tasks/propose-diamond-cut";
 import "./tasks/execute-safe-tx";
 import "./tasks/propose-dstack-app";
 import "./tasks/transfer-ownership";
+import "./tasks/verify-compose-hash";
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/lit-api-server/blockchain/lit_node_express/tasks/execute-safe-tx.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/execute-safe-tx.ts
@@ -28,6 +28,14 @@ task("execute-safe-tx", "Verify a Safe transaction has been executed and return 
       process.exit(1);
     }
 
+    if (safeTransaction.isSuccessful === false) {
+      console.error(
+        `\nSafe transaction was executed but REVERTED on-chain (tx: ${safeTransaction.transactionHash}). ` +
+        `The addComposeHash call did not succeed. Check the transaction on Basescan.`
+      );
+      process.exit(1);
+    }
+
     console.log(`\nTransaction already executed on-chain.`);
     console.log(`Transaction hash: ${safeTransaction.transactionHash}`);
     // Machine-readable output for CI pipelines

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-dstack-app.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-dstack-app.ts
@@ -5,10 +5,8 @@ import { ethers } from "ethers";
 
 // AppAuth contract ABI for compose-hash whitelisting (from @phala/cloud SDK).
 // Each Phala CVM with on-chain KMS has its own AppAuth (DstackApp) contract.
-// The correct address is the CVM's app_id (with 0x prefix), available from the
-// provision response or `GET /info` → app_id.
-// NOTE: Do NOT use kms_info.dstack_app_address — that is the KMS's own DstackApp,
-// not the CVM's. Whitelisting on the wrong contract causes "Compose hash not allowed".
+// The correct address comes from kms_info.dstack_app_address (matches the CVM's
+// app_id with 0x prefix).
 const APP_AUTH_ABI = [
   "function addComposeHash(bytes32 composeHash)",
   "function owner() view returns (address)",

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-dstack-app.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-dstack-app.ts
@@ -4,9 +4,11 @@ import Safe from "@safe-global/protocol-kit";
 import { ethers } from "ethers";
 
 // AppAuth contract ABI for compose-hash whitelisting (from @phala/cloud SDK).
-// Each Phala CVM with on-chain KMS has its own AppAuth contract (the dstack_app_address).
-// NOTE: The KMS factory at 0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C is NOT the AppAuth —
-// pass the per-app dstack_app_address (visible via `phala cvms get <name> --json` → kms_info.dstack_app_address).
+// Each Phala CVM with on-chain KMS has its own AppAuth (DstackApp) contract.
+// The correct address is the CVM's app_id (with 0x prefix), available from the
+// provision response or `GET /info` → app_id.
+// NOTE: Do NOT use kms_info.dstack_app_address — that is the KMS's own DstackApp,
+// not the CVM's. Whitelisting on the wrong contract causes "Compose hash not allowed".
 const APP_AUTH_ABI = [
   "function addComposeHash(bytes32 composeHash)",
   "function owner() view returns (address)",

--- a/lit-api-server/blockchain/lit_node_express/tasks/verify-compose-hash.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/verify-compose-hash.ts
@@ -34,8 +34,9 @@ task("verify-compose-hash", "Verify a compose hash is whitelisted on the DstackA
 
     if (!isAllowed) {
       console.error(
-        `\nCompose hash is NOT whitelisted on the DstackApp contract. ` +
-        `The addComposeHash transaction may have reverted or not been executed.`
+        `\nCompose hash is NOT whitelisted on DstackApp at ${appAuthAddress}. ` +
+        `The CVM will reject this deployment with "Compose hash not allowed". ` +
+        `Verify the Safe transaction targeted the correct contract (CVM app_id, not kms_info.dstack_app_address).`
       );
       process.exit(1);
     }

--- a/lit-api-server/blockchain/lit_node_express/tasks/verify-compose-hash.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/verify-compose-hash.ts
@@ -1,0 +1,42 @@
+import { task } from "hardhat/config";
+import { ethers } from "ethers";
+
+const DSTACK_APP_ABI = [
+  "function allowedComposeHashes(bytes32) view returns (bool)",
+];
+
+task("verify-compose-hash", "Verify a compose hash is whitelisted on the DstackApp contract")
+  .addParam("appAuth", "AppAuth (DstackApp) contract address")
+  .addParam("composeHash", "The compose hash to verify (hex, 32 bytes)")
+  .setAction(async (taskArgs, hre) => {
+    const { appAuth: appAuthAddress, composeHash } = taskArgs;
+    const chainId = hre.network.config.chainId;
+
+    if (!chainId) {
+      throw new Error(`Chain ID not configured for network ${hre.network.name}`);
+    }
+
+    console.log(`Network: ${hre.network.name} (chain ${chainId})`);
+    console.log(`AppAuth: ${appAuthAddress}`);
+    console.log(`Compose Hash: ${composeHash}`);
+
+    const rpcUrl =
+      (hre.network.config as { url?: string }).url || "https://mainnet.base.org";
+    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const contract = new ethers.Contract(appAuthAddress, DSTACK_APP_ABI, provider);
+
+    const composeHashBytes = composeHash.startsWith("0x") ? composeHash : `0x${composeHash}`;
+    const isAllowed: boolean = await contract.allowedComposeHashes(composeHashBytes);
+
+    console.log(`\nOn-chain result: allowedComposeHashes(${composeHashBytes}) = ${isAllowed}`);
+    // Machine-readable output for CI pipelines
+    console.log(`ALLOWED=${isAllowed}`);
+
+    if (!isAllowed) {
+      console.error(
+        `\nCompose hash is NOT whitelisted on the DstackApp contract. ` +
+        `The addComposeHash transaction may have reverted or not been executed.`
+      );
+      process.exit(1);
+    }
+  });


### PR DESCRIPTION
## Summary
- Phase 1 now **computes the compose hash client-side** using the `@phala/cloud` SDK's `getComposeHash()` on the full app-compose (fetched via `GET /cvms/{id}/compose_file`) instead of trusting the provision API's `compose_hash`
- The provision API hash is preserved as `provision_hash` — used as a reference key for the PATCH/commit call
- The client-side `compose_hash` is used for the Safe `addComposeHash` proposal (matches what the CVM computes at boot and what the KMS checks via `allowedComposeHashes`)
- **execute-safe-tx** now checks `isSuccessful` (not just `isExecuted`) so reverted Safe txs fail early
- New **verify-compose-hash** hardhat task queries `allowedComposeHashes()` on-chain as a gate before commit
- Persists `app_auth_address` and `provision_hash` in `deploy-context.json`

## Root cause
The v1.0.3 deployment failed with `"Compose hash not allowed"`. The Phala provision API's `compose_hash` is a reference key for the PATCH call — it does not match the SHA-256 of the full `app-compose.json` that the CVM receives (which includes server-managed fields like `pre_launch_script`, `features`, `manifest_version`, etc.).

The Safe tx whitelisted the provision hash (`c1aa8c24…`), but the CVM computed a different hash at boot (`84ebbe35…`). Verified on-chain:
```
allowedComposeHashes(0xc1aa8c24…) = true   ← whitelisted, but not what the CVM has
allowedComposeHashes(0x84ebbe35…) = false   ← what the CVM actually computes
```

Client-side `getComposeHash()` on the full app-compose matches the CVM boot hash, confirming the fix.

## Test plan
- [x] `npx hardhat compile` — tasks register
- [x] `npx hardhat verify-compose-hash --network base` — confirms on-chain state matches expectations
- [x] Client-side `getComposeHash(full_app_compose)` = CVM boot hash (verified locally)
- [ ] End-to-end: re-run Phase 1 + Phase 2 with fix — CVM should boot successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)