### PR TITLE
ci: remove lit-static preview deploy

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'lit-static/**'
       - '.github/workflows/deploy-static.yml'
-  pull_request:
-    paths:
-      - 'lit-static/**'
-      - '.github/workflows/deploy-static.yml'
 
 permissions:
   contents: read
@@ -46,21 +42,3 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy lit-static --project-name=lit-static-next --branch=main
-
-  deploy-preview:
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Inject API URL
-        run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/app.js
-
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy lit-static --project-name=lit-static-dev --branch=${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- Add `deploy-prod-3-static.yml` workflow to deploy lit-static to production (`lit-static-chipotle` Cloudflare Pages project) with the prod API URL (`api.chipotle.litprotocol.com`). Triggered by the Phase 2 deploy workflow or manually via `workflow_dispatch`.
- Remove the PR preview deploy job and `pull_request` trigger from `deploy-static.yml`.

## Test plan
- [ ] Verify `deploy-prod-3-static.yml` triggers correctly after "Deploy Prod 2" completes
- [ ] Verify manual `workflow_dispatch` with a version tag works
- [ ] Confirm `deploy-static.yml` still deploys dev/next correctly on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)