### PR TITLE
fix: preserve annotated tags in build checkout for correct git_version

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -97,8 +97,14 @@ jobs:
           - service: otel-collector
             dockerfile: Dockerfile.otel-collector
     steps:
+      # Check out by commit SHA, not by tag ref. actions/checkout@v4 does a
+      # "ref fixup" fetch that overwrites annotated tag refs with raw commit
+      # pointers (git fetch origin +<sha>:refs/tags/<tag>), which causes
+      # git describe --always to skip the tag. Checking out by SHA avoids the
+      # fixup entirely, keeping annotated tags intact for git_version!().
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Install cosign

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -137,8 +137,14 @@ jobs:
           - service: otel-collector
             dockerfile: Dockerfile.otel-collector
     steps:
+      # Check out by commit SHA, not by tag ref. actions/checkout@v4 does a
+      # "ref fixup" fetch that overwrites annotated tag refs with raw commit
+      # pointers (git fetch origin +<sha>:refs/tags/<tag>), which causes
+      # git describe --always to skip the tag. Checking out by SHA avoids the
+      # fixup entirely, keeping annotated tags intact for git_version!().
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Install cosign


### PR DESCRIPTION
## Summary

- Fix version mismatch where prod binary reports `v1.0.3-4-g61baae8` instead of `v1.0.4`
- Root cause: `actions/checkout@v4` does a "ref fixup" fetch on tag-triggered workflows that overwrites annotated tag refs with raw commit pointers (`git fetch --no-tags origin +<sha>:refs/tags/<tag>`). This converts annotated tags to lightweight-like refs. Since `git describe --always` (used by `git_version!()` at compile time) only considers annotated tags, it skips the current tag and falls back to an older one.
- Fix: check out by commit SHA (`ref: ${{ github.sha }}`) instead of the default tag ref, which avoids the ref fixup entirely and keeps annotated tags intact in the `.git` directory that gets `COPY`'d into the Docker build.

## Test plan

- [ ] Tag a new version (e.g. `v1.0.5`) and push — verify Phase 1 build logs show the correct `git describe` output
- [ ] Run Phase 2 and confirm `wait-for-api-restart` version matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)