### PR TITLE
fix: support non-owner delegate signing in propose-diamond-cut

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
@@ -58,31 +58,52 @@ task("propose-diamond-cut", "Propose a diamondCut transaction through a Safe mul
       ],
     });
 
-    // Sign the transaction with the proposer's key
-    const signedTransaction = await protocolKit.signTransaction(safeTransaction);
-    const safeTxHash = await protocolKit.getTransactionHash(signedTransaction);
-
+    const safeTxHash = await protocolKit.getTransactionHash(safeTransaction);
     console.log(`\nSafe transaction hash: ${safeTxHash}`);
+
+    // Check if proposer is an owner. If not, sign as delegate using eth_sign.
+    const proposerWallet = new ethers.Wallet(proposerKey);
+    const proposerAddress = proposerWallet.address;
+    const owners = await protocolKit.getOwners();
+    const isOwner = owners.some(
+      (o) => o.toLowerCase() === proposerAddress.toLowerCase()
+    );
+
+    let senderSignature: string;
+
+    if (isOwner) {
+      const signed = await protocolKit.signTransaction(safeTransaction);
+      senderSignature = signed.encodedSignatures();
+    } else {
+      console.log(`\nProposer is not an owner — signing as delegate (eth_sign)`);
+      const messageBytes = ethers.getBytes(safeTxHash);
+      const rawSig = proposerWallet.signingKey.sign(
+        ethers.hashMessage(messageBytes)
+      );
+      // Safe expects v to be 31 or 32 for eth_sign signatures (v + 4)
+      const v = rawSig.v - 27 + 31;
+      senderSignature = ethers.solidityPacked(
+        ["bytes32", "bytes32", "uint8"],
+        [rawSig.r, rawSig.s, v]
+      );
+    }
 
     // Submit to Safe Transaction Service
     const apiKit = new SafeApiKit({ chainId: BigInt(chainId) });
 
-    const signerAddress = new ethers.Wallet(proposerKey).address;
-
     await apiKit.proposeTransaction({
       safeAddress,
-      safeTransactionData: signedTransaction.data,
+      safeTransactionData: safeTransaction.data,
       safeTxHash,
-      senderAddress: signerAddress,
-      senderSignature: signedTransaction.encodedSignatures(),
+      senderAddress: proposerAddress,
+      senderSignature,
     });
 
     console.log(`\nTransaction proposed to Safe Transaction Service.`);
     console.log(
       `\nSafe UI: https://app.safe.global/transactions/queue?safe=base:${safeAddress}`
     );
-    console.log(
-      `\nOther signers can review and sign the transaction in the Safe UI.`
-    );
     console.log(`Safe TX Hash: ${safeTxHash}`);
+    // Machine-readable output for CI pipelines
+    console.log(`SAFE_TX_HASH=${safeTxHash}`);
   });


### PR DESCRIPTION
## Summary

- The `propose-diamond-cut` hardhat task previously called `protocolKit.signTransaction()` which requires the signer to be a Safe owner
- The proposer key (`SAFE_PROPOSER_PRIVATE_KEY`) is a delegate, not an owner, so this fails with "Transactions can only be signed by Safe owners"
- Applies the same delegate signing pattern already used in `propose-dstack-app`: checks if the proposer is an owner, and falls back to `eth_sign` with adjusted `v` value (v+4) for delegates

## Test plan

- [ ] Re-run the "Contract Upgrade Prod 1: Propose" workflow and confirm the proposal is submitted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)