### PR TITLE
feat: monitor accordion fix and layout rearrangement (CPL-261)

### DIFF
--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -874,6 +874,49 @@ async function refreshBalances() {
   }
 }
 
+/* ═══ Accordion ══════════════════════════════════════════════════════════════ */
+
+function toggleAccordion(card) {
+  if (!card) return;
+  const header = card.querySelector(':scope > .card-header');
+  const body = card.querySelector(':scope > .card-body');
+  const willCollapse = !card.classList.contains('collapsed');
+  if (body) {
+    if (willCollapse) {
+      body.style.maxHeight = body.scrollHeight + 'px';
+      requestAnimationFrame(() => {
+        card.classList.add('collapsed');
+        body.style.maxHeight = '0px';
+      });
+    } else {
+      card.classList.remove('collapsed');
+      body.style.maxHeight = body.scrollHeight + 'px';
+      const onEnd = (e) => {
+        if (e.propertyName !== 'max-height') return;
+        body.style.maxHeight = '';
+        body.removeEventListener('transitionend', onEnd);
+      };
+      body.addEventListener('transitionend', onEnd);
+    }
+  }
+  if (header) header.setAttribute('aria-expanded', String(!willCollapse));
+}
+
+document.addEventListener('click', (e) => {
+  const header = e.target.closest('[data-accordion] > .card-header');
+  if (!header) return;
+  if (e.target.closest('button, input, select, textarea, a')) return;
+  toggleAccordion(header.parentElement);
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  const header = e.target.closest('[data-accordion] > .card-header');
+  if (!header || e.target !== header) return;
+  e.preventDefault();
+  toggleAccordion(header.parentElement);
+});
+
 /* ═══ Settings panel ═════════════════════════════════════════════════════════ */
 
 el('btn-toggle-settings')?.addEventListener('click', () => {

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -331,6 +331,11 @@
         cursor: pointer;
         user-select: none;
       }
+      .card-header:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        border-radius: 6px;
+      }
       .card-header .chevron {
         transition: transform 0.2s ease;
         color: var(--muted);
@@ -342,17 +347,15 @@
       }
       .card-body {
         overflow: hidden;
-        transition: max-height 0.25s ease, opacity 0.2s ease;
-        max-height: 2000px;
+        transition: max-height 0.25s ease, opacity 0.2s ease, visibility 0s;
         opacity: 1;
-        visibility: visible;
-        pointer-events: auto;
       }
       .card.collapsed .card-body {
         max-height: 0;
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
+        transition: max-height 0.25s ease, opacity 0.2s ease, visibility 0s 0.25s;
       }
 
       /* ── Wallet picker dialog ── */
@@ -410,7 +413,7 @@
 
         <!-- Payer Health Table (primary view) -->
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Payer Health</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
@@ -446,7 +449,7 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Server Version</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
@@ -476,7 +479,7 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Node Express - Configuration</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
@@ -505,7 +508,7 @@
       <div class="col">
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Supported Chain Config Keys</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
@@ -521,7 +524,7 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Action Client Configuration</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
@@ -547,10 +550,10 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div style="display:flex;align-items:center;gap:0.75rem">
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Account Configuration Contract</h2>
-              <button type="button" id="btn-refresh-contract" onclick="event.stopPropagation()" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
+              <button type="button" id="btn-refresh-contract" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
             </div>
             <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
@@ -591,10 +594,10 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div style="display:flex;align-items:center;gap:0.75rem">
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Node Configuration</h2>
-              <button type="button" id="btn-refresh-node-config" onclick="event.stopPropagation()" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
+              <button type="button" id="btn-refresh-node-config" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
             </div>
             <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
@@ -627,7 +630,7 @@
         </div>
 
         <div class="card" data-accordion>
-          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">API Payer Accounts</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -627,7 +627,7 @@
             <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">API Payer Accounts</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
-                Sets the default API payer account. and sets number of payers the node will use to process mutable API calls.  If rebalance is enabled, the node will rebalance the payers to ensure each payer has equal funds, using funds that exist in the admin API payer account.
+                Sets the default API payer account and the number of payers the node will use to process mutable API calls. If rebalance is enabled, the node will rebalance the payers to ensure each payer has equal funds, using funds that exist in the admin API payer account.
               </p>
             </div>
             <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -625,7 +625,7 @@
         <div class="card" data-accordion>
           <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
             <div>
-              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Api Payer Accounts</h2>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">API Payer Accounts</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
                 Sets the default API payer account. and sets number of payers the node will use to process mutable API calls.  If rebalance is enabled, the node will rebalance the payers to ensure each payer has equal funds, using funds that exist in the admin API payer account.
               </p>

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -345,10 +345,14 @@
         transition: max-height 0.25s ease, opacity 0.2s ease;
         max-height: 2000px;
         opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
       }
       .card.collapsed .card-body {
         max-height: 0;
         opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
       }
 
       /* ── Wallet picker dialog ── */

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -323,6 +323,34 @@
         color: var(--text);
       }
 
+      /* ── Accordion ── */
+      .card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        cursor: pointer;
+        user-select: none;
+      }
+      .card-header .chevron {
+        transition: transform 0.2s ease;
+        color: var(--muted);
+        flex-shrink: 0;
+        margin-left: 0.75rem;
+      }
+      .card.collapsed .card-header .chevron {
+        transform: rotate(-90deg);
+      }
+      .card-body {
+        overflow: hidden;
+        transition: max-height 0.25s ease, opacity 0.2s ease;
+        max-height: 2000px;
+        opacity: 1;
+      }
+      .card.collapsed .card-body {
+        max-height: 0;
+        opacity: 0;
+      }
+
       /* ── Wallet picker dialog ── */
       dialog::backdrop {
         background: rgba(0, 0, 0, 0.6);
@@ -377,206 +405,257 @@
       <div class="col">
 
         <!-- Payer Health Table (primary view) -->
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Payer Health</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            <code>GET /get_api_payers</code> — balance health based on configurable thresholds. Click addresses to copy.
-          </p>
-          <div id="api-payers-results" style="display: none; margin-top: 1rem">
-            <div id="api-payers-list"></div>
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Payer Health</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                <code>GET /get_api_payers</code> — balance health based on configurable thresholds. Click addresses to copy.
+              </p>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <div id="api-payers-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
+          <div class="card-body">
+            <div id="api-payers-results" style="display: none; margin-top: 1rem">
+              <div id="api-payers-list"></div>
+            </div>
+            <div id="api-payers-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
 
-          <button type="button" class="settings-toggle" id="btn-toggle-settings">&#9881; Thresholds</button>
-          <div id="settings-panel" class="settings-panel">
-            <div class="settings-row">
-              <label for="threshold-warning">Warning</label>
-              <input type="number" id="threshold-warning" step="0.001" min="0" placeholder="0.02" />
+            <button type="button" class="settings-toggle" id="btn-toggle-settings">&#9881; Thresholds</button>
+            <div id="settings-panel" class="settings-panel">
+              <div class="settings-row">
+                <label for="threshold-warning">Warning</label>
+                <input type="number" id="threshold-warning" step="0.001" min="0" placeholder="0.02" />
+              </div>
+              <div class="settings-row">
+                <label for="threshold-critical">Critical</label>
+                <input type="number" id="threshold-critical" step="0.001" min="0" placeholder="0.005" />
+              </div>
+              <div class="settings-row">
+                <label for="threshold-target">Target</label>
+                <input type="number" id="threshold-target" step="0.001" min="0" placeholder="0.05" />
+              </div>
+              <button type="button" id="btn-save-thresholds" style="font-size: 0.8rem; padding: 0.3rem 0.75rem;">Save</button>
+              <span id="threshold-status" style="display: none; font-size: 0.8rem; margin-left: 0.5rem;"></span>
             </div>
-            <div class="settings-row">
-              <label for="threshold-critical">Critical</label>
-              <input type="number" id="threshold-critical" step="0.001" min="0" placeholder="0.005" />
-            </div>
-            <div class="settings-row">
-              <label for="threshold-target">Target</label>
-              <input type="number" id="threshold-target" step="0.001" min="0" placeholder="0.05" />
-            </div>
-            <button type="button" id="btn-save-thresholds" style="font-size: 0.8rem; padding: 0.3rem 0.75rem;">Save</button>
-            <span id="threshold-status" style="display: none; font-size: 0.8rem; margin-left: 0.5rem;"></span>
           </div>
         </div>
 
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Server Version</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            <code>GET /version</code>
-          </p>
-          <div id="version-results" style="display: none; margin-top: 1rem">
-            <div class="result-row">
-              <span class="result-label">name</span>
-              <span class="result-value" id="ver-name">—</span>
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Server Version</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                <code>GET /version</code>
+              </p>
             </div>
-            <div class="result-row">
-              <span class="result-label">version</span>
-              <span class="result-value" id="ver-version">—</span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">commit</span>
-              <span class="result-value" id="ver-commit-version">—</span>
-            </div>
-            <div style="margin-top: 0.75rem" id="ver-submodules"></div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <div id="version-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
+          <div class="card-body">
+            <div id="version-results" style="display: none; margin-top: 1rem">
+              <div class="result-row">
+                <span class="result-label">name</span>
+                <span class="result-value" id="ver-name">—</span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">version</span>
+                <span class="result-value" id="ver-version">—</span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">commit</span>
+                <span class="result-value" id="ver-commit-version">—</span>
+              </div>
+              <div style="margin-top: 0.75rem" id="ver-submodules"></div>
+            </div>
+            <div id="version-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
+          </div>
         </div>
 
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Node Express - Configuration</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            <code>GET /get_node_chain_config</code>
-          </p>
-          <div id="chain-config-results" style="display: none; margin-top: 1rem">
-            <div class="result-row"><span class="result-label">chain_name</span><span class="result-value" id="cc-chain-name">—</span></div>
-            <div class="result-row"><span class="result-label">chain_id</span><span class="result-value" id="cc-chain-id">—</span></div>
-            <div class="result-row"><span class="result-label">is_evm</span><span class="result-value" id="cc-is-evm">—</span></div>
-            <div class="result-row"><span class="result-label">testnet</span><span class="result-value" id="cc-testnet">—</span></div>
-            <div class="result-row"><span class="result-label">token</span><span class="result-value" id="cc-token">—</span></div>
-            <div class="result-row"><span class="result-label">rpc_url</span><input type="text" id="cc-rpc-url" placeholder="—" style="flex:1;padding:0.3rem 0.5rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);" /></div>
-            <div class="result-row"><span class="result-label">contract_address</span><span class="result-value" id="cc-contract-address">—</span></div>
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Node Express - Configuration</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                <code>GET /get_node_chain_config</code>
+              </p>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <div id="chain-config-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
-        </div>
-
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Action Client Configuration</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            <code>GET /get_lit_action_client_config</code> — effective builder values, including any chain-config overrides.
-          </p>
-          <div id="lit-action-config-results" style="display: none;">
-            <div class="result-row"><span class="result-label">timeout_ms</span><span class="result-value" id="lac-timeout-ms">—</span></div>
-            <div class="result-row"><span class="result-label">async_timeout_ms</span><span class="result-value" id="lac-async-timeout-ms">—</span></div>
-            <div class="result-row"><span class="result-label">memory_limit_mb</span><span class="result-value" id="lac-memory-limit-mb">—</span></div>
-            <div class="result-row"><span class="result-label">max_code_length</span><span class="result-value" id="lac-max-code-length">—</span></div>
-            <div class="result-row"><span class="result-label">max_response_length</span><span class="result-value" id="lac-max-response-length">—</span></div>
-            <div class="result-row"><span class="result-label">max_console_log_length</span><span class="result-value" id="lac-max-console-log-length">—</span></div>
-            <div class="result-row"><span class="result-label">max_fetch_count</span><span class="result-value" id="lac-max-fetch-count">—</span></div>
-            <div class="result-row"><span class="result-label">max_get_keys_count</span><span class="result-value" id="lac-max-get-keys-count">—</span></div>
-            <div class="result-row"><span class="result-label">max_retries</span><span class="result-value" id="lac-max-retries">—</span></div>
+          <div class="card-body">
+            <div id="chain-config-results" style="display: none; margin-top: 1rem">
+              <div class="result-row"><span class="result-label">chain_name</span><span class="result-value" id="cc-chain-name">—</span></div>
+              <div class="result-row"><span class="result-label">chain_id</span><span class="result-value" id="cc-chain-id">—</span></div>
+              <div class="result-row"><span class="result-label">is_evm</span><span class="result-value" id="cc-is-evm">—</span></div>
+              <div class="result-row"><span class="result-label">testnet</span><span class="result-value" id="cc-testnet">—</span></div>
+              <div class="result-row"><span class="result-label">token</span><span class="result-value" id="cc-token">—</span></div>
+              <div class="result-row"><span class="result-label">rpc_url</span><input type="text" id="cc-rpc-url" placeholder="—" style="flex:1;padding:0.3rem 0.5rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);" /></div>
+              <div class="result-row"><span class="result-label">contract_address</span><span class="result-value" id="cc-contract-address">—</span></div>
+            </div>
+            <div id="chain-config-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
           </div>
-          <div id="lit-action-config-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
-        </div>
-
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Supported Chain Config Keys</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            <code>GET /get_chain_config_keys</code> — all recognised <code>ConfigKeys</code> variants that the node reads from chain.
-          </p>
-          <div id="chain-config-keys-list"></div>
-          <div id="chain-config-keys-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
-        </div>
-
-        <div class="card">
-          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.25rem">
-            <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Account Configuration Contract</h2>
-            <button type="button" id="btn-refresh-contract" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
-          </div>
-          <input type="hidden" id="contract-address" />
-
-          <div class="results" id="results" style="display: none">
-            <h2>Contract values</h2>
-            <div class="result-row">
-              <span class="result-label">pricing</span
-              ><span class="result-value" id="val-pricing-operator">—</span
-              ><span class="result-value" id="val-pricing-operator-balance" style="color:var(--muted);margin-left:auto"></span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">admin Payer</span
-              ><span class="result-value" id="val-admin-api-payer">—</span
-              ><span class="result-value" id="val-admin-api-payer-balance" style="color:var(--muted);margin-left:auto"></span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">Actual #</span
-              ><span class="result-value" id="val-payer-count">—</span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">Requested #</span
-              ><span class="result-value" id="val-requested-api-payer-count">—</span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">Rebalance</span
-              ><span class="result-value" id="val-rebalance-amount">—</span>
-            </div>
-            <div class="result-row">
-              <span class="result-label">PKP count</span
-              ><span class="result-value" id="val-pkp-count">—</span>
-            </div>
-          </div>
-          <div class="error" id="error" style="display: none"></div>
         </div>
 
       </div>
 
-      <!-- ═══ RIGHT COLUMN — updateable / interactive ═══ -->
+      <!-- ═══ RIGHT COLUMN — config & interactive ═══ -->
       <div class="col">
 
-        <div class="card">
-          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.25rem">
-            <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Node Configuration</h2>
-            <button type="button" id="btn-refresh-node-config" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Supported Chain Config Keys</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                <code>GET /get_chain_config_keys</code> — all recognised <code>ConfigKeys</code> variants that the node reads from chain.
+              </p>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            Key-value pairs stored on-chain via <code>setNodeConfiguration</code>. Read by the node every 30 seconds.
-          </p>
-
-          <table>
-            <thead>
-              <tr><th>Key</th><th>Value</th></tr>
-            </thead>
-            <tbody id="node-config-table">
-              <tr><td colspan="2" style="color:var(--muted)">Loading…</td></tr>
-            </tbody>
-          </table>
-          <div id="node-config-fetch-error" style="display:none;color:#f87171;font-size:0.85rem;margin-top:0.5rem;"></div>
-
-          <div class="form-group" style="margin-top:1.5rem">
-            <label for="node-config-key">Key</label>
-            <input type="text" id="node-config-key" placeholder="e.g. LIT_ACTION_DEFAULT_TIMEOUT_MS" />
+          <div class="card-body">
+            <div id="chain-config-keys-list"></div>
+            <div id="chain-config-keys-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
           </div>
-          <div class="form-group">
-            <label for="node-config-value">Value</label>
-            <input type="text" id="node-config-value" placeholder="e.g. 60000" />
-          </div>
-          <button type="button" id="btn-set-node-config">Set Configuration</button>
-          <div id="node-config-status" style="display:none;font-size:0.85rem;margin-top:0.5rem;font-family:'JetBrains Mono',monospace;word-break:break-all;"></div>
         </div>
 
-        <div class="card">
-          <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Api Payer Accounts</h2>
-          <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
-            Sets the default API payer account. and sets number of payers the node will use to process mutable API calls.  If rebalance is enabled, the node will rebalance the payers to ensure each payer has equal funds, using funds that exist in the admin API payer account.
-          </p>
-
-          <div class="form-group" style="margin-top: 1.25rem">
-            <label for="default-api-payer">Admin API payer address</label>
-            <input type="text" id="default-api-payer" placeholder="0x…" />
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Action Client Configuration</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                <code>GET /get_lit_action_client_config</code> — effective builder values, including any chain-config overrides.
+              </p>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <button type="button" id="btn-set-default-api-payer">Set Default</button>
-          <div id="default-api-payer-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
-
-          <div class="form-group">
-            <label for="payer-count">Requested payer count</label>
-            <select id="payer-count">
-              <option value="" disabled selected>loading…</option>
-            </select>
+          <div class="card-body">
+            <div id="lit-action-config-results" style="display: none;">
+              <div class="result-row"><span class="result-label">timeout_ms</span><span class="result-value" id="lac-timeout-ms">—</span></div>
+              <div class="result-row"><span class="result-label">async_timeout_ms</span><span class="result-value" id="lac-async-timeout-ms">—</span></div>
+              <div class="result-row"><span class="result-label">memory_limit_mb</span><span class="result-value" id="lac-memory-limit-mb">—</span></div>
+              <div class="result-row"><span class="result-label">max_code_length</span><span class="result-value" id="lac-max-code-length">—</span></div>
+              <div class="result-row"><span class="result-label">max_response_length</span><span class="result-value" id="lac-max-response-length">—</span></div>
+              <div class="result-row"><span class="result-label">max_console_log_length</span><span class="result-value" id="lac-max-console-log-length">—</span></div>
+              <div class="result-row"><span class="result-label">max_fetch_count</span><span class="result-value" id="lac-max-fetch-count">—</span></div>
+              <div class="result-row"><span class="result-label">max_get_keys_count</span><span class="result-value" id="lac-max-get-keys-count">—</span></div>
+              <div class="result-row"><span class="result-label">max_retries</span><span class="result-value" id="lac-max-retries">—</span></div>
+            </div>
+            <div id="lit-action-config-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
           </div>
-          <button type="button" id="btn-set-payer-count">Confirm</button>
-          <div id="payer-count-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
+        </div>
 
-          <div class="form-group" style="margin-top: 1.25rem">
-            <label for="rebalance-amount">Rebalance amount (ETH)</label>
-            <input type="text" id="rebalance-amount" placeholder="e.g. 0.05" />
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div style="display:flex;align-items:center;gap:0.75rem">
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Account Configuration Contract</h2>
+              <button type="button" id="btn-refresh-contract" onclick="event.stopPropagation()" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
           </div>
-          <button type="button" id="btn-set-rebalance-amount">Set Rebalance Amount</button>
-          <div id="rebalance-amount-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
+          <div class="card-body">
+            <input type="hidden" id="contract-address" />
+
+            <div class="results" id="results" style="display: none">
+              <h2>Contract values</h2>
+              <div class="result-row">
+                <span class="result-label">pricing</span
+                ><span class="result-value" id="val-pricing-operator">—</span
+                ><span class="result-value" id="val-pricing-operator-balance" style="color:var(--muted);margin-left:auto"></span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">admin Payer</span
+                ><span class="result-value" id="val-admin-api-payer">—</span
+                ><span class="result-value" id="val-admin-api-payer-balance" style="color:var(--muted);margin-left:auto"></span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">Actual #</span
+                ><span class="result-value" id="val-payer-count">—</span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">Requested #</span
+                ><span class="result-value" id="val-requested-api-payer-count">—</span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">Rebalance</span
+                ><span class="result-value" id="val-rebalance-amount">—</span>
+              </div>
+              <div class="result-row">
+                <span class="result-label">PKP count</span
+                ><span class="result-value" id="val-pkp-count">—</span>
+              </div>
+            </div>
+            <div class="error" id="error" style="display: none"></div>
+          </div>
+        </div>
+
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div style="display:flex;align-items:center;gap:0.75rem">
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0">Node Configuration</h2>
+              <button type="button" id="btn-refresh-node-config" onclick="event.stopPropagation()" style="margin-top:0;padding:0.3rem 0.75rem;font-size:0.8rem;">Refresh</button>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
+          </div>
+          <div class="card-body">
+            <p style="color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem">
+              Key-value pairs stored on-chain via <code>setNodeConfiguration</code>. Read by the node every 30 seconds.
+            </p>
+
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Value</th></tr>
+              </thead>
+              <tbody id="node-config-table">
+                <tr><td colspan="2" style="color:var(--muted)">Loading…</td></tr>
+              </tbody>
+            </table>
+            <div id="node-config-fetch-error" style="display:none;color:#f87171;font-size:0.85rem;margin-top:0.5rem;"></div>
+
+            <div class="form-group" style="margin-top:1.5rem">
+              <label for="node-config-key">Key</label>
+              <input type="text" id="node-config-key" placeholder="e.g. LIT_ACTION_DEFAULT_TIMEOUT_MS" />
+            </div>
+            <div class="form-group">
+              <label for="node-config-value">Value</label>
+              <input type="text" id="node-config-value" placeholder="e.g. 60000" />
+            </div>
+            <button type="button" id="btn-set-node-config">Set Configuration</button>
+            <div id="node-config-status" style="display:none;font-size:0.85rem;margin-top:0.5rem;font-family:'JetBrains Mono',monospace;word-break:break-all;"></div>
+          </div>
+        </div>
+
+        <div class="card" data-accordion>
+          <div class="card-header" onclick="this.parentElement.classList.toggle('collapsed')">
+            <div>
+              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Api Payer Accounts</h2>
+              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
+                Sets the default API payer account. and sets number of payers the node will use to process mutable API calls.  If rebalance is enabled, the node will rebalance the payers to ensure each payer has equal funds, using funds that exist in the admin API payer account.
+              </p>
+            </div>
+            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="form-group" style="margin-top: 1.25rem">
+              <label for="default-api-payer">Admin API payer address</label>
+              <input type="text" id="default-api-payer" placeholder="0x…" />
+            </div>
+            <button type="button" id="btn-set-default-api-payer">Set Default</button>
+            <div id="default-api-payer-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
+
+            <div class="form-group">
+              <label for="payer-count">Requested payer count</label>
+              <select id="payer-count">
+                <option value="" disabled selected>loading…</option>
+              </select>
+            </div>
+            <button type="button" id="btn-set-payer-count">Confirm</button>
+            <div id="payer-count-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
+
+            <div class="form-group" style="margin-top: 1.25rem">
+              <label for="rebalance-amount">Rebalance amount (ETH)</label>
+              <input type="text" id="rebalance-amount" placeholder="e.g. 0.05" />
+            </div>
+            <button type="button" id="btn-set-rebalance-amount">Set Rebalance Amount</button>
+            <div id="rebalance-amount-status" style="display: none; font-size: 0.85rem; margin-top: 0.5rem; font-family: 'JetBrains Mono', monospace; word-break: break-all;"></div>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary

Addresses [CPL-261](https://linear.app/litprotocol/issue/CPL-261/monitor-updates-2) — monitor dashboard UI fixes:

- **Fix accordion collapse/expand** — All card sections now have clickable headers with chevron indicators that toggle collapse/expand via CSS transitions. Buttons inside headers (e.g., Refresh) use `event.stopPropagation()` so they don't trigger the accordion.
- **Rearrange layout** — Moved "Supported Chain Config Keys", "Lit Action Client Configuration", and "Account Configuration Contract" from the left column to the right column, per the ticket's requested layout changes.

**New layout:**
- **Left:** Payer Health, Server Version, Lit Node Express Configuration
- **Right:** Supported Chain Config Keys, Lit Action Client Config, Account Configuration Contract, Node Configuration, Api Payer Accounts

## Test plan
- [ ] Verify each card section can be collapsed and expanded by clicking its header
- [ ] Verify Refresh buttons inside card headers work without toggling the accordion
- [ ] Verify the layout matches: left column has 3 cards, right column has 5 cards
- [ ] Verify data still loads correctly in all sections after the layout rearrangement

🤖 Generated with [Claude Code](https://claude.com/claude-code)