### PR TITLE
ci: add prod Phase 3 static deploy to lit-static-chipotle

### DIFF
--- a/.github/workflows/deploy-prod-3-static.yml
+++ b/.github/workflows/deploy-prod-3-static.yml
@@ -1,0 +1,53 @@
+# Deploy Static Site to Production — Production deployment Phase 3
+#
+# Deploys the lit-static/ directory to the lit-static-chipotle Cloudflare Pages
+# project with the production API URL (https://api.chipotle.litprotocol.com)
+# injected. Triggers automatically when the Phase 2 deploy workflow completes
+# successfully, and can also be run manually via workflow_dispatch.
+#
+# Required secrets:
+#   CLOUDFLARE_API_TOKEN - Cloudflare API token with Pages permissions
+#
+# Required vars:
+#   CLOUDFLARE_ACCOUNT_ID - Cloudflare account ID
+
+name: "Deploy Prod 3: Static Site"
+
+on:
+  workflow_run:
+    workflows: ["Deploy Prod 2: Execute and Verify"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Version tag (e.g. v1.2.3). Only needed for manual runs."
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-prod-static
+  cancel-in-progress: false
+
+jobs:
+  deploy-static:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version_tag || github.event.workflow_run.head_sha }}
+
+      - name: Inject API URL
+        run: sed -i "s|__LIT_API_BASE_URL__|https://api.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/app.js
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy lit-static --project-name=lit-static-chipotle --branch=main

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy lit-static --project-name=lit-static --branch=main
+          command: pages deploy lit-static --project-name=lit-static-dev --branch=main
 
   deploy-next:
     if: github.ref == 'refs/heads/next'
@@ -63,4 +63,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy lit-static --project-name=lit-static --branch=${{ github.head_ref }}
+          command: pages deploy lit-static --project-name=lit-static-dev --branch=${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- Adds new `deploy-prod-3-static.yml` workflow that deploys the static dashboard to the `lit-static-chipotle` Cloudflare Pages project with `https://api.chipotle.litprotocol.com` injected as the API URL
- Triggers automatically after Phase 2 (`Deploy Prod 2: Execute and Verify`) completes successfully, or can be run manually via `workflow_dispatch`
- Renames the dev CF Pages project from `lit-static` to `lit-static-dev` in `deploy-static.yml`

## Test plan
- [ ] Verify `lit-static-chipotle` CF Pages project exists in Cloudflare
- [ ] Run Phase 3 workflow manually with a known version tag
- [ ] Confirm dev/preview deploys still target `lit-static-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)