### PR TITLE
feat: module import cleanup, showImportDetails(), and security hardening (CPL-211)

### DIFF
--- a/Dockerfile.lit-actions
+++ b/Dockerfile.lit-actions
@@ -28,5 +28,6 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 COPY --from=builder /build/lit-actions/target/release/lit_actions /usr/local/bin/
+COPY lit-actions/integrity.lock /app/integrity.lock
 
-CMD ["lit_actions", "--socket", "/tmp/lit_actions.sock"]
+CMD ["lit_actions", "--socket", "/tmp/lit_actions.sock", "--integrity-lock", "/app/integrity.lock"]

--- a/docs/lit-actions/chipotle.mdx
+++ b/docs/lit-actions/chipotle.mdx
@@ -23,6 +23,8 @@ title: Lit Actions SDK
 *   [Action Utilities](#action-utilities)
 *   [setResponse](#setresponse)
     *   [Parameters](#parameters-5)
+*   [Debugging](#debugging)
+*   [showImportDetails](#showimportdetails)
 *   [Runtime Globals](#runtime-globals)
 *   [LitActions](#litactions)
 *   [ethers](#ethers)
@@ -118,6 +120,16 @@ Set the response returned to the client
 *   `params` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
 
     *   `params.response` **any** The response to send to the client. If this is not a string, it will be JSON-encoded before being sent. A value of undefined is encoded as null.
+
+## Debugging
+
+Diagnostic functions for inspecting the runtime state of a Lit Action.
+
+## Lit.Actions.showImportDetails
+
+Log and return details of all modules imported by this Lit Action. Returns an array of objects with the resolved CDN URL and SHA-384 integrity hash for each imported module. The details are also written to the action's console log via the print opCode.
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)\<{url: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), hash: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}\>** Array of imported module details
 
 ## Runtime Globals
 

--- a/docs/lit-actions/imports.mdx
+++ b/docs/lit-actions/imports.mdx
@@ -10,8 +10,8 @@ Until now, the only JavaScript available inside a Lit Action was what shipped wi
 That limitation is gone. Lit Actions can now **import ES modules at runtime** from [jsDelivr](https://www.jsdelivr.com/), a public CDN that serves npm packages as ready-to-run ESM. You write a standard `import` statement with a version-pinned package specifier and the runtime resolves it to jsDelivr, fetches, verifies, caches, and executes it.
 
 ```javascript
-import { z } from "zod@3.22.4/+esm";
-import { formatDistance } from "date-fns@3.6.0/+esm";
+import { z } from "zod@3.22.4";
+import { formatDistance } from "date-fns@3.6.0";
 ```
 
 This opens the door to thousands of npm packages: validation libraries, date/time utilities, encoding tools, math libraries, protocol implementations, and more.
@@ -24,7 +24,7 @@ Every import goes through three stages before any bytes reach the V8 engine.
 
 ### 1. Resolution
 
-The runtime resolves the import specifier to a jsDelivr URL. You can write either a short npm specifier (`zod@3.22.4/+esm`) or a full URL (`https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm`). The runtime converts npm specifiers to their full jsDelivr URL automatically. Bare package names without a version (`import { z } from "zod"`) and relative paths (`./util.js`) are rejected. Every import must include a pinned version.
+The runtime resolves the import specifier to a jsDelivr URL. You can write a short npm specifier (`zod@3.22.4`), an explicit ESM specifier (`zod@3.22.4/+esm`), or a full URL (`https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm`). When no file path is specified after the version, the runtime automatically appends `/+esm` to request the ESM entry point from jsDelivr. Bare package names without a version (`import { z } from "zod"`) and relative paths (`./util.js`) are rejected. Every import must include a pinned version.
 
 ### 2. Integrity Verification
 
@@ -40,23 +40,26 @@ Once a module is verified, its source is held in an in-memory cache. Subsequent 
 
 ## Import Syntax
 
-Imports use an npm-style specifier with a pinned version. The runtime automatically resolves these to jsDelivr URLs.
+Imports use an npm-style specifier with a pinned version. The runtime automatically resolves these to jsDelivr URLs and appends `/+esm` when no file path is specified.
 
 ```javascript
 // Import a specific named export
-import { z } from "zod@3.22.4/+esm";
+import { z } from "zod@3.22.4";
 
 // Import a default export
-import Ajv from "ajv@8.12.0/+esm";
+import Ajv from "ajv@8.12.0";
 
 // Import multiple named exports
-import { encode, decode } from "cbor-x@1.5.9/+esm";
+import { encode, decode } from "cbor-x@1.5.9";
 
 // Scoped packages
-import { render } from "@preact/render-to-string@6.4.1/+esm";
+import { render } from "@preact/render-to-string@6.4.1";
 
-// Specific file path
+// Specific file path (no /+esm auto-appended)
 import { format } from "date-fns@3.6.0/esm/index.js";
+
+// Explicit /+esm still works (backward compatible)
+import { z } from "zod@3.22.4/+esm";
 ```
 
 The specifier format is:
@@ -65,17 +68,17 @@ The specifier format is:
 <package>@<version>[/<file>]
 ```
 
-The `@<version>` pin is required and ensures you always get the exact same bytes. The `/<file>` part is optional. Use `/+esm` to get the package's ESM entry point, or specify a path to a specific file in the package.
+The `@<version>` pin is required and ensures you always get the exact same bytes. The `/<file>` part is optional. When omitted, `/+esm` is automatically appended to request the package's ESM entry point from jsDelivr. You can also specify a path to a specific file in the package.
 
 ### Inline Integrity Hash
 
 You can append a `#sha384-<hash>` fragment to any import specifier to declare the expected integrity hash directly in your code. The runtime will verify the fetched content against this hash before execution.
 
 ```javascript
-import { z } from "zod@3.22.4/+esm#sha384-oKhMb3mCbOey4gFjFHm1YmKJF/WuNdbiLPSLHMwbkPE1mEpMJOoDQMHTcIltUJQ+";
+import { z } from "zod@3.22.4#sha384-oKhMb3mCbOey4gFjFHm1YmKJF/WuNdbiLPSLHMwbkPE1mEpMJOoDQMHTcIltUJQ+";
 ```
 
-This makes integrity verification self-contained in the action code, with no dependency on an external lockfile. When an inline hash is provided, it takes priority over any entry in `integrity.lock`.
+This makes integrity verification self-contained in the action code, with no dependency on an external lockfile. When an inline hash is provided, it takes priority over any entry in `integrity.lock`. The `/+esm` suffix is still auto-appended when no file path precedes the `#` fragment.
 
 The fragment is never sent over the network (per the URL specification). It is stripped before fetching and used only for local verification.
 
@@ -99,7 +102,7 @@ import { z } from "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm#sha384-oKhMb3m..
 ### Validate Input with Zod
 
 ```javascript
-import { z } from "zod@3.22.4/+esm";
+import { z } from "zod@3.22.4";
 
 // js_params: { pkpId, userData }
 async function main({ pkpId, userData }) {
@@ -126,7 +129,7 @@ async function main({ pkpId, userData }) {
 ### Format and Sign a Timestamp Proof
 
 ```javascript
-import { format, utcToZonedTime } from "date-fns-tz@2.0.1/+esm";
+import { format, utcToZonedTime } from "date-fns-tz@2.0.1";
 
 // js_params: { pkpId, timezone }
 async function main({ pkpId, timezone }) {
@@ -146,7 +149,7 @@ async function main({ pkpId, timezone }) {
 ### Encode Data as CBOR Before Signing
 
 ```javascript
-import { encode } from "cbor-x@1.5.9/+esm";
+import { encode } from "cbor-x@1.5.9";
 
 // js_params: { pkpId, payload }
 async function main({ pkpId, payload }) {
@@ -167,7 +170,7 @@ async function main({ pkpId, payload }) {
 ### JSON Schema Validation with AJV
 
 ```javascript
-import Ajv from "ajv@8.12.0/+esm";
+import Ajv from "ajv@8.12.0";
 
 // js_params: { pkpId, data, schema }
 async function main({ pkpId, data, schema }) {
@@ -283,6 +286,30 @@ Module imports are subject to the same [resource limits](/lit-actions/limits) as
 - **Timeout** — Module fetch time counts toward the action's execution timeout (default 15 minutes).
 - **Network** — Module fetches use a separate HTTP client from the action's `fetch()` API and do not count toward the per-action fetch limit. However, they share the same execution timeout.
 - **Module size** — Individual modules are capped at 10 MB.
+
+---
+
+## Debugging Imports
+
+Use `Lit.Actions.showImportDetails()` to inspect which modules were loaded and their integrity hashes. This is useful for debugging import resolution, verifying that the expected modules were fetched, and auditing the integrity of imported code.
+
+```javascript
+import { z } from "zod@3.22.4";
+
+async function main() {
+  const details = Lit.Actions.showImportDetails();
+  // details is an array of { url, hash } objects:
+  // [
+  //   {
+  //     "url": "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm",
+  //     "hash": "sha384-oKhMb3mCbOey4gFjFHm1..."
+  //   }
+  // ]
+  return details;
+}
+```
+
+The import details are also written to the action's console log, so they appear alongside other `console.log` output in the response logs.
 
 ---
 

--- a/lit-actions/ext/bindings.rs
+++ b/lit-actions/ext/bindings.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{Arc, RwLock};
 
 use deno_core::{OpState, extension, op2};
 use deno_error::JsErrorBox;
@@ -7,6 +8,22 @@ use lit_actions_grpc::proto::*;
 use tracing::instrument;
 
 use crate::macros::*;
+
+/// Per-execution tracker that records every module loaded during a single
+/// Lit Action run, including its resolved CDN URL and SHA-384 hash.
+/// Shared between the module loader and OpState so that `showImportDetails()`
+/// can read it from user code.
+#[derive(Clone, Default)]
+pub struct LoadedModules(pub Arc<RwLock<Vec<LoadedModuleInfo>>>);
+
+/// Metadata for a single loaded CDN module.
+#[derive(Clone, Debug)]
+pub struct LoadedModuleInfo {
+    /// The resolved CDN URL (without fragment).
+    pub url: String,
+    /// The base64-encoded SHA-384 hash of the module content.
+    pub hash: String,
+}
 
 #[instrument(skip_all, ret)]
 #[op2(fast)]
@@ -194,6 +211,46 @@ async fn op_update_resource_usage(
 }
 
 #[instrument(skip_all, ret)]
+#[op2]
+#[string]
+fn op_show_import_details(state: &mut OpState) -> Result<String, JsErrorBox> {
+    // Clone the Arc to release the borrow on OpState before calling remote_op!
+    let loaded_modules: LoadedModules = state
+        .try_borrow::<LoadedModules>()
+        .cloned()
+        .ok_or_else(|| JsErrorBox::generic("Import tracking not available"))?;
+
+    let modules = loaded_modules
+        .0
+        .read()
+        .map_err(|e| JsErrorBox::generic(format!("Failed to read import details: {e}")))?;
+
+    // Build JSON array of {url, hash} objects
+    let details: Vec<serde_json::Value> = modules
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "url": m.url,
+                "hash": format!("sha384-{}", m.hash),
+            })
+        })
+        .collect();
+
+    let json = serde_json::to_string_pretty(&details)
+        .map_err(|e| JsErrorBox::generic(format!("Failed to serialize import details: {e}")))?;
+
+    // Log via the existing print opCode
+    remote_op!(
+        op_show_import_details,
+        state,
+        PrintRequest {
+            message: format!("[Import Details]\n{json}\n")
+        },
+        UnionRequest::Print(_) => Ok(json)
+    )
+}
+
+#[instrument(skip_all, ret)]
 pub async fn op_update_resource_usage_external(
     state: Rc<RefCell<OpState>>,
     tick: u32,
@@ -219,6 +276,7 @@ extension!(
         op_get_private_key,
         op_increment_fetch_count,
         op_set_response,
+        op_show_import_details,
         op_update_resource_usage,
     ],
     esm_entry_point = "ext:lit_actions/99_patches.js",

--- a/lit-actions/ext/bindings.rs
+++ b/lit-actions/ext/bindings.rs
@@ -230,8 +230,8 @@ fn op_show_import_details(state: &mut OpState) -> Result<String, JsErrorBox> {
         .iter()
         .map(|m| {
             serde_json::json!({
-                "url": m.url,
-                "hash": format!("sha384-{}", m.hash),
+                "url": &m.url,
+                "hash": format!("sha384-{}", &m.hash),
             })
         })
         .collect();

--- a/lit-actions/ext/js/02_litActionsSDK.js
+++ b/lit-actions/ext/js/02_litActionsSDK.js
@@ -89,6 +89,20 @@ function getLitActionWalletAddress({ ipfsId }) {
   return ops.op_get_lit_action_wallet_address(ipfsId);
 }
 
+/**
+ * Log and return details of all modules imported by this Lit Action.
+ * Returns an array of objects with the resolved CDN URL and SHA-384 integrity
+ * hash for each imported module. The details are also written to the action's
+ * console log via the print opCode.
+ * @name Lit.Actions.showImportDetails
+ * @function showImportDetails
+ * @returns {Array<{url: string, hash: string}>} Array of imported module details
+ */
+function showImportDetails() {
+  const json = ops.op_show_import_details();
+  return JSON.parse(json);
+}
+
 globalThis.LitActions = {
   Encrypt,
   Decrypt,
@@ -97,4 +111,5 @@ globalThis.LitActions = {
   getLitActionPublicKey,
   getLitActionWalletAddress,
   setResponse,
+  showImportDetails,
 };

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -396,13 +396,11 @@ impl ModuleLoader for CdnModuleLoader {
                     max = MAX_MODULE_COUNT,
                     "CDN module load rejected: maximum module count exceeded"
                 );
-                return ModuleLoadResponse::Sync(Err(
-                    JsErrorBox::generic(format!(
-                        "Maximum module count ({MAX_MODULE_COUNT}) exceeded. \
+                return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
+                    "Maximum module count ({MAX_MODULE_COUNT}) exceeded. \
                          Reduce the number of imported modules."
-                    ))
-                    .into(),
-                ));
+                ))
+                .into()));
             }
         }
 
@@ -462,14 +460,12 @@ impl ModuleLoader for CdnModuleLoader {
                             manifest_hash = %format!("sha384-{stored}"),
                             "CDN module cache: inline hash does not match manifest hash"
                         );
-                        return ModuleLoadResponse::Sync(Err(
-                            JsErrorBox::generic(format!(
-                                "Integrity check failed for cached {url}: \
+                        return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
+                            "Integrity check failed for cached {url}: \
                                  inline hash sha384-{declared} does not match \
                                  manifest hash sha384-{stored}"
-                            ))
-                            .into(),
-                        ));
+                        ))
+                        .into()));
                     }
                 }
             }

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -442,47 +442,49 @@ impl ModuleLoader for CdnModuleLoader {
         if let Ok(cache) = self.cache.read()
             && let Some(cached_bytes) = cache.get(&url)
         {
-            // If an inline hash was provided, verify it matches the manifest hash
-            // for this URL. This prevents a cached module from being served when the
-            // caller declared a different expected hash in their import specifier.
-            if let Some(ref declared) = inline_hash {
-                let manifest_hash = self
-                    .integrity
-                    .read()
-                    .expect("integrity lock poisoned")
-                    .get(&url)
-                    .cloned();
-                if let Some(ref stored) = manifest_hash {
-                    if declared != stored {
-                        error!(
-                            module_url = %url,
-                            inline_hash = %format!("sha384-{declared}"),
-                            manifest_hash = %format!("sha384-{stored}"),
-                            "CDN module cache: inline hash does not match manifest hash"
-                        );
-                        return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
-                            "Integrity check failed for cached {url}: \
-                                 inline hash sha384-{declared} does not match \
-                                 manifest hash sha384-{stored}"
-                        ))
-                        .into()));
-                    }
+            // If an expected hash exists (inline or manifest), verify it against
+            // the actual cached bytes. This catches both stale manifest entries and
+            // inline hash mismatches, even when the URL has no manifest entry.
+            if let Some(ref expected_b64) = expected_hash {
+                let mut hasher = Sha384::new();
+                hasher.update(cached_bytes);
+                let cached_digest = hasher.finalize();
+                let cached_b64 = base64::engine::general_purpose::STANDARD.encode(cached_digest);
+                if !constant_time_eq(cached_b64.as_bytes(), expected_b64.as_bytes()) {
+                    error!(
+                        module_url = %url,
+                        expected_hash = %format!("sha384-{expected_b64}"),
+                        cached_hash = %format!("sha384-{cached_b64}"),
+                        "CDN module cache: integrity check failed for cached bytes"
+                    );
+                    return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
+                        "Integrity check failed for cached {url}: \
+                             expected sha384-{expected_b64}, got sha384-{cached_b64}"
+                    ))
+                    .into()));
                 }
             }
 
-            // Record the loaded module for showImportDetails()
-            let hash = self
-                .integrity
-                .read()
-                .expect("integrity lock poisoned")
-                .get(&url)
-                .cloned()
+            // Record the loaded module for showImportDetails().
+            // Use expected_hash (inline or manifest) when available, so inline-hash-only
+            // imports don't lose the declared hash.
+            let hash = expected_hash
+                .clone()
+                .or_else(|| {
+                    self.integrity
+                        .read()
+                        .expect("integrity lock poisoned")
+                        .get(&url)
+                        .cloned()
+                })
                 .unwrap_or_default();
             if let Ok(mut modules) = self.loaded_modules.0.write() {
-                modules.push(LoadedModuleInfo {
-                    url: url.clone(),
-                    hash,
-                });
+                if !modules.iter().any(|m| m.url == url) {
+                    modules.push(LoadedModuleInfo {
+                        url: url.clone(),
+                        hash,
+                    });
+                }
             }
             debug!(module_url = %url, size_bytes = cached_bytes.len(), "CDN module loaded from cache");
             return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
@@ -673,12 +675,14 @@ impl ModuleLoader for CdnModuleLoader {
                 }
             }
 
-            // Record the loaded module for showImportDetails()
+            // Record the loaded module for showImportDetails() (dedup by URL)
             if let Ok(mut modules) = loaded_modules.0.write() {
-                modules.push(LoadedModuleInfo {
-                    url: url.clone(),
-                    hash: actual_b64.clone(),
-                });
+                if !modules.iter().any(|m| m.url == url) {
+                    modules.push(LoadedModuleInfo {
+                        url: url.clone(),
+                        hash: actual_b64.clone(),
+                    });
+                }
             }
 
             // Cache the verified module source (bounded by MAX_CACHE_BYTES)

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -26,8 +26,13 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-/// Allowed CDN URL prefix for module imports.
+/// Allowed CDN URL prefix for module imports (origin only, used for URL construction).
 const ALLOWED_CDN_PREFIX: &str = "https://cdn.jsdelivr.net/";
+
+/// Allowed CDN URL prefix restricted to the npm backend.
+/// Only npm packages are permitted; other jsDelivr backends (/gh/, /wp/, etc.)
+/// serve mutable content and are rejected.
+const ALLOWED_NPM_PREFIX: &str = "https://cdn.jsdelivr.net/npm/";
 
 /// Maximum response body size (10 MB).
 const MAX_MODULE_SIZE_BYTES: usize = 10 * 1024 * 1024;
@@ -38,8 +43,15 @@ const MAX_CACHE_BYTES: usize = 100 * 1024 * 1024;
 /// HTTP request timeout.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Maximum number of distinct modules that can be loaded per action execution.
+/// Prevents DoS via dependency graphs with thousands of tiny files.
+const MAX_MODULE_COUNT: usize = 100;
+
 /// Thread-safe cache for fetched and integrity-verified module sources.
 pub type ModuleCache = Arc<RwLock<HashMap<String, Vec<u8>>>>;
+
+// Re-export from ext crate for convenience.
+pub use lit_actions_ext::bindings::{LoadedModuleInfo, LoadedModules};
 
 pub struct CdnModuleLoader {
     /// Maps CDN URLs to their expected base64-encoded SHA-384 hashes.
@@ -56,6 +68,8 @@ pub struct CdnModuleLoader {
     /// Path to integrity.lock file on disk. When set, enables trust-on-first-use:
     /// new modules are double-fetched, verified, and pinned to the lockfile.
     lockfile_path: Option<PathBuf>,
+    /// Per-execution tracker of all loaded modules and their hashes.
+    loaded_modules: LoadedModules,
 }
 
 impl CdnModuleLoader {
@@ -71,6 +85,7 @@ impl CdnModuleLoader {
             Arc::new(RwLock::new(HashMap::new())),
             None,
             None,
+            LoadedModules::default(),
         )
     }
 
@@ -87,13 +102,14 @@ impl CdnModuleLoader {
     }
 
     /// Create a new `CdnModuleLoader` with a shared cache, optional lockfile path,
-    /// and optional shared HTTP client.
+    /// optional shared HTTP client, and per-execution module tracker.
     pub fn with_options(
         integrity: Arc<RwLock<HashMap<String, String>>>,
         strict: bool,
         cache: ModuleCache,
         lockfile_path: Option<PathBuf>,
         client: Option<Arc<reqwest::Client>>,
+        loaded_modules: LoadedModules,
     ) -> Self {
         Self {
             integrity,
@@ -101,7 +117,13 @@ impl CdnModuleLoader {
             client: client.unwrap_or_else(Self::build_http_client),
             cache,
             lockfile_path,
+            loaded_modules,
         }
+    }
+
+    /// Returns the per-execution loaded modules tracker, for sharing with OpState.
+    pub fn loaded_modules(&self) -> LoadedModules {
+        self.loaded_modules.clone()
     }
 
     /// Parse an `integrity.lock` file into a URL → hash map.
@@ -142,18 +164,24 @@ impl CdnModuleLoader {
         map
     }
 
-    /// Check whether a URL is from the allowed CDN.
+    /// Check whether a URL is from the allowed CDN npm backend.
+    /// Only `https://cdn.jsdelivr.net/npm/` URLs are accepted; other jsDelivr
+    /// backends (`/gh/`, `/wp/`, etc.) serve mutable content and are rejected.
     fn is_allowed_cdn(url: &str) -> bool {
-        url.starts_with(ALLOWED_CDN_PREFIX)
+        url.starts_with(ALLOWED_NPM_PREFIX)
     }
 
     /// Parse an npm package specifier into a full jsDelivr URL.
     ///
     /// Accepts these formats:
-    /// - `package@version` → `https://cdn.jsdelivr.net/npm/package@version`
+    /// - `package@version` → `https://cdn.jsdelivr.net/npm/package@version/+esm`
+    /// - `package@version/+esm` → `https://cdn.jsdelivr.net/npm/package@version/+esm`
     /// - `package@version/file` → `https://cdn.jsdelivr.net/npm/package@version/file`
-    /// - `@scope/package@version` → `https://cdn.jsdelivr.net/npm/@scope/package@version`
+    /// - `@scope/package@version` → `https://cdn.jsdelivr.net/npm/@scope/package@version/+esm`
     /// - `@scope/package@version/file` → `https://cdn.jsdelivr.net/npm/@scope/package@version/file`
+    ///
+    /// When no file path is specified after the version, `/+esm` is automatically
+    /// appended to request the ESM entry point from jsDelivr.
     ///
     /// An optional `#sha384-<hash>` fragment is preserved on the output URL for
     /// inline integrity verification.
@@ -186,7 +214,14 @@ impl CdnModuleLoader {
             return None;
         }
 
-        let mut url = format!("{ALLOWED_CDN_PREFIX}npm/{spec}");
+        // Auto-append /+esm when no file path is specified after the version.
+        // This ensures jsDelivr serves the ESM entry point by default.
+        let has_path = after_at.contains('/');
+        let mut url = if has_path {
+            format!("{ALLOWED_CDN_PREFIX}npm/{spec}")
+        } else {
+            format!("{ALLOWED_CDN_PREFIX}npm/{spec}/+esm")
+        };
         if let Some(frag) = fragment {
             url.push('#');
             url.push_str(frag);
@@ -276,7 +311,7 @@ impl ModuleLoader for CdnModuleLoader {
         referrer: &str,
         _kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, ModuleLoaderError> {
-        // Resolve relative imports against the referrer when the referrer is a jsDelivr URL.
+        // Resolve relative imports against the referrer when the referrer is a jsDelivr npm URL.
         // ESM modules on jsDelivr can have relative imports between files in the same package.
         if (specifier.starts_with("./") || specifier.starts_with("../"))
             && Self::is_allowed_cdn(referrer)
@@ -289,6 +324,8 @@ impl ModuleLoader for CdnModuleLoader {
                     "Failed to resolve relative import \"{specifier}\" against {referrer}: {e}"
                 ))
             })?;
+            // Verify the resolved URL stays within the /npm/ backend.
+            // Relative traversal (../../) could escape to /gh/ or other backends.
             if Self::is_allowed_cdn(resolved.as_str()) {
                 info!(
                     specifier,
@@ -302,10 +339,10 @@ impl ModuleLoader for CdnModuleLoader {
                 specifier,
                 referrer,
                 resolved_url = %resolved,
-                "CDN module resolve rejected: relative import resolved to non-jsDelivr URL"
+                "CDN module resolve rejected: relative import resolved outside /npm/ boundary"
             );
             return Err(JsErrorBox::generic(format!(
-                "Relative import \"{specifier}\" resolved to {resolved}, which is not on the allowed CDN"
+                "Relative import \"{specifier}\" resolved to {resolved}, which is outside the allowed /npm/ CDN path"
             ))
             .into());
         }
@@ -337,7 +374,7 @@ impl ModuleLoader for CdnModuleLoader {
         );
         Err(JsErrorBox::generic(format!(
             "Invalid import specifier: \"{specifier}\". \
-             Use an npm specifier with a pinned version (e.g. zod@3.22.4/+esm) \
+             Use an npm specifier with a pinned version (e.g. zod@3.22.4) \
              or a full jsDelivr URL (e.g. https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm)"
         ))
         .into())
@@ -350,6 +387,25 @@ impl ModuleLoader for CdnModuleLoader {
         _is_dyn_import: bool,
         _requested_module_type: RequestedModuleType,
     ) -> ModuleLoadResponse {
+        // Enforce per-execution module count limit to prevent DoS via
+        // dependency graphs with thousands of tiny files.
+        if let Ok(modules) = self.loaded_modules.0.read() {
+            if modules.len() >= MAX_MODULE_COUNT {
+                error!(
+                    module_count = modules.len(),
+                    max = MAX_MODULE_COUNT,
+                    "CDN module load rejected: maximum module count exceeded"
+                );
+                return ModuleLoadResponse::Sync(Err(
+                    JsErrorBox::generic(format!(
+                        "Maximum module count ({MAX_MODULE_COUNT}) exceeded. \
+                         Reduce the number of imported modules."
+                    ))
+                    .into(),
+                ));
+            }
+        }
+
         // Extract inline hash from URL fragment (e.g. #sha384-abc123...)
         let inline_hash = module_specifier
             .fragment()
@@ -388,6 +444,50 @@ impl ModuleLoader for CdnModuleLoader {
         if let Ok(cache) = self.cache.read()
             && let Some(cached_bytes) = cache.get(&url)
         {
+            // If an inline hash was provided, verify it matches the manifest hash
+            // for this URL. This prevents a cached module from being served when the
+            // caller declared a different expected hash in their import specifier.
+            if let Some(ref declared) = inline_hash {
+                let manifest_hash = self
+                    .integrity
+                    .read()
+                    .expect("integrity lock poisoned")
+                    .get(&url)
+                    .cloned();
+                if let Some(ref stored) = manifest_hash {
+                    if declared != stored {
+                        error!(
+                            module_url = %url,
+                            inline_hash = %format!("sha384-{declared}"),
+                            manifest_hash = %format!("sha384-{stored}"),
+                            "CDN module cache: inline hash does not match manifest hash"
+                        );
+                        return ModuleLoadResponse::Sync(Err(
+                            JsErrorBox::generic(format!(
+                                "Integrity check failed for cached {url}: \
+                                 inline hash sha384-{declared} does not match \
+                                 manifest hash sha384-{stored}"
+                            ))
+                            .into(),
+                        ));
+                    }
+                }
+            }
+
+            // Record the loaded module for showImportDetails()
+            let hash = self
+                .integrity
+                .read()
+                .expect("integrity lock poisoned")
+                .get(&url)
+                .cloned()
+                .unwrap_or_default();
+            if let Ok(mut modules) = self.loaded_modules.0.write() {
+                modules.push(LoadedModuleInfo {
+                    url: url.clone(),
+                    hash,
+                });
+            }
             debug!(module_url = %url, size_bytes = cached_bytes.len(), "CDN module loaded from cache");
             return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
                 ModuleType::JavaScript,
@@ -402,6 +502,7 @@ impl ModuleLoader for CdnModuleLoader {
         let integrity = self.integrity.clone();
         let lockfile_path = self.lockfile_path.clone();
         let strict = self.strict;
+        let loaded_modules = self.loaded_modules.clone();
 
         let fut = async move {
             info!(module_url = %url, "CDN module fetch: downloading");
@@ -576,6 +677,14 @@ impl ModuleLoader for CdnModuleLoader {
                 }
             }
 
+            // Record the loaded module for showImportDetails()
+            if let Ok(mut modules) = loaded_modules.0.write() {
+                modules.push(LoadedModuleInfo {
+                    url: url.clone(),
+                    hash: actual_b64.clone(),
+                });
+            }
+
             // Cache the verified module source (bounded by MAX_CACHE_BYTES)
             if let Ok(mut cache_w) = cache.write() {
                 let total: usize = cache_w.values().map(|v| v.len()).sum();
@@ -633,10 +742,12 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
 
     #[test]
     fn test_parse_npm_specifier() {
+        // Bare specifiers without a path get /+esm auto-appended
         assert_eq!(
             CdnModuleLoader::parse_npm_specifier("zod@3.22.4"),
-            Some("https://cdn.jsdelivr.net/npm/zod@3.22.4".to_string())
+            Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm".to_string())
         );
+        // Explicit /+esm is preserved as-is
         assert_eq!(
             CdnModuleLoader::parse_npm_specifier("zod@3.22.4/+esm"),
             Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm".to_string())
@@ -645,10 +756,12 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
             CdnModuleLoader::parse_npm_specifier("@scope/pkg@1.0.0/+esm"),
             Some("https://cdn.jsdelivr.net/npm/@scope/pkg@1.0.0/+esm".to_string())
         );
+        // Scoped package without path gets /+esm auto-appended
         assert_eq!(
             CdnModuleLoader::parse_npm_specifier("@scope/pkg@2.0.0"),
-            Some("https://cdn.jsdelivr.net/npm/@scope/pkg@2.0.0".to_string())
+            Some("https://cdn.jsdelivr.net/npm/@scope/pkg@2.0.0/+esm".to_string())
         );
+        // Explicit file path is preserved (no /+esm appended)
         assert_eq!(
             CdnModuleLoader::parse_npm_specifier("date-fns@3.6.0/esm/index.js"),
             Some("https://cdn.jsdelivr.net/npm/date-fns@3.6.0/esm/index.js".to_string())
@@ -661,6 +774,11 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
             CdnModuleLoader::parse_npm_specifier("@scope/pkg@1.0.0/+esm#sha384-xyz789"),
             Some("https://cdn.jsdelivr.net/npm/@scope/pkg@1.0.0/+esm#sha384-xyz789".to_string())
         );
+        // Bare specifier with hash fragment gets /+esm auto-appended
+        assert_eq!(
+            CdnModuleLoader::parse_npm_specifier("zod@3.22.4#sha384-abc123"),
+            Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm#sha384-abc123".to_string())
+        );
         assert_eq!(CdnModuleLoader::parse_npm_specifier("lodash-es"), None);
         assert_eq!(CdnModuleLoader::parse_npm_specifier("./local.js"), None);
         assert_eq!(CdnModuleLoader::parse_npm_specifier("@scope/pkg"), None);
@@ -669,8 +787,17 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
     #[test]
     fn test_resolve_npm_specifiers() {
         let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        // Explicit /+esm
         let result = loader
             .resolve("zod@3.22.4/+esm", "file:///main.js", ResolutionKind::Import)
+            .unwrap();
+        assert_eq!(
+            result.as_str(),
+            "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm"
+        );
+        // Bare specifier — /+esm auto-appended
+        let result = loader
+            .resolve("zod@3.22.4", "file:///main.js", ResolutionKind::Import)
             .unwrap();
         assert_eq!(
             result.as_str(),
@@ -762,6 +889,36 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
     }
 
     #[test]
+    fn test_resolve_rejects_jsdelivr_gh_backend() {
+        let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        // Direct /gh/ URL should be rejected even though it's on jsdelivr
+        assert!(
+            loader
+                .resolve(
+                    "https://cdn.jsdelivr.net/gh/user/repo@main/file.js",
+                    "file:///main.js",
+                    ResolutionKind::Import
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_rejects_npm_escape_to_gh() {
+        let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        // Relative traversal that escapes from /npm/ into /gh/ should be rejected
+        assert!(
+            loader
+                .resolve(
+                    "../../../gh/user/repo@main/file.js",
+                    "https://cdn.jsdelivr.net/npm/pkg@1.0.0/lib/index.js",
+                    ResolutionKind::Import
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_strict_mode_allows_tofu_for_unknown_modules() {
         // Even without a lockfile, strict mode should fall through to async
         // TOFU verification instead of rejecting synchronously.
@@ -789,8 +946,14 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
             "https://cdn.jsdelivr.net/npm/known@1.0.0/+esm".to_string(),
             b"export default 42;\n".to_vec(),
         );
-        let loader =
-            CdnModuleLoader::with_options(Arc::new(RwLock::new(manifest)), true, cache, None, None);
+        let loader = CdnModuleLoader::with_options(
+            Arc::new(RwLock::new(manifest)),
+            true,
+            cache,
+            None,
+            None,
+            LoadedModules::default(),
+        );
         let specifier =
             ModuleSpecifier::parse("https://cdn.jsdelivr.net/npm/known@1.0.0/+esm").unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -389,19 +389,19 @@ impl ModuleLoader for CdnModuleLoader {
     ) -> ModuleLoadResponse {
         // Enforce per-execution module count limit to prevent DoS via
         // dependency graphs with thousands of tiny files.
-        if let Ok(modules) = self.loaded_modules.0.read() {
-            if modules.len() >= MAX_MODULE_COUNT {
-                error!(
-                    module_count = modules.len(),
-                    max = MAX_MODULE_COUNT,
-                    "CDN module load rejected: maximum module count exceeded"
-                );
-                return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
-                    "Maximum module count ({MAX_MODULE_COUNT}) exceeded. \
-                         Reduce the number of imported modules."
-                ))
-                .into()));
-            }
+        if let Ok(modules) = self.loaded_modules.0.read()
+            && modules.len() >= MAX_MODULE_COUNT
+        {
+            error!(
+                module_count = modules.len(),
+                max = MAX_MODULE_COUNT,
+                "CDN module load rejected: maximum module count exceeded"
+            );
+            return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(format!(
+                "Maximum module count ({MAX_MODULE_COUNT}) exceeded. \
+                     Reduce the number of imported modules."
+            ))
+            .into()));
         }
 
         // Extract inline hash from URL fragment (e.g. #sha384-abc123...)
@@ -478,13 +478,13 @@ impl ModuleLoader for CdnModuleLoader {
                         .cloned()
                 })
                 .unwrap_or_default();
-            if let Ok(mut modules) = self.loaded_modules.0.write() {
-                if !modules.iter().any(|m| m.url == url) {
-                    modules.push(LoadedModuleInfo {
-                        url: url.clone(),
-                        hash,
-                    });
-                }
+            if let Ok(mut modules) = self.loaded_modules.0.write()
+                && !modules.iter().any(|m| m.url == url)
+            {
+                modules.push(LoadedModuleInfo {
+                    url: url.clone(),
+                    hash,
+                });
             }
             debug!(module_url = %url, size_bytes = cached_bytes.len(), "CDN module loaded from cache");
             return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
@@ -676,13 +676,13 @@ impl ModuleLoader for CdnModuleLoader {
             }
 
             // Record the loaded module for showImportDetails() (dedup by URL)
-            if let Ok(mut modules) = loaded_modules.0.write() {
-                if !modules.iter().any(|m| m.url == url) {
-                    modules.push(LoadedModuleInfo {
-                        url: url.clone(),
-                        hash: actual_b64.clone(),
-                    });
-                }
+            if let Ok(mut modules) = loaded_modules.0.write()
+                && !modules.iter().any(|m| m.url == url)
+            {
+                modules.push(LoadedModuleInfo {
+                    url: url.clone(),
+                    hash: actual_b64.clone(),
+                });
             }
 
             // Cache the verified module source (bounded by MAX_CACHE_BYTES)

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow, bail};
 use deno_core::{JsRuntime, v8};
 
-use crate::cdn_module_loader::{CdnModuleLoader, ModuleCache};
+use crate::cdn_module_loader::{CdnModuleLoader, LoadedModules, ModuleCache};
 use crate::import_rewriter;
 use deno_resolver::npm::{DenoInNpmPackageChecker, ManagedNpmResolver};
 use deno_runtime::{
@@ -63,6 +63,7 @@ fn build_main_worker_and_inject_sdk(
     module_cache: ModuleCache,
     lockfile_path: Option<PathBuf>,
     http_client: Arc<reqwest::Client>,
+    loaded_modules: LoadedModules,
 ) -> Result<MainWorker> {
     let options = WorkerOptions {
         bootstrap: BootstrapOptions {
@@ -116,6 +117,7 @@ fn build_main_worker_and_inject_sdk(
                 module_cache,
                 lockfile_path,
                 Some(http_client),
+                loaded_modules,
             )),
             node_services: Default::default(),
             npm_process_state_provider: Default::default(),
@@ -279,6 +281,8 @@ pub(crate) async fn execute_js(
     let timeout_ms = timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
     let memory_limit_mb = memory_limit_mb.unwrap_or(DEFAULT_MEMORY_LIMIT_MB);
 
+    let loaded_modules = LoadedModules::default();
+
     let mut worker = build_main_worker_and_inject_sdk(
         &None,
         &auth_context,
@@ -289,6 +293,7 @@ pub(crate) async fn execute_js(
         module_cache,
         lockfile_path,
         http_client,
+        loaded_modules.clone(),
     )
     .context("Error building main worker")
     .map_err(|e| anyhow!("{e:#}"))?; // Ensure to keep context when downcasting JS errors later
@@ -299,6 +304,7 @@ pub(crate) async fn execute_js(
         let mut state = op_state.borrow_mut();
         state.put(outbound_tx);
         state.put(inbound_rx);
+        state.put(loaded_modules);
         drop(state);
     }
 


### PR DESCRIPTION
## Summary

Implements [CPL-211](https://linear.app/litprotocol/issue/CPL-211/module-import-cleanup-and-logging): module import cleanup and logging for Lit Actions.

**Import Cleanup**
- Auto-append `/+esm` when no file path is specified in npm specifiers. Users can now write `import { z } from "zod@3.22.4"` instead of requiring `/+esm`. Explicit paths (`/+esm`, `/esm/index.js`) are preserved as-is.

**showImportDetails() opCode**
- New `Lit.Actions.showImportDetails()` function that logs and returns all imported module URLs and their SHA-384 integrity hashes. Hooks into the existing Print opCode for logging (no protobuf changes). Per-execution `LoadedModules` tracker shared between `CdnModuleLoader` and `OpState`.

**Security Hardening** (from Codex adversarial review)
- Tightened CDN allowlist from `https://cdn.jsdelivr.net/` to `https://cdn.jsdelivr.net/npm/` only, blocking `/gh/` and other jsDelivr backends that serve mutable content
- Verify inline `#sha384-` hash against manifest on cache hits, preventing stale hash bypass
- Added `MAX_MODULE_COUNT = 100` per-execution cap to prevent DoS via unbounded import graphs
- Docker image now copies `integrity.lock` and passes `--integrity-lock` flag to the binary

**Documentation**
- Updated `imports.mdx`: examples without `/+esm`, auto-append behavior documented, new "Debugging Imports" section
- Updated `chipotle.mdx`: `showImportDetails` added to SDK API reference

## Files Changed
- `Dockerfile.lit-actions` — lockfile copy + CLI flag
- `lit-actions/ext/bindings.rs` — `LoadedModules` type + `op_show_import_details`
- `lit-actions/ext/js/02_litActionsSDK.js` — `showImportDetails()` JS wrapper
- `lit-actions/server/cdn_module_loader.rs` — auto-esm, `/npm/` allowlist, cache hash check, module count cap, loaded module tracking
- `lit-actions/server/runtime.rs` — wire `LoadedModules` through worker + OpState
- `docs/lit-actions/imports.mdx` — updated examples and docs
- `docs/lit-actions/chipotle.mdx` — SDK reference update

## Test plan
- [x] `cargo check` passes for `lit-actions-ext` and `lit-actions-server`
- [x] All 22 integration tests pass (0 failures)
- [x] New unit tests for `/gh/` URL rejection and relative import escape
- [x] New unit test for bare specifier auto-`/+esm` append
- [x] Codex adversarial review: all 4 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)