### PR TITLE
fix: correct Lit Action pricing text in dashboard (CPL-196)

### DIFF
--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -356,7 +356,7 @@
         <button type="button" class="modal-close" id="billing-modal-close-btn" aria-label="Close">&times;</button>
       </div>
       <div class="modal-body">
-        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.01 per Lit Action).</p>
+        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.01 per second for Lit Action execution with a 1-second minimum).</p>
         <div class="form-group">
           <label for="billing-amount">Amount (USD)</label>
           <select id="billing-amount" class="input">


### PR DESCRIPTION
## Summary

The "Add Funds" modal in the production dashboard displayed **"$0.01 per Lit Action"**, which is inaccurate after the per-second billing model shipped in CPL-174 (#247). 

Updated the pricing text to: **"$0.01 per second for Lit Action execution with a 1-second minimum"** — matching the actual billing logic in `stripe.rs` (`COST_LIT_ACTION_PER_SECOND_CENTS`) and the press release documentation.

**File changed:** `lit-static/dapps/dashboard/index.html:359`

## Pre-Landing Review

No issues found. Single text correction in static HTML.

## Test plan

- [ ] Verify the "Add Funds" modal on the dashboard shows the updated pricing text
- [ ] Confirm pricing text matches `docs/management/pricing.mdx` and `docs/press_releases/2026-03-30.md`

Closes CPL-196

🤖 Generated with [Claude Code](https://claude.com/claude-code)