### PR TITLE
fix: remove empty line after doc comment in import_rewriter

### DIFF
--- a/lit-actions/server/import_rewriter.rs
+++ b/lit-actions/server/import_rewriter.rs
@@ -42,7 +42,6 @@ pub(crate) struct RewriteResult {
 /// preserved unchanged. The scanner is aware of single-line comments (`//`),
 /// block comments (`/* */`), and string/template literals so that import-like
 /// text inside those constructs is never mistakenly rewritten.
-
 pub(crate) fn rewrite_imports(code: &str) -> RewriteResult {
     let main_pos = find_main_declaration(code);
     let preamble = &code[..main_pos];


### PR DESCRIPTION
## Summary
- Removes empty line between doc comment and `rewrite_imports` function in `lit-actions/server/import_rewriter.rs`
- Fixes `clippy::empty_line_after_doc_comments` lint error that was failing CI on PR #277

## Test plan
- [ ] CI clippy check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)