### PR TITLE
feat: add dev environment shutdown warning modal (CPL-245)

### DIFF
--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -1596,8 +1596,21 @@ async function initActionRunner() {
 }
 
 // ----- Init -----
+function showDevWarning() {
+  if (location.hostname === 'dashboard.dev.litprotocol.com') {
+    const overlay = document.getElementById('dev-warning-overlay');
+    if (overlay) {
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
+    }
+    return true;
+  }
+  return false;
+}
+
 function init() {
   setTheme(getTheme());
+  if (showDevWarning()) return;
   initModalClose();
   initConfirmClose();
   updateAuthUI();

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -314,7 +314,7 @@
 
   <!-- Dev shutdown warning -->
   <div id="dev-warning-overlay" class="modal-overlay" aria-hidden="true">
-    <div class="modal-dialog" role="alertdialog" aria-modal="true" aria-labelledby="dev-warning-title">
+    <div class="modal-dialog" tabindex="-1" role="alertdialog" aria-modal="true" aria-labelledby="dev-warning-title">
       <div class="modal-header">
         <h3 id="dev-warning-title" class="modal-title">&#9888;&#65039; DEV Environment Shut Down</h3>
       </div>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -312,6 +312,27 @@
     </div>
   </div>
 
+  <!-- Dev shutdown warning -->
+  <div id="dev-warning-overlay" class="modal-overlay" aria-hidden="true">
+    <div class="modal-dialog" role="alertdialog" aria-modal="true" aria-labelledby="dev-warning-title">
+      <div class="modal-header">
+        <h3 id="dev-warning-title" class="modal-title">&#9888;&#65039; DEV Environment Shut Down</h3>
+      </div>
+      <div class="modal-body">
+        <p>The free <strong>DEV</strong> site has been shut down as anticipated. Production has been live for over a week and is ready for use.</p>
+        <p style="margin-top:0.75rem;">You can sign up and continue working on the production site:</p>
+        <ul style="margin:0.5rem 0 0.75rem 1.25rem;line-height:1.8;">
+          <li>Dashboard: <a href="https://dashboard.chipotle.litprotocol.com/" target="_blank" rel="noopener">dashboard.chipotle.litprotocol.com</a></li>
+          <li>API: <a href="https://api.chipotle.litprotocol.com" target="_blank" rel="noopener">api.chipotle.litprotocol.com</a></li>
+        </ul>
+        <p style="margin-top:0.75rem;">Questions or comments? Contact <a href="mailto:support@litprotocol.com">support@litprotocol.com</a> or reach out on our Telegram and Discord groups.</p>
+      </div>
+      <div class="modal-footer">
+        <a href="https://dashboard.chipotle.litprotocol.com/" class="btn btn-primary">Go to Production Dashboard</a>
+      </div>
+    </div>
+  </div>
+
   <!-- Modal for Add / Edit (reused) -->
   <div id="modal-overlay" class="modal-overlay" aria-hidden="true">
     <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title">


### PR DESCRIPTION
## Summary

When users visit `dashboard.dev.litprotocol.com`, a non-dismissible warning modal appears explaining that the free DEV site has been shut down. Users are directed to the production dashboard at `dashboard.chipotle.litprotocol.com` and API at `api.chipotle.litprotocol.com`, with links to support channels.

The warning short-circuits `init()` so no dashboard logic, API calls, or billing retries execute behind the overlay. This prevents background traffic to the shut-down dev API and ensures users can't bypass the warning to use the dashboard.

**Changes:**
- **index.html**: New `#dev-warning-overlay` modal with shutdown message, production links, and support contact info
- **app.js**: `showDevWarning()` checks `location.hostname` and returns early from `init()` when on the dev domain

## Pre-Landing Review

Pre-Landing Review: 1 issue (1 critical, 0 informational)

**AUTO-FIXED:**
- [app.js:1611] Dashboard fully initialized behind warning overlay, enabling background API calls and DevTools bypass. Fixed: `init()` now bails early when dev warning is shown.

Adversarial review (Claude + Codex): Both models confirmed the init short-circuit as the key fix. Codex additionally flagged that `lit-static-dev.pages.dev` (Cloudflare Pages default domain) could bypass the hostname check if still active.

## Test plan
- [ ] Deploy to dev environment and verify modal appears on `dashboard.dev.litprotocol.com`
- [ ] Verify modal does NOT appear on `dashboard.chipotle.litprotocol.com` (production)
- [ ] Verify "Go to Production Dashboard" link works
- [ ] Verify no API calls are made when warning is shown (check Network tab)
- [ ] Verify dashboard does not initialize behind the overlay (no sidebar, no tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)