### PR TITLE
feat: skip build and deploy when no code changes detected

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -120,8 +120,84 @@ jobs:
           echo "base_url=https://${DOMAIN}" >> "$GITHUB_OUTPUT"
           echo "api_root_url=https://${DOMAIN}/core/v1" >> "$GITHUB_OUTPUT"
 
+  detect-changes:
+    needs: [determine-target]
+    runs-on: self-hosted
+    outputs:
+      deploy_needed: ${{ steps.check.outputs.deploy_needed }}
+      deployed_sha: ${{ steps.check.outputs.deployed_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if deploy-relevant paths changed
+        id: check
+        run: |
+          API_ROOT_URL="${{ needs.determine-target.outputs.api_root_url }}"
+
+          # For workflow_dispatch (manual trigger), always deploy
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual trigger — deploying unconditionally"
+            echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
+            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fetch the currently deployed commit version
+          COMMIT_VERSION=$(curl -sf "${API_ROOT_URL}/version" 2>/dev/null | jq -r '.commit_version // empty' 2>/dev/null || true)
+          if [ -z "$COMMIT_VERSION" ]; then
+            echo "Could not reach /version endpoint — deploying"
+            echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
+            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Deployed commit_version: $COMMIT_VERSION"
+
+          # Parse SHA from git describe --always output:
+          #   bare SHA: "abc1234" → "abc1234"
+          #   describe: "v0.3.14-5-gabc1234" → "abc1234"
+          if echo "$COMMIT_VERSION" | grep -qE '-g[0-9a-f]+$'; then
+            DEPLOYED_SHA=$(echo "$COMMIT_VERSION" | sed 's/.*-g//')
+          else
+            DEPLOYED_SHA="$COMMIT_VERSION"
+          fi
+
+          # Verify the SHA exists in the repo
+          if ! git rev-parse --verify "$DEPLOYED_SHA^{commit}" >/dev/null 2>&1; then
+            echo "Deployed SHA '$DEPLOYED_SHA' not found in repo history — deploying"
+            echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
+            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "deployed_sha=$DEPLOYED_SHA" >> "$GITHUB_OUTPUT"
+
+          # Check for changes in deploy-relevant paths
+          DEPLOY_PATHS=(
+            lit-actions/
+            lit-api-server/
+            lit-core/
+            otel-collector/
+            Dockerfile.lit-actions
+            Dockerfile.lit-api-server
+            Dockerfile.otel-collector
+            docker-compose.phala.yml
+            .github/workflows/deploy-staging.yml
+          )
+          CHANGED=$(git diff --name-only "$DEPLOYED_SHA" HEAD -- "${DEPLOY_PATHS[@]}")
+          if [ -n "$CHANGED" ]; then
+            echo "Deploy-relevant changes detected:"
+            echo "$CHANGED"
+            echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No deploy-relevant changes since $DEPLOYED_SHA — skipping build & deploy"
+            echo "deploy_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
-    needs: [validate-secrets, determine-target]
+    needs: [validate-secrets, determine-target, detect-changes]
+    if: needs.detect-changes.outputs.deploy_needed == 'true'
     runs-on: self-hosted
     permissions:
       id-token: write  # required for Sigstore keyless signing (OIDC token)
@@ -177,7 +253,8 @@ jobs:
           path: digest-${{ matrix.service }}.txt
 
   deploy:
-    needs: [determine-target, build]
+    needs: [determine-target, build, detect-changes]
+    if: needs.detect-changes.outputs.deploy_needed == 'true'
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -239,11 +316,12 @@ jobs:
             -e "CERTBOT_AWS_REGION=${{ vars.CERTBOT_AWS_REGION }}"
 
   wait-for-api-available:
-    needs: [deploy, determine-target]
+    needs: [deploy, determine-target, detect-changes]
+    if: ${{ !cancelled() && needs.determine-target.result == 'success' && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') }}
     uses: ./.github/workflows/wait-for-api-restart.yml
     with:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
-      expected_sha: ${{ github.sha }}
+      expected_sha: ${{ needs.detect-changes.outputs.deploy_needed == 'true' && github.sha || needs.detect-changes.outputs.deployed_sha }}
       runner: '["self-hosted"]'
 
   verify-attestation:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -311,7 +311,7 @@ jobs:
 
   wait-for-api-available:
     needs: [deploy, determine-target, detect-changes]
-    if: ${{ !cancelled() && needs.determine-target.result == 'success' && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') }}
+    if: ${{ !cancelled() && needs.determine-target.result == 'success' && needs.detect-changes.result == 'success' && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') }}
     uses: ./.github/workflows/wait-for-api-restart.yml
     with:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -125,7 +125,6 @@ jobs:
     runs-on: self-hosted
     outputs:
       deploy_needed: ${{ steps.check.outputs.deploy_needed }}
-      deployed_sha: ${{ steps.check.outputs.deployed_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -140,7 +139,6 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual trigger — deploying unconditionally"
             echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
-            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -149,7 +147,6 @@ jobs:
           if [ -z "$COMMIT_VERSION" ]; then
             echo "Could not reach /version endpoint — deploying"
             echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
-            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Deployed commit_version: $COMMIT_VERSION"
@@ -167,11 +164,8 @@ jobs:
           if ! git rev-parse --verify "$DEPLOYED_SHA^{commit}" >/dev/null 2>&1; then
             echo "Deployed SHA '$DEPLOYED_SHA' not found in repo history — deploying"
             echo "deploy_needed=true" >> "$GITHUB_OUTPUT"
-            echo "deployed_sha=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          echo "deployed_sha=$DEPLOYED_SHA" >> "$GITHUB_OUTPUT"
 
           # Check for changes in deploy-relevant paths
           DEPLOY_PATHS=(
@@ -321,7 +315,7 @@ jobs:
     uses: ./.github/workflows/wait-for-api-restart.yml
     with:
       api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
-      expected_sha: ${{ needs.detect-changes.outputs.deploy_needed == 'true' && github.sha || needs.detect-changes.outputs.deployed_sha }}
+      expected_sha: ${{ needs.detect-changes.outputs.deploy_needed == 'true' && github.sha || '' }}
       runner: '["self-hosted"]'
 
   verify-attestation:

--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -1,12 +1,13 @@
 # Reusable workflow: wait for an API deployment to complete
 #
-# Polls the /version endpoint until commit_version matches the expected
-# git-describe output for the given SHA, then confirms /health is OK.
+# When expected_sha is provided, polls the /version endpoint until
+# commit_version matches the expected git-describe output, then confirms
+# /health is OK. When expected_sha is omitted, just confirms /health.
 #
 # Call with api_root_url (direct) or phala_app_name (get from Phala CLI):
 #   uses: ./.github/workflows/wait-for-api-restart.yml
 #   with:
-#     expected_sha: ${{ github.sha }}
+#     expected_sha: ${{ github.sha }}  # optional — omit to skip version check
 #     api_root_url: "https://example.com/core/v1"   # OR phala_app_name
 #     # phala_app_name: "lit-api-server"        # CVM name; requires PHALA_CLOUD_API_KEY secret
 #     # timeout: 600  # optional, seconds (default 600)
@@ -27,9 +28,10 @@ on:
         value: ${{ jobs.wait.outputs.api_root_url }}
     inputs:
       expected_sha:
-        description: "Expected git commit SHA for the new deployment"
-        required: true
+        description: "Expected git commit SHA for the new deployment (omit to skip version check)"
+        required: false
         type: string
+        default: ''
       api_root_url:
         description: "API base URL (e.g. https://example.com/core/v1); use when not using phala_app_name"
         required: false
@@ -60,6 +62,7 @@ jobs:
       api_root_url: ${{ steps.resolve-url.outputs.api_root_url }}
     steps:
       - name: Checkout (for git describe)
+        if: inputs.expected_sha != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -105,12 +108,12 @@ jobs:
           echo "api_root_url=$BASE_URL" >> "$GITHUB_OUTPUT"
           echo "API base URL: $BASE_URL"
 
-      - name: Wait for expected version and health
+      - name: Wait for expected version
+        if: inputs.expected_sha != ''
         run: |
           BASE_URL="${{ steps.resolve-url.outputs.api_root_url }}"
           TIMEOUT="${{ inputs.timeout }}"
           VERSION_URL="${BASE_URL}/version"
-          HEALTH_URL="${BASE_URL%/core/v1}/health"
 
           # The API's commit_version is produced by git_version!() which runs
           # git describe --always at compile time. Reproduce the same output
@@ -134,11 +137,17 @@ jobs:
             sleep 10
           done
 
-          # Confirm health endpoint is OK
-          echo "Version matched — confirming $HEALTH_URL is healthy..."
+      - name: Confirm health
+        run: |
+          BASE_URL="${{ steps.resolve-url.outputs.api_root_url }}"
+          HEALTH_URL="${BASE_URL%/core/v1}/health"
+          TIMEOUT="${{ inputs.timeout }}"
+          deadline=$(( $(date +%s) + TIMEOUT ))
+
+          echo "Confirming $HEALTH_URL is healthy..."
           until curl -sf "$HEALTH_URL" > /dev/null; do
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::Version matched but health check failed within timeout"
+              echo "::error::Health check failed within timeout"
               exit 1
             fi
             echo "Health not ready, retrying in 5s..."


### PR DESCRIPTION
## Summary

- Adds a `detect-changes` job that queries the deployed API's `/core/v1/version` endpoint, parses the deployed commit SHA from the `git describe --always` output, and diffs against HEAD on deploy-relevant paths (`lit-actions/`, `lit-api-server/`, `lit-core/`, `otel-collector/`, Dockerfiles, compose template, and the workflow itself)
- Skips `build` and `deploy` when no relevant paths changed, saving build time and avoiding unnecessary CVM restarts
- `wait-for-api`, `verify-attestation`, `openapi-spec-check`, and all k6 tests still run against the existing deployment
- Falls back to deploying unconditionally on `workflow_dispatch`, unreachable API, or unknown deployed SHA

## Test plan

- [ ] Merge a commit that only touches `k6/` or `docs/` → verify `build` and `deploy` are skipped, k6 tests run
- [ ] Merge a commit that touches `lit-api-server/` → verify full build+deploy+test pipeline runs
- [ ] Trigger `workflow_dispatch` → verify full pipeline runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)