### PR TITLE
feat: refactor contract owner to diamond storage (CPL-188)

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfig.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfig.sol
@@ -32,7 +32,7 @@ contract AccountConfig {
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         require(s.api_payers.length() == 0, "already initialized");
         s.pricingOperator = owner;
-        s.owner = owner;
+        s.configOperator = owner;
         s.pricing[1] = 1;
         s.requestedApiPayerCount = 3; // just a default for spinning up a new instance
     }

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/APIConfigFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/APIConfigFacet.sol
@@ -16,7 +16,7 @@ contract APIConfigFacet {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     function setConfigOperator(address newConfigOperator) public {
-        SecurityLib.revertIfNotApiPayerOrOwner(msg.sender);
+        SecurityLib.revertIfNotConfigOperatorOrOwner(msg.sender);
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         s.configOperator = newConfigOperator;
     }

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/APIConfigFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/APIConfigFacet.sol
@@ -15,6 +15,12 @@ contract APIConfigFacet {
     using EnumerableSet for EnumerableSet.UintSet;
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    function setConfigOperator(address newConfigOperator) public {
+        SecurityLib.revertIfNotApiPayerOrOwner(msg.sender);
+        AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
+        s.configOperator = newConfigOperator;
+    }
+
     function setRequestedApiPayerCount(
         uint256 newRequestedApiPayerCount
     ) public {

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
@@ -108,7 +108,7 @@ library AppStorage {
         mapping(uint256 => address) allPkpIds; // mapping from a counter to a pkp id, allowing us to get a list of all pkp ids ever generated
         mapping(uint256 => uint256) pricing; // mapping from a pricing item id to it's price
         EnumerableSet.AddressSet api_payers; // set of accounts that pays for state mutation made by api calls, optionally mutates state on behalf of an api key holder.
-        address configOperator; // account that can set the api_payer
+        address configOperator; // operator that can perform config management alongside the diamond owner
         address pricingOperator; // account that can mutate certain state for operational purposes ( like pricing ).
         uint256 pkpCount; // counter for creating unique pkp ids
         uint256 accountCount; // counter for creating unique account ids

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
@@ -41,6 +41,7 @@ library AppStorage {
     error NotAllowedToRemovePkpFromGroup(uint256 apiKeyHash, uint256 groupId);
     error NotAllowedToManageIPFSIdsInGroup(uint256 apiKeyHash, uint256 groupId);
     error InvalidRequest(string message);
+    error OnlyConfigOperatorOrOwner(address caller);
 
     struct PkpData {
         uint256 id; // keccak256 of the pkp id - this is used to prove existence of the struct.
@@ -107,7 +108,7 @@ library AppStorage {
         mapping(uint256 => address) allPkpIds; // mapping from a counter to a pkp id, allowing us to get a list of all pkp ids ever generated
         mapping(uint256 => uint256) pricing; // mapping from a pricing item id to it's price
         EnumerableSet.AddressSet api_payers; // set of accounts that pays for state mutation made by api calls, optionally mutates state on behalf of an api key holder.
-        address owner; // account that can set the api_payer
+        address configOperator; // account that can set the api_payer
         address pricingOperator; // account that can mutate certain state for operational purposes ( like pricing ).
         uint256 pkpCount; // counter for creating unique pkp ids
         uint256 accountCount; // counter for creating unique account ids

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
@@ -9,7 +9,7 @@ import {
     EnumerableSet
 } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {AppStorage} from "./AppStorage.sol";
-import { LibDiamond } from "../../libraries/LibDiamond.sol";
+import {LibDiamond} from "../../libraries/LibDiamond.sol";
 
 library SecurityLib {
     using EnumerableSet for EnumerableSet.UintSet;

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
@@ -9,6 +9,7 @@ import {
     EnumerableSet
 } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {AppStorage} from "./AppStorage.sol";
+import { LibDiamond } from "../../libraries/LibDiamond.sol";
 
 library SecurityLib {
     using EnumerableSet for EnumerableSet.UintSet;
@@ -104,12 +105,18 @@ library SecurityLib {
             revert AppStorage.OnlyApiPayerOrPricingOperator(caller);
         }
     }
+    function revertIfNotConfigOperatorOrwner(address caller) internal view {
+        AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
+        if (caller != s.configOperator && caller != LibDiamond.contractOwner()) {
+            revert AppStorage.OnlyConfigOperatorOrOwner(caller);
+        }
+    }
 
     function revertIfNotApiPayerOrOwner(address caller) internal view {
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         if (
             !s.api_payers.contains(caller) &&
-            caller != s.owner &&
+            caller != LibDiamond.contractOwner() &&
             caller != s.adminApiPayerAccount
         ) {
             revert AppStorage.OnlyApiPayerOrOwner(caller);
@@ -134,7 +141,7 @@ library SecurityLib {
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         if (
             !s.api_payers.contains(caller) &&
-            caller != s.owner &&
+            caller != LibDiamond.contractOwner() &&
             caller != s.adminApiPayerAccount
         ) {
             revert AppStorage.OnlyApiPayerOrOwner(caller);

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
@@ -105,7 +105,7 @@ library SecurityLib {
             revert AppStorage.OnlyApiPayerOrPricingOperator(caller);
         }
     }
-    function revertIfNotConfigOperatorOrwner(address caller) internal view {
+    function revertIfNotConfigOperatorOrOwner(address caller) internal view {
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         if (caller != s.configOperator && caller != LibDiamond.contractOwner()) {
             revert AppStorage.OnlyConfigOperatorOrOwner(caller);

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
@@ -56,6 +56,10 @@ contract ViewsFacet {
         return AppStorage.getStorage().pricingOperator;
     }
 
+    function configOperator() public view returns (address) {
+        return AppStorage.getStorage().configOperator;
+    }
+
     function pkpCount() public view returns (uint256) {
         return AppStorage.getStorage().pkpCount;
     }

--- a/lit-api-server/src/accounts/contracts/AccountConfig.json
+++ b/lit-api-server/src/accounts/contracts/AccountConfig.json
@@ -898,6 +898,19 @@
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "configOperator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "uint256",
@@ -1555,6 +1568,17 @@
       "inputs": [
         {
           "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyConfigOperatorOrOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
           "name": "newAdminApiPayerAccount",
           "type": "address"
         }
@@ -1573,6 +1597,19 @@
         }
       ],
       "name": "setApiPayers",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newConfigOperator",
+          "type": "address"
+        }
+      ],
+      "name": "setConfigOperator",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/lit-api-server/src/accounts/contracts/account_config_contract.rs
+++ b/lit-api-server/src/accounts/contracts/account_config_contract.rs
@@ -514,6 +514,22 @@ pub mod account_config {
                     },],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("configOperator"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("configOperator"),
+                        inputs: ::std::vec![],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("creditApiKey"),
                     ::std::vec![::ethers::core::abi::ethabi::Function {
                         name: ::std::borrow::ToOwned::to_owned("creditApiKey"),
@@ -1535,6 +1551,22 @@ pub mod account_config {
                     },],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("setConfigOperator"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("setConfigOperator"),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("newConfigOperator"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        outputs: ::std::vec![],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::NonPayable,
+                    },],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("setNodeConfiguration"),
                     ::std::vec![::ethers::core::abi::ethabi::Function {
                         name: ::std::borrow::ToOwned::to_owned("setNodeConfiguration",),
@@ -2112,6 +2144,19 @@ pub mod account_config {
                     },],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("OnlyConfigOperatorOrOwner"),
+                    ::std::vec![::ethers::core::abi::ethabi::AbiError {
+                        name: ::std::borrow::ToOwned::to_owned("OnlyConfigOperatorOrOwner",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("caller"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                    },],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("PkpDoesNotExist"),
                     ::std::vec![::ethers::core::abi::ethabi::AbiError {
                         name: ::std::borrow::ToOwned::to_owned("PkpDoesNotExist"),
@@ -2377,6 +2422,14 @@ pub mod account_config {
         ) -> ::ethers::contract::builders::ContractCall<M, bool> {
             self.0
                 .method_hash([134, 68, 113, 67], (api_key_hash, cid_hash, wallet_address))
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `configOperator` (0x142a62ce) function
+        pub fn config_operator(
+            &self,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+            self.0
+                .method_hash([20, 42, 98, 206], ())
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `creditApiKey` (0x683f2de8) function
@@ -2748,6 +2801,15 @@ pub mod account_config {
                 .method_hash([174, 140, 73, 165], new_api_payers)
                 .expect("method not found (this should never happen)")
         }
+        ///Calls the contract's `setConfigOperator` (0xeaca4614) function
+        pub fn set_config_operator(
+            &self,
+            new_config_operator: ::ethers::core::types::Address,
+        ) -> ::ethers::contract::builders::ContractCall<M, ()> {
+            self.0
+                .method_hash([234, 202, 70, 20], new_config_operator)
+                .expect("method not found (this should never happen)")
+        }
         ///Calls the contract's `setNodeConfiguration` (0x9b80fe83) function
         pub fn set_node_configuration(
             &self,
@@ -3101,6 +3163,26 @@ pub mod account_config {
     pub struct OnlyApiPayerOrPricingOperator {
         pub caller: ::ethers::core::types::Address,
     }
+    ///Custom Error type `OnlyConfigOperatorOrOwner` with signature `OnlyConfigOperatorOrOwner(address)` and selector `0x0bd0b9b4`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthError,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[etherror(
+        name = "OnlyConfigOperatorOrOwner",
+        abi = "OnlyConfigOperatorOrOwner(address)"
+    )]
+    pub struct OnlyConfigOperatorOrOwner {
+        pub caller: ::ethers::core::types::Address,
+    }
     ///Custom Error type `PkpDoesNotExist` with signature `PkpDoesNotExist(uint256,uint256,address)` and selector `0x2593917a`
     #[derive(
         Clone,
@@ -3166,6 +3248,7 @@ pub mod account_config {
         NotMasterAccount(NotMasterAccount),
         OnlyApiPayerOrOwner(OnlyApiPayerOrOwner),
         OnlyApiPayerOrPricingOperator(OnlyApiPayerOrPricingOperator),
+        OnlyConfigOperatorOrOwner(OnlyConfigOperatorOrOwner),
         PkpDoesNotExist(PkpDoesNotExist),
         UsageApiKeyDoesNotExist(UsageApiKeyDoesNotExist),
         /// The standard solidity revert string, with selector
@@ -3226,6 +3309,11 @@ pub mod account_config {
             {
                 return Ok(Self::OnlyApiPayerOrPricingOperator(decoded));
             }
+            if let Ok(decoded) =
+                <OnlyConfigOperatorOrOwner as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::OnlyConfigOperatorOrOwner(decoded));
+            }
             if let Ok(decoded) = <PkpDoesNotExist as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::PkpDoesNotExist(decoded));
             }
@@ -3260,6 +3348,9 @@ pub mod account_config {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
                 Self::OnlyApiPayerOrPricingOperator(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
+                Self::OnlyConfigOperatorOrOwner(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
                 Self::PkpDoesNotExist(element) => ::ethers::core::abi::AbiEncode::encode(element),
@@ -3315,6 +3406,10 @@ pub mod account_config {
                     true
                 }
                 _ if selector
+                    == <OnlyConfigOperatorOrOwner as ::ethers::contract::EthError>::selector() => {
+                    true
+                }
+                _ if selector
                     == <PkpDoesNotExist as ::ethers::contract::EthError>::selector() => {
                     true
                 }
@@ -3341,6 +3436,7 @@ pub mod account_config {
                 Self::OnlyApiPayerOrPricingOperator(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
+                Self::OnlyConfigOperatorOrOwner(element) => ::core::fmt::Display::fmt(element, f),
                 Self::PkpDoesNotExist(element) => ::core::fmt::Display::fmt(element, f),
                 Self::UsageApiKeyDoesNotExist(element) => ::core::fmt::Display::fmt(element, f),
                 Self::RevertString(s) => ::core::fmt::Display::fmt(s, f),
@@ -3400,6 +3496,11 @@ pub mod account_config {
     impl ::core::convert::From<OnlyApiPayerOrPricingOperator> for AccountConfigErrors {
         fn from(value: OnlyApiPayerOrPricingOperator) -> Self {
             Self::OnlyApiPayerOrPricingOperator(value)
+        }
+    }
+    impl ::core::convert::From<OnlyConfigOperatorOrOwner> for AccountConfigErrors {
+        fn from(value: OnlyConfigOperatorOrOwner) -> Self {
+            Self::OnlyConfigOperatorOrOwner(value)
         }
     }
     impl ::core::convert::From<PkpDoesNotExist> for AccountConfigErrors {
@@ -3720,6 +3821,21 @@ pub mod account_config {
         pub cid_hash: ::ethers::core::types::U256,
         pub wallet_address: ::ethers::core::types::Address,
     }
+    ///Container type for all input parameters for the `configOperator` function with signature `configOperator()` and selector `0x142a62ce`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(name = "configOperator", abi = "configOperator()")]
+    pub struct ConfigOperatorCall;
     ///Container type for all input parameters for the `creditApiKey` function with signature `creditApiKey(uint256,uint256)` and selector `0x683f2de8`
     #[derive(
         Clone,
@@ -4321,6 +4437,23 @@ pub mod account_config {
     pub struct SetApiPayersCall {
         pub new_api_payers: ::std::vec::Vec<::ethers::core::types::Address>,
     }
+    ///Container type for all input parameters for the `setConfigOperator` function with signature `setConfigOperator(address)` and selector `0xeaca4614`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(name = "setConfigOperator", abi = "setConfigOperator(address)")]
+    pub struct SetConfigOperatorCall {
+        pub new_config_operator: ::ethers::core::types::Address,
+    }
     ///Container type for all input parameters for the `setNodeConfiguration` function with signature `setNodeConfiguration(string,string)` and selector `0x9b80fe83`
     #[derive(
         Clone,
@@ -4569,6 +4702,7 @@ pub mod account_config {
         CanExecuteActionFast(CanExecuteActionFastCall),
         CanUseWalletInAction(CanUseWalletInActionCall),
         CanUseWalletInActionFast(CanUseWalletInActionFastCall),
+        ConfigOperator(ConfigOperatorCall),
         CreditApiKey(CreditApiKeyCall),
         DebitApiKey(DebitApiKeyCall),
         GetAccountWalletAddress(GetAccountWalletAddressCall),
@@ -4601,6 +4735,7 @@ pub mod account_config {
         RequestedApiPayerCount(RequestedApiPayerCountCall),
         SetAdminApiPayerAccount(SetAdminApiPayerAccountCall),
         SetApiPayers(SetApiPayersCall),
+        SetConfigOperator(SetConfigOperatorCall),
         SetNodeConfiguration(SetNodeConfigurationCall),
         SetPricing(SetPricingCall),
         SetPricingOperator(SetPricingOperatorCall),
@@ -4685,6 +4820,11 @@ pub mod account_config {
                 <CanUseWalletInActionFastCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
                 return Ok(Self::CanUseWalletInActionFast(decoded));
+            }
+            if let Ok(decoded) =
+                <ConfigOperatorCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::ConfigOperator(decoded));
             }
             if let Ok(decoded) = <CreditApiKeyCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
@@ -4824,6 +4964,11 @@ pub mod account_config {
                 return Ok(Self::SetApiPayers(decoded));
             }
             if let Ok(decoded) =
+                <SetConfigOperatorCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::SetConfigOperator(decoded));
+            }
+            if let Ok(decoded) =
                 <SetNodeConfigurationCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
                 return Ok(Self::SetNodeConfiguration(decoded));
@@ -4905,6 +5050,7 @@ pub mod account_config {
                 Self::CanUseWalletInActionFast(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
+                Self::ConfigOperator(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::CreditApiKey(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::DebitApiKey(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetAccountWalletAddress(element) => {
@@ -4965,6 +5111,7 @@ pub mod account_config {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
                 Self::SetApiPayers(element) => ::ethers::core::abi::AbiEncode::encode(element),
+                Self::SetConfigOperator(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::SetNodeConfiguration(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
@@ -5013,6 +5160,7 @@ pub mod account_config {
                 Self::CanExecuteActionFast(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CanUseWalletInAction(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CanUseWalletInActionFast(element) => ::core::fmt::Display::fmt(element, f),
+                Self::ConfigOperator(element) => ::core::fmt::Display::fmt(element, f),
                 Self::CreditApiKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DebitApiKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetAccountWalletAddress(element) => ::core::fmt::Display::fmt(element, f),
@@ -5045,6 +5193,7 @@ pub mod account_config {
                 Self::RequestedApiPayerCount(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetAdminApiPayerAccount(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetApiPayers(element) => ::core::fmt::Display::fmt(element, f),
+                Self::SetConfigOperator(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetNodeConfiguration(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetPricing(element) => ::core::fmt::Display::fmt(element, f),
                 Self::SetPricingOperator(element) => ::core::fmt::Display::fmt(element, f),
@@ -5136,6 +5285,11 @@ pub mod account_config {
     impl ::core::convert::From<CanUseWalletInActionFastCall> for AccountConfigCalls {
         fn from(value: CanUseWalletInActionFastCall) -> Self {
             Self::CanUseWalletInActionFast(value)
+        }
+    }
+    impl ::core::convert::From<ConfigOperatorCall> for AccountConfigCalls {
+        fn from(value: ConfigOperatorCall) -> Self {
+            Self::ConfigOperator(value)
         }
     }
     impl ::core::convert::From<CreditApiKeyCall> for AccountConfigCalls {
@@ -5296,6 +5450,11 @@ pub mod account_config {
     impl ::core::convert::From<SetApiPayersCall> for AccountConfigCalls {
         fn from(value: SetApiPayersCall) -> Self {
             Self::SetApiPayers(value)
+        }
+    }
+    impl ::core::convert::From<SetConfigOperatorCall> for AccountConfigCalls {
+        fn from(value: SetConfigOperatorCall) -> Self {
+            Self::SetConfigOperator(value)
         }
     }
     impl ::core::convert::From<SetNodeConfigurationCall> for AccountConfigCalls {
@@ -5533,6 +5692,20 @@ pub mod account_config {
         Hash,
     )]
     pub struct CanUseWalletInActionFastReturn(pub bool);
+    ///Container type for all return fields from the `configOperator` function with signature `configOperator()` and selector `0x142a62ce`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct ConfigOperatorReturn(pub ::ethers::core::types::Address);
     ///Container type for all return fields from the `getAccountWalletAddress` function with signature `getAccountWalletAddress(uint256)` and selector `0x50ed5bb8`
     #[derive(
         Clone,


### PR DESCRIPTION
## Summary
- Rename `owner` storage field to `configOperator` in AppStorage, separating config management from diamond ownership
- Add `setConfigOperator` setter (gated by `revertIfNotConfigOperatorOrOwner`) and `configOperator()` view
- Replace `s.owner` references in SecurityLib with `LibDiamond.contractOwner()` for authorization checks
- Regenerate Rust ABI bindings

## Test plan
- [ ] Verify contract compilation with `npx hardhat compile`
- [ ] Verify `setConfigOperator` is only callable by current config operator or diamond owner
- [ ] Verify `configOperator()` view returns correct address after initialization
- [ ] Verify existing `revertIfNotApiPayerOrOwner` checks now use diamond owner correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)