### PR TITLE
docs: migrate URLs from dev.litprotocol.com to new domains

### DIFF
--- a/docs/api_direct.mdx
+++ b/docs/api_direct.mdx
@@ -10,7 +10,7 @@ The same workflows can be done via the REST API. The API itself is under `/core/
 - `X-Api-Key: your-api-key`
 - or `Authorization: Bearer your-api-key`
 
-Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=http://localhost:8000` (local dev node) and JavaScript snippets use `BASE=https://api.dev.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
+Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=http://localhost:8000` (local dev node) and JavaScript snippets use `BASE=https://api.chipotle.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
 
 **API workflow:**
 
@@ -31,7 +31,7 @@ Create a new account (returns API key and wallet address). Or verify an existing
     ```javascript
     import { createClient } from './core_sdk.js';
     
-    const client = createClient('https://api.dev.litprotocol.com');
+    const client = createClient('https://api.chipotle.litprotocol.com');
     
     // New account
     const res = await client.newAccount({
@@ -51,7 +51,7 @@ Create a new account (returns API key and wallet address). Or verify an existing
   <Tab title="cURL">
     ```bash
     # New account
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/new_account" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/new_account" \
       -H "Content-Type: application/json" \
       -d '{"account_name":"My App","account_description":"Optional","email":"you@example.com"}'
     
@@ -391,13 +391,13 @@ Update the name and description of a registered action. The action is identified
 
 Both request/response shapes and OpenAPI spec are available directly in the dev system. For a Swagger UI implementation of the OpenAPI spec, please browse to:\
 \
-https://api.dev.litprotocol.com/swagger-ui/
+https://api.chipotle.litprotocol.com/core/v1/swagger-ui
 
 
 ### Open API Specification
 
 The OpenAPI spec itself can be found at:\
 \
-[https://api.dev.litprotocol.com/core/v1/openapi.json](https://api.dev.litprotocol.com/core/v1/openapi.json)
+[https://api.chipotle.litprotocol.com/core/v1/openapi.json](https://api.chipotle.litprotocol.com/core/v1/openapi.json)
 
 Note that these specs are subject to minor changes and will always be available with the dev server endpoints.

--- a/docs/architecture/verification/index.mdx
+++ b/docs/architecture/verification/index.mdx
@@ -61,4 +61,4 @@ Once full verification passes, pin the TLS certificate fingerprint:
 - [RTMR3 Calculator](https://rtmr3-calculator.vercel.app/) — web tool for computing compose hashes
 - [dstack Verification Script](https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py) — reference Python implementation
 - [Phala Trust Center](https://github.com/Phala-Network/trust-center) — reference verification implementation
-- [Sigstore cosign](https://docs.sigstore.dev/cosign/overview/)
+- [Sigstore cosign](https://docs.sigstore.dev/cosign/signing/overview/)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,12 +69,7 @@
     "dark": "/logo/dark.svg"
   },
   "navbar": {
-    "links": [
-      {
-        "label": "Support",
-        "href": "https://developer.litprotocol.com/support/intro"
-      }
-    ]
+    "links": []
   },
   "contextual": {
     "options": [

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,7 +3,7 @@ title: "Quick Start"
 description: "Get started with Lit Chipotle using the Lit Chipotle Dashboard or the REST API (Core SDK and cURL), the fastest and easiest method to get started with Lit Actions."
 ---
 
-This guide introduces the [**Lit Chipotle API**](https://api.dev.litprotocol.com/) and its web interface, the [**Lit Chipotle Dashboard**](https://dashboard.dev.litprotocol.com/dapps/dashboard/) which allows both web3 and non-web3 developers to quickly set up their Lit environment and start using Lit Actions.
+This guide introduces the [**Lit Chipotle API**](https://api.chipotle.litprotocol.com/) and its web interface, the [**Lit Chipotle Dashboard**](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) which allows both web3 and non-web3 developers to quickly set up their Lit environment and start using Lit Actions.
 
 ## Zero to LitAction
 
@@ -17,7 +17,7 @@ This guide introduces the [**Lit Chipotle API**](https://api.dev.litprotocol.com
 
 ## Overview
 
-The [**Lit Chipotle Dashboard**](https://dashboard.dev.litprotocol.com/dapps/dashboard/) is the front end to the [**Lit Chipotle API**](https://api.dev.litprotocol.com) server, designed to quickly and efficiently execute Lit Actions and to manage your user accounts, usage parameters, client wallet creation (PKPs), and IPFS based actions, through a simple set of groups. \
+The [**Lit Chipotle Dashboard**](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) is the front end to the [**Lit Chipotle API**](https://api.chipotle.litprotocol.com) server, designed to quickly and efficiently execute Lit Actions and to manage your user accounts, usage parameters, client wallet creation (PKPs), and IPFS based actions, through a simple set of groups. \
 \
 Specifically it lets you:
 
@@ -28,13 +28,13 @@ Specifically it lets you:
 - Organize all your resources into **groups** that combine PKPs, IPFS actions, and usage API keys in any combination.
 - Send **lit-actions** to the node for execution, authorized by a usage or account API key.
 
-All of this can be done via the [**Dashboard**](https://dashboard.dev.litprotocol.com/dapps/dashboard/) (web GUI) or directly via the [**REST API**](https://api.dev.litprotocol.com), using a light-weight JS SDK, or even directly through cURL commands. Data is secure and on-chain—all configuration within the Dashboard can be achieved by talking directly to our contracts located on **BASE**.
+All of this can be done via the [**Dashboard**](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) (web GUI) or directly via the [**REST API**](https://api.chipotle.litprotocol.com), using a light-weight JS SDK, or even directly through cURL commands. Data is secure and on-chain—all configuration within the Dashboard can be achieved by talking directly to our contracts located on **BASE**.
 
 ## Using the Dashboard
 
-The [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) is a web management GUI for Lit's Chipotle offering. Open it from your browser at
+The [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) is a web management GUI for Lit's Chipotle offering. Open it from your browser at
 
-`https://dashboard.dev.litprotocol.com/dapps/dashboard/`
+`https://dashboard.chipotle.litprotocol.com/dapps/dashboard/`
 
 It supports light/dark theme for your convenience and provides simple management tools.
 
@@ -78,4 +78,4 @@ The dashboard is just your human-friendly configuration tool. Once your account 
 - [Pricing](/management/pricing) — Credit-based billing model
 - [Lit Actions](/lit-actions/index) — Writing and deploying Lit Actions
 - [Architecture](/architecture/index) — System design and auth model
-- [OpenAPI Spec](https://api.dev.litprotocol.com/core/v1/openapi.json) / [Swagger UI](https://api.dev.litprotocol.com/swagger-ui/)
+- [OpenAPI Spec](https://api.chipotle.litprotocol.com/core/v1/openapi.json) / [Swagger UI](https://api.chipotle.litprotocol.com/core/v1/swagger-ui)

--- a/docs/lit-actions/index.mdx
+++ b/docs/lit-actions/index.mdx
@@ -22,7 +22,7 @@ A Programmable Key Pair (PKP) is a wallet — an elliptic-curve key pair — man
 
 When a Lit Action executes, it can retrieve the private key of a PKP using `Lit.Actions.getPrivateKey({ pkpId })` and use it (via [ethers.js](https://docs.ethers.org/v5/)) to sign transactions, messages, or any arbitrary data.
 
-Which actions are permitted to use which PKPs is enforced **on-chain** through the `AccountConfig` contract and managed via the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/).
+Which actions are permitted to use which PKPs is enforced **on-chain** through the `AccountConfig` contract and managed via the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/).
 
 ## What is a Proof?
 

--- a/docs/lit-actions/migration/encryption.mdx
+++ b/docs/lit-actions/migration/encryption.mdx
@@ -3,9 +3,9 @@ title: "Encryption & Decryption"
 description: "How encryption and decryption work in Chipotle compared to the official Lit SDK's access-control-conditions approach."
 ---
 
-## The Official SDK Approach
+## The Lit V1 SDK Approach
 
-The [official Lit documentation](https://developer.litprotocol.com/sdk/auth-context-consumption/encrypt-and-decrypt) shows a full encrypt/decrypt flow using the `@lit-protocol/access-control-conditions` package. The steps are:
+The Lit V1 / Naga SDK encrypt/decrypt flow using the `@lit-protocol/access-control-conditions` package was:
 
 1. **Install the package** — `npm install @lit-protocol/access-control-conditions`
 2. **Define access control conditions** — Build an `accs` object that describes *who* can decrypt (e.g. a specific wallet address, a token balance check, an NFT ownership check). These are evaluated at decrypt time across the Lit node network.

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -11,7 +11,7 @@ The same workflows can be done via the REST API. The API itself is under `/core/
 - `X-Api-Key: your-api-key`
 - or `Authorization: Bearer your-api-key`
 
-Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=http://localhost:8000` (local dev node) and JavaScript snippets use `BASE=https://api.dev.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
+Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=http://localhost:8000` (local dev node) and JavaScript snippets use `BASE=https://api.chipotle.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
 
 **API workflow:**
 
@@ -32,7 +32,7 @@ Create a new account (returns API key and wallet address). Or verify an existing
     ```javascript
     import { createClient } from './core_sdk.js';
 
-    const client = createClient('https://api.dev.litprotocol.com');
+    const client = createClient('https://api.chipotle.litprotocol.com');
 
     // New account
     const res = await client.newAccount({
@@ -52,7 +52,7 @@ Create a new account (returns API key and wallet address). Or verify an existing
   <Tab title="cURL">
     ```bash
     # New account
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/new_account" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/new_account" \
       -H "Content-Type: application/json" \
       -d '{"account_name":"My App","account_description":"Optional","email":"optional@example.com"}'
 
@@ -284,13 +284,13 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 
 Both request/response shapes and OpenAPI spec are available directly in the dev system. For a Swagger UI implementation of the OpenAPI spec, please browse to:\
 \
-https://api.dev.litprotocol.com/swagger-ui/
+https://api.chipotle.litprotocol.com/core/v1/swagger-ui
 
 
 ### Open API Specification
 
 The OpenAPI spec itself can be found at:\
 \
-[https://api.dev.litprotocol.com/core/v1/openapi.json](https://api.dev.litprotocol.com/core/v1/openapi.json)
+[https://api.chipotle.litprotocol.com/core/v1/openapi.json](https://api.chipotle.litprotocol.com/core/v1/openapi.json)
 
 Note that these specs are subject to minor changes and will always be available with the dev server endpoints.

--- a/docs/management/api_keys.mdx
+++ b/docs/management/api_keys.mdx
@@ -46,11 +46,11 @@ Usage keys are scoped, rotatable keys intended for day-to-day operations — for
 
 ### Managing Usage Keys
 
-Usage keys can be managed through the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) or directly via the REST API. Both require your account key to authenticate.
+Usage keys can be managed through the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) or directly via the REST API. Both require your account key to authenticate.
 
 #### Via the Dashboard
 
-In the **Usage API Keys** section of the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/):
+In the **Usage API Keys** section of the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/):
 
 - **Add** — Click **Add**, optionally set a name and description, then confirm. The new key is displayed once — copy it immediately.
 - **Delete** — Select a key and delete it. This takes effect immediately; any service still using the key will receive authentication errors.
@@ -87,7 +87,7 @@ Returns the new key once in the response (`usage_api_key`). Permissions are set 
   </Tab>
   <Tab title="cURL">
     ```bash
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/add_usage_api_key" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/add_usage_api_key" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: YOUR_ACCOUNT_KEY" \
       -d '{
@@ -142,7 +142,7 @@ Returns a paginated list of usage keys on the account. The key value itself is n
   </Tab>
   <Tab title="cURL">
     ```bash
-    curl -s "https://api.dev.litprotocol.com/core/v1/list_api_keys?page_number=0&page_size=20" \
+    curl -s "https://api.chipotle.litprotocol.com/core/v1/list_api_keys?page_number=0&page_size=20" \
       -H "X-Api-Key: YOUR_ACCOUNT_KEY"
     ```
   </Tab>
@@ -174,7 +174,7 @@ Replaces all permissions on an existing usage key. Pass the usage key value (not
   </Tab>
   <Tab title="cURL">
     ```bash
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/update_usage_api_key" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/update_usage_api_key" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: YOUR_ACCOUNT_KEY" \
       -d '{
@@ -212,7 +212,7 @@ Updates only the name and description without touching permissions.
   </Tab>
   <Tab title="cURL">
     ```bash
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/update_usage_api_key_metadata" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/update_usage_api_key_metadata" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: YOUR_ACCOUNT_KEY" \
       -d '{
@@ -241,7 +241,7 @@ Permanently removes a usage key. Pass the key value (not an ID) in the request b
   </Tab>
   <Tab title="cURL">
     ```bash
-    curl -s -X POST "https://api.dev.litprotocol.com/core/v1/remove_usage_api_key" \
+    curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/remove_usage_api_key" \
       -H "Content-Type: application/json" \
       -H "X-Api-Key: YOUR_ACCOUNT_KEY" \
       -d '{"usage_api_key": "THE_USAGE_KEY_VALUE"}'
@@ -249,7 +249,7 @@ Permanently removes a usage key. Pass the key value (not an ID) in the request b
   </Tab>
 </Tabs>
 
-For the full API reference and all available endpoints, see [Using the API directly](/management/api_direct) or browse the [Swagger UI](https://api.dev.litprotocol.com/swagger-ui/).
+For the full API reference and all available endpoints, see [Using the API directly](/management/api_direct) or browse the [Swagger UI](https://api.chipotle.litprotocol.com/core/v1/swagger-ui).
 
 ---
 

--- a/docs/management/dashboard.mdx
+++ b/docs/management/dashboard.mdx
@@ -1,9 +1,9 @@
 
 ## Using the Dashboard
 
-The [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) is a web management GUI for Lit's Chipotle offering. Open it from your browser at
+The [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) is a web management GUI for Lit's Chipotle offering. Open it from your browser at
 
-`https://dashboard.dev.litprotocol.com/dapps/dashboard/`
+`https://dashboard.chipotle.litprotocol.com/dapps/dashboard/`
 
 It supports light/dark theme for your convenience and provides simple management tools.
 

--- a/docs/management/pricing.mdx
+++ b/docs/management/pricing.mdx
@@ -45,7 +45,7 @@ Credits can be purchased directly in the dashboard using a credit card. Stripe p
 
 **To add funds:**
 
-1. Log in to the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/).
+1. Log in to the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/).
 2. Click **Add Funds** in the top-right corner.
 3. Select a credit package from the table below.
 4. Enter your card details and click **Pay**.

--- a/docs/press_releases/2026-03-30.md
+++ b/docs/press_releases/2026-03-30.md
@@ -12,11 +12,11 @@ Developers building applications that require cryptographic signing, secret mana
 
 Chipotle eliminates this trade-off with three composable layers:
 
-- **TEE Enclave** — A hardware-isolated execution environment that holds root key material and derives signing keys on demand. Key material never leaves the enclave, and every execution is sandboxed. Developers can [verify the full chain of trust](https://docs.dev.litprotocol.com/architecture/verification/index) cryptographically.
+- **TEE Enclave** — A hardware-isolated execution environment that holds root key material and derives signing keys on demand. Key material never leaves the enclave, and every execution is sandboxed. Developers can [verify the full chain of trust](https://developer.litprotocol.com/architecture/verification/index) cryptographically.
 
-- **On-Chain Permissions (Base)** — All authorization state — accounts, API key scopes, wallet registrations, and permission groups — lives on-chain in smart contracts. Developers can manage permissions through the API or submit transactions directly from an EOA or multisig for full [self-sovereign control](https://docs.dev.litprotocol.com/architecture/index).
+- **On-Chain Permissions (Base)** — All authorization state — accounts, API key scopes, wallet registrations, and permission groups — lives on-chain in smart contracts. Developers can manage permissions through the API or submit transactions directly from an EOA or multisig for full [self-sovereign control](https://developer.litprotocol.com/architecture/index).
 
-- **Lit Actions** — Immutable JavaScript programs identified by their IPFS content ID (CID). Developers submit code directly, and the system computes the CID to verify integrity — no IPFS storage is required. For additional transparency, developers can optionally publish their code to IPFS so anyone can independently verify it matches the CID. The TEE executes actions at runtime with access to derived key material. See the full [Lit Actions overview](https://docs.dev.litprotocol.com/lit-actions/index).
+- **Lit Actions** — Immutable JavaScript programs identified by their IPFS content ID (CID). Developers submit code directly, and the system computes the CID to verify integrity — no IPFS storage is required. For additional transparency, developers can optionally publish their code to IPFS so anyone can independently verify it matches the CID. The TEE executes actions at runtime with access to derived key material. See the full [Lit Actions overview](https://developer.litprotocol.com/lit-actions/index).
 
 ## What Developers Can Build
 
@@ -24,30 +24,30 @@ Chipotle is designed to serve both Web3 and traditional developers:
 
 - **Verifiable price feeds** — Fetch live market data, sign it with a network-managed wallet, and let smart contracts verify the signature on-chain. No off-chain trust required.
 - **On-chain access gating** — Only sign or decrypt when a user holds a specific NFT, token balance, or meets any on-chain condition.
-- **Programmable wallets** — Create and manage elliptic-curve key pairs ([PKPs](https://docs.dev.litprotocol.com/lit-actions/index)) that sign transactions without ever exposing private keys.
+- **Programmable wallets** — Create and manage elliptic-curve key pairs ([PKPs](https://developer.litprotocol.com/lit-actions/index)) that sign transactions without ever exposing private keys.
 - **Secret encryption and decryption** — Secure sensitive data with PKP-derived keys and store ciphertexts anywhere.
 - **Serverless backend functions** — Run JavaScript that can hold keys, call external APIs, read smart contracts, and return signed results — with no servers to manage.
 
-For common patterns and copy-paste code, see the [Examples guide](https://docs.dev.litprotocol.com/lit-actions/examples) and [Design Patterns](https://docs.dev.litprotocol.com/lit-actions/patterns).
+For common patterns and copy-paste code, see the [Examples guide](https://developer.litprotocol.com/lit-actions/examples) and [Design Patterns](https://developer.litprotocol.com/lit-actions/patterns).
 
 ## Getting Started
 
-The fastest way to get started is through the [Dashboard](https://dashboard.dev.litprotocol.com/dapps/dashboard/) — a full web interface for account management, wallet creation, and action execution. Create an account, generate an API key, set up a wallet, and run your first Lit Action — no terminal needed.
+The fastest way to get started is through the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/) — a full web interface for account management, wallet creation, and action execution. Create an account, generate an API key, set up a wallet, and run your first Lit Action — no terminal needed.
 
 For developers who prefer the command line, every dashboard operation is also available via `curl`:
 
 ```bash
 # Create an account
-curl -s -X POST https://api.dev.litprotocol.com/core/v1/new_account \
+curl -s -X POST https://api.chipotle.litprotocol.com/core/v1/new_account \
   -H "Content-Type: application/json" \
   -d '{"account_name": "my-app", "account_description": "Getting started"}'
 
 # Create a wallet
-curl -s https://api.dev.litprotocol.com/core/v1/create_wallet \
+curl -s https://api.chipotle.litprotocol.com/core/v1/create_wallet \
   -H "X-Api-Key: $API_KEY"
 
 # Run a Lit Action
-curl -s -X POST https://api.dev.litprotocol.com/core/v1/lit_action \
+curl -s -X POST https://api.chipotle.litprotocol.com/core/v1/lit_action \
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"code": "async function main() { return { hello: \"world\" }; }"}'
@@ -55,20 +55,20 @@ curl -s -X POST https://api.dev.litprotocol.com/core/v1/lit_action \
 
 ## Pricing
 
-Chipotle uses a simple [credit-based billing model](https://docs.dev.litprotocol.com/management/pricing) with no subscriptions or per-seat fees. All read-only operations are free. Write operations and Lit Action execution cost **$0.01 per second**, with each Lit Action billed at a **minimum of 1 second**. Common operations like ECDSA signing complete in under a second. Credit packages start at $5.00 with no expiry.
+Chipotle uses a simple [credit-based billing model](https://developer.litprotocol.com/management/pricing) with no subscriptions or per-seat fees. All read-only operations are free. Write operations and Lit Action execution cost **$0.01 per second**, with each Lit Action billed at a **minimum of 1 second**. Common operations like ECDSA signing complete in under a second. Credit packages start at $5.00 with no expiry.
 
 ## Open and Self-Sovereign
 
-Chipotle is not a walled garden. The platform supports both a managed SaaS experience and a fully self-sovereign deployment posture. Developers can deploy on any dstack-compatible platform, manage their account contract through a multisig, and scope API keys to enforce least-privilege access. See the [Architecture overview](https://docs.dev.litprotocol.com/architecture/index) for details.
+Chipotle is not a walled garden. The platform supports both a managed SaaS experience and a fully self-sovereign deployment posture. Developers can deploy on any dstack-compatible platform, manage their account contract through a multisig, and scope API keys to enforce least-privilege access. See the [Architecture overview](https://developer.litprotocol.com/architecture/index) for details.
 
 ## Resources
 
-- **Documentation:** [docs.dev.litprotocol.com](https://docs.dev.litprotocol.com/)
-- **Dashboard:** [dashboard.dev.litprotocol.com](https://dashboard.dev.litprotocol.com/dapps/dashboard/)
-- **API Reference (Swagger):** [api.dev.litprotocol.com/core/v1/swagger-ui](https://api.dev.litprotocol.com/core/v1/swagger-ui)
-- **Architecture:** [Architecture overview](https://docs.dev.litprotocol.com/architecture/index)
-- **Lit Actions:** [Overview](https://docs.dev.litprotocol.com/lit-actions/index) · [Examples](https://docs.dev.litprotocol.com/lit-actions/examples) · [Patterns](https://docs.dev.litprotocol.com/lit-actions/patterns)
-- **Pricing:** [Credit-based pricing](https://docs.dev.litprotocol.com/management/pricing)
+- **Documentation:** [developer.litprotocol.com](https://developer.litprotocol.com/)
+- **Dashboard:** [dashboard.chipotle.litprotocol.com](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/)
+- **API Reference (Swagger):** [api.chipotle.litprotocol.com/core/v1/swagger-ui](https://api.chipotle.litprotocol.com/core/v1/swagger-ui)
+- **Architecture:** [Architecture overview](https://developer.litprotocol.com/architecture/index)
+- **Lit Actions:** [Overview](https://developer.litprotocol.com/lit-actions/index) · [Examples](https://developer.litprotocol.com/lit-actions/examples) · [Patterns](https://developer.litprotocol.com/lit-actions/patterns)
+- **Pricing:** [Credit-based pricing](https://developer.litprotocol.com/management/pricing)
 
 ## About Lit Protocol
 


### PR DESCRIPTION
## Summary
- Replaces all `dev.litprotocol.com` URLs across 10 docs files with the correct new domains: `api.chipotle.litprotocol.com`, `dashboard.chipotle.litprotocol.com`, and `developer.litprotocol.com`
- Fixes broken swagger-ui path (`/swagger-ui/` → `/core/v1/swagger-ui`) which was returning 404
- Removes broken Support navbar link from `docs.json`
- Fixes broken SDK link in encryption migration doc by replacing it with inline content

## Test plan
- [x] All new URLs verified returning 200 via curl
- [ ] Verify Mintlify docs render correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)