### PR TITLE
fix: clean up stale deploy-context.json on self-hosted runners

### DIFF
--- a/.github/workflows/deploy-prod-2-execute.yml
+++ b/.github/workflows/deploy-prod-2-execute.yml
@@ -54,6 +54,9 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           sudo apt-get update && sudo apt-get install -y gh
 
+      - name: Clean up stale artifacts from previous runs
+        run: rm -f deploy-context.json
+
       - name: Download deployment context from Phase 1 release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a cleanup step before `gh release download` in the `deploy-prod-2-execute` workflow to remove any leftover `deploy-context.json` from previous runs
- Self-hosted runners retain files between workflow runs, causing `gh release download` to fail with "already exists" when the file persists from a prior run

## Test plan
- [ ] Re-run the failed deploy-prod-2-execute workflow and confirm the `download-context` job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)