### PR TITLE
docs: add Chipotle launch press release (CPL-173)

### DIFF
--- a/docs/press_releases/2026-03-30.md
+++ b/docs/press_releases/2026-03-30.md
@@ -1,0 +1,80 @@
+# Lit Protocol Launches Chipotle: Programmable Key Management and Verifiable Compute in a Single API Call
+
+**March 31, 2026 — San Francisco, CA**
+
+Lit Protocol today announced the general availability of **Lit Chipotle**, a REST API and developer platform for confidential compute and programmable key management. Chipotle enables developers to run JavaScript inside Trusted Execution Environments (TEEs), sign transactions with network-managed wallets, and return cryptographically verifiable results — all without managing private keys or running infrastructure.
+
+## The Problem
+
+Developers building applications that require cryptographic signing, secret management, or verifiable compute face a painful trade-off: either run complex key management infrastructure themselves, or trust a centralized custodian with their private keys. Both options introduce operational burden, security risk, or vendor lock-in.
+
+## The Solution
+
+Chipotle eliminates this trade-off with three composable layers:
+
+- **TEE Enclave** — A hardware-isolated execution environment that holds root key material and derives signing keys on demand. Key material never leaves the enclave, and every execution is sandboxed. Developers can [verify the full chain of trust](https://docs.dev.litprotocol.com/architecture/verification/index) cryptographically.
+
+- **On-Chain Permissions (Base)** — All authorization state — accounts, API key scopes, wallet registrations, and permission groups — lives on-chain in smart contracts. Developers can manage permissions through the API or submit transactions directly from an EOA or multisig for full [self-sovereign control](https://docs.dev.litprotocol.com/architecture/index).
+
+- **Lit Actions** — Immutable JavaScript programs identified by their IPFS content ID (CID). Developers submit code directly, and the system computes the CID to verify integrity — no IPFS storage is required. For additional transparency, developers can optionally publish their code to IPFS so anyone can independently verify it matches the CID. The TEE executes actions at runtime with access to derived key material. See the full [Lit Actions overview](https://docs.dev.litprotocol.com/lit-actions/index).
+
+## What Developers Can Build
+
+Chipotle is designed to serve both Web3 and traditional developers:
+
+- **Verifiable price feeds** — Fetch live market data, sign it with a network-managed wallet, and let smart contracts verify the signature on-chain. No off-chain trust required.
+- **On-chain access gating** — Only sign or decrypt when a user holds a specific NFT, token balance, or meets any on-chain condition.
+- **Programmable wallets** — Create and manage elliptic-curve key pairs ([PKPs](https://docs.dev.litprotocol.com/lit-actions/index)) that sign transactions without ever exposing private keys.
+- **Secret encryption and decryption** — Secure sensitive data with PKP-derived keys and store ciphertexts anywhere.
+- **Serverless backend functions** — Run JavaScript that can hold keys, call external APIs, read smart contracts, and return signed results — with no servers to manage.
+
+For common patterns and copy-paste code, see the [Examples guide](https://docs.dev.litprotocol.com/lit-actions/examples) and [Design Patterns](https://docs.dev.litprotocol.com/lit-actions/patterns).
+
+## Getting Started
+
+Developers can start building in minutes with no SDK required — just `curl`:
+
+```bash
+# Create an account
+curl -s -X POST https://api.dev.litprotocol.com/core/v1/new_account \
+  -H "Content-Type: application/json" \
+  -d '{"account_name": "my-app", "account_description": "Getting started"}'
+
+# Create a wallet
+curl -s https://api.dev.litprotocol.com/core/v1/create_wallet \
+  -H "X-Api-Key: $API_KEY"
+
+# Run a Lit Action
+curl -s -X POST https://api.dev.litprotocol.com/core/v1/lit_action \
+  -H "X-Api-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"code": "async function main() { return { hello: \"world\" }; }"}'
+```
+
+The platform also includes a full web [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) for account management, wallet creation, and action execution — no terminal needed.
+
+## Pricing
+
+Chipotle uses a simple [credit-based billing model](https://docs.dev.litprotocol.com/management/pricing) with no subscriptions or per-seat fees. All read-only operations are free. Write operations and Lit Action execution cost **$0.01 per second**, and common operations like ECDSA signing complete in under a second. Credit packages start at $5.00 with no expiry.
+
+## Open and Self-Sovereign
+
+Chipotle is not a walled garden. The platform supports both a managed SaaS experience and a fully self-sovereign deployment posture. Developers can deploy on any dstack-compatible platform, manage their account contract through a multisig, and scope API keys to enforce least-privilege access. See the [Architecture overview](https://docs.dev.litprotocol.com/architecture/index) for details.
+
+## Resources
+
+- **Documentation:** [docs.dev.litprotocol.com](https://docs.dev.litprotocol.com/)
+- **Dashboard:** [dashboard.dev.litprotocol.com](https://dashboard.dev.litprotocol.com/dapps/dashboard/)
+- **API Reference (Swagger):** [api.dev.litprotocol.com/core/v1/swagger-ui](https://api.dev.litprotocol.com/core/v1/swagger-ui)
+- **Architecture:** [Architecture overview](https://docs.dev.litprotocol.com/architecture/index)
+- **Lit Actions:** [Overview](https://docs.dev.litprotocol.com/lit-actions/index) · [Examples](https://docs.dev.litprotocol.com/lit-actions/examples) · [Patterns](https://docs.dev.litprotocol.com/lit-actions/patterns)
+- **Pricing:** [Credit-based pricing](https://docs.dev.litprotocol.com/management/pricing)
+
+## About Lit Protocol
+
+Lit Protocol is a decentralized key management and compute network. Lit gives developers programmable signing, encryption, and compute — powered by a distributed network of TEE nodes. Learn more at [litprotocol.com](https://litprotocol.com).
+
+---
+
+**Media Contact:**
+press@litprotocol.com


### PR DESCRIPTION
## Summary

Adds the Chipotle GA launch press release for March 31, 2026 under `docs/press_releases/2026-03-30.md`.

Covers:
- **TEE Enclave** — hardware-isolated execution and key management
- **On-Chain Permissions (Base)** — smart contract authorization layer
- **Lit Actions** — JavaScript verified via IPFS CID (no IPFS storage required)
- **Getting Started** — curl examples and dashboard link
- **Pricing** — credit-based billing at $0.01/sec

## Pre-Landing Review
No code changes — docs only. No issues found.

## Test Coverage
No application code changed — no tests applicable.

## Plan Completion
No plan file detected.

## Test plan
- [x] Press release content reviewed for accuracy
- [x] Lit Actions section correctly describes IPFS CID verification (code submitted directly, IPFS optional for transparency)
- [x] All documentation links reference docs.dev.litprotocol.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)