### PR TITLE
fix: truncate long specifiers in CdnModuleLoader resolve logs (CPL-255)

### DIFF
--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -975,4 +975,25 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
             "known cached module should load synchronously"
         );
     }
+
+    #[test]
+    fn test_truncate_for_log_short_string() {
+        let short = "hello world";
+        assert_eq!(truncate_for_log(short), "hello world");
+    }
+
+    #[test]
+    fn test_truncate_for_log_exactly_1000_chars() {
+        let s = "a".repeat(1000);
+        assert_eq!(truncate_for_log(&s), s);
+    }
+
+    #[test]
+    fn test_truncate_for_log_over_1000_chars() {
+        let s = "b".repeat(1500);
+        let result = truncate_for_log(&s);
+        assert!(result.starts_with(&"b".repeat(100)));
+        assert!(result.contains("[truncated, len=1500]"));
+        assert!(result.len() < 200);
+    }
 }

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -14,6 +14,16 @@ use futures::FutureExt;
 use sha2::{Digest, Sha384};
 use tracing::{debug, error, info, instrument, warn};
 
+/// Truncate a string to the first 100 characters (with "…[truncated]" suffix)
+/// if it exceeds 1000 characters. Used to prevent logging huge base64 blobs.
+fn truncate_for_log(s: &str) -> String {
+    if s.len() > 1000 {
+        format!("{}…[truncated, len={}]", &s[..100], s.len())
+    } else {
+        s.to_string()
+    }
+}
+
 /// Constant-time byte comparison to prevent timing side-channels on integrity hashes.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -330,16 +340,16 @@ impl ModuleLoader for CdnModuleLoader {
             // Relative traversal (../../) could escape to /gh/ or other backends.
             if Self::is_allowed_cdn(resolved.as_str()) {
                 info!(
-                    specifier,
-                    referrer,
+                    specifier = %truncate_for_log(specifier),
+                    referrer = %truncate_for_log(referrer),
                     resolved_url = %resolved,
                     "CDN module resolve: relative import resolved against jsDelivr referrer"
                 );
                 return Ok(resolved);
             }
             warn!(
-                specifier,
-                referrer,
+                specifier = %truncate_for_log(specifier),
+                referrer = %truncate_for_log(referrer),
                 resolved_url = %resolved,
                 "CDN module resolve rejected: relative import resolved outside /npm/ boundary"
             );
@@ -351,7 +361,7 @@ impl ModuleLoader for CdnModuleLoader {
 
         // If it's already a full jsDelivr URL, pass through
         if Self::is_allowed_cdn(specifier) {
-            info!(specifier, "CDN module resolve: full URL accepted");
+            info!(specifier = %truncate_for_log(specifier), "CDN module resolve: full URL accepted");
             return ModuleSpecifier::parse(specifier).map_err(|e| {
                 JsErrorBox::generic(format!("Invalid module URL: {specifier}: {e}")).into()
             });
@@ -360,7 +370,7 @@ impl ModuleLoader for CdnModuleLoader {
         // Try parsing as an npm specifier (e.g. "zod@3.22.4/+esm")
         if let Some(cdn_url) = Self::parse_npm_specifier(specifier) {
             info!(
-                specifier,
+                specifier = %truncate_for_log(specifier),
                 resolved_url = %cdn_url,
                 "CDN module resolve: npm specifier resolved to jsDelivr URL"
             );
@@ -371,8 +381,9 @@ impl ModuleLoader for CdnModuleLoader {
 
         // Reject everything else
         warn!(
-            specifier,
-            referrer, "CDN module resolve rejected: not a valid npm specifier or jsDelivr URL"
+            specifier = %truncate_for_log(specifier),
+            referrer = %truncate_for_log(referrer),
+            "CDN module resolve rejected: not a valid npm specifier or jsDelivr URL"
         );
         Err(JsErrorBox::generic(format!(
             "Invalid import specifier: \"{specifier}\". \

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -14,11 +14,16 @@ use futures::FutureExt;
 use sha2::{Digest, Sha384};
 use tracing::{debug, error, info, instrument, warn};
 
-/// Truncate a string to the first 100 characters (with "…[truncated]" suffix)
-/// if it exceeds 1000 characters. Used to prevent logging huge base64 blobs.
+/// Truncate a string to approximately the first 100 bytes (on a valid UTF-8
+/// char boundary) if it exceeds 1000 bytes. Used to prevent logging huge
+/// base64 blobs in module specifiers.
 fn truncate_for_log(s: &str) -> String {
     if s.len() > 1000 {
-        format!("{}…[truncated, len={}]", &s[..100], s.len())
+        let mut end = 100.min(s.len());
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…[truncated, len={}]", &s[..end], s.len())
     } else {
         s.to_string()
     }
@@ -329,11 +334,16 @@ impl ModuleLoader for CdnModuleLoader {
             && Self::is_allowed_cdn(referrer)
         {
             let base = ModuleSpecifier::parse(referrer).map_err(|e| {
-                JsErrorBox::generic(format!("Invalid referrer URL: {referrer}: {e}"))
+                JsErrorBox::generic(format!(
+                    "Invalid referrer URL: {}: {e}",
+                    truncate_for_log(referrer)
+                ))
             })?;
             let resolved = base.join(specifier).map_err(|e| {
                 JsErrorBox::generic(format!(
-                    "Failed to resolve relative import \"{specifier}\" against {referrer}: {e}"
+                    "Failed to resolve relative import \"{}\" against {}: {e}",
+                    truncate_for_log(specifier),
+                    truncate_for_log(referrer)
                 ))
             })?;
             // Verify the resolved URL stays within the /npm/ backend.
@@ -354,7 +364,8 @@ impl ModuleLoader for CdnModuleLoader {
                 "CDN module resolve rejected: relative import resolved outside /npm/ boundary"
             );
             return Err(JsErrorBox::generic(format!(
-                "Relative import \"{specifier}\" resolved to {resolved}, which is outside the allowed /npm/ CDN path"
+                "Relative import \"{}\" resolved to {resolved}, which is outside the allowed /npm/ CDN path",
+                truncate_for_log(specifier)
             ))
             .into());
         }
@@ -363,7 +374,11 @@ impl ModuleLoader for CdnModuleLoader {
         if Self::is_allowed_cdn(specifier) {
             info!(specifier = %truncate_for_log(specifier), "CDN module resolve: full URL accepted");
             return ModuleSpecifier::parse(specifier).map_err(|e| {
-                JsErrorBox::generic(format!("Invalid module URL: {specifier}: {e}")).into()
+                JsErrorBox::generic(format!(
+                    "Invalid module URL: {}: {e}",
+                    truncate_for_log(specifier)
+                ))
+                .into()
             });
         }
 
@@ -386,9 +401,10 @@ impl ModuleLoader for CdnModuleLoader {
             "CDN module resolve rejected: not a valid npm specifier or jsDelivr URL"
         );
         Err(JsErrorBox::generic(format!(
-            "Invalid import specifier: \"{specifier}\". \
+            "Invalid import specifier: \"{}\". \
              Use an npm specifier with a pinned version (e.g. zod@3.22.4) \
-             or a full jsDelivr URL (e.g. https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm)"
+             or a full jsDelivr URL (e.g. https://cdn.jsdelivr.net/npm/zod@3.22.4/+esm)",
+            truncate_for_log(specifier)
         ))
         .into())
     }
@@ -995,5 +1011,15 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
         assert!(result.starts_with(&"b".repeat(100)));
         assert!(result.contains("[truncated, len=1500]"));
         assert!(result.len() < 200);
+    }
+
+    #[test]
+    fn test_truncate_for_log_multibyte_utf8() {
+        // 4-byte emoji repeated: byte 100 falls mid-character, must not panic
+        let s = "\u{1F600}".repeat(500); // 2000 bytes, each char is 4 bytes
+        let result = truncate_for_log(&s);
+        assert!(result.contains("[truncated, len=2000]"));
+        // Should truncate to a valid char boundary (100 bytes / 4 bytes per char = 25 chars)
+        assert!(result.starts_with(&"\u{1F600}".repeat(25)));
     }
 }

--- a/lit-actions/server/cdn_module_loader.rs
+++ b/lit-actions/server/cdn_module_loader.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -17,15 +18,15 @@ use tracing::{debug, error, info, instrument, warn};
 /// Truncate a string to approximately the first 100 bytes (on a valid UTF-8
 /// char boundary) if it exceeds 1000 bytes. Used to prevent logging huge
 /// base64 blobs in module specifiers.
-fn truncate_for_log(s: &str) -> String {
+fn truncate_for_log(s: &str) -> Cow<'_, str> {
     if s.len() > 1000 {
         let mut end = 100.min(s.len());
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }
-        format!("{}…[truncated, len={}]", &s[..end], s.len())
+        Cow::Owned(format!("{}…[truncated, len={}]", &s[..end], s.len()))
     } else {
-        s.to_string()
+        Cow::Borrowed(s)
     }
 }
 
@@ -995,13 +996,17 @@ https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm sha384-xyz789
     #[test]
     fn test_truncate_for_log_short_string() {
         let short = "hello world";
-        assert_eq!(truncate_for_log(short), "hello world");
+        let result = truncate_for_log(short);
+        assert_eq!(&*result, "hello world");
+        assert!(matches!(result, Cow::Borrowed(_)));
     }
 
     #[test]
     fn test_truncate_for_log_exactly_1000_chars() {
         let s = "a".repeat(1000);
-        assert_eq!(truncate_for_log(&s), s);
+        let result = truncate_for_log(&s);
+        assert_eq!(&*result, s);
+        assert!(matches!(result, Cow::Borrowed(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Limits logging length in `CdnModuleLoader::resolve` to prevent large base64 inline dependencies from bloating logs (CPL-255).

**Log truncation:**
- Adds `truncate_for_log()` helper that caps strings over 1000 bytes to ~100 bytes (on a valid UTF-8 char boundary) with a `…[truncated, len=N]` suffix
- Applied to all `specifier` and `referrer` fields in `resolve()` log statements (5 sites)

**Error message truncation:**
- Also truncates specifier/referrer in error messages returned from `resolve()`, since `#[instrument(skip_all, err)]` logs returned errors — without this, full untruncated strings still reach logs via the instrumentation error path

**Safety:**
- UTF-8 safe: finds the nearest char boundary before byte 100, preventing panics on multi-byte input
- No behavioral changes to resolve/load logic — only affects what gets logged

## Test Coverage

Tests: 12 → 16 (+4 new)

```
CODE PATH COVERAGE
===========================
[+] truncate_for_log()
    ├── [★★★ TESTED] Short string pass-through — test_truncate_for_log_short_string
    ├── [★★★ TESTED] Exact 1000-byte boundary — test_truncate_for_log_exactly_1000_chars
    ├── [★★★ TESTED] Over 1000 bytes (ASCII) — test_truncate_for_log_over_1000_chars
    └── [★★★ TESTED] Multi-byte UTF-8 safety — test_truncate_for_log_multibyte_utf8

COVERAGE: 4/4 new paths tested (100%)
```

## Pre-Landing Review

No issues found. Small, focused diff — pure function with no SQL, concurrency, or security boundaries.

## Adversarial Review

Cross-model review (Claude + Codex) found 2 issues, both fixed:
- **[FIXED]** `&s[..100]` panics on multi-byte UTF-8 at byte boundary → now uses `is_char_boundary()` 
- **[FIXED]** `#[instrument(skip_all, err)]` logs returned errors containing full untruncated specifiers → error messages now also truncated

## Test plan
- [x] All 45 cargo tests pass (1 pre-existing failure on main, unrelated)
- [x] `cargo check` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)