### PR TITLE
fix: install gh CLI on self-hosted runners

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -397,6 +397,15 @@ jobs:
           echo "Deployment context:"
           cat deploy-context.json
 
+      - name: Install GitHub CLI
+        run: |
+          if command -v gh &> /dev/null; then exit 0; fi
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update && sudo apt-get install -y gh
+
       - name: Create draft GitHub release with deployment context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-prod-2-execute.yml
+++ b/.github/workflows/deploy-prod-2-execute.yml
@@ -43,6 +43,15 @@ jobs:
       source_sha: ${{ steps.read.outputs.source_sha }}
       encrypted_env: ${{ steps.read.outputs.encrypted_env }}
     steps:
+      - name: Install GitHub CLI
+        run: |
+          if command -v gh &> /dev/null; then exit 0; fi
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update && sudo apt-get install -y gh
+
       - name: Download deployment context from Phase 1 release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -195,6 +204,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Install GitHub CLI
+        run: |
+          if command -v gh &> /dev/null; then exit 0; fi
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update && sudo apt-get install -y gh
+
       - name: Publish draft release and remove deployment context asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Self-hosted runners don't have `gh` pre-installed, causing `command not found` failures ([failed run](https://github.com/LIT-Protocol/chipotle/actions/runs/23756807238/job/69213574919))
- Adds an "Install GitHub CLI" step (official apt method with `command -v` guard) to the three jobs that use `gh`:
  - `deploy-prod-1-propose.yml` → `create-draft-release`
  - `deploy-prod-2-execute.yml` → `download-context` and `publish-release`

## Test plan
- [ ] Re-run the failed `download-context` job to confirm `gh` installs and the release download succeeds
- [ ] Trigger a full deploy cycle and verify all three `gh`-using jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)