### PR TITLE
fix: grep pattern interpreted as option flag in detect-changes

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -154,7 +154,7 @@ jobs:
           # Parse SHA from git describe --always output:
           #   bare SHA: "abc1234" → "abc1234"
           #   describe: "v0.3.14-5-gabc1234" → "abc1234"
-          if echo "$COMMIT_VERSION" | grep -qE '-g[0-9a-f]+$'; then
+          if echo "$COMMIT_VERSION" | grep -qE -- '-g[0-9a-f]+$'; then
             DEPLOYED_SHA=$(echo "$COMMIT_VERSION" | sed 's/.*-g//')
           else
             DEPLOYED_SHA="$COMMIT_VERSION"


### PR DESCRIPTION
## Summary
- The `grep -qE '-g[0-9a-f]+$'` pattern in the `detect-changes` job starts with a dash, causing grep to interpret `-g` as an invalid option flag
- This was observed in CI: `grep: invalid option -- 'g'`
- As a result, the SHA parsing branch is never taken, and `DEPLOYED_SHA` is set to the full `git describe` string (e.g. `v1.0.4-8-g726d230`) instead of just the commit hash (`726d230`)
- Fix: add `--` before the pattern to signal end of options

## Test plan
- [ ] Verify the deploy-staging workflow no longer produces the `grep: invalid option` error
- [ ] Verify `DEPLOYED_SHA` is correctly extracted as a bare commit hash when `commit_version` is a `git describe` string

🤖 Generated with [Claude Code](https://claude.com/claude-code)