### PR TITLE
feat: document 429 response in OpenAPI spec for /lit_action

### DIFF
--- a/lit-api-server/src/bin/openapi_spec.rs
+++ b/lit-api-server/src/bin/openapi_spec.rs
@@ -19,7 +19,9 @@ fn main() {
     });
     if let Some(path_item) = spec.paths.get_mut("/lit_action") {
         if let Some(ref mut op) = path_item.post {
-            op.responses.responses.insert("429".to_string(), too_many_requests);
+            op.responses
+                .responses
+                .insert("429".to_string(), too_many_requests);
         }
     }
 

--- a/lit-api-server/src/bin/openapi_spec.rs
+++ b/lit-api-server/src/bin/openapi_spec.rs
@@ -1,5 +1,5 @@
 use lit_api_server::core::v1::endpoints::routes_with_spec;
-use rocket_okapi::okapi::openapi3::Server;
+use rocket_okapi::okapi::openapi3::{RefOr, Response, Server};
 
 fn main() {
     let (_, mut spec) = routes_with_spec();
@@ -8,6 +8,21 @@ fn main() {
         description: Some("Lit Protocol Express API (Core v1)".to_string()),
         ..Default::default()
     });
+
+    // Document 429 for endpoints behind the CpuAvailable guard.
+    let too_many_requests = RefOr::Object(Response {
+        description: "Too Many Requests \u{2014} the node is CPU-overloaded and shedding \
+            load. Clients receiving this response should retry the request up to \
+            five times with exponential backoff."
+            .to_string(),
+        ..Default::default()
+    });
+    if let Some(path_item) = spec.paths.get_mut("/lit_action") {
+        if let Some(ref mut op) = path_item.post {
+            op.responses.responses.insert("429".to_string(), too_many_requests);
+        }
+    }
+
     println!(
         "{}",
         serde_json::to_string_pretty(&spec).expect("Failed to serialize OpenAPI spec")

--- a/lit-api-server/src/bin/openapi_spec.rs
+++ b/lit-api-server/src/bin/openapi_spec.rs
@@ -17,12 +17,12 @@ fn main() {
             .to_string(),
         ..Default::default()
     });
-    if let Some(path_item) = spec.paths.get_mut("/lit_action") {
-        if let Some(ref mut op) = path_item.post {
-            op.responses
-                .responses
-                .insert("429".to_string(), too_many_requests);
-        }
+    if let Some(path_item) = spec.paths.get_mut("/lit_action")
+        && let Some(ref mut op) = path_item.post
+    {
+        op.responses
+            .responses
+            .insert("429".to_string(), too_many_requests);
     }
 
     println!(

--- a/spec.json
+++ b/spec.json
@@ -230,6 +230,9 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too Many Requests — the node is CPU-overloaded and shedding load. Clients receiving this response should retry the request up to five times with exponential backoff."
           }
         }
       }


### PR DESCRIPTION
## Summary
- Adds a `429 Too Many Requests` response to the `/lit_action` endpoint in the OpenAPI spec
- The `CpuAvailable` request guard already returns 429 under CPU overload, but this was undocumented
- Clients are informed they may retry the request up to five times with exponential backoff

## Test plan
- [x] `cargo run --bin openapi_spec` compiles and produces valid JSON
- [ ] Verify `spec.json` contains the 429 entry under `/lit_action`
- [ ] Confirm no other endpoints are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)