### PR TITLE
docs: update Lit Action limits to match current API defaults (CPL-198)

### DIFF
--- a/docs/lit-actions/limits.mdx
+++ b/docs/lit-actions/limits.mdx
@@ -13,11 +13,11 @@ The following limits apply to all Lit Action executions on Chipotle. They are de
 
 | Limit | Default |
 |---|---|
-| Maximum action code size (inline) | 10 MB |
+| Maximum action code size (inline) | 16 MB |
 | Maximum IPFS action size | N/A |
 | Maximum `js_params` payload | 64 KB |
 
-Action code submitted inline via the API or Dashboard must not exceed 10 MB. Downloading actions via IPFS is not currently supported. If your action requires large static data, consider fetching it at runtime via `fetch` rather than bundling it into the action itself.
+Action code submitted inline via the API or Dashboard must not exceed 16 MB. Downloading actions via IPFS is not currently supported. If your action requires large static data, consider fetching it at runtime via `fetch` rather than bundling it into the action itself.
 
 ---
 
@@ -26,9 +26,11 @@ Action code submitted inline via the API or Dashboard must not exceed 10 MB. Dow
 | Limit | Default |
 |---|---|
 | Maximum execution time | 15 minutes |
-| Maximum memory | 128 MB |
-| Maximum outbound HTTP requests per action | 100 |
-| Maximum response payload size | 1 MB |
+| Maximum memory | 64 MB |
+| Maximum outbound HTTP requests per action | 50 |
+| Maximum response payload size | 100 KB |
+| Maximum console log output | 100 KB |
+| Maximum key/signature requests per action | 10 |
 
 Actions that exceed the execution time limit are terminated and return a timeout error. Long-running workflows should be broken into smaller actions or offload heavy computation to an external service and fetch the result.
 


### PR DESCRIPTION
## Summary

Updates `docs/lit-actions/limits.mdx` to match the actual defaults in the API server code (`lit-api-server/src/actions/client/mod.rs`).

**Changes:**
- Maximum action code size: 10 MB → 16 MB
- Maximum memory: 128 MB → 64 MB
- Maximum outbound HTTP requests: 100 → 50
- Maximum response payload size: 1 MB → 100 KB
- Added two previously undocumented limits: console log output (100 KB) and key/signature requests per action (10)

## Pre-Landing Review

No issues found. Docs-only change, no application code.

## Test plan

- [x] Docs-only change — no tests needed
- [x] Values cross-checked against API server source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)