### PR TITLE
feat: remove balance from Usage API Keys table (CPL-244)

### DIFF
--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -712,14 +712,12 @@ function renderUsageKeysTable() {
       if (!ts) return '—';
       return new Date(ts * 1000).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
     })();
-    const balance = item.balance != null ? String(item.balance) : '—';
     const tr = document.createElement('tr');
     tr.innerHTML =
       '<td>' + escapeHtml(item.name || '') + '</td>' +
       '<td class="mono">' + escapeHtml(item.description || '') + '</td>' +
       '<td class="mono" style="font-size:0.82em;">' + escapeHtml(renderPermissionSummary(item)) + '</td>' +
       '<td class="mono">' + escapeHtml(expiration) + '</td>' +
-      '<td class="mono">' + escapeHtml(balance) + '</td>' +
       '<td class="cell-actions"></td>';
     const actionsCell = tr.querySelector('.cell-actions');
     const fullKey = item.api_key || (!item.api_key_hash ? item.usage_api_key : null);
@@ -776,7 +774,6 @@ function normalizeUsageKeyItem(item) {
     name: item.name,
     description: item.description,
     expiration: item.expiration,
-    balance: item.balance,
     can_create_groups: item.can_create_groups ?? false,
     can_delete_groups: item.can_delete_groups ?? false,
     can_create_pkps: item.can_create_pkps ?? false,
@@ -820,7 +817,6 @@ async function loadUsageKeys() {
       name: it.name ?? '',
       description: it.description ?? '',
       expiration: it.expiration,
-      balance: it.balance,
       can_create_groups: it.can_create_groups ?? false,
       can_delete_groups: it.can_delete_groups ?? false,
       can_create_pkps: it.can_create_pkps ?? false,
@@ -1306,7 +1302,6 @@ function openUsageKeyModal(item = null) {
             name: name || '',
             description: description || '',
             expiration: '',
-            balance: 0,
           });
           window._statUsageKeys = getUsageKeysStore().length;
           renderUsageKeysTable();

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -186,7 +186,7 @@
               <div class="card-body">
                 <div class="table-wrap">
                   <table class="data-table" id="usage-keys-table">
-                    <thead><tr><th>Name</th><th>Description</th><th>Permissions</th><th>Expiration</th><th>Balance</th><th class="th-actions"></th></tr></thead>
+                    <thead><tr><th>Name</th><th>Description</th><th>Permissions</th><th>Expiration</th><th class="th-actions"></th></tr></thead>
                     <tbody id="usage-keys-tbody"></tbody>
                   </table>
                   <p id="usage-keys-empty" class="empty-state" style="display: none;">No usage API keys.</p>


### PR DESCRIPTION
## Summary

Removes the "Balance" column from the Usage API Keys table in the Dashboard app per [CPL-244](https://linear.app/litprotocol/issue/CPL-244).

The balance field is dead data on the contract side (`ViewsFacet.sol`) and billing enforcement is wallet-scoped (`stripe.rs`, `billing.rs`), making the per-key balance column misleading.

**Changes across 2 files:**
- `index.html:189` — removed `<th>Balance</th>` column header
- `app.js:715` — removed balance variable and `<td>` cell from row rendering
- `app.js:779` — removed `balance` from `normalizeUsageKeyItem()`
- `app.js:823` — removed `balance` from `loadUsageKeys()` data mapping
- `app.js:1309` — removed `balance: 0` from new key creation defaults

## Pre-Landing Review

No issues found. PR Quality Score: 10/10.

Reviewed by Claude structured review, Claude adversarial subagent, and Codex adversarial challenge. All clean.

## Test Coverage

Deletion-only diff (7 lines removed). No new code paths to audit.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] Pre-landing review: clean (0 critical, 0 informational)
- [x] Adversarial review: clean (Claude + Codex, both models confirm no regressions)
- [x] Remaining `balance` references in codebase are for separate billing balance UI, not per-key balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)