### PR TITLE
feat: warn about no funds in dashboard instructions (CPL-248)

### DIFF
--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -66,6 +66,8 @@ function updateAuthUI() {
   if (addFundsBtn) addFundsBtn.style.display = 'none';
   if (notRequiredEl) notRequiredEl.style.display = 'none';
   if (billingBanner) billingBanner.style.display = 'none';
+  const noFundsWarning = document.getElementById('no-funds-warning');
+  if (noFundsWarning) noFundsWarning.style.display = 'none';
   if (hasKey) {
     const capturedKey = getApiKey();
     refreshOverviewAccount();
@@ -268,12 +270,18 @@ async function loadBillingBalance() {
   if (!apiKey) return;
   const el = document.getElementById('billing-balance-display');
   if (!el) return;
+  const noFundsWarning = document.getElementById('no-funds-warning');
   try {
     const client = await getClient();
     const data = await client.getBillingBalance(apiKey);
     el.textContent = data.balance_display || '';
+    // balance_cents is negative when credits are available; 0 or positive means no funds
+    if (noFundsWarning) {
+      noFundsWarning.style.display = (data.balance_cents >= 0) ? '' : 'none';
+    }
   } catch (_) {
     el.textContent = '';
+    if (noFundsWarning) noFundsWarning.style.display = 'none';
   }
 }
 
@@ -335,6 +343,8 @@ function initBilling() {
   const payBtn = document.getElementById('billing-pay-btn');
 
   if (addFundsBtn) addFundsBtn.addEventListener('click', openAddFundsModal);
+  const noFundsLink = document.getElementById('no-funds-add-funds');
+  if (noFundsLink) noFundsLink.addEventListener('click', (e) => { e.preventDefault(); openAddFundsModal(); });
   if (closeBtn) closeBtn.addEventListener('click', closeBillingModal);
   if (cancelBtn) cancelBtn.addEventListener('click', closeBillingModal);
 

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -92,6 +92,9 @@ function refreshBillingUI(capturedKey, balanceEl, addFundsBtn, notRequiredEl, bi
     } else {
       if (notRequiredEl) notRequiredEl.style.display = '';
       if (billingBanner) billingBanner.style.display = '';
+      // Hide no-funds warning when billing is unavailable (contradicts "Payment Not Required")
+      const nfw = document.getElementById('no-funds-warning');
+      if (nfw) nfw.style.display = 'none';
       // Schedule a retry so transient failures recover without a reload.
       if (_billingRetryTimer) clearTimeout(_billingRetryTimer);
       _billingRetryTimer = setTimeout(() => {
@@ -277,7 +280,8 @@ async function loadBillingBalance() {
     el.textContent = data.balance_display || '';
     // balance_cents is negative when credits are available; 0 or positive means no funds
     if (noFundsWarning) {
-      noFundsWarning.style.display = (data.balance_cents >= 0) ? '' : 'none';
+      const hasNoFunds = typeof data.balance_cents === 'number' && data.balance_cents >= 0;
+      noFundsWarning.style.display = hasNoFunds ? '' : 'none';
     }
   } catch (_) {
     el.textContent = '';

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -160,6 +160,10 @@
                 <h3 class="card-title">Instructions</h3>
               </div>
               <div class="card-body">
+                <div id="no-funds-warning" class="no-funds-warning" role="alert" style="display: none;">
+                  <strong>No funds available</strong>
+                  <p>Your account has no credit balance. Please <a href="#" id="no-funds-add-funds">add funds</a> for Lit Actions to work.</p>
+                </div>
                 <div class="instructions-block">
                   <p>You can control access to the Lit Actions run by this node in the following ways:</p>
                   <ul>

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -306,6 +306,30 @@ body.has-api-key .dashboard-wrap {
   white-space: nowrap;
 }
 
+/* No-funds warning (instructions section) */
+.no-funds-warning {
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.35);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  color: #92400e;
+}
+.no-funds-warning strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+.no-funds-warning p {
+  margin: 0;
+  line-height: 1.5;
+}
+.no-funds-warning a {
+  color: var(--primary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* Billing disabled banner (dashboard body) */
 .billing-disabled-banner {
   background: var(--bg-muted, #f3f4f6);


### PR DESCRIPTION
## Summary

Adds a warning banner in the dashboard's Instructions section when the account has zero credit balance ([CPL-248](https://linear.app/litprotocol/issue/CPL-248/warn-about-no-funds)).

- **No-funds warning** — amber banner appears above instructions when `balance_cents >= 0`, with a link to the Add Funds modal
- **State management** — warning is hidden on logout, when billing is unavailable ("Payment Not Required"), and when the API response is missing/invalid
- **Null safety** — `balance_cents` is guarded with a type check to prevent `null` coercion from showing a false warning

## Files Changed

- `lit-static/dapps/dashboard/index.html` — new `#no-funds-warning` element
- `lit-static/dapps/dashboard/app.js` — show/hide logic in `loadBillingBalance()`, `updateAuthUI()`, `refreshBillingUI()`, and click handler in `initBilling()`
- `lit-static/dapps/dashboard/styles.css` — `.no-funds-warning` amber warning styles

## Pre-Landing Review

No issues found. Adversarial review (Claude + Codex) identified two edge cases that were fixed:
- Contradictory UI when billing toggles from available to unavailable (warning + "Payment Not Required" both visible)
- `null` coercion on `balance_cents` producing a false positive warning

## Scope Drift

Scope Check: CLEAN. All changes directly implement CPL-248.

## Test plan

- [ ] Dashboard with zero credit balance shows amber "No funds available" warning above instructions
- [ ] Dashboard with negative balance (has credits) does not show warning
- [ ] Clicking "add funds" link in warning opens the Add Funds modal
- [ ] Warning hidden when billing is unavailable (Stripe disabled)
- [ ] Warning hidden after logging out
- [ ] Rust backend compiles clean (`cargo check` passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)