### PR TITLE
feat: short-circuit for cached lit action code (CPL-256)

### DIFF
--- a/lit-actions/grpc/proto.rs
+++ b/lit-actions/grpc/proto.rs
@@ -87,6 +87,7 @@ impl std::fmt::Debug for DebugExecutionRequest<'_> {
             .field("timeout", &req.timeout)
             .field("memory_limit", &req.memory_limit)
             .field("http_headers", &req.http_headers)
+            .field("ipfs_id", &req.ipfs_id)
             .finish()
     }
 }

--- a/lit-actions/grpc/schema/lit_actions.proto
+++ b/lit-actions/grpc/schema/lit_actions.proto
@@ -29,6 +29,7 @@ message ExecuteJsRequest {
     optional uint64 timeout = 4;       // milliseconds
     optional uint32 memory_limit = 5;  // megabytes
     map<string, string> http_headers = 6;
+    optional string ipfs_id = 7;       // IPFS CID for code cache lookup
   }
 
   message ErrorResponse {

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -383,7 +383,11 @@ pub(crate) async fn execute_js(
 
     let (rewritten_code, dynamic_imports, has_imports) = if let Some(cached) = cached {
         debug!("Code cache hit for IPFS CID");
-        (cached.rewritten_code, cached.dynamic_imports, cached.has_imports)
+        (
+            cached.rewritten_code,
+            cached.dynamic_imports,
+            cached.has_imports,
+        )
     } else {
         // Rewrite static ES `import` statements into dynamic `import()` calls.
         // Static imports are not valid in script mode, so we strip them from the

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -372,13 +372,13 @@ pub(crate) async fn execute_js(
 
     // Try to use cached rewrite result keyed by IPFS CID to skip import parsing.
     // On cache hit, verify the code hash to prevent cache poisoning from mismatched CIDs.
-    let code_digest = hash_code(&code);
+    // Only compute the hash when we have a CID (avoids O(n) hashing on every call).
     let cached = ipfs_id.as_deref().and_then(|cid| {
         code_cache
             .read()
             .ok()
             .and_then(|cache| cache.get(cid).cloned())
-            .filter(|entry| entry.code_hash == code_digest)
+            .filter(|entry| entry.code_hash == hash_code(&code))
     });
 
     let (rewritten_code, dynamic_imports, has_imports) = if let Some(cached) = cached {
@@ -406,20 +406,33 @@ pub(crate) async fn execute_js(
         };
 
         // Cache the rewrite result for future calls with the same IPFS CID.
+        // Use the entry API so existing CIDs can always be updated (e.g. code changed),
+        // while new inserts are blocked once the cache is at capacity.
         if let Some(cid) = ipfs_id.as_deref() {
             if let Ok(mut cache) = code_cache.write() {
-                if cache.len() < CODE_CACHE_MAX_ENTRIES {
-                    cache.insert(
-                        cid.to_string(),
-                        CachedRewrite {
-                            code_hash: code_digest,
-                            rewritten_code: rewritten_code.clone(),
-                            dynamic_imports: dynamic_imports.clone(),
-                            has_imports,
-                        },
-                    );
-                } else {
-                    debug!("Code cache full ({CODE_CACHE_MAX_ENTRIES} entries), skipping insert");
+                let cached_rewrite = CachedRewrite {
+                    code_hash: hash_code(&code),
+                    rewritten_code: rewritten_code.clone(),
+                    dynamic_imports: dynamic_imports.clone(),
+                    has_imports,
+                };
+
+                // Check capacity before borrowing via entry() to avoid
+                // simultaneous mutable + immutable borrow of the HashMap.
+                let at_capacity = cache.len() >= CODE_CACHE_MAX_ENTRIES;
+                match cache.entry(cid.to_string()) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        entry.insert(cached_rewrite);
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        if !at_capacity {
+                            entry.insert(cached_rewrite);
+                        } else {
+                            debug!(
+                                "Code cache full ({CODE_CACHE_MAX_ENTRIES} entries), skipping insert"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -670,6 +683,29 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// Helper that mirrors the entry-based insert logic used in execute_js.
+    fn cache_insert(cache: &CodeCache, cid: &str, entry: CachedRewrite) -> bool {
+        if let Ok(mut c) = cache.write() {
+            let at_capacity = c.len() >= CODE_CACHE_MAX_ENTRIES;
+            match c.entry(cid.to_string()) {
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    slot.insert(entry);
+                    true
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    if !at_capacity {
+                        slot.insert(entry);
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        } else {
+            false
+        }
+    }
+
     #[test]
     fn code_cache_respects_max_entries() {
         let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
@@ -692,12 +728,42 @@ mod tests {
 
         assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
 
-        // Attempting to insert when full should not increase size
+        // New CID insert should be rejected when full
+        let inserted = cache_insert(
+            &cache,
+            "QmOverflow",
+            CachedRewrite {
+                code_hash: [0u8; 32],
+                rewritten_code: String::new(),
+                dynamic_imports: String::new(),
+                has_imports: false,
+            },
+        );
+
+        assert!(!inserted);
+        assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
+        assert!(!cache.read().unwrap().contains_key("QmOverflow"));
+    }
+
+    #[test]
+    fn code_cache_allows_update_when_full() {
+        let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
+
+        // Fill the cache to capacity, including a known CID "QmExisting"
         {
             let mut c = cache.write().unwrap();
-            if c.len() < CODE_CACHE_MAX_ENTRIES {
+            c.insert(
+                "QmExisting".to_string(),
+                CachedRewrite {
+                    code_hash: [1u8; 32],
+                    rewritten_code: "old".to_string(),
+                    dynamic_imports: String::new(),
+                    has_imports: false,
+                },
+            );
+            for i in 1..CODE_CACHE_MAX_ENTRIES {
                 c.insert(
-                    "QmOverflow".to_string(),
+                    format!("Qm{i}"),
                     CachedRewrite {
                         code_hash: [0u8; 32],
                         rewritten_code: String::new(),
@@ -709,7 +775,24 @@ mod tests {
         }
 
         assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
-        assert!(!cache.read().unwrap().contains_key("QmOverflow"));
+
+        // Updating an existing CID should succeed even when full
+        let updated = cache_insert(
+            &cache,
+            "QmExisting",
+            CachedRewrite {
+                code_hash: [2u8; 32],
+                rewritten_code: "new".to_string(),
+                dynamic_imports: String::new(),
+                has_imports: false,
+            },
+        );
+
+        assert!(updated);
+        assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
+        let entry = cache.read().unwrap().get("QmExisting").cloned().unwrap();
+        assert_eq!(entry.rewritten_code, "new");
+        assert_eq!(entry.code_hash, [2u8; 32]);
     }
 
     #[test]

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -408,30 +408,30 @@ pub(crate) async fn execute_js(
         // Cache the rewrite result for future calls with the same IPFS CID.
         // Use the entry API so existing CIDs can always be updated (e.g. code changed),
         // while new inserts are blocked once the cache is at capacity.
-        if let Some(cid) = ipfs_id.as_deref() {
-            if let Ok(mut cache) = code_cache.write() {
-                let cached_rewrite = CachedRewrite {
-                    code_hash: hash_code(&code),
-                    rewritten_code: rewritten_code.clone(),
-                    dynamic_imports: dynamic_imports.clone(),
-                    has_imports,
-                };
+        if let Some(cid) = ipfs_id.as_deref()
+            && let Ok(mut cache) = code_cache.write()
+        {
+            let cached_rewrite = CachedRewrite {
+                code_hash: hash_code(&code),
+                rewritten_code: rewritten_code.clone(),
+                dynamic_imports: dynamic_imports.clone(),
+                has_imports,
+            };
 
-                // Check capacity before borrowing via entry() to avoid
-                // simultaneous mutable + immutable borrow of the HashMap.
-                let at_capacity = cache.len() >= CODE_CACHE_MAX_ENTRIES;
-                match cache.entry(cid.to_string()) {
-                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+            // Check capacity before borrowing via entry() to avoid
+            // simultaneous mutable + immutable borrow of the HashMap.
+            let at_capacity = cache.len() >= CODE_CACHE_MAX_ENTRIES;
+            match cache.entry(cid.to_string()) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.insert(cached_rewrite);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    if !at_capacity {
                         entry.insert(cached_rewrite);
-                    }
-                    std::collections::hash_map::Entry::Vacant(entry) => {
-                        if !at_capacity {
-                            entry.insert(cached_rewrite);
-                        } else {
-                            debug!(
-                                "Code cache full ({CODE_CACHE_MAX_ENTRIES} entries), skipping insert"
-                            );
-                        }
+                    } else {
+                        debug!(
+                            "Code cache full ({CODE_CACHE_MAX_ENTRIES} entries), skipping insert"
+                        );
                     }
                 }
             }

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -36,6 +36,33 @@ const DEFAULT_MEMORY_LIMIT_MB: usize = 128; // 128MB
 const MEMORY_SAMPLE_INTERVAL_MS: u64 = 500; // 500ms
 const EXECUTION_TERMINATED_ERROR: &str = "Uncaught Error: execution terminated";
 
+/// Maximum number of entries in the code rewrite cache.
+const CODE_CACHE_MAX_ENTRIES: usize = 1_000;
+
+/// Cached result of import rewriting for a given IPFS CID.
+#[derive(Clone)]
+pub(crate) struct CachedRewrite {
+    /// SHA-256 digest of the original code, used to verify cache integrity.
+    pub code_hash: [u8; 32],
+    /// User code with import statements stripped.
+    pub rewritten_code: String,
+    /// Pre-rendered dynamic import statements (empty string when no imports).
+    pub dynamic_imports: String,
+    /// Whether the original code had imports.
+    pub has_imports: bool,
+}
+
+/// Thread-safe cache mapping IPFS CID → rewrite result.
+pub(crate) type CodeCache = Arc<RwLock<HashMap<String, CachedRewrite>>>;
+
+/// Compute a SHA-256 hash of the code for cache integrity verification.
+fn hash_code(code: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(code.as_bytes());
+    hasher.finalize().into()
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 enum ExecutionResult {
     Complete,
@@ -269,6 +296,8 @@ pub(crate) async fn execute_js(
     module_cache: ModuleCache,
     lockfile_path: Option<PathBuf>,
     http_client: Arc<reqwest::Client>,
+    ipfs_id: Option<String>,
+    code_cache: CodeCache,
 ) -> Result<()> {
     // Fast path to do nothing, allowing us to benchmark with and without Deno involved
     if code.is_empty() || code.bytes().all(|b| b.is_ascii_whitespace()) {
@@ -341,16 +370,60 @@ pub(crate) async fn execute_js(
     let js_params = js_params.as_ref().unwrap_or_default();
     let js_func_params = js_params.to_string();
 
-    // Rewrite static ES `import` statements into dynamic `import()` calls.
-    // Static imports are not valid in script mode, so we strip them from the
-    // user code and generate equivalent dynamic imports inside the async wrapper
-    // where `await` is available and the imported bindings are in lexical scope.
-    let import_rewriter::RewriteResult {
-        code: rewritten_code,
-        imports,
-    } = import_rewriter::rewrite_imports(&code);
+    // Try to use cached rewrite result keyed by IPFS CID to skip import parsing.
+    // On cache hit, verify the code hash to prevent cache poisoning from mismatched CIDs.
+    let code_digest = hash_code(&code);
+    let cached = ipfs_id.as_deref().and_then(|cid| {
+        code_cache
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(cid).cloned())
+            .filter(|entry| entry.code_hash == code_digest)
+    });
 
-    let code = if imports.is_empty() {
+    let (rewritten_code, dynamic_imports, has_imports) = if let Some(cached) = cached {
+        debug!("Code cache hit for IPFS CID");
+        (cached.rewritten_code, cached.dynamic_imports, cached.has_imports)
+    } else {
+        // Rewrite static ES `import` statements into dynamic `import()` calls.
+        // Static imports are not valid in script mode, so we strip them from the
+        // user code and generate equivalent dynamic imports inside the async wrapper
+        // where `await` is available and the imported bindings are in lexical scope.
+        let import_rewriter::RewriteResult {
+            code: rewritten_code,
+            imports,
+        } = import_rewriter::rewrite_imports(&code);
+
+        let has_imports = !imports.is_empty();
+        let dynamic_imports = if has_imports {
+            import_rewriter::generate_dynamic_imports(&imports)
+        } else {
+            String::new()
+        };
+
+        // Cache the rewrite result for future calls with the same IPFS CID.
+        if let Some(cid) = ipfs_id.as_deref() {
+            if let Ok(mut cache) = code_cache.write() {
+                if cache.len() < CODE_CACHE_MAX_ENTRIES {
+                    cache.insert(
+                        cid.to_string(),
+                        CachedRewrite {
+                            code_hash: code_digest,
+                            rewritten_code: rewritten_code.clone(),
+                            dynamic_imports: dynamic_imports.clone(),
+                            has_imports,
+                        },
+                    );
+                } else {
+                    debug!("Code cache full ({CODE_CACHE_MAX_ENTRIES} entries), skipping insert");
+                }
+            }
+        }
+
+        (rewritten_code, dynamic_imports, has_imports)
+    };
+
+    let code = if !has_imports {
         // No imports — preserve the existing wrapper layout unchanged.
         format!(
             "
@@ -367,7 +440,6 @@ pub(crate) async fn execute_js(
     } else {
         // Has imports — move user code inside the async IIFE so that the
         // dynamically imported bindings are in lexical scope for main().
-        let dynamic_imports = import_rewriter::generate_dynamic_imports(&imports);
         format!(
             "
         (async () => {{
@@ -522,4 +594,127 @@ fn start_controller_thread(
 
         res
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_code_is_deterministic() {
+        let code = "async function main() { return 42; }";
+        assert_eq!(hash_code(code), hash_code(code));
+    }
+
+    #[test]
+    fn hash_code_differs_for_different_input() {
+        let a = hash_code("async function main() { return 1; }");
+        let b = hash_code("async function main() { return 2; }");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn code_cache_hit_returns_cached_entry() {
+        let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
+        let code = "async function main() {}";
+        let digest = hash_code(code);
+
+        cache.write().unwrap().insert(
+            "QmTest123".to_string(),
+            CachedRewrite {
+                code_hash: digest,
+                rewritten_code: code.to_string(),
+                dynamic_imports: String::new(),
+                has_imports: false,
+            },
+        );
+
+        let result = cache
+            .read()
+            .ok()
+            .and_then(|c| c.get("QmTest123").cloned())
+            .filter(|entry| entry.code_hash == digest);
+
+        assert!(result.is_some());
+        assert!(!result.unwrap().has_imports);
+    }
+
+    #[test]
+    fn code_cache_rejects_mismatched_hash() {
+        let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
+        let original_code = "async function main() { return 1; }";
+        let different_code = "async function main() { return 2; }";
+
+        cache.write().unwrap().insert(
+            "QmTest456".to_string(),
+            CachedRewrite {
+                code_hash: hash_code(original_code),
+                rewritten_code: original_code.to_string(),
+                dynamic_imports: String::new(),
+                has_imports: false,
+            },
+        );
+
+        // Lookup with a different code should fail the hash check
+        let different_digest = hash_code(different_code);
+        let result = cache
+            .read()
+            .ok()
+            .and_then(|c| c.get("QmTest456").cloned())
+            .filter(|entry| entry.code_hash == different_digest);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn code_cache_respects_max_entries() {
+        let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
+
+        // Fill the cache to capacity
+        {
+            let mut c = cache.write().unwrap();
+            for i in 0..CODE_CACHE_MAX_ENTRIES {
+                c.insert(
+                    format!("Qm{i}"),
+                    CachedRewrite {
+                        code_hash: [0u8; 32],
+                        rewritten_code: String::new(),
+                        dynamic_imports: String::new(),
+                        has_imports: false,
+                    },
+                );
+            }
+        }
+
+        assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
+
+        // Attempting to insert when full should not increase size
+        {
+            let mut c = cache.write().unwrap();
+            if c.len() < CODE_CACHE_MAX_ENTRIES {
+                c.insert(
+                    "QmOverflow".to_string(),
+                    CachedRewrite {
+                        code_hash: [0u8; 32],
+                        rewritten_code: String::new(),
+                        dynamic_imports: String::new(),
+                        has_imports: false,
+                    },
+                );
+            }
+        }
+
+        assert_eq!(cache.read().unwrap().len(), CODE_CACHE_MAX_ENTRIES);
+        assert!(!cache.read().unwrap().contains_key("QmOverflow"));
+    }
+
+    #[test]
+    fn code_cache_miss_returns_none() {
+        let cache: CodeCache = Arc::new(RwLock::new(HashMap::new()));
+        let result = cache
+            .read()
+            .ok()
+            .and_then(|c| c.get("QmNonexistent").cloned());
+        assert!(result.is_none());
+    }
 }

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -4,6 +4,7 @@ use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
 use crate::cdn_module_loader::{CdnModuleLoader, ModuleCache};
+use crate::runtime::CodeCache;
 
 use anyhow::Result;
 use deno_core::error::CoreError;
@@ -41,6 +42,8 @@ pub struct Server {
     lockfile_path: Option<PathBuf>,
     /// Shared HTTP client for CDN fetches (connection pooling across executions).
     http_client: Arc<reqwest::Client>,
+    /// Shared cache for import-rewritten code keyed by IPFS CID.
+    code_cache: CodeCache,
 }
 
 impl Server {
@@ -63,6 +66,7 @@ impl Server {
             module_cache: Arc::new(RwLock::new(HashMap::new())),
             lockfile_path,
             http_client: CdnModuleLoader::build_http_client(),
+            code_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -74,6 +78,7 @@ impl Server {
             module_cache: Arc::new(RwLock::new(HashMap::new())),
             lockfile_path: None,
             http_client: CdnModuleLoader::build_http_client(),
+            code_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -98,6 +103,7 @@ impl Action for Server {
         let module_cache = self.module_cache.clone();
         let lockfile_path = self.lockfile_path.clone();
         let http_client = self.http_client.clone();
+        let code_cache = self.code_cache.clone();
 
         // Put incoming requests into channel
         let send_exec_req_span = debug_span!("send_exec_req");
@@ -185,6 +191,8 @@ impl Action for Server {
                                     module_cache.clone(),
                                     lockfile_path.clone(),
                                     http_client.clone(),
+                                    req.ipfs_id,
+                                    code_cache.clone(),
                                 )
                                 .await;
                                 let _ = outbound_tx

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -215,6 +215,11 @@ impl Client {
                     http_headers: self.http_headers.clone(),
                     timeout: Some(self.timeout_ms),
                     memory_limit: Some(self.memory_limit_mb),
+                    ipfs_id: if self.ipfs_id.is_empty() {
+                        None
+                    } else {
+                        Some(self.ipfs_id.clone())
+                    },
                 }
                 .into(),
             )


### PR DESCRIPTION
## Summary

Adds an IPFS CID-based code cache to skip import rewriting on repeated lit action executions.

**What changed:**
- Added `optional string ipfs_id` field to the `ExecutionRequest` proto message
- `lit-api-server` now sends the IPFS CID alongside the code when calling `execute_js`
- `lit-actions-server` caches import rewriting results keyed by IPFS CID
- On cache hit, the import parsing step is skipped entirely
- Cache is bounded at 1,000 entries and verifies code integrity via SHA-256 hash

**Security hardening (from pre-landing review):**
- Cache entries are verified against a SHA-256 hash of the incoming code to prevent cache poisoning from mismatched CIDs
- Cache size is bounded to prevent unbounded memory growth

## Files Changed
- `lit-actions/grpc/schema/lit_actions.proto` — new `ipfs_id` field on `ExecutionRequest`
- `lit-actions/grpc/proto.rs` — include `ipfs_id` in debug output
- `lit-actions/server/runtime.rs` — `CachedRewrite`, `CodeCache`, `hash_code()`, cache logic in `execute_js`, 6 unit tests
- `lit-actions/server/server.rs` — `code_cache` field on `Server`, threaded to `execute_js`
- `lit-api-server/src/actions/client/execution.rs` — send `ipfs_id` in `ExecutionRequest`

## Test Coverage
6 new unit tests covering:
- Hash determinism and uniqueness
- Cache hit with valid hash
- Cache rejection on hash mismatch (poisoning prevention)
- Cache capacity enforcement (max 1,000 entries)
- Cache miss behavior

47 tests pass, 1 pre-existing failure (`cdn_module_loader::tests::test_strict_mode_serves_known_module_from_cache`).

## Pre-Landing Review
2 critical findings, both auto-fixed:
- [AUTO-FIXED] Unbounded cache growth — added CODE_CACHE_MAX_ENTRIES cap
- [AUTO-FIXED] Cache poisoning from unverified CID — added SHA-256 hash verification

## Test plan
- [x] All new unit tests pass (6/6)
- [x] Existing unit tests pass (41/42, 1 pre-existing failure)
- [x] Both lit-actions-server and lit-api-server compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)