### PR TITLE
feat: add $100 and $200 payment options to dashboard (CPL-213)

### DIFF
--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -386,6 +386,8 @@
             <option value="1000">$10.00</option>
             <option value="2500">$25.00</option>
             <option value="5000">$50.00</option>
+            <option value="10000">$100.00</option>
+            <option value="20000">$200.00</option>
           </select>
         </div>
         <div class="form-group">


### PR DESCRIPTION
## Summary
- Add $100.00 and $200.00 options to the Stripe payment amount dropdown in the dashboard billing modal (`lit-static/dapps/dashboard/index.html:389-390`)
- Values follow existing pattern: stored in cents (10000, 20000), displayed as formatted USD
- No backend changes needed — `create_payment_intent` accepts any amount >= $5.00 (`stripe.rs:323`)

## Test Coverage
No new application code paths — static HTML `<option>` tags only.

## Pre-Landing Review
No issues found. Backend enforces minimum ($5.00) via `MIN_TOPUP_CENTS` in `stripe.rs:22`. No maximum cap — new values are within Stripe's own limits.

## Adversarial Review
Claude + Codex adversarial review ran (2x, both /ship runs). All findings are **pre-existing** (not introduced by this diff):
- TOCTOU race in `confirm_payment` credited metadata check — concurrent requests can double-credit (pre-existing)
- Stranded funds if crash between metadata update and balance tx (pre-existing)
- No server-side max amount validation (pre-existing)
- Double-click race on Pay button (pre-existing)
- False-failure path on intermediate Stripe status (pre-existing)

## Scope Drift
Scope Check: CLEAN — delivers exactly what CPL-213 requested, nothing more.

## Plan Completion
No plan file detected.

## TODOS
No TODO items completed in this PR. 5 items remaining.

## Test plan
- [x] Pre-landing review: no issues (2 runs)
- [x] Adversarial review: no new issues (2 runs, Claude + Codex)
- [x] CI checks: all passing (contract-bindings, lit-actions, lit-core, lit-api-server, k6-client-check)
- [ ] Manual: open dashboard → Add Funds → verify $100.00 and $200.00 appear in dropdown
- [ ] Manual: select $100.00 → confirm Stripe payment intent created for 10000 cents

🤖 Generated with [Claude Code](https://claude.com/claude-code)