### PR TITLE
fix: surface Safe API 422 error body in propose-diamond-cut

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
@@ -88,24 +88,32 @@ task("propose-diamond-cut", "Propose a diamondCut transaction through a Safe mul
       );
     }
 
-    // Submit to Safe Transaction Service
-    const apiKit = new SafeApiKit({ chainId: BigInt(chainId) });
-
+    // Submit to Safe Transaction Service via direct HTTP (the SDK swallows
+    // error response bodies, making 422 errors impossible to debug).
     console.log(`\nProposer address: ${proposerAddress}`);
     console.log(`Is owner: ${isOwner}`);
 
-    try {
-      await apiKit.proposeTransaction({
-        safeAddress,
-        safeTransactionData: safeTransaction.data,
-        safeTxHash,
-        senderAddress: proposerAddress,
-        senderSignature,
-      });
-    } catch (error: unknown) {
-      // Surface the full API error body for debugging
-      console.error(`\nSafe API error:`, JSON.stringify(error, Object.getOwnPropertyNames(error as object), 2));
-      throw error;
+    const txServiceUrl = `https://safe-transaction-base.safe.global/api/v1/safes/${safeAddress}/multisig-transactions/`;
+    const body = {
+      ...safeTransaction.data,
+      contractTransactionHash: safeTxHash,
+      sender: proposerAddress,
+      signature: senderSignature,
+    };
+
+    console.log(`\nPOST ${txServiceUrl}`);
+    console.log(`Request nonce: ${body.nonce}`);
+
+    const response = await fetch(txServiceUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(`\nSafe API error ${response.status}: ${errorBody}`);
+      throw new Error(`Safe Transaction Service returned ${response.status}: ${errorBody}`);
     }
 
     console.log(`\nTransaction proposed to Safe Transaction Service.`);

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
@@ -46,11 +46,12 @@ task("propose-diamond-cut", "Propose a diamondCut transaction through a Safe mul
       safeAddress,
     });
 
-    // Create the Safe transaction
+    // Create the Safe transaction (checksum the target address — the Rust
+    // deployer outputs lowercase hex which the Safe API rejects).
     const safeTransaction = await protocolKit.createTransaction({
       transactions: [
         {
-          to: proposalData.to,
+          to: ethers.getAddress(proposalData.to),
           data: proposalData.data,
           value: proposalData.value || "0",
           operation: proposalData.operation ?? 0,

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
@@ -89,33 +89,19 @@ task("propose-diamond-cut", "Propose a diamondCut transaction through a Safe mul
       );
     }
 
-    // Submit to Safe Transaction Service via direct HTTP (the SDK swallows
-    // error response bodies, making 422 errors impossible to debug).
+    // Submit to Safe Transaction Service
+    const apiKit = new SafeApiKit({ chainId: BigInt(chainId) });
+
     console.log(`\nProposer address: ${proposerAddress}`);
     console.log(`Is owner: ${isOwner}`);
 
-    const txServiceUrl = `https://safe-transaction-base.safe.global/api/v1/safes/${safeAddress}/multisig-transactions/`;
-    const body = {
-      ...safeTransaction.data,
-      contractTransactionHash: safeTxHash,
-      sender: proposerAddress,
-      signature: senderSignature,
-    };
-
-    console.log(`\nPOST ${txServiceUrl}`);
-    console.log(`Request nonce: ${body.nonce}`);
-
-    const response = await fetch(txServiceUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
+    await apiKit.proposeTransaction({
+      safeAddress,
+      safeTransactionData: safeTransaction.data,
+      safeTxHash,
+      senderAddress: proposerAddress,
+      senderSignature,
     });
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      console.error(`\nSafe API error ${response.status}: ${errorBody}`);
-      throw new Error(`Safe Transaction Service returned ${response.status}: ${errorBody}`);
-    }
 
     console.log(`\nTransaction proposed to Safe Transaction Service.`);
     console.log(

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-diamond-cut.ts
@@ -104,14 +104,7 @@ task("propose-diamond-cut", "Propose a diamondCut transaction through a Safe mul
       });
     } catch (error: unknown) {
       // Surface the full API error body for debugging
-      if (error instanceof Error) {
-        const anyErr = error as Record<string, unknown>;
-        if (anyErr.response) {
-          const resp = anyErr.response as Record<string, unknown>;
-          console.error(`\nSafe API error status: ${resp.status}`);
-          console.error(`Safe API error body: ${JSON.stringify(resp.data ?? resp.body)}`);
-        }
-      }
+      console.error(`\nSafe API error:`, JSON.stringify(error, Object.getOwnPropertyNames(error as object), 2));
       throw error;
     }
 


### PR DESCRIPTION
## Summary

- Replace Safe API Kit's `proposeTransaction` with a direct `fetch` call to the Safe Transaction Service
- The SDK swallows HTTP response bodies, making 422 errors impossible to debug
- The full error response is now logged so we can identify why delegate proposals are being rejected

## Test plan

- [ ] Re-run "Contract Upgrade Prod 1: Propose" workflow — if it still 422s, the error body will be visible in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)