### PR TITLE
fix: add setup-node to static site deploy workflows

### DIFF
--- a/.github/workflows/deploy-prod-3-static.yml
+++ b/.github/workflows/deploy-prod-3-static.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           ref: ${{ inputs.version_tag }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://api.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/app.js
 

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://api.dev.litprotocol.com|g" lit-static/dapps/dashboard/app.js
 
@@ -32,6 +36,10 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/app.js


### PR DESCRIPTION
## Summary
- The `deploy-prod-3-static` and `deploy-static` workflows fail on self-hosted runners because `npm` is not in PATH
- `cloudflare/wrangler-action@v3` needs npm to install wrangler, but the self-hosted runner doesn't have Node.js preconfigured
- Adds `actions/setup-node@v4` (Node 20) before the wrangler deploy step, matching the pattern used by all other workflows in this repo

## Test plan
- [ ] Trigger `Deploy Prod 3: Static Site` workflow with tag `v1.0.6` and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)