### PR TITLE
feat: per-second billing for Lit Action execution (CPL-174)

### DIFF
--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -85,14 +85,19 @@ impl Client {
                 // &auth_context,
                 0,
             ));
-            let execution_result = tokio::time::timeout(timeout, execution)
-                .await
-                .map_err(|e| {
-                    unexpected_err(
-                        e,
+            let execution_result = match tokio::time::timeout(timeout, execution).await {
+                Ok(result) => result,
+                Err(_) => {
+                    // Flush any accumulated billing before returning the timeout error.
+                    if let Err(e) = self.flush_unbilled_seconds().await {
+                        warn!("Billing flush failed on timeout: {e}");
+                    }
+                    return Err(unexpected_err(
+                        anyhow!("timeout"),
                         Some(format!("lit_actions didn't respond within {timeout:?}")),
-                    )
-                })?;
+                    ));
+                }
+            };
             match execution_result {
                 Ok(state) => return Ok(state),
                 Err(e) => {
@@ -212,45 +217,52 @@ impl Client {
             .await
             .context("failed to send execution request")?;
 
-        // Handle responses from server
-        while let Some(resp) = stream.try_next().await? {
-            match resp.union {
-                // Return final result from server
-                Some(UnionResponse::Result(res)) => {
-                    // NOTE: Side effects (signatures, contract calls) have already
-                    // executed by this point. If billing fails here, the caller gets
-                    // an error but the effects are not reversible. This is an accepted
-                    // tradeoff — the alternative (pre-billing) was removed in favour
-                    // of per-second metering.
-                    self.flush_unbilled_seconds().await?;
-                    if !res.success {
-                        bail!(res.error);
-                    }
-                    // Return current state, which might be updated by subsequent code executions
-                    return Ok(self.state.clone());
-                }
-                // Handle op requests
-                Some(op) => {
-                    let resp = self.handle_op(op, call_depth).await.unwrap_or_else(|e| {
-                        ErrorResponse {
-                            error: e.to_string(),
+        // Handle responses from server.
+        // Wrap the loop in a closure so we can always flush billing on exit,
+        // even if stream reads or op sends fail mid-flight.
+        let loop_result: Result<ExecutionState> = async {
+            while let Some(resp) = stream.try_next().await? {
+                match resp.union {
+                    // Return final result from server
+                    Some(UnionResponse::Result(res)) => {
+                        // NOTE: Side effects (signatures, contract calls) have already
+                        // executed by this point. If billing fails here, the caller gets
+                        // an error but the effects are not reversible. This is an accepted
+                        // tradeoff — the alternative (pre-billing) was removed in favour
+                        // of per-second metering.
+                        self.flush_unbilled_seconds().await?;
+                        if !res.success {
+                            bail!(res.error);
                         }
-                        .into()
-                    });
-                    outbound_tx
-                        .send_async(resp)
-                        .await
-                        .context("failed to send op response")?;
-                }
-                // Ignore empty responses
-                None => {}
-            };
+                        // Return current state, which might be updated by subsequent code executions
+                        return Ok(self.state.clone());
+                    }
+                    // Handle op requests
+                    Some(op) => {
+                        let resp = self.handle_op(op, call_depth).await.unwrap_or_else(|e| {
+                            ErrorResponse {
+                                error: e.to_string(),
+                            }
+                            .into()
+                        });
+                        outbound_tx
+                            .send_async(resp)
+                            .await
+                            .context("failed to send op response")?;
+                    }
+                    // Ignore empty responses
+                    None => {}
+                };
+            }
+            bail!("Server unexpectedly closed connection")
         }
+        .await;
 
-        // Best-effort flush — connection already lost, so log but don't mask the real error.
-        if let Err(e) = self.flush_unbilled_seconds().await {
-            warn!("Billing flush failed after connection close: {e}");
+        // If the loop exited via an error (stream failure, send failure, connection
+        // close), do a best-effort billing flush before propagating the error.
+        if loop_result.is_err() && let Err(e) = self.flush_unbilled_seconds().await {
+            warn!("Billing flush failed after error exit: {e}");
         }
-        bail!("Server unexpectedly closed connection")
+        loop_result
     }
 }

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -25,22 +25,23 @@ impl Client {
     async fn flush_unbilled_seconds(&mut self) -> Result<()> {
         if let Some(ref stripe) = self.stripe_state {
             // Minimum billed amount for any action is 1 second.
-            let seconds = self.state.unbilled_seconds.max(
-                if self.state.last_billed_second == 0 { 1 } else { 0 }
-            );
+            let seconds = self
+                .state
+                .unbilled_seconds
+                .max(if self.state.last_billed_second == 0 {
+                    1
+                } else {
+                    0
+                });
             if seconds == 0 {
                 return Ok(());
             }
-            crate::stripe::charge_lit_action_time(
-                &self.api_key,
-                seconds,
-                stripe,
-            )
-            .await
-            .map_err(|e| {
-                warn!("Failed to bill remaining {seconds} seconds at end of action: {e}");
-                anyhow!("Billing failed for {seconds} seconds of execution: {e}")
-            })?;
+            crate::stripe::charge_lit_action_time(&self.api_key, seconds, stripe)
+                .await
+                .map_err(|e| {
+                    warn!("Failed to bill remaining {seconds} seconds at end of action: {e}");
+                    anyhow!("Billing failed for {seconds} seconds of execution: {e}")
+                })?;
             self.state.unbilled_seconds = 0;
         }
         Ok(())

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -260,7 +260,9 @@ impl Client {
 
         // If the loop exited via an error (stream failure, send failure, connection
         // close), do a best-effort billing flush before propagating the error.
-        if loop_result.is_err() && let Err(e) = self.flush_unbilled_seconds().await {
+        if loop_result.is_err()
+            && let Err(e) = self.flush_unbilled_seconds().await
+        {
             warn!("Billing flush failed after error exit: {e}");
         }
         loop_result

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -3,6 +3,7 @@ use super::models::{ExecutionOptions, ExecutionState};
 use crate::error::{Error, unexpected_err};
 use anyhow::{Context, Result, anyhow, bail};
 use std::path::PathBuf;
+use tracing::warn;
 
 use crate::actions::jobs::{ActionJob, ActionStore, JobId};
 use futures::{FutureExt as _, TryFutureExt};
@@ -17,6 +18,34 @@ use tokio::time::Duration;
 use tracing::instrument;
 
 impl Client {
+    /// Bill any remaining accumulated seconds to Stripe.
+    /// Called at the end of execution to ensure no time goes unbilled.
+    /// Enforces a minimum charge of 1 second per action.
+    /// Returns `Err` if the charge fails — the caller should abort the action.
+    async fn flush_unbilled_seconds(&mut self) -> Result<()> {
+        if let Some(ref stripe) = self.stripe_state {
+            // Minimum billed amount for any action is 1 second.
+            let seconds = self.state.unbilled_seconds.max(
+                if self.state.last_billed_second == 0 { 1 } else { 0 }
+            );
+            if seconds == 0 {
+                return Ok(());
+            }
+            crate::stripe::charge_lit_action_time(
+                &self.api_key,
+                seconds,
+                stripe,
+            )
+            .await
+            .map_err(|e| {
+                warn!("Failed to bill remaining {seconds} seconds at end of action: {e}");
+                anyhow!("Billing failed for {seconds} seconds of execution: {e}")
+            })?;
+            self.state.unbilled_seconds = 0;
+        }
+        Ok(())
+    }
+
     #[instrument(level = "debug", skip_all, ret)]
     pub async fn execute_js_async(
         &self,
@@ -43,8 +72,6 @@ impl Client {
         opts: impl Into<ExecutionOptions>,
     ) -> Result<ExecutionState, Error> {
         self.reset_state();
-        // self.dynamic_payment
-        // .add(LitActionPriceComponent::BaseAmount, 1)?;
         let opts = opts.into();
         let timeout = self.client_timeout();
 
@@ -165,6 +192,9 @@ impl Client {
             .await?
             .into_inner();
 
+        // Start the billing clock before execution begins.
+        self.state.execution_start = Some(tokio::time::Instant::now());
+
         // Send initial execution request to server
         outbound_tx
             .send_async(
@@ -186,6 +216,12 @@ impl Client {
             match resp.union {
                 // Return final result from server
                 Some(UnionResponse::Result(res)) => {
+                    // NOTE: Side effects (signatures, contract calls) have already
+                    // executed by this point. If billing fails here, the caller gets
+                    // an error but the effects are not reversible. This is an accepted
+                    // tradeoff — the alternative (pre-billing) was removed in favour
+                    // of per-second metering.
+                    self.flush_unbilled_seconds().await?;
                     if !res.success {
                         bail!(res.error);
                     }
@@ -210,6 +246,10 @@ impl Client {
             };
         }
 
+        // Best-effort flush — connection already lost, so log but don't mask the real error.
+        if let Err(e) = self.flush_unbilled_seconds().await {
+            warn!("Billing flush failed after connection close: {e}");
+        }
         bail!("Server unexpectedly closed connection")
     }
 }

--- a/lit-api-server/src/actions/client/handle_ops.rs
+++ b/lit-api-server/src/actions/client/handle_ops.rs
@@ -145,11 +145,12 @@ impl Client {
                 let cancel_action = if let Some(ref stripe) = self.stripe_state {
                     // Use wall-clock time from execution_start (set before execution begins)
                     // instead of the gRPC `tick` field, which reports near-zero.
-                    let current_second = self.state.execution_start
+                    let current_second = self
+                        .state
+                        .execution_start
                         .map(|s| s.elapsed().as_secs())
                         .unwrap_or(0);
-                    let new_seconds =
-                        current_second.saturating_sub(self.state.last_billed_second);
+                    let new_seconds = current_second.saturating_sub(self.state.last_billed_second);
 
                     if new_seconds > 0 {
                         self.state.unbilled_seconds += new_seconds;
@@ -170,9 +171,7 @@ impl Client {
                                 false
                             }
                             Err(e) => {
-                                warn!(
-                                    "Per-second billing failed, cancelling action: {e}"
-                                );
+                                warn!("Per-second billing failed, cancelling action: {e}");
                                 self.state.unbilled_seconds = 0;
                                 true
                             }

--- a/lit-api-server/src/actions/client/handle_ops.rs
+++ b/lit-api-server/src/actions/client/handle_ops.rs
@@ -1,9 +1,12 @@
 use super::op_code_helpers;
 use anyhow::{Result, bail};
 use lit_actions_grpc::proto::*;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use super::Client;
+
+/// How many seconds of execution to accumulate before flushing a charge to Stripe.
+const BILLING_FLUSH_INTERVAL_SECS: u64 = 5;
 
 impl Client {
     #[instrument(level = "debug", skip(self, op), err)]
@@ -139,12 +142,47 @@ impl Client {
                 tick: _,
                 used_kb: _,
             }) => {
-                // // For now, we'll just return a success response
-                // let r = self
-                //     .dynamic_payment
-                //     .add(LitActionPriceComponent::MemoryUsage, used_kb as u64);
-                // let cancel_action = r.is_err();
-                let cancel_action = false;
+                let cancel_action = if let Some(ref stripe) = self.stripe_state {
+                    // Use wall-clock time from execution_start (set before execution begins)
+                    // instead of the gRPC `tick` field, which reports near-zero.
+                    let current_second = self.state.execution_start
+                        .map(|s| s.elapsed().as_secs())
+                        .unwrap_or(0);
+                    let new_seconds =
+                        current_second.saturating_sub(self.state.last_billed_second);
+
+                    if new_seconds > 0 {
+                        self.state.unbilled_seconds += new_seconds;
+                        self.state.last_billed_second = current_second;
+                    }
+
+                    // Flush to Stripe every BILLING_FLUSH_INTERVAL_SECS accumulated seconds
+                    if self.state.unbilled_seconds >= BILLING_FLUSH_INTERVAL_SECS {
+                        match crate::stripe::charge_lit_action_time(
+                            &self.api_key,
+                            self.state.unbilled_seconds,
+                            stripe,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                self.state.unbilled_seconds = 0;
+                                false
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Per-second billing failed, cancelling action: {e}"
+                                );
+                                self.state.unbilled_seconds = 0;
+                                true
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
                 UpdateResourceUsageResponse { cancel_action }.into()
             }
             UnionResponse::Result(_) => unreachable!(), // handled in main loop

--- a/lit-api-server/src/actions/client/mod.rs
+++ b/lit-api-server/src/actions/client/mod.rs
@@ -8,9 +8,11 @@ pub mod op_code_helpers;
 use crate::actions::client::models::DenoExecutionEnv;
 use crate::actions::client::models::ExecutionState;
 use crate::actions::grpc::GrpcClientPool;
+use crate::stripe::StripeState;
 use derive_builder::Builder;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -86,8 +88,12 @@ pub struct Client {
     #[serde(skip)]
     pub(crate) client_grpc_channels: GrpcClientPool<tonic::transport::Channel>,
 
-    // #[builder(default)]
-    // pub dynamic_payment: DynamicPayment,
+    /// Stripe state for per-second billing during Lit Action execution.
+    /// `None` when billing is disabled.
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip)]
+    pub(crate) stripe_state: Option<Arc<StripeState>>,
+
     // State
     #[builder(setter(skip))]
     #[serde(skip)]

--- a/lit-api-server/src/actions/client/models.rs
+++ b/lit-api-server/src/actions/client/models.rs
@@ -62,7 +62,7 @@ pub struct ExecutionState {
     pub broadcast_and_collect_count: u32,
     #[serde(skip)]
     pub ops_count: u32,
-    /// Wall-clock start of execution, set on the first `UpdateResourceUsage` tick.
+    /// Wall-clock start of execution, set before the gRPC execution request is sent.
     /// Used to derive elapsed seconds for billing instead of the unreliable gRPC `tick` field.
     #[serde(skip)]
     pub execution_start: Option<Instant>,

--- a/lit-api-server/src/actions/client/models.rs
+++ b/lit-api-server/src/actions/client/models.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use moka::future::Cache;
 use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct SignedData {
@@ -61,6 +62,17 @@ pub struct ExecutionState {
     pub broadcast_and_collect_count: u32,
     #[serde(skip)]
     pub ops_count: u32,
+    /// Wall-clock start of execution, set on the first `UpdateResourceUsage` tick.
+    /// Used to derive elapsed seconds for billing instead of the unreliable gRPC `tick` field.
+    #[serde(skip)]
+    pub execution_start: Option<Instant>,
+    /// Tracks the last second of execution that was accounted for, for per-second charging.
+    #[serde(skip)]
+    pub last_billed_second: u64,
+    /// Seconds of execution accumulated but not yet charged to Stripe.
+    /// Flushed to Stripe every 5 seconds and at the end of execution.
+    #[serde(skip)]
+    pub unbilled_seconds: u64,
     #[serde(skip)]
     pub wallet_permission_cache: HashMap<String, bool>,
 }

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -12,6 +12,7 @@ use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::LitActionRequest;
 use crate::core::v1::models::response::{LitActionClientConfigResponse, LitActionResponse};
 use crate::observability::RequestSpan;
+use crate::stripe::StripeState;
 use crate::utils::parse_with_hash::ipfs_cid_to_u256;
 use ipfs_hasher::IpfsHasher;
 use moka::future::Cache;
@@ -29,6 +30,7 @@ pub async fn lit_action(
     ipfs_cache: &Cache<String, String>,
     http_client: &reqwest::Client,
     chain_config: Arc<ChainConfig>,
+    stripe_state: Option<Arc<StripeState>>,
     lit_action_request: Json<LitActionRequest>,
 ) -> Result<LitActionResponse, ApiStatus> {
     let request_id = request_span.request_id.clone();
@@ -62,6 +64,10 @@ pub async fn lit_action(
         .api_key(api_key.to_string())
         .ipfs_id(derived_ipfs_id.clone())
         .client_grpc_channels((*grpc_client_pool).clone());
+
+    if let Some(stripe) = stripe_state {
+        builder.stripe_state(stripe);
+    }
 
     let mut client = match builder.build().map_err(|e| e.to_string()) {
         Ok(client) => client,

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -22,6 +22,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tracing::instrument;
 
+#[allow(clippy::too_many_arguments)]
 #[instrument(name = "core_features::lit_action", level = "debug", skip_all, err)]
 pub async fn lit_action(
     request_span: &RequestSpan,

--- a/lit-api-server/src/core/v1/endpoints/actions.rs
+++ b/lit-api-server/src/core/v1/endpoints/actions.rs
@@ -10,6 +10,7 @@ use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::LitActionRequest;
 use crate::core::v1::models::response::LitActionResponse;
 use crate::observability::RequestSpan;
+use crate::stripe::StripeState;
 use moka::future::Cache;
 use rocket::State;
 use rocket::post;
@@ -28,6 +29,7 @@ pub(super) async fn lit_action(
     ipfs_cache: &State<Cache<String, String>>,
     http_client: &State<reqwest::Client>,
     chain_config: &State<Arc<ChainConfig>>,
+    stripe_state: &State<Option<Arc<StripeState>>>,
     lit_action_request: Json<LitActionRequest>,
 ) -> OpenApiResponse<LitActionResponse, ErrMessage> {
     OpenApiResponse {
@@ -39,6 +41,7 @@ pub(super) async fn lit_action(
                 ipfs_cache.inner(),
                 http_client.inner(),
                 chain_config.inner().clone(),
+                stripe_state.inner().clone(),
                 lit_action_request,
             )
             .await,

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -1,7 +1,10 @@
-/// Rocket request guards that extract the API key **and** debit a Stripe billing charge
-/// before the handler runs.
+/// Rocket request guards that extract the API key and enforce billing.
 ///
-/// If Stripe is not configured (no `StripeState` managed), the guard succeeds without charging.
+/// - `BilledManagementApiKey`: charges upfront ($0.01 per call).
+/// - `BilledLitActionApiKey`: checks credit availability only; per-second billing
+///   happens during execution via `UpdateResourceUsage`.
+///
+/// If Stripe is not configured (no `StripeState` managed), guards succeed without charging.
 /// If the customer has insufficient credits the guard fails with `402 Payment Required`.
 use std::sync::Arc;
 

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -104,7 +104,11 @@ impl<'r> OpenApiFromRequest<'r> for BilledManagementApiKey {
 
 // ─── BilledLitActionApiKey ────────────────────────────────────────────────────
 
-/// Guards a lit-action endpoint ($0.01 per call).
+/// Guards a lit-action endpoint.
+///
+/// Validates that the API key has credits available (Stripe balance < 0)
+/// but does NOT charge upfront — per-second billing happens during execution
+/// via the `UpdateResourceUsage` opcode.
 pub struct BilledLitActionApiKey(pub String);
 
 #[rocket::async_trait]
@@ -112,9 +116,46 @@ impl<'r> FromRequest<'r> for BilledLitActionApiKey {
     type Error = ();
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        charge_guard(request, stripe::charge_lit_action)
-            .await
-            .map(BilledLitActionApiKey)
+        let Some(key) = extract_api_key(request) else {
+            return Outcome::Error((Status::Unauthorized, ()));
+        };
+
+        // If Stripe is configured, verify the customer has credits available.
+        if let Some(state) = request.rocket().state::<Option<Arc<StripeState>>>()
+            && let Some(stripe) = state.as_ref()
+        {
+            match stripe::resolve_wallet_address(&key, stripe).await {
+                Ok(wallet) => {
+                    match stripe::get_customer_by_wallet(&wallet, stripe).await {
+                        Ok(customer_id) => {
+                            match stripe::get_credit_balance(&customer_id, stripe).await {
+                                Ok(balance) if balance >= 0 => {
+                                    tracing::warn!(
+                                        "billing guard: insufficient credits (balance={balance})"
+                                    );
+                                    return Outcome::Error((Status::PaymentRequired, ()));
+                                }
+                                Err(e) => {
+                                    tracing::warn!("billing guard: balance check failed: {e}");
+                                    return Outcome::Error((Status::PaymentRequired, ()));
+                                }
+                                _ => {} // balance < 0 means credits available
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("billing guard: customer lookup failed: {e}");
+                            return Outcome::Error((Status::PaymentRequired, ()));
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("billing guard: wallet resolution failed: {e}");
+                    return Outcome::Error((Status::PaymentRequired, ()));
+                }
+            }
+        }
+
+        Outcome::Success(BilledLitActionApiKey(key))
     }
 }
 

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -17,7 +17,7 @@ use reqwest::StatusCode;
 
 /// Cost constants in US cents.
 pub const COST_MANAGEMENT_CENTS: i64 = 1; // $0.01
-pub const COST_LIT_ACTION_CENTS: i64 = 1; // $0.01
+pub const COST_LIT_ACTION_PER_SECOND_CENTS: i64 = 1; // $0.01 per second of execution
 /// Minimum top-up (500 cents = $5.00).
 pub const MIN_TOPUP_CENTS: i64 = 500;
 
@@ -25,6 +25,7 @@ pub const MIN_TOPUP_CENTS: i64 = 500;
 
 #[derive(Clone)]
 pub struct StripeState {
+    // NOTE: Debug is implemented manually below to redact secret_key.
     pub publishable_key: String,
     secret_key: String,
     client: reqwest::Client,
@@ -35,6 +36,15 @@ pub struct StripeState {
     /// Resolves both master and usage API keys to the account's creator wallet address
     /// via the on-chain `allApiKeyHashesToMaster` mapping, avoiding a contract call per charge.
     wallet_cache: Cache<String, String>,
+}
+
+impl std::fmt::Debug for StripeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StripeState")
+            .field("publishable_key", &self.publishable_key)
+            .field("secret_key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// Initialise Stripe from environment variables.  Returns `None` if the env vars are absent
@@ -271,9 +281,18 @@ pub async fn charge_management(api_key: &str, state: &StripeState) -> Result<()>
     charge(api_key, COST_MANAGEMENT_CENTS, state).await
 }
 
-/// Charge $0.01 for a Lit Action execution.
-pub async fn charge_lit_action(api_key: &str, state: &StripeState) -> Result<()> {
-    charge(api_key, COST_LIT_ACTION_CENTS, state).await
+/// Charge for `seconds` of Lit Action execution time.
+/// Returns `Ok(())` if the charge succeeds, `Err` if insufficient credits.
+pub async fn charge_lit_action_time(
+    api_key: &str,
+    seconds: u64,
+    state: &StripeState,
+) -> Result<()> {
+    let cost = COST_LIT_ACTION_PER_SECOND_CENTS * seconds as i64;
+    if cost == 0 {
+        return Ok(());
+    }
+    charge(api_key, cost, state).await
 }
 
 /// Create a PaymentIntent for `amount_cents`.  Returns `(client_secret, payment_intent_id)`.

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -288,7 +288,11 @@ pub async fn charge_lit_action_time(
     seconds: u64,
     state: &StripeState,
 ) -> Result<()> {
-    let cost = COST_LIT_ACTION_PER_SECOND_CENTS * seconds as i64;
+    let seconds_i64 =
+        i64::try_from(seconds).map_err(|_| anyhow::anyhow!("seconds overflow: {seconds}"))?;
+    let cost = COST_LIT_ACTION_PER_SECOND_CENTS
+        .checked_mul(seconds_i64)
+        .ok_or_else(|| anyhow::anyhow!("cost overflow for {seconds} seconds"))?;
     if cost == 0 {
         return Ok(());
     }


### PR DESCRIPTION
## Summary

Replaces the upfront per-call Lit Action charge with per-second metered billing during execution.

**Billing flow:**
- Guard checks credit availability (balance < 0) without charging upfront
- `UpdateResourceUsage` opcode tracks wall-clock elapsed seconds via `Instant`
- Charges flush to Stripe every 5 accumulated seconds
- At end of execution, remaining time is billed with a **1-second minimum** per action
- Billing failure aborts the action (periodic flush sets `cancel_action=true`, final flush returns error)

**Files changed:**
- `stripe.rs` — Add `charge_lit_action_time()`, remove dead `charge_lit_action()`
- `billing.rs` — Replace upfront charge with credit-availability check
- `handle_ops.rs` — Wall-clock billing accumulation in `UpdateResourceUsage`
- `execution.rs` — `flush_unbilled_seconds()` with 1-second minimum, error propagation
- `models.rs` — Add `execution_start`, `last_billed_second`, `unbilled_seconds` to `ExecutionState`
- `mod.rs` — Add `stripe_state` to `Client` struct
- `core_features.rs` + `actions.rs` — Thread `StripeState` through to Client builder

## Pre-Landing Review

Review ran with Claude structured + adversarial + Codex adversarial. Key findings fixed:
- **tick value was near-zero** (Codex found `tick_no.elapsed()` measures time since interval fired, not cumulative). Fixed: track wall-clock `Instant` in API server.
- **Double-charge on billing failure** — `unbilled_seconds` not reset on error, causing retry. Fixed: reset on both success and failure.
- **Dead code** — removed `charge_lit_action()` and `COST_LIT_ACTION_CENTS`. Extracted magic `5` to `BILLING_FLUSH_INTERVAL_SECS`.

## Known Limitations

- **Concurrent overdraft** — `charge()` does read-then-write (TOCTOU). Multiple parallel actions from same customer can overspend. Stripe has no atomic balance check-and-debit.
- **Side effects before final billing** — Action side effects (signatures, contract calls) execute before the final flush. If billing fails at the end, effects are not reversible. Documented in code comments.

## Test plan
- [x] `cargo test -p lit-api-server` — 33 passed, 3 pre-existing failures (Linux-only, unrelated)
- [x] `cargo check` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)