### PR TITLE
feat: recursively bundle nested jsDelivr imports as data URLs (CPL-249)

### DIFF
--- a/lit-actions/Cargo.lock
+++ b/lit-actions/Cargo.lock
@@ -5203,6 +5203,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/lit-actions/server/Cargo.toml
+++ b/lit-actions/server/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+url = "2"
 
 [build-dependencies]
 lit-actions-ext = { workspace = true }

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha384};
 use tracing::{debug, error, info, instrument, warn};
 
 /// Constant-time byte comparison to prevent timing side-channels on integrity hashes.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }
@@ -27,12 +27,12 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// Allowed CDN URL prefix for module imports (origin only, used for URL construction).
-const ALLOWED_CDN_PREFIX: &str = "https://cdn.jsdelivr.net/";
+pub(crate) const ALLOWED_CDN_PREFIX: &str = "https://cdn.jsdelivr.net/";
 
 /// Allowed CDN URL prefix restricted to the npm backend.
 /// Only npm packages are permitted; other jsDelivr backends (/gh/, /wp/, etc.)
 /// serve mutable content and are rejected.
-const ALLOWED_NPM_PREFIX: &str = "https://cdn.jsdelivr.net/npm/";
+pub(crate) const ALLOWED_NPM_PREFIX: &str = "https://cdn.jsdelivr.net/npm/";
 
 /// Maximum response body size (10 MB).
 const MAX_MODULE_SIZE_BYTES: usize = 10 * 1024 * 1024;
@@ -45,7 +45,7 @@ const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum number of distinct modules that can be loaded per action execution.
 /// Prevents DoS via dependency graphs with thousands of tiny files.
-const MAX_MODULE_COUNT: usize = 100;
+pub(crate) const MAX_MODULE_COUNT: usize = 100;
 
 /// Thread-safe cache for fetched and integrity-verified module sources.
 pub type ModuleCache = Arc<RwLock<HashMap<String, Vec<u8>>>>;
@@ -187,7 +187,7 @@ impl CdnModuleLoader {
     /// inline integrity verification.
     ///
     /// Returns None if the specifier doesn't match the expected format.
-    fn parse_npm_specifier(specifier: &str) -> Option<String> {
+    pub(crate) fn parse_npm_specifier(specifier: &str) -> Option<String> {
         // Split off the optional #hash fragment before parsing
         let (spec, fragment) = match specifier.split_once('#') {
             Some((s, f)) => (s, Some(f)),
@@ -232,7 +232,7 @@ impl CdnModuleLoader {
     /// Fetch a URL with streaming body read, enforcing size limits during download.
     /// Returns the response bytes and optionally the SRI hash from CDN headers.
     #[instrument(skip_all, err)]
-    async fn fetch_with_size_limit(
+    pub(crate) async fn fetch_with_size_limit(
         client: &reqwest::Client,
         url: &str,
         label: &str,
@@ -313,6 +313,13 @@ impl ModuleLoader for CdnModuleLoader {
         referrer: &str,
         _kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, ModuleLoaderError> {
+        // Pass through data: URLs unchanged (used by the bundling pipeline to inline modules).
+        if specifier.starts_with("data:") {
+            return ModuleSpecifier::parse(specifier).map_err(|e| {
+                JsErrorBox::generic(format!("Invalid data URL: {e}")).into()
+            });
+        }
+
         // Resolve relative imports against the referrer when the referrer is a jsDelivr npm URL.
         // ESM modules on jsDelivr can have relative imports between files in the same package.
         if (specifier.starts_with("./") || specifier.starts_with("../"))
@@ -347,6 +354,24 @@ impl ModuleLoader for CdnModuleLoader {
                 "Relative import \"{specifier}\" resolved to {resolved}, which is outside the allowed /npm/ CDN path"
             ))
             .into());
+        }
+
+        // Handle root-relative /npm/ paths from jsDelivr's ESM output.
+        // jsDelivr's +esm endpoint rewrites nested imports as root-relative paths
+        // (e.g. `from"/npm/@noble/hashes@1.3.2/hmac/+esm"`). Resolve these by
+        // prepending the CDN origin, then validate the result.
+        if specifier.starts_with("/npm/") {
+            let full_url = format!("{ALLOWED_CDN_PREFIX}{}", &specifier[1..]);
+            if Self::is_allowed_cdn(&full_url) {
+                info!(
+                    specifier,
+                    resolved_url = %full_url,
+                    "CDN module resolve: root-relative /npm/ import resolved to full jsDelivr URL"
+                );
+                return ModuleSpecifier::parse(&full_url).map_err(|e| {
+                    JsErrorBox::generic(format!("Invalid resolved URL: {full_url}: {e}")).into()
+                });
+            }
         }
 
         // If it's already a full jsDelivr URL, pass through
@@ -864,6 +889,54 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
             "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm#sha384-abc123def"
         );
         assert_eq!(result.fragment(), Some("sha384-abc123def"));
+    }
+
+    #[test]
+    fn test_resolve_root_relative_npm_imports() {
+        let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        // jsDelivr's +esm output uses root-relative /npm/ paths for nested imports
+        let result = loader
+            .resolve(
+                "/npm/@noble/hashes@1.3.2/hmac/+esm",
+                "https://cdn.jsdelivr.net/npm/ethers@6.13.4/+esm",
+                ResolutionKind::Import,
+            )
+            .unwrap();
+        assert_eq!(
+            result.as_str(),
+            "https://cdn.jsdelivr.net/npm/@noble/hashes@1.3.2/hmac/+esm"
+        );
+    }
+
+    #[test]
+    fn test_resolve_root_relative_npm_unscoped() {
+        let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        let result = loader
+            .resolve(
+                "/npm/aes-js@4.0.0-beta.5/+esm",
+                "https://cdn.jsdelivr.net/npm/ethers@6.13.4/+esm",
+                ResolutionKind::Import,
+            )
+            .unwrap();
+        assert_eq!(
+            result.as_str(),
+            "https://cdn.jsdelivr.net/npm/aes-js@4.0.0-beta.5/+esm"
+        );
+    }
+
+    #[test]
+    fn test_resolve_root_relative_rejects_non_npm() {
+        let loader = CdnModuleLoader::new(Arc::new(RwLock::new(HashMap::new())), false);
+        // /gh/ root-relative paths should be rejected (mutable content)
+        assert!(
+            loader
+                .resolve(
+                    "/gh/user/repo@main/file.js",
+                    "https://cdn.jsdelivr.net/npm/pkg@1.0.0/+esm",
+                    ResolutionKind::Import
+                )
+                .is_err()
+        );
     }
 
     #[test]

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -315,9 +315,8 @@ impl ModuleLoader for CdnModuleLoader {
     ) -> Result<ModuleSpecifier, ModuleLoaderError> {
         // Pass through data: URLs unchanged (used by the bundling pipeline to inline modules).
         if specifier.starts_with("data:") {
-            return ModuleSpecifier::parse(specifier).map_err(|e| {
-                JsErrorBox::generic(format!("Invalid data URL: {e}")).into()
-            });
+            return ModuleSpecifier::parse(specifier)
+                .map_err(|e| JsErrorBox::generic(format!("Invalid data URL: {e}")).into());
         }
 
         // Resolve relative imports against the referrer when the referrer is a jsDelivr npm URL.

--- a/lit-actions/server/import_rewriter.rs
+++ b/lit-actions/server/import_rewriter.rs
@@ -6,6 +6,10 @@
 //! `async function main`, strips them from the source, and returns structured
 //! data that the runtime uses to generate equivalent dynamic `import()` calls
 //! inside the async wrapper.
+//!
+//! Additionally, the bundling pipeline (`bundle_imports`) recursively fetches all
+//! transitive dependencies from jsDelivr and inlines them as `data:` URLs so that
+//! no module loader network I/O is needed at runtime.
 
 /// A single binding from an import statement.
 #[derive(Debug, Clone, PartialEq)]
@@ -223,6 +227,7 @@ fn find_main_declaration(code: &str) -> usize {
 /// - Side-effect: `await import("specifier");`
 /// - Named/default/namespace: `const { a, b: c, default: D } = await import("specifier");`
 /// - Namespace: `const Mod = await import("specifier");`
+#[cfg(test)]
 pub(crate) fn generate_dynamic_imports(imports: &[ParsedImport]) -> String {
     let mut out = String::new();
     for imp in imports {
@@ -287,6 +292,558 @@ pub(crate) fn generate_dynamic_imports(imports: &[ParsedImport]) -> String {
         }
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// CDN module bundling pipeline
+// ---------------------------------------------------------------------------
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::ops::Range;
+use std::sync::{Arc, RwLock};
+
+use base64::Engine;
+use deno_core::error::ModuleLoaderError;
+use deno_error::JsErrorBox;
+use tracing::{info, warn};
+
+use std::path::PathBuf;
+
+use crate::cdn_module_loader::{
+    constant_time_eq, CdnModuleLoader, ALLOWED_NPM_PREFIX, MAX_MODULE_COUNT,
+};
+
+/// A resolved module in the dependency graph.
+struct ResolvedModule {
+    /// Raw source bytes fetched from jsDelivr.
+    source: Vec<u8>,
+    /// SHA-384 hash (base64) of the original bytes.
+    hash: String,
+    /// Nested import specifier locations: (byte range of the string content, resolved URL).
+    nested_imports: Vec<(Range<usize>, String)>,
+}
+
+/// Result of the full bundling pipeline.
+pub(crate) struct BundleResult {
+    /// JavaScript code containing `const { ... } = await import("data:...");`
+    /// statements, fully self-contained with all dependencies inlined.
+    pub dynamic_imports: String,
+    /// All loaded modules and their hashes, for showImportDetails().
+    pub loaded_modules: Vec<(String, String)>,
+}
+
+/// Scan module source code (from jsDelivr) for import/export specifiers.
+///
+/// Finds `from"..."`, `from '...'`, `import"..."` (side-effect), and
+/// `export...from"..."` patterns. Returns each specifier's byte range
+/// (of the quoted string content) and value.
+///
+/// Handles minified code (no spaces between `from` and quote) and skips
+/// strings, comments, and template literals.
+pub(crate) fn scan_cdn_imports(source: &str) -> Vec<(Range<usize>, String)> {
+    let bytes = source.as_bytes();
+    let mut results = Vec::new();
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        let b = bytes[pos];
+
+        // Skip single-line comments
+        if b == b'/' && bytes.get(pos + 1) == Some(&b'/') {
+            match source[pos..].find('\n') {
+                Some(nl) => {
+                    pos += nl + 1;
+                    continue;
+                }
+                None => break,
+            }
+        }
+
+        // Skip block comments
+        if b == b'/' && bytes.get(pos + 1) == Some(&b'*') {
+            match source[pos + 2..].find("*/") {
+                Some(end) => {
+                    pos += end + 4;
+                    continue;
+                }
+                None => break,
+            }
+        }
+
+        // Skip string literals (avoid false matches inside strings)
+        if b == b'"' || b == b'\'' {
+            if let Some(len) = skip_string_literal(&source[pos..], b) {
+                pos += len;
+                continue;
+            }
+            pos += 1;
+            continue;
+        }
+
+        // Skip template literals
+        if b == b'`' {
+            if let Some(len) = skip_template_literal(&source[pos..]) {
+                pos += len;
+                continue;
+            }
+            pos += 1;
+            continue;
+        }
+
+        // Look for `from` keyword followed by a quoted string
+        if b == b'f'
+            && source[pos..].starts_with("from")
+            && !is_ident_byte(bytes.get(pos + 4).copied())
+        {
+            // Check that preceding char is not an identifier char (word boundary)
+            if pos > 0 && is_ident_byte(Some(bytes[pos - 1])) {
+                pos += 1;
+                continue;
+            }
+            let mut j = pos + 4;
+            // skip whitespace between `from` and quote
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && (bytes[j] == b'"' || bytes[j] == b'\'') {
+                let quote = bytes[j];
+                let str_start = j + 1;
+                let mut str_end = str_start;
+                while str_end < bytes.len() && bytes[str_end] != quote {
+                    if bytes[str_end] == b'\\' {
+                        str_end += 2;
+                        continue;
+                    }
+                    str_end += 1;
+                }
+                if str_end < bytes.len() {
+                    let spec = source[str_start..str_end].to_string();
+                    results.push((str_start..str_end, spec));
+                    pos = str_end + 1;
+                    continue;
+                }
+            }
+        }
+
+        // Look for side-effect `import` followed directly by a quoted string
+        // (e.g., `import"/npm/..."` or `import "/npm/..."`)
+        if b == b'i'
+            && source[pos..].starts_with("import")
+            && !is_ident_byte(bytes.get(pos + 6).copied())
+        {
+            let mut j = pos + 6;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            // Only match if the next char is a quote (side-effect import),
+            // not `{`, `*`, or an identifier (which would be a binding import
+            // handled by the `from` branch above)
+            if j < bytes.len() && (bytes[j] == b'"' || bytes[j] == b'\'') {
+                let quote = bytes[j];
+                let str_start = j + 1;
+                let mut str_end = str_start;
+                while str_end < bytes.len() && bytes[str_end] != quote {
+                    if bytes[str_end] == b'\\' {
+                        str_end += 2;
+                        continue;
+                    }
+                    str_end += 1;
+                }
+                if str_end < bytes.len() {
+                    let spec = source[str_start..str_end].to_string();
+                    results.push((str_start..str_end, spec));
+                    pos = str_end + 1;
+                    continue;
+                }
+            }
+        }
+
+        pos += 1;
+    }
+
+    results
+}
+
+/// Resolve a specifier found in a CDN module to a full jsDelivr URL.
+///
+/// Handles:
+/// - `/npm/...` root-relative paths → prepend CDN origin
+/// - `./` and `../` relative paths → join against referrer URL
+/// - Full `https://cdn.jsdelivr.net/npm/...` URLs → passthrough
+/// - npm specifiers like `pkg@version` → convert to jsDelivr URL
+///
+/// Returns `None` if the specifier cannot be resolved to a valid jsDelivr npm URL.
+fn resolve_cdn_specifier(specifier: &str, referrer_url: &str) -> Option<String> {
+    // Root-relative /npm/ paths (jsDelivr's +esm output format)
+    if let Some(rest) = specifier.strip_prefix("/npm/") {
+        let full = format!("{ALLOWED_NPM_PREFIX}{rest}");
+        return Some(full);
+    }
+
+    // Relative imports against the referrer
+    if (specifier.starts_with("./") || specifier.starts_with("../"))
+        && referrer_url.starts_with(ALLOWED_NPM_PREFIX)
+    {
+        if let Ok(base) = url::Url::parse(referrer_url) {
+            if let Ok(resolved) = base.join(specifier) {
+                let s = resolved.to_string();
+                if s.starts_with(ALLOWED_NPM_PREFIX) {
+                    return Some(s);
+                }
+            }
+        }
+        return None;
+    }
+
+    // Full jsDelivr URL passthrough
+    if specifier.starts_with(ALLOWED_NPM_PREFIX) {
+        return Some(specifier.to_string());
+    }
+
+    // npm specifier (e.g., "zod@3.22.4")
+    CdnModuleLoader::parse_npm_specifier(specifier)
+}
+
+/// Recursively fetch all transitive dependencies from jsDelivr, then inline
+/// them bottom-up as `data:text/javascript;base64,...` URLs.
+///
+/// Returns a `BundleResult` with self-contained dynamic import statements
+/// and metadata for all loaded modules.
+pub(crate) async fn bundle_imports(
+    imports: &[ParsedImport],
+    client: &reqwest::Client,
+    integrity: &Arc<RwLock<HashMap<String, String>>>,
+    strict: bool,
+    lockfile_path: &Option<PathBuf>,
+) -> Result<BundleResult, ModuleLoaderError> {
+    // Phase 1: Build dependency graph via BFS
+    let mut graph: HashMap<String, ResolvedModule> = HashMap::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    let mut visited: HashSet<String> = HashSet::new();
+
+    // Seed queue with user's top-level import specifiers
+    let mut root_urls: Vec<String> = Vec::new();
+    for imp in imports {
+        if let Some(url) = resolve_cdn_specifier(&imp.specifier, "") {
+            let fetch_url = url.split('#').next().unwrap_or(&url).to_string();
+            root_urls.push(fetch_url.clone());
+            if !visited.contains(&fetch_url) {
+                queue.push_back(fetch_url.clone());
+                visited.insert(fetch_url);
+            }
+        }
+    }
+
+    while let Some(url) = queue.pop_front() {
+        if graph.len() >= MAX_MODULE_COUNT {
+            return Err(JsErrorBox::generic(format!(
+                "Maximum module count ({MAX_MODULE_COUNT}) exceeded during dependency bundling."
+            ))
+            .into());
+        }
+
+        info!(module_url = %url, "Bundler: fetching module");
+        let (bytes, cdn_sri_hash) =
+            CdnModuleLoader::fetch_with_size_limit(client, &url, "Bundler").await?;
+
+        // Compute SHA-384 hash
+        use sha2::{Digest, Sha384};
+        let mut hasher = Sha384::new();
+        hasher.update(&bytes);
+        let actual_digest = hasher.finalize();
+        let actual_b64 = base64::engine::general_purpose::STANDARD.encode(&actual_digest);
+
+        // Integrity verification — mirrors CdnModuleLoader::load()
+        let expected_hash = integrity
+            .read()
+            .expect("integrity lock poisoned")
+            .get(&url)
+            .cloned();
+
+        if let Some(ref expected_b64) = expected_hash {
+            // Known module: verify against stored hash
+            let expected_digest = base64::engine::general_purpose::STANDARD
+                .decode(expected_b64)
+                .map_err(|e| {
+                    JsErrorBox::generic(format!(
+                        "Invalid base64 in integrity manifest for {url}: {e}"
+                    ))
+                })?;
+            if actual_digest.len() != expected_digest.len()
+                || !constant_time_eq(&actual_digest, &expected_digest)
+            {
+                return Err(JsErrorBox::generic(format!(
+                    "Integrity check failed for {url}: \
+                     expected sha384-{expected_b64}, got sha384-{actual_b64}"
+                ))
+                .into());
+            }
+            info!(
+                module_url = %url,
+                hash = %format!("sha384-{actual_b64}"),
+                "Bundler: integrity check passed"
+            );
+        } else if strict {
+            // Unknown module in strict mode: TOFU double-fetch verification
+            info!(
+                module_url = %url,
+                first_hash = %format!("sha384-{actual_b64}"),
+                "Bundler TOFU: new module detected, starting verification fetch"
+            );
+
+            let (bytes2, _) =
+                CdnModuleLoader::fetch_with_size_limit(client, &url, "Bundler TOFU").await?;
+            let mut hasher2 = Sha384::new();
+            hasher2.update(&bytes2);
+            let verify_digest = hasher2.finalize();
+
+            if !constant_time_eq(&actual_digest, &verify_digest) {
+                return Err(JsErrorBox::generic(format!(
+                    "Bundler TOFU: CDN returned inconsistent content for {url}. \
+                     Hash mismatch between first and second fetch. Possible tampering."
+                ))
+                .into());
+            }
+
+            // Verify against CDN's SRI hash header if available
+            if let Some(ref sri_b64) = cdn_sri_hash {
+                let sri_digest = base64::engine::general_purpose::STANDARD
+                    .decode(sri_b64)
+                    .map_err(|e| {
+                        JsErrorBox::generic(format!(
+                            "CDN SRI header for {url} contains invalid base64: {e}"
+                        ))
+                    })?;
+                if !constant_time_eq(&actual_digest, &sri_digest) {
+                    return Err(JsErrorBox::generic(format!(
+                        "Bundler TOFU: computed hash does not match CDN SRI header for {url}."
+                    ))
+                    .into());
+                }
+            }
+
+            // Pin to lockfile on disk
+            if let Some(path) = lockfile_path {
+                use std::io::Write;
+                let mut file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)
+                    .map_err(|e| {
+                        JsErrorBox::generic(format!("Failed to open integrity lockfile: {e}"))
+                    })?;
+                writeln!(file, "{url} sha384-{actual_b64}").map_err(|e| {
+                    JsErrorBox::generic(format!("Failed to write integrity lockfile: {e}"))
+                })?;
+                file.flush().map_err(|e| {
+                    JsErrorBox::generic(format!("Failed to flush integrity lockfile: {e}"))
+                })?;
+                info!(
+                    module_url = %url,
+                    hash = %format!("sha384-{actual_b64}"),
+                    "Bundler TOFU: pinned new module to integrity lockfile"
+                );
+            }
+
+            // Update in-memory manifest
+            if let Ok(mut map) = integrity.write() {
+                map.entry(url.clone()).or_insert(actual_b64.clone());
+            }
+        } else {
+            // Non-strict mode: accept without TOFU, pin hash in memory
+            if let Ok(mut map) = integrity.write() {
+                map.entry(url.clone()).or_insert(actual_b64.clone());
+            }
+        }
+
+        let hash = actual_b64;
+
+        // Scan for nested imports (ES modules must be valid UTF-8)
+        let source_str = String::from_utf8(bytes.clone()).map_err(|e| {
+            JsErrorBox::generic(format!("Module {url} is not valid UTF-8: {e}"))
+        })?;
+        let found_imports = scan_cdn_imports(&source_str);
+
+        let mut nested = Vec::new();
+        for (range, spec) in found_imports {
+            if let Some(resolved) = resolve_cdn_specifier(&spec, &url) {
+                let fetch_resolved = resolved.split('#').next().unwrap_or(&resolved).to_string();
+                nested.push((range, fetch_resolved.clone()));
+                if !visited.contains(&fetch_resolved) {
+                    visited.insert(fetch_resolved.clone());
+                    queue.push_back(fetch_resolved);
+                }
+            } else {
+                warn!(
+                    module_url = %url,
+                    nested_specifier = %spec,
+                    "Bundler: could not resolve nested import specifier, skipping"
+                );
+            }
+        }
+
+        graph.insert(
+            url,
+            ResolvedModule {
+                source: bytes,
+                hash,
+                nested_imports: nested,
+            },
+        );
+    }
+
+    // Phase 2: Topological sort (Kahn's algorithm)
+    // Build adjacency: module → set of modules it depends on
+    let urls: Vec<String> = graph.keys().cloned().collect();
+    let url_to_idx: HashMap<&str, usize> = urls.iter().enumerate().map(|(i, u)| (u.as_str(), i)).collect();
+    let n = urls.len();
+    let mut in_degree = vec![0usize; n];
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n]; // dep → list of modules that import it
+
+    for (i, url) in urls.iter().enumerate() {
+        if let Some(module) = graph.get(url) {
+            for (_, dep_url) in &module.nested_imports {
+                if let Some(&dep_idx) = url_to_idx.get(dep_url.as_str()) {
+                    in_degree[i] += 1;
+                    dependents[dep_idx].push(i);
+                }
+            }
+        }
+    }
+
+    // Start with leaf modules (no dependencies within the graph)
+    let mut topo_queue: VecDeque<usize> = VecDeque::new();
+    for i in 0..n {
+        if in_degree[i] == 0 {
+            topo_queue.push_back(i);
+        }
+    }
+
+    let mut topo_order: Vec<usize> = Vec::with_capacity(n);
+    while let Some(idx) = topo_queue.pop_front() {
+        topo_order.push(idx);
+        for &dependent in &dependents[idx] {
+            in_degree[dependent] -= 1;
+            if in_degree[dependent] == 0 {
+                topo_queue.push_back(dependent);
+            }
+        }
+    }
+
+    if topo_order.len() != n {
+        return Err(JsErrorBox::generic(
+            "Circular dependency detected in jsDelivr modules. Cannot bundle.",
+        )
+        .into());
+    }
+
+    // Phase 3: Bottom-up data URL inlining
+    let mut data_urls: HashMap<String, String> = HashMap::new();
+
+    for &idx in &topo_order {
+        let url = &urls[idx];
+        let module = &graph[url];
+        let mut source = module.source.clone();
+
+        // Replace nested import specifiers with data URLs, processing from end to start
+        // to preserve byte offsets
+        let mut replacements: Vec<(Range<usize>, String)> = module
+            .nested_imports
+            .iter()
+            .filter_map(|(range, dep_url)| {
+                data_urls.get(dep_url).map(|data_url| (range.clone(), data_url.clone()))
+            })
+            .collect();
+        // Sort by range start descending so we replace from end to start
+        replacements.sort_by(|a, b| b.0.start.cmp(&a.0.start));
+
+        for (range, data_url) in replacements {
+            let before = &source[..range.start];
+            let after = &source[range.end..];
+            let mut new_source = Vec::with_capacity(before.len() + data_url.len() + after.len());
+            new_source.extend_from_slice(before);
+            new_source.extend_from_slice(data_url.as_bytes());
+            new_source.extend_from_slice(after);
+            source = new_source;
+        }
+
+        // Create data URL
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&source);
+        let data_url = format!("data:text/javascript;base64,{encoded}");
+        data_urls.insert(url.clone(), data_url);
+    }
+
+    // Phase 4: Generate dynamic import statements using data URLs
+    let mut dynamic_imports = String::new();
+    for (imp, root_url) in imports.iter().zip(root_urls.iter()) {
+        let data_url = match data_urls.get(root_url) {
+            Some(u) => u,
+            None => continue,
+        };
+        let escaped = js_escape(data_url);
+
+        if imp.bindings.is_empty() {
+            dynamic_imports.push_str(&format!("await import(\"{escaped}\");\n"));
+            continue;
+        }
+
+        if imp.bindings.len() == 1 {
+            if let ImportBinding::Namespace(ref name) = imp.bindings[0] {
+                dynamic_imports.push_str(&format!("const {name} = await import(\"{escaped}\");\n"));
+                continue;
+            }
+        }
+
+        let mut parts = Vec::new();
+        let mut has_namespace = false;
+        let mut ns_name = String::new();
+
+        for binding in &imp.bindings {
+            match binding {
+                ImportBinding::Default(name) => {
+                    if name == "default" {
+                        parts.push("default".to_string());
+                    } else {
+                        parts.push(format!("default: {name}"));
+                    }
+                }
+                ImportBinding::Named { imported, local } => {
+                    if imported == local {
+                        parts.push(imported.clone());
+                    } else {
+                        parts.push(format!("{imported}: {local}"));
+                    }
+                }
+                ImportBinding::Namespace(name) => {
+                    has_namespace = true;
+                    ns_name = name.clone();
+                }
+            }
+        }
+
+        if has_namespace && !parts.is_empty() {
+            dynamic_imports.push_str(&format!("const {ns_name} = await import(\"{escaped}\");\n"));
+            dynamic_imports.push_str(&format!("const {{ {} }} = {ns_name};\n", parts.join(", ")));
+        } else if !parts.is_empty() {
+            dynamic_imports.push_str(&format!(
+                "const {{ {} }} = await import(\"{escaped}\");\n",
+                parts.join(", "),
+            ));
+        } else if has_namespace {
+            dynamic_imports.push_str(&format!("const {ns_name} = await import(\"{escaped}\");\n"));
+        }
+    }
+
+    // Collect loaded module metadata
+    let loaded_modules: Vec<(String, String)> = graph
+        .iter()
+        .map(|(url, m)| (url.clone(), m.hash.clone()))
+        .collect();
+
+    Ok(BundleResult {
+        dynamic_imports,
+        loaded_modules,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -878,6 +1435,151 @@ async function main() {}";
         assert!(result.imports.is_empty());
         assert_eq!(result.code, code);
     }
+
+    // -----------------------------------------------------------------------
+    // CDN import scanning (scan_cdn_imports)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn scan_minified_named_import() {
+        let source = r#"import{hmac as t}from"/npm/@noble/hashes@1.3.2/hmac/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "/npm/@noble/hashes@1.3.2/hmac/+esm");
+    }
+
+    #[test]
+    fn scan_multiple_imports() {
+        let source = r#"import{a}from"/npm/pkg-a@1.0.0/+esm";import{b}from"/npm/pkg-b@2.0.0/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].1, "/npm/pkg-a@1.0.0/+esm");
+        assert_eq!(results[1].1, "/npm/pkg-b@2.0.0/+esm");
+    }
+
+    #[test]
+    fn scan_export_from() {
+        let source = r#"export{hmac}from"/npm/@noble/hashes@1.3.2/hmac/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "/npm/@noble/hashes@1.3.2/hmac/+esm");
+    }
+
+    #[test]
+    fn scan_side_effect_import() {
+        let source = r#"import"/npm/polyfill@1.0.0/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "/npm/polyfill@1.0.0/+esm");
+    }
+
+    #[test]
+    fn scan_skips_string_content() {
+        // `from"/npm/..."` inside a string should not be detected
+        let source = r#"var s="from\"/npm/fake@1.0.0/+esm\"";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn scan_skips_block_comment() {
+        let source = r#"/* import{a}from"/npm/pkg@1.0.0/+esm"; */ var x = 1;"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn scan_returns_byte_ranges() {
+        let source = r#"import{a}from"/npm/pkg@1.0.0/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        let (range, spec) = &results[0];
+        // The range should point to the string content inside the quotes
+        assert_eq!(&source[range.clone()], spec.as_str());
+    }
+
+    #[test]
+    fn scan_single_quoted() {
+        let source = "import{a}from'/npm/pkg@1.0.0/+esm';";
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "/npm/pkg@1.0.0/+esm");
+    }
+
+    #[test]
+    fn scan_with_spaces() {
+        let source = r#"import { a } from "/npm/pkg@1.0.0/+esm";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "/npm/pkg@1.0.0/+esm");
+    }
+
+    #[test]
+    fn scan_relative_import() {
+        let source = r#"import{a}from"./utils.js";"#;
+        let results = scan_cdn_imports(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "./utils.js");
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_cdn_specifier
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_root_relative_npm() {
+        let result = resolve_cdn_specifier(
+            "/npm/@noble/hashes@1.3.2/hmac/+esm",
+            "https://cdn.jsdelivr.net/npm/ethers@6.13.4/+esm",
+        );
+        assert_eq!(
+            result,
+            Some("https://cdn.jsdelivr.net/npm/@noble/hashes@1.3.2/hmac/+esm".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_relative_path() {
+        let result = resolve_cdn_specifier(
+            "./utils.js",
+            "https://cdn.jsdelivr.net/npm/pkg@1.0.0/lib/index.js",
+        );
+        assert_eq!(
+            result,
+            Some("https://cdn.jsdelivr.net/npm/pkg@1.0.0/lib/utils.js".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_full_url_passthrough() {
+        let result = resolve_cdn_specifier(
+            "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm",
+            "",
+        );
+        assert_eq!(
+            result,
+            Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_npm_specifier() {
+        let result = resolve_cdn_specifier("zod@3.22.4", "");
+        assert_eq!(
+            result,
+            Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_non_npm() {
+        let result = resolve_cdn_specifier("/gh/user/repo@main/file.js", "");
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Comment / string / template literal awareness (existing tests below)
+    // -----------------------------------------------------------------------
 
     #[test]
     fn real_import_after_block_comment() {

--- a/lit-actions/server/import_rewriter.rs
+++ b/lit-actions/server/import_rewriter.rs
@@ -521,15 +521,34 @@ pub(crate) async fn bundle_imports(
     let mut queue: VecDeque<String> = VecDeque::new();
     let mut visited: HashSet<String> = HashSet::new();
 
-    // Seed queue with user's top-level import specifiers
+    // Seed queue with user's top-level import specifiers.
+    // Track inline #sha384-... hashes separately for integrity verification.
     let mut root_urls: Vec<String> = Vec::new();
+    let mut inline_hashes: HashMap<String, String> = HashMap::new();
     for imp in imports {
-        if let Some(url) = resolve_cdn_specifier(&imp.specifier, "") {
-            let fetch_url = url.split('#').next().unwrap_or(&url).to_string();
-            root_urls.push(fetch_url.clone());
-            if !visited.contains(&fetch_url) {
-                queue.push_back(fetch_url.clone());
-                visited.insert(fetch_url);
+        match resolve_cdn_specifier(&imp.specifier, "") {
+            Some(url) => {
+                let fetch_url = url.split('#').next().unwrap_or(&url).to_string();
+                // Preserve inline integrity hash from URL fragment
+                if let Some(fragment) = url.split_once('#').map(|(_, f)| f) {
+                    if let Some(hash) = fragment.strip_prefix("sha384-") {
+                        inline_hashes.insert(fetch_url.clone(), hash.to_string());
+                    }
+                }
+                root_urls.push(fetch_url.clone());
+                if !visited.contains(&fetch_url) {
+                    queue.push_back(fetch_url.clone());
+                    visited.insert(fetch_url);
+                }
+            }
+            None => {
+                return Err(JsErrorBox::generic(format!(
+                    "Unable to resolve import specifier: \"{}\". \
+                     Use an npm specifier with a pinned version (e.g. zod@3.22.4) \
+                     or a full jsDelivr URL.",
+                    imp.specifier
+                ))
+                .into());
             }
         }
     }
@@ -554,11 +573,11 @@ pub(crate) async fn bundle_imports(
         let actual_b64 = base64::engine::general_purpose::STANDARD.encode(&actual_digest);
 
         // Integrity verification — mirrors CdnModuleLoader::load()
-        let expected_hash = integrity
-            .read()
-            .expect("integrity lock poisoned")
+        // Inline hash takes priority, then lockfile manifest (same as load())
+        let expected_hash = inline_hashes
             .get(&url)
-            .cloned();
+            .cloned()
+            .or_else(|| integrity.read().ok().and_then(|map| map.get(&url).cloned()));
 
         if let Some(ref expected_b64) = expected_hash {
             // Known module: verify against stored hash
@@ -659,9 +678,9 @@ pub(crate) async fn bundle_imports(
         let hash = actual_b64;
 
         // Scan for nested imports (ES modules must be valid UTF-8)
-        let source_str = String::from_utf8(bytes.clone())
+        let source_str = std::str::from_utf8(&bytes)
             .map_err(|e| JsErrorBox::generic(format!("Module {url} is not valid UTF-8: {e}")))?;
-        let found_imports = scan_cdn_imports(&source_str);
+        let found_imports = scan_cdn_imports(source_str);
 
         let mut nested = Vec::new();
         for (range, spec) in found_imports {

--- a/lit-actions/server/import_rewriter.rs
+++ b/lit-actions/server/import_rewriter.rs
@@ -484,12 +484,12 @@ fn resolve_cdn_specifier(specifier: &str, referrer_url: &str) -> Option<String> 
     if (specifier.starts_with("./") || specifier.starts_with("../"))
         && referrer_url.starts_with(ALLOWED_NPM_PREFIX)
     {
-        if let Ok(base) = url::Url::parse(referrer_url) {
-            if let Ok(resolved) = base.join(specifier) {
-                let s = resolved.to_string();
-                if s.starts_with(ALLOWED_NPM_PREFIX) {
-                    return Some(s);
-                }
+        if let Ok(base) = url::Url::parse(referrer_url)
+            && let Ok(resolved) = base.join(specifier)
+        {
+            let s = resolved.to_string();
+            if s.starts_with(ALLOWED_NPM_PREFIX) {
+                return Some(s);
             }
         }
         return None;
@@ -530,10 +530,10 @@ pub(crate) async fn bundle_imports(
             Some(url) => {
                 let fetch_url = url.split('#').next().unwrap_or(&url).to_string();
                 // Preserve inline integrity hash from URL fragment
-                if let Some(fragment) = url.split_once('#').map(|(_, f)| f) {
-                    if let Some(hash) = fragment.strip_prefix("sha384-") {
-                        inline_hashes.insert(fetch_url.clone(), hash.to_string());
-                    }
+                if let Some(fragment) = url.split_once('#').map(|(_, f)| f)
+                    && let Some(hash) = fragment.strip_prefix("sha384-")
+                {
+                    inline_hashes.insert(fetch_url.clone(), hash.to_string());
                 }
                 root_urls.push(fetch_url.clone());
                 if !visited.contains(&fetch_url) {
@@ -570,7 +570,7 @@ pub(crate) async fn bundle_imports(
         let mut hasher = Sha384::new();
         hasher.update(&bytes);
         let actual_digest = hasher.finalize();
-        let actual_b64 = base64::engine::general_purpose::STANDARD.encode(&actual_digest);
+        let actual_b64 = base64::engine::general_purpose::STANDARD.encode(actual_digest);
 
         // Integrity verification — mirrors CdnModuleLoader::load()
         // Inline hash takes priority, then lockfile manifest (same as load())
@@ -735,8 +735,8 @@ pub(crate) async fn bundle_imports(
 
     // Start with leaf modules (no dependencies within the graph)
     let mut topo_queue: VecDeque<usize> = VecDeque::new();
-    for i in 0..n {
-        if in_degree[i] == 0 {
+    for (i, &deg) in in_degree.iter().enumerate() {
+        if deg == 0 {
             topo_queue.push_back(i);
         }
     }
@@ -811,11 +811,11 @@ pub(crate) async fn bundle_imports(
             continue;
         }
 
-        if imp.bindings.len() == 1 {
-            if let ImportBinding::Namespace(ref name) = imp.bindings[0] {
-                dynamic_imports.push_str(&format!("const {name} = await import(\"{escaped}\");\n"));
-                continue;
-            }
+        if imp.bindings.len() == 1
+            && let ImportBinding::Namespace(ref name) = imp.bindings[0]
+        {
+            dynamic_imports.push_str(&format!("const {name} = await import(\"{escaped}\");\n"));
+            continue;
         }
 
         let mut parts = Vec::new();

--- a/lit-actions/server/import_rewriter.rs
+++ b/lit-actions/server/import_rewriter.rs
@@ -310,7 +310,7 @@ use tracing::{info, warn};
 use std::path::PathBuf;
 
 use crate::cdn_module_loader::{
-    constant_time_eq, CdnModuleLoader, ALLOWED_NPM_PREFIX, MAX_MODULE_COUNT,
+    ALLOWED_NPM_PREFIX, CdnModuleLoader, MAX_MODULE_COUNT, constant_time_eq,
 };
 
 /// A resolved module in the dependency graph.
@@ -659,9 +659,8 @@ pub(crate) async fn bundle_imports(
         let hash = actual_b64;
 
         // Scan for nested imports (ES modules must be valid UTF-8)
-        let source_str = String::from_utf8(bytes.clone()).map_err(|e| {
-            JsErrorBox::generic(format!("Module {url} is not valid UTF-8: {e}"))
-        })?;
+        let source_str = String::from_utf8(bytes.clone())
+            .map_err(|e| JsErrorBox::generic(format!("Module {url} is not valid UTF-8: {e}")))?;
         let found_imports = scan_cdn_imports(&source_str);
 
         let mut nested = Vec::new();
@@ -695,7 +694,11 @@ pub(crate) async fn bundle_imports(
     // Phase 2: Topological sort (Kahn's algorithm)
     // Build adjacency: module → set of modules it depends on
     let urls: Vec<String> = graph.keys().cloned().collect();
-    let url_to_idx: HashMap<&str, usize> = urls.iter().enumerate().map(|(i, u)| (u.as_str(), i)).collect();
+    let url_to_idx: HashMap<&str, usize> = urls
+        .iter()
+        .enumerate()
+        .map(|(i, u)| (u.as_str(), i))
+        .collect();
     let n = urls.len();
     let mut in_degree = vec![0usize; n];
     let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n]; // dep → list of modules that import it
@@ -751,7 +754,9 @@ pub(crate) async fn bundle_imports(
             .nested_imports
             .iter()
             .filter_map(|(range, dep_url)| {
-                data_urls.get(dep_url).map(|data_url| (range.clone(), data_url.clone()))
+                data_urls
+                    .get(dep_url)
+                    .map(|data_url| (range.clone(), data_url.clone()))
             })
             .collect();
         // Sort by range start descending so we replace from end to start
@@ -1450,7 +1455,8 @@ async function main() {}";
 
     #[test]
     fn scan_multiple_imports() {
-        let source = r#"import{a}from"/npm/pkg-a@1.0.0/+esm";import{b}from"/npm/pkg-b@2.0.0/+esm";"#;
+        let source =
+            r#"import{a}from"/npm/pkg-a@1.0.0/+esm";import{b}from"/npm/pkg-b@2.0.0/+esm";"#;
         let results = scan_cdn_imports(source);
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].1, "/npm/pkg-a@1.0.0/+esm");
@@ -1552,10 +1558,7 @@ async function main() {}";
 
     #[test]
     fn resolve_full_url_passthrough() {
-        let result = resolve_cdn_specifier(
-            "https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm",
-            "",
-        );
+        let result = resolve_cdn_specifier("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm", "");
         assert_eq!(
             result,
             Some("https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm".to_string())

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -283,6 +283,10 @@ pub(crate) async fn execute_js(
     let memory_limit_mb = memory_limit_mb.unwrap_or(DEFAULT_MEMORY_LIMIT_MB);
 
     let loaded_modules = LoadedModules::default();
+    let bundler_client = http_client.clone();
+    let bundler_loaded_modules = loaded_modules.clone();
+    let bundler_integrity = integrity_manifest.clone();
+    let bundler_lockfile = lockfile_path.clone();
 
     let mut worker = build_main_worker_and_inject_sdk(
         &None,
@@ -365,9 +369,31 @@ pub(crate) async fn execute_js(
         }})();"
         )
     } else {
-        // Has imports — move user code inside the async IIFE so that the
-        // dynamically imported bindings are in lexical scope for main().
-        let dynamic_imports = import_rewriter::generate_dynamic_imports(&imports);
+        // Has imports — bundle all transitive dependencies from jsDelivr as
+        // data: URLs so the module loader needs no network I/O at runtime.
+        let bundle_result = import_rewriter::bundle_imports(
+            &imports,
+            &bundler_client,
+            &bundler_integrity,
+            strict_imports,
+            &bundler_lockfile,
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to bundle CDN imports: {e}"))?;
+
+        // Record loaded modules for showImportDetails()
+        if let Ok(mut modules) = bundler_loaded_modules.0.write() {
+            for (url, hash) in &bundle_result.loaded_modules {
+                if !modules.iter().any(|m| &m.url == url) {
+                    modules.push(crate::cdn_module_loader::LoadedModuleInfo {
+                        url: url.clone(),
+                        hash: hash.clone(),
+                    });
+                }
+            }
+        }
+
+        let dynamic_imports = &bundle_result.dynamic_imports;
         format!(
             "
         (async () => {{


### PR DESCRIPTION
## Summary

Resolves [CPL-249](https://linear.app/litprotocol/issue/CPL-249/nested-imports-jsdelivr): When importing npm packages via jsDelivr's `/+esm` endpoint (e.g., `ethers@6.13.4`), transitive dependencies use root-relative `/npm/` import paths that were not resolved. This caused any package with inter-package dependencies to fail at runtime.

### What changed

**`import_rewriter.rs`** (main change):
- `scan_cdn_imports()` — Scans minified jsDelivr module source for `import...from"..."` and `export...from"..."` specifiers, handling strings/comments correctly
- `resolve_cdn_specifier()` — Resolves `/npm/` root-relative, `./`/`../` relative, full URL, and npm specifier formats to full jsDelivr URLs
- `bundle_imports()` — Async bundling pipeline that:
  1. BFS-fetches all transitive dependencies from jsDelivr
  2. Performs integrity verification (manifest hash check, TOFU double-fetch in strict mode, SRI header verification, lockfile pinning)
  3. Topologically sorts the dependency graph (with cycle detection)
  4. Inlines modules bottom-up as `data:text/javascript;base64,...` URLs
  5. Generates self-contained dynamic import statements

**`cdn_module_loader.rs`**:
- Made `fetch_with_size_limit`, `parse_npm_specifier`, `constant_time_eq`, and CDN prefix constants `pub(crate)` for reuse by the bundler
- Added `data:` URL passthrough in `resolve()` for bundled modules
- Added `/npm/` root-relative path resolution as safety net

**`runtime.rs`**:
- Replaced `generate_dynamic_imports()` with `bundle_imports()` call when imports are present
- Records loaded module metadata for `showImportDetails()`

## Test plan
- [x] 59 unit tests pass (15 new for scan_cdn_imports, resolve_cdn_specifier, and resolve() changes)
- [x] Clean `cargo check` build with no warnings
- [x] 1 pre-existing test failure on main (`test_strict_mode_serves_known_module_from_cache`) — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)