### PR TITLE
fix: k6 integration test picks up wildcard sentinel from list_actions

### DIFF
--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -244,8 +244,9 @@ export default function (data: IntegrationSetupData) {
       }
     },
   }, "listActions");
-  const listActionsBody = JSON.parse(listActionsRes.response.body as string) as { id: string }[];
-  const hashedCid = listActionsBody[0]?.id ?? "";
+  const listActionsBody = JSON.parse(listActionsRes.response.body as string) as { id: string; name: string }[];
+  const actionItem = listActionsBody.find((a) => a.name === "hello-world");
+  const hashedCid = actionItem?.id ?? "";
   // ── 10. addPkpToGroup ─────────────────────────────────────────────────────
   const addPkpRes = client.addPkpToGroup(
     { group_id: parseInt(groupId), pkp_id: walletAddress },


### PR DESCRIPTION
## Summary
- The `list_actions` API returns a wildcard sentinel entry with `id: "n/a"` (representing `U256::zero()` — "Any action") alongside real actions
- The k6 integration test blindly grabbed `listActionsBody[0]?.id`, which picked up this sentinel
- When `"n/a"` was passed to `updateActionMetadata` as `hashed_cid`, the server parsed it as `0x0` and rejected it with "Cannot update action with hash 0x0"
- Fix: find the specific action by name (`"hello-world"`) instead of taking the first array element

## Test plan
- [ ] Verify the `k6-correctness / correctness` job passes in CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)