### PR TITLE
fix: rename default Docker image to chipotle

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Conventions: https://github.com/casey/just
 
-image_base := env('DOCKER_IMAGE', 'litptcl/lit-node-express')
+image_base := env('DOCKER_IMAGE', 'litptcl/chipotle')
 # Tag used only to satisfy the registry push requirement; the deploy step uses
 # the @sha256: digest captured after push, never this tag. Override with
 # DOCKER_TAG to reuse a previously-pushed image (digest files must then exist).


### PR DESCRIPTION
## Summary
- Update the justfile default `DOCKER_IMAGE` from `litptcl/lit-node-express` to `litptcl/chipotle`
- This is a functional change that affects local `just deploy` commands when `DOCKER_IMAGE` env var is not set

## Test plan
- [ ] Verify `just deploy` uses `litptcl/chipotle` as the default image base
- [ ] Ensure Docker Hub repo `litptcl/chipotle` exists before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)