### PR TITLE
feat: pool of pre-warmed JsRuntimes built from the snapshot (CPL-265)

### DIFF
--- a/lit-actions/server/lib.rs
+++ b/lit-actions/server/lib.rs
@@ -2,6 +2,7 @@ mod bundler;
 pub mod cdn_module_loader;
 mod import_rewriter;
 mod runtime;
+pub mod worker_pool;
 
 pub mod server;
 

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -445,8 +445,7 @@ pub(crate) fn inject_lit_namespace(
 
     if http_headers
         .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-        .unwrap_or(&"false".to_string())
-        == "true"
+        .is_some_and(|v| v == "true")
     {
         debug!("Populating LitHeaders: **PRIVACY MODE**");
     } else {
@@ -528,8 +527,7 @@ fn inject_params_globals(
 
     if http_headers
         .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-        .unwrap_or(&"false".to_string())
-        == "true"
+        .is_some_and(|v| v == "true")
     {
         debug!("Injecting params as globals: **PRIVACY MODE**");
     } else {

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -28,6 +28,7 @@ use ipfs_hasher::IpfsHasher;
 use lit_actions_grpc::proto::{ExecuteJsRequest, ExecuteJsResponse};
 use lit_api_core::context::HEADER_KEY_X_PRIVACY_MODE;
 use lit_observability::channels::TracedReceiver;
+use lit_observability::logging::clear_task_request_context;
 use sys_traits::impls::RealSys;
 use tokio::sync::{mpsc, oneshot};
 use tonic::Status;
@@ -35,7 +36,7 @@ use tracing::{debug, error, info_span, instrument};
 
 // Same default limits as in lit-node's action client
 const DEFAULT_TIMEOUT_MS: u64 = 1000 * 60 * 15; // 15 minutes
-const DEFAULT_MEMORY_LIMIT_MB: usize = 128; // 128MB
+pub(crate) const DEFAULT_MEMORY_LIMIT_MB: usize = 128; // 128MB
 const MEMORY_SAMPLE_INTERVAL_MS: u64 = 500; // 500ms
 const EXECUTION_TERMINATED_ERROR: &str = "Uncaught Error: execution terminated";
 const MAX_ACTION_CODE_CACHE_BYTES: usize = 100 * 1024 * 1024;
@@ -191,6 +192,40 @@ enum ExecutionResult {
     OutOfMemory,
 }
 
+/// State shared across all worker constructions in a single process.
+/// Built once at server startup; cloned cheaply via `Arc` clone of fields.
+#[derive(Clone)]
+pub(crate) struct PoolSharedState {
+    pub integrity_manifest: Arc<RwLock<HashMap<String, String>>>,
+    pub strict_imports: bool,
+    pub module_cache: ModuleCache,
+    pub lockfile_path: Option<PathBuf>,
+    pub http_client: Arc<reqwest::Client>,
+    /// Heap limit in MB. Pool workers always use `DEFAULT_MEMORY_LIMIT_MB`;
+    /// the legacy cold path uses whatever the caller specified.
+    pub memory_limit_mb: usize,
+}
+
+/// A `MainWorker` that has been bootstrapped from the V8 snapshot but has
+/// not yet had any per-request JS injected. Carries the `LoadedModules`
+/// handle that was wired into its `CdnModuleLoader`; the same handle is
+/// later inserted into `op_state` so billing sees a single source of truth.
+///
+/// `PreparedWorker` is consumed by value in `execute_with_worker` to enforce
+/// one-shot lifecycle at the type level: the worker cannot be reused after
+/// a single execution.
+pub(crate) struct PreparedWorker {
+    pub worker: MainWorker,
+    pub loaded_modules: LoadedModules,
+}
+
+#[cfg(test)]
+impl PreparedWorker {
+    pub(crate) fn loaded_modules_for_test(&self) -> LoadedModules {
+        self.loaded_modules.clone()
+    }
+}
+
 static RUNTIME_SNAPSHOT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/RUNTIME_SNAPSHOT.bin"));
 
 fn deno_isolate_init() -> Option<&'static [u8]> {
@@ -313,16 +348,23 @@ async fn get_or_prepare_action_code(
     Ok(prepared_code)
 }
 
-// using the worker built into deno
-#[allow(clippy::too_many_arguments)]
+/// Build a `MainWorker` from the V8 snapshot. Warm-time safe: does no JS
+/// injection, so it can run off the request path before `auth_context` and
+/// `http_headers` are known. The single `LoadedModules` handle wired into
+/// the `CdnModuleLoader` is also returned on the `PreparedWorker`, so the
+/// caller can insert the same `Arc` into `op_state` later.
 #[instrument(skip_all, err)]
-fn build_main_worker_and_inject_sdk(
-    globals_to_inject: &Option<serde_json::Value>,
-    auth_context: &Option<serde_json::Value>,
-    http_headers: BTreeMap<String, String>,
-    memory_limit_mb: Option<usize>,
-    module_loader: Rc<dyn deno_core::ModuleLoader>,
-) -> Result<MainWorker> {
+pub(crate) fn build_worker_base(shared: &PoolSharedState) -> Result<PreparedWorker> {
+    let loaded_modules = LoadedModules::default();
+    let module_loader: Rc<dyn deno_core::ModuleLoader> = Rc::new(CdnModuleLoader::with_options(
+        shared.integrity_manifest.clone(),
+        shared.strict_imports,
+        shared.module_cache.clone(),
+        shared.lockfile_path.clone(),
+        Some(shared.http_client.clone()),
+        loaded_modules.clone(),
+    ));
+
     let options = WorkerOptions {
         bootstrap: BootstrapOptions {
             cpu_count: 1,
@@ -334,8 +376,9 @@ fn build_main_worker_and_inject_sdk(
         extensions: vec![lit_actions_ext::lit_actions::init_ops()],
         startup_snapshot: deno_isolate_init(),
         skip_op_registration: false,
-        create_params: memory_limit_mb
-            .map(|limit| v8::CreateParams::default().heap_limits(0, limit * 1024 * 1024)),
+        create_params: Some(
+            v8::CreateParams::default().heap_limits(0, shared.memory_limit_mb * 1024 * 1024),
+        ),
         unsafely_ignore_certificate_errors: None,
         seed: None,
         create_web_worker_cb: Arc::new(|_| {
@@ -382,103 +425,131 @@ fn build_main_worker_and_inject_sdk(
 
     let main_module =
         deno_core::resolve_url_or_path("./$lit$actions.js", Path::new(env!("CARGO_MANIFEST_DIR")))?;
-    let mut worker = MainWorker::bootstrap_from_options(&main_module, services, options);
+    let worker = MainWorker::bootstrap_from_options(&main_module, services, options);
 
+    Ok(PreparedWorker {
+        worker,
+        loaded_modules,
+    })
+}
+
+/// Inject `LitNamespace.js` (LitActions / LitAuth / LitHeaders globals).
+/// Request-time only: needs `auth_context` and `http_headers`. Runs BEFORE
+/// `PatchDeno.js` so it can rely on the unmodified `Deno` namespace if needed.
+pub(crate) fn inject_lit_namespace(
+    worker: &mut MainWorker,
+    auth_context: &Option<serde_json::Value>,
+    http_headers: &BTreeMap<String, String>,
+) -> Result<()> {
+    let _span = info_span!("LitNamespace.js").entered();
+
+    if http_headers
+        .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
+        .unwrap_or(&"false".to_string())
+        == "true"
     {
-        let _span = info_span!("LitNamespace.js").entered();
-
-        if http_headers
-            .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-            .unwrap_or(&"false".to_string())
-            == "true"
-        {
-            debug!("Populating LitHeaders: **PRIVACY MODE**");
-        } else {
-            debug!("Populating LitHeaders: {http_headers:?}");
-        }
-
-        // NB: globalThis.LitActions is already part of the V8 snapshot
-        let mut code = formatdoc! {r#"
-            "use strict";
-            (function (actions, auth, headers) {{
-                const {{ freeze }} = Object;
-                const readOnly = value => ({{ value, enumerable: true, writable: false, configurable: false }});
-
-                Object.defineProperties(globalThis, {{
-                    LitActions: readOnly(freeze(actions)),
-                    LitAuth: readOnly(freeze(auth)),
-                    LitHeaders: readOnly(headers),
-                }});
-
-                Object.defineProperty(globalThis, "Lit", readOnly(freeze({{
-                    Actions: LitActions,
-                    Auth: LitAuth,
-                    Headers: LitHeaders,
-                }})));
-            }})(LitActions, {auth}, new Headers({headers}));
-            "#,
-            auth = if let Some(ctx) = auth_context {
-                serde_json::to_string(ctx).context("Could not serialize auth_context")?
-            } else {
-                "{}".to_string()
-            },
-            headers = serde_json::to_string(&http_headers).context("Could not serialize HTTP headers")?
-        };
-
-        // Remove LitTest from non-debug builds
-        if !cfg!(debug_assertions) {
-            code.push_str("delete globalThis.LitTest;\n");
-        }
-
-        worker
-            .execute_script("LitNamespace.js", code.into())
-            .context("Error populating Lit namespace")?;
+        debug!("Populating LitHeaders: **PRIVACY MODE**");
+    } else {
+        debug!("Populating LitHeaders: {http_headers:?}");
     }
 
+    // NB: globalThis.LitActions is already part of the V8 snapshot
+    let mut code = formatdoc! {r#"
+        "use strict";
+        (function (actions, auth, headers) {{
+            const {{ freeze }} = Object;
+            const readOnly = value => ({{ value, enumerable: true, writable: false, configurable: false }});
+
+            Object.defineProperties(globalThis, {{
+                LitActions: readOnly(freeze(actions)),
+                LitAuth: readOnly(freeze(auth)),
+                LitHeaders: readOnly(headers),
+            }});
+
+            Object.defineProperty(globalThis, "Lit", readOnly(freeze({{
+                Actions: LitActions,
+                Auth: LitAuth,
+                Headers: LitHeaders,
+            }})));
+        }})(LitActions, {auth}, new Headers({headers}));
+        "#,
+        auth = if let Some(ctx) = auth_context {
+            serde_json::to_string(ctx).context("Could not serialize auth_context")?
+        } else {
+            "{}".to_string()
+        },
+        headers = serde_json::to_string(http_headers).context("Could not serialize HTTP headers")?
+    };
+
+    // Remove LitTest from non-debug builds
+    if !cfg!(debug_assertions) {
+        code.push_str("delete globalThis.LitTest;\n");
+    }
+
+    worker
+        .execute_script("LitNamespace.js", code.into())
+        .context("Error populating Lit namespace")?;
+
+    Ok(())
+}
+
+/// Strip privileged `Deno.*` surface and disable `Worker`. Must run AFTER
+/// `inject_lit_namespace` to preserve today's bootstrap order.
+fn execute_patch_deno(worker: &mut MainWorker) -> Result<()> {
+    let _span = info_span!("PatchDeno.js").entered();
+
+    let code = formatdoc! {r#"
+        "use strict";
+        delete Deno.build;
+        delete Deno.permissions;
+        delete Deno.version;
+        delete globalThis.Worker;
+    "#};
+
+    worker
+        .execute_script("PatchDeno.js", code.into())
+        .context("Error patching Deno runtime")?;
+
+    Ok(())
+}
+
+/// Inject caller-supplied globals via `Params.js`. Reserved for future use:
+/// `execute_js` always passes `None` today, so this is normally a no-op.
+fn inject_params_globals(
+    worker: &mut MainWorker,
+    globals_to_inject: &Option<serde_json::Value>,
+    http_headers: &BTreeMap<String, String>,
+) -> Result<()> {
+    let Some(params) = globals_to_inject else {
+        return Ok(());
+    };
+
+    let _span = info_span!("Params.js").entered();
+
+    if http_headers
+        .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
+        .unwrap_or(&"false".to_string())
+        == "true"
     {
-        let _span = info_span!("PatchDeno.js").entered();
-
-        let code = formatdoc! {r#"
-            "use strict";
-            delete Deno.build;
-            delete Deno.permissions;
-            delete Deno.version;
-            delete globalThis.Worker;
-        "#};
-
-        worker
-            .execute_script("PatchDeno.js", code.into())
-            .context("Error patching Deno runtime")?;
+        debug!("Injecting params as globals: **PRIVACY MODE**");
+    } else {
+        debug!("Injecting params as globals: {params:?}");
     }
 
-    if let Some(params) = globals_to_inject {
-        let _span = info_span!("Params.js").entered();
+    let _ = params
+        .as_object()
+        .context("Could not convert params to map")?;
 
-        if http_headers
-            .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
-            .unwrap_or(&"false".to_string())
-            == "true"
-        {
-            debug!("Injecting params as globals: **PRIVACY MODE**");
-        } else {
-            debug!("Injecting params as globals: {params:?}");
-        }
+    let code = formatdoc! {r#"
+        "use strict";
+        Object.assign(globalThis, {params});
+    "#};
 
-        let _ = params
-            .as_object()
-            .context("Could not convert params to map")?;
+    worker
+        .execute_script("Params.js", code.into())
+        .context("Error injecting params as globals")?;
 
-        let code = formatdoc! {r#"
-            "use strict";
-            Object.assign(globalThis, {params});
-        "#};
-
-        worker
-            .execute_script("Params.js", code.into())
-            .context("Error injecting params as globals")?;
-    }
-
-    Ok(worker)
+    Ok(())
 }
 
 // NB: Due to the new PKU feature introduced in V8 11.6, we need to init the V8
@@ -503,6 +574,13 @@ pub fn init_v8() {
     JsRuntime::init_platform(None, false);
 }
 
+/// Legacy cold path: build a one-off `PoolSharedState` with the caller's
+/// `memory_limit_mb`, bootstrap a fresh `MainWorker`, inject per-request
+/// state, and execute.
+///
+/// Pool path callers (see `worker_pool::WorkerPool`) instead call
+/// `build_worker_base` once at warm-time, then `inject_lit_namespace` +
+/// `execute_with_worker` per request against a pre-warmed `PreparedWorker`.
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, err)]
 pub(crate) async fn execute_js(
@@ -531,8 +609,109 @@ pub(crate) async fn execute_js(
     static COLOR_INIT: Once = Once::new();
     COLOR_INIT.call_once(|| deno_runtime::colors::set_use_color(false));
 
+    let shared = Arc::new(PoolSharedState {
+        integrity_manifest,
+        strict_imports,
+        module_cache,
+        lockfile_path,
+        http_client,
+        memory_limit_mb: memory_limit_mb.unwrap_or(DEFAULT_MEMORY_LIMIT_MB),
+    });
+
+    let mut prepared = build_worker_base(&shared)
+        .context("Error building main worker")
+        .map_err(|e| anyhow!("{e:#}"))?; // Ensure to keep context when downcasting JS errors later
+
+    inject_lit_namespace(&mut prepared.worker, &auth_context, &http_headers)?;
+
+    execute_with_worker(
+        prepared,
+        shared,
+        code,
+        js_params,
+        http_headers,
+        timeout_ms,
+        outbound_tx,
+        inbound_rx,
+        is_test_server,
+        action_code_cache,
+    )
+    .await
+}
+
+/// Run a single request against an already-bootstrapped `PreparedWorker`.
+/// Consumes `prepared` by value to enforce one-shot lifecycle: the worker
+/// is dropped when this function returns. Owns everything from the post-
+/// bootstrap body of the original `execute_js`: `PatchDeno.js`, op-state
+/// wiring, controller thread, near-heap callback, resource-usage polling,
+/// action code cache lookup, user code execution, termination select loop,
+/// and final `clear_task_request_context`.
+#[allow(clippy::too_many_arguments)]
+#[instrument(skip_all, err)]
+pub(crate) async fn execute_with_worker(
+    prepared: PreparedWorker,
+    shared: Arc<PoolSharedState>,
+    code: String,
+    js_params: Option<serde_json::Value>,
+    http_headers: BTreeMap<String, String>,
+    timeout_ms: Option<u64>,
+    outbound_tx: flume::Sender<tonic::Result<ExecuteJsResponse>>,
+    inbound_rx: TracedReceiver<ExecuteJsRequest>,
+    is_test_server: bool,
+    action_code_cache: ActionCodeCache,
+) -> Result<()> {
+    let result = execute_with_worker_inner(
+        prepared,
+        shared,
+        code,
+        js_params,
+        http_headers,
+        timeout_ms,
+        outbound_tx,
+        inbound_rx,
+        is_test_server,
+        action_code_cache,
+    )
+    .await;
+
+    // Always clear request context at the end of a request. The pool
+    // worker thread is reused for refill state machinery before being
+    // dropped; the legacy thread is also reused by the OS thread pool
+    // implicitly. Either way, leaving stale tracing fields would leak
+    // request_id / correlation_id into unrelated spans.
+    clear_task_request_context();
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_with_worker_inner(
+    prepared: PreparedWorker,
+    shared: Arc<PoolSharedState>,
+    code: String,
+    js_params: Option<serde_json::Value>,
+    http_headers: BTreeMap<String, String>,
+    timeout_ms: Option<u64>,
+    outbound_tx: flume::Sender<tonic::Result<ExecuteJsResponse>>,
+    inbound_rx: TracedReceiver<ExecuteJsRequest>,
+    is_test_server: bool,
+    action_code_cache: ActionCodeCache,
+) -> Result<()> {
+    let PreparedWorker {
+        mut worker,
+        loaded_modules,
+    } = prepared;
+
     let timeout_ms = timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
-    let memory_limit_mb = memory_limit_mb.unwrap_or(DEFAULT_MEMORY_LIMIT_MB);
+    let memory_limit_mb = shared.memory_limit_mb;
+
+    // PatchDeno.js must run AFTER LitNamespace.js (which the caller already
+    // injected) to preserve the original bootstrap order.
+    execute_patch_deno(&mut worker)?;
+    // Reserved hook: today's call sites always pass globals=None; preserved
+    // here so re-enabling globals injection drops in at the historical spot
+    // (between PatchDeno.js and op-state wiring).
+    inject_params_globals(&mut worker, &None, &http_headers)?;
 
     // Check the action code cache early so we can skip prepare_action_code
     // on cache hit (the real performance win). We always use CdnModuleLoader
@@ -548,26 +727,6 @@ pub(crate) async fn execute_js(
     if cached_code.is_some() {
         debug!(action_ipfs_id, "action code cache hit");
     }
-
-    let loaded_modules = LoadedModules::default();
-    let module_loader: Rc<dyn deno_core::ModuleLoader> = Rc::new(CdnModuleLoader::with_options(
-        integrity_manifest.clone(),
-        strict_imports,
-        module_cache.clone(),
-        lockfile_path.clone(),
-        Some(http_client.clone()),
-        loaded_modules.clone(),
-    ));
-
-    let mut worker = build_main_worker_and_inject_sdk(
-        &None,
-        &auth_context,
-        http_headers,
-        Some(memory_limit_mb),
-        module_loader,
-    )
-    .context("Error building main worker")
-    .map_err(|e| anyhow!("{e:#}"))?; // Ensure to keep context when downcasting JS errors later
 
     let op_state = worker.js_runtime.op_state();
     {
@@ -619,11 +778,11 @@ pub(crate) async fn execute_js(
         cached
     } else {
         let prepare_context = ActionCodePrepareContext {
-            client: &http_client,
-            integrity: &integrity_manifest,
-            strict_imports,
-            lockfile_path: &lockfile_path,
-            module_cache: &module_cache,
+            client: &shared.http_client,
+            integrity: &shared.integrity_manifest,
+            strict_imports: shared.strict_imports,
+            lockfile_path: &shared.lockfile_path,
+            module_cache: &shared.module_cache,
         };
         get_or_prepare_action_code(&code, &action_ipfs_id, &action_code_cache, &prepare_context)
             .await?
@@ -875,5 +1034,37 @@ mod tests {
         assert!(cache.total_bytes() < MAX_ACTION_CODE_CACHE_BYTES);
         assert!(cache.entries.contains_key("QmNew"));
         assert!(!cache.entries.contains_key("QmOld"));
+    }
+
+    /// Each `PreparedWorker` must have a fresh `LoadedModules` `Arc`.
+    /// If two workers ever shared the same accumulator, per-tenant module
+    /// state would leak between the requests dispatched to those workers.
+    /// This is the core safety invariant for the pool.
+    #[test]
+    fn prepared_workers_have_distinct_loaded_modules_arcs() {
+        use std::sync::Once;
+        static INIT_V8_ONCE: Once = Once::new();
+        INIT_V8_ONCE.call_once(super::init_v8);
+
+        let shared = PoolSharedState {
+            integrity_manifest: Arc::new(RwLock::new(HashMap::new())),
+            strict_imports: false,
+            module_cache: Arc::new(RwLock::new(HashMap::new())),
+            lockfile_path: None,
+            http_client: CdnModuleLoader::build_http_client(),
+            memory_limit_mb: DEFAULT_MEMORY_LIMIT_MB,
+        };
+
+        let w1 = build_worker_base(&shared).expect("first worker built");
+        let w2 = build_worker_base(&shared).expect("second worker built");
+
+        let m1 = w1.loaded_modules_for_test();
+        let m2 = w2.loaded_modules_for_test();
+
+        assert!(
+            !Arc::ptr_eq(&m1.0, &m2.0),
+            "two PreparedWorkers must not share a LoadedModules Arc; \
+             this would leak per-request module state between tenants",
+        );
     }
 }

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -233,7 +233,7 @@ impl Action for Server {
                         debug!("{:?}", DebugExecutionRequest::from(&req));
                     }
 
-                    dispatch_execute_request(&dispatch, req, outbound_tx, inbound_rx, span);
+                    dispatch_execute_request(&dispatch, req, outbound_tx, inbound_rx, span).await;
                 }
                 _ => {} // Ignore empty requests
             }
@@ -253,7 +253,7 @@ impl Action for Server {
 /// Custom `memory_limit` requests bypass the pool entirely: pool workers
 /// are bootstrapped at `DEFAULT_MEMORY_LIMIT_MB` and V8's heap limit is
 /// immutable post-creation.
-fn dispatch_execute_request(
+async fn dispatch_execute_request(
     dispatch: &DispatchState,
     req: ExecutionRequest,
     outbound_tx: flume::Sender<tonic::Result<ExecuteJsResponse>>,
@@ -263,12 +263,20 @@ fn dispatch_execute_request(
     // Empty-code shortcut: never consume a pre-warmed worker for this.
     // Mirrors the fast path in `runtime::execute_js` but moved up so the
     // pool isn't drained and refilled for a no-op.
+    //
+    // Use `send_async().await` rather than `try_send`: `outbound_tx` is a
+    // rendezvous channel (`flume::bounded(0)`), and the receiver is the
+    // tonic response stream. If the dispatcher fires before tonic begins
+    // polling the stream, `try_send` drops the only response and the client
+    // observes an empty stream / hang.
     if req.code.is_empty() || req.code.bytes().all(|b| b.is_ascii_whitespace()) {
-        let _ = outbound_tx.try_send(Ok(ExecutionResult {
-            success: true,
-            ..Default::default()
-        }
-        .into()));
+        let _ = outbound_tx
+            .send_async(Ok(ExecutionResult {
+                success: true,
+                ..Default::default()
+            }
+            .into()))
+            .await;
         return;
     }
 

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -233,13 +233,7 @@ impl Action for Server {
                         debug!("{:?}", DebugExecutionRequest::from(&req));
                     }
 
-                    dispatch_execute_request(
-                        &dispatch,
-                        req,
-                        outbound_tx,
-                        inbound_rx,
-                        span,
-                    );
+                    dispatch_execute_request(&dispatch, req, outbound_tx, inbound_rx, span);
                 }
                 _ => {} // Ignore empty requests
             }
@@ -313,26 +307,24 @@ fn dispatch_execute_request(
         span,
     };
 
-    if can_pool {
-        if let Some(handle) = dispatch.pool.try_acquire() {
-            match handle.work_tx.try_send(work) {
-                Ok(()) => return,
-                Err(flume::TrySendError::Disconnected(reclaimed)) => {
-                    // Worker thread died between publishing its handle and
-                    // the dispatcher trying to hand it work. Reclaim the
-                    // WorkItem and route to legacy.
-                    dispatch.pool.note_disconnected();
-                    spawn_legacy(dispatch, reclaimed, memory_limit_mb);
-                    return;
-                }
-                Err(flume::TrySendError::Full(reclaimed)) => {
-                    // One-shot lifecycle invariant violation: the work
-                    // channel is bounded(1) and no work has been sent yet.
-                    // Logged at WARN with a separate counter; still safe.
-                    dispatch.pool.note_full_error();
-                    spawn_legacy(dispatch, reclaimed, memory_limit_mb);
-                    return;
-                }
+    if can_pool && let Some(handle) = dispatch.pool.try_acquire() {
+        match handle.work_tx.try_send(work) {
+            Ok(()) => return,
+            Err(flume::TrySendError::Disconnected(reclaimed)) => {
+                // Worker thread died between publishing its handle and
+                // the dispatcher trying to hand it work. Reclaim the
+                // WorkItem and route to legacy.
+                dispatch.pool.note_disconnected();
+                spawn_legacy(dispatch, reclaimed, memory_limit_mb);
+                return;
+            }
+            Err(flume::TrySendError::Full(reclaimed)) => {
+                // One-shot lifecycle invariant violation: the work
+                // channel is bounded(1) and no work has been sent yet.
+                // Logged at WARN with a separate counter; still safe.
+                dispatch.pool.note_full_error();
+                spawn_legacy(dispatch, reclaimed, memory_limit_mb);
+                return;
             }
         }
         // Pool miss (empty ready channel, breaker open, etc): fall
@@ -346,11 +338,7 @@ fn dispatch_execute_request(
 /// the snapshot inside `runtime::execute_js`, and execute. Preserves the
 /// original execution model for custom `memory_limit` requests and as the
 /// fallback when the pool can't service a request.
-fn spawn_legacy(
-    dispatch: &DispatchState,
-    work: WorkItem,
-    memory_limit_mb: Option<usize>,
-) {
+fn spawn_legacy(dispatch: &DispatchState, work: WorkItem, memory_limit_mb: Option<usize>) {
     let integrity_manifest = dispatch.integrity_manifest.clone();
     let strict_imports = dispatch.strict_imports;
     let module_cache = dispatch.module_cache.clone();

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -4,7 +4,10 @@ use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
 use crate::cdn_module_loader::{CdnModuleLoader, ModuleCache};
-use crate::runtime::{ActionCodeCache, new_action_code_cache};
+use crate::runtime::{
+    ActionCodeCache, DEFAULT_MEMORY_LIMIT_MB, PoolSharedState, new_action_code_cache,
+};
+use crate::worker_pool::{WorkItem, WorkerPool};
 
 use anyhow::Result;
 use deno_core::error::CoreError;
@@ -15,13 +18,18 @@ use lit_actions_grpc::{proto::*, unix};
 use lit_api_core::context::{HEADER_KEY_X_CORRELATION_ID, HEADER_KEY_X_REQUEST_ID};
 use lit_observability::{
     PRIVACY_MODE_TAG,
-    channels::{ChannelMsg, new_traced_bounded_channel},
+    channels::{ChannelMsg, TracedReceiver, new_traced_bounded_channel},
     logging::{clear_task_request_context, set_request_context},
 };
 use temp_file::TempFile;
 use tokio_stream::{Stream, StreamExt as _};
 use tonic::{Request, Response, Status};
-use tracing::{Instrument, debug, debug_span, error, instrument};
+use tracing::{Instrument, Span, debug, debug_span, error, instrument};
+
+/// Env var that overrides the default pool size. `0` disables the pool
+/// entirely (every request goes via the legacy cold path). Default: 10.
+const POOL_SIZE_ENV: &str = "LIT_ACTIONS_POOL_SIZE";
+const DEFAULT_POOL_SIZE: usize = 10;
 
 #[derive(Default, PartialEq)]
 pub enum ServerType {
@@ -44,6 +52,8 @@ pub struct Server {
     lockfile_path: Option<PathBuf>,
     /// Shared HTTP client for CDN fetches (connection pooling across executions).
     http_client: Arc<reqwest::Client>,
+    /// Pre-warmed worker pool. `target_size = 0` disables the pool entirely.
+    pool: Arc<WorkerPool>,
 }
 
 impl Server {
@@ -53,32 +63,105 @@ impl Server {
             .max_decoding_message_size(usize::MAX)
     }
 
+    pub fn pool(&self) -> Arc<WorkerPool> {
+        self.pool.clone()
+    }
+
+    fn build_pool(
+        integrity_manifest: Arc<RwLock<HashMap<String, String>>>,
+        strict_imports: bool,
+        module_cache: ModuleCache,
+        lockfile_path: Option<PathBuf>,
+        http_client: Arc<reqwest::Client>,
+    ) -> Arc<WorkerPool> {
+        let shared = Arc::new(PoolSharedState {
+            integrity_manifest,
+            strict_imports,
+            module_cache,
+            lockfile_path,
+            http_client,
+            memory_limit_mb: DEFAULT_MEMORY_LIMIT_MB,
+        });
+        WorkerPool::new(pool_size_from_env(), shared)
+    }
+
     /// Create a production server with an integrity manifest.
     pub fn with_integrity(
         integrity_manifest: Arc<RwLock<HashMap<String, String>>>,
         strict_imports: bool,
         lockfile_path: Option<PathBuf>,
     ) -> Self {
+        let module_cache: ModuleCache = Arc::new(RwLock::new(HashMap::new()));
+        let http_client = CdnModuleLoader::build_http_client();
+        let pool = Self::build_pool(
+            integrity_manifest.clone(),
+            strict_imports,
+            module_cache.clone(),
+            lockfile_path.clone(),
+            http_client.clone(),
+        );
         Self {
             server_type: ServerType::Production,
             integrity_manifest,
             strict_imports,
-            module_cache: Arc::new(RwLock::new(HashMap::new())),
+            module_cache,
             action_code_cache: new_action_code_cache(),
             lockfile_path,
-            http_client: CdnModuleLoader::build_http_client(),
+            http_client,
+            pool,
         }
     }
 
-    fn new_test_server() -> Self {
+    pub fn new_test_server() -> Self {
+        let module_cache: ModuleCache = Arc::new(RwLock::new(HashMap::new()));
+        let http_client = CdnModuleLoader::build_http_client();
+        let integrity_manifest = Arc::new(RwLock::new(HashMap::new()));
+        let pool = Self::build_pool(
+            integrity_manifest.clone(),
+            false,
+            module_cache.clone(),
+            None,
+            http_client.clone(),
+        );
         Self {
             server_type: ServerType::Test,
-            integrity_manifest: Default::default(),
+            integrity_manifest,
             strict_imports: false,
-            module_cache: Arc::new(RwLock::new(HashMap::new())),
+            module_cache,
             action_code_cache: new_action_code_cache(),
             lockfile_path: None,
-            http_client: CdnModuleLoader::build_http_client(),
+            http_client,
+            pool,
+        }
+    }
+}
+
+/// Per-request dispatch context cloned from `Server` once per incoming
+/// request so the dispatcher can route between the pool and legacy paths
+/// without holding a reference to `Server`.
+#[derive(Clone)]
+struct DispatchState {
+    pool: Arc<WorkerPool>,
+    is_test_server: bool,
+    integrity_manifest: Arc<RwLock<HashMap<String, String>>>,
+    strict_imports: bool,
+    module_cache: ModuleCache,
+    action_code_cache: ActionCodeCache,
+    lockfile_path: Option<PathBuf>,
+    http_client: Arc<reqwest::Client>,
+}
+
+impl DispatchState {
+    fn from_server(server: &Server) -> Self {
+        Self {
+            pool: server.pool.clone(),
+            is_test_server: server.server_type == ServerType::Test,
+            integrity_manifest: server.integrity_manifest.clone(),
+            strict_imports: server.strict_imports,
+            module_cache: server.module_cache.clone(),
+            action_code_cache: server.action_code_cache.clone(),
+            lockfile_path: server.lockfile_path.clone(),
+            http_client: server.http_client.clone(),
         }
     }
 }
@@ -97,13 +180,7 @@ impl Action for Server {
         let mut stream = request.into_inner();
         let (inbound_tx, inbound_rx) = new_traced_bounded_channel(0);
         let (outbound_tx, outbound_rx) = flume::bounded(0);
-        let is_test_server = self.server_type == ServerType::Test;
-        let integrity_manifest = self.integrity_manifest.clone();
-        let strict_imports = self.strict_imports;
-        let module_cache = self.module_cache.clone();
-        let action_code_cache = self.action_code_cache.clone();
-        let lockfile_path = self.lockfile_path.clone();
-        let http_client = self.http_client.clone();
+        let dispatch = DispatchState::from_server(self);
 
         // Put incoming requests into channel
         let send_exec_req_span = debug_span!("send_exec_req");
@@ -156,73 +233,13 @@ impl Action for Server {
                         debug!("{:?}", DebugExecutionRequest::from(&req));
                     }
 
-                    std::thread::spawn(move || {
-                        // Extract IDs from http_headers for log injection context.
-                        // The request_id arrives pre-tagged with PRIVACY_MODE_TAG
-                        // from lit-api-server if privacy mode was requested.
-                        let request_id = req
-                            .http_headers
-                            .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
-                            .cloned();
-                        let correlation_id = req
-                            .http_headers
-                            .get(&HEADER_KEY_X_CORRELATION_ID.to_ascii_lowercase())
-                            .cloned();
-
-                        if request_id.is_some() || correlation_id.is_some() {
-                            set_request_context(request_id, correlation_id);
-                        }
-
-                        create_and_run_current_thread(
-                            async move {
-                                let res = crate::runtime::execute_js(
-                                    req.code,
-                                    req.js_params.and_then(|v| serde_json::from_slice(&v).ok()),
-                                    req.auth_context
-                                        .and_then(|v| serde_json::from_slice(&v).ok()),
-                                    req.http_headers,
-                                    req.timeout,
-                                    req.memory_limit.map(|limit| limit as usize),
-                                    outbound_tx.clone(),
-                                    inbound_rx.clone(),
-                                    is_test_server,
-                                    integrity_manifest.clone(),
-                                    strict_imports,
-                                    module_cache.clone(),
-                                    action_code_cache.clone(),
-                                    lockfile_path.clone(),
-                                    http_client.clone(),
-                                )
-                                .await;
-                                let _ = outbound_tx
-                                    .send_async(match res {
-                                        Ok(()) => Ok(ExecutionResult {
-                                            success: true,
-                                            ..Default::default()
-                                        }
-                                        .into()),
-                                        Err(err) => {
-                                            // Return Tonic error as-is, otherwise return ExecutionResult
-                                            if let Some(status) = err.downcast_ref::<Status>() {
-                                                error!("{status:#}");
-                                                Err(status.clone())
-                                            } else {
-                                                Ok(ExecutionResult {
-                                                    success: false,
-                                                    error: format_error(&err),
-                                                }
-                                                .into())
-                                            }
-                                        }
-                                    })
-                                    .inspect_err(|e| {
-                                        error!("failed to send execution result: {e:#}")
-                                    })
-                                    .await;
-                            }
-                            .instrument(span),
-                        );
-                    });
+                    dispatch_execute_request(
+                        &dispatch,
+                        req,
+                        outbound_tx,
+                        inbound_rx,
+                        span,
+                    );
                 }
                 _ => {} // Ignore empty requests
             }
@@ -233,12 +250,208 @@ impl Action for Server {
     }
 }
 
-fn format_error(err: &anyhow::Error) -> String {
+/// Route an incoming `ExecuteJsRequest` to either the pre-warmed worker
+/// pool or the legacy cold path.
+///
+/// Empty-code requests short-circuit BEFORE pool acquisition so they never
+/// consume a pre-warmed worker.
+///
+/// Custom `memory_limit` requests bypass the pool entirely: pool workers
+/// are bootstrapped at `DEFAULT_MEMORY_LIMIT_MB` and V8's heap limit is
+/// immutable post-creation.
+fn dispatch_execute_request(
+    dispatch: &DispatchState,
+    req: ExecutionRequest,
+    outbound_tx: flume::Sender<tonic::Result<ExecuteJsResponse>>,
+    inbound_rx: TracedReceiver<ExecuteJsRequest>,
+    span: Span,
+) {
+    // Empty-code shortcut: never consume a pre-warmed worker for this.
+    // Mirrors the fast path in `runtime::execute_js` but moved up so the
+    // pool isn't drained and refilled for a no-op.
+    if req.code.is_empty() || req.code.bytes().all(|b| b.is_ascii_whitespace()) {
+        let _ = outbound_tx.try_send(Ok(ExecutionResult {
+            success: true,
+            ..Default::default()
+        }
+        .into()));
+        return;
+    }
+
+    let memory_limit_mb = req.memory_limit.map(|limit| limit as usize);
+    // Custom-limit requests can't ride pool workers (heap limits are baked
+    // in at isolate creation). Default-limit and unspecified-limit requests
+    // can.
+    let can_pool = match memory_limit_mb {
+        None => true,
+        Some(m) => m == DEFAULT_MEMORY_LIMIT_MB,
+    };
+
+    let request_id = req
+        .http_headers
+        .get(&HEADER_KEY_X_REQUEST_ID.to_ascii_lowercase())
+        .cloned();
+    let correlation_id = req
+        .http_headers
+        .get(&HEADER_KEY_X_CORRELATION_ID.to_ascii_lowercase())
+        .cloned();
+
+    let work = WorkItem {
+        code: req.code,
+        js_params: req.js_params.and_then(|v| serde_json::from_slice(&v).ok()),
+        auth_context: req
+            .auth_context
+            .and_then(|v| serde_json::from_slice(&v).ok()),
+        http_headers: req.http_headers,
+        timeout_ms: req.timeout,
+        outbound_tx: outbound_tx.clone(),
+        inbound_rx,
+        is_test_server: dispatch.is_test_server,
+        action_code_cache: dispatch.action_code_cache.clone(),
+        request_id,
+        correlation_id,
+        span,
+    };
+
+    if can_pool {
+        if let Some(handle) = dispatch.pool.try_acquire() {
+            match handle.work_tx.try_send(work) {
+                Ok(()) => return,
+                Err(flume::TrySendError::Disconnected(reclaimed)) => {
+                    // Worker thread died between publishing its handle and
+                    // the dispatcher trying to hand it work. Reclaim the
+                    // WorkItem and route to legacy.
+                    dispatch.pool.note_disconnected();
+                    spawn_legacy(dispatch, reclaimed, memory_limit_mb);
+                    return;
+                }
+                Err(flume::TrySendError::Full(reclaimed)) => {
+                    // One-shot lifecycle invariant violation: the work
+                    // channel is bounded(1) and no work has been sent yet.
+                    // Logged at WARN with a separate counter; still safe.
+                    dispatch.pool.note_full_error();
+                    spawn_legacy(dispatch, reclaimed, memory_limit_mb);
+                    return;
+                }
+            }
+        }
+        // Pool miss (empty ready channel, breaker open, etc): fall
+        // through to the legacy cold path with the same WorkItem.
+    }
+
+    spawn_legacy(dispatch, work, memory_limit_mb);
+}
+
+/// Legacy cold path: spawn an OS thread, build a fresh `MainWorker` from
+/// the snapshot inside `runtime::execute_js`, and execute. Preserves the
+/// original execution model for custom `memory_limit` requests and as the
+/// fallback when the pool can't service a request.
+fn spawn_legacy(
+    dispatch: &DispatchState,
+    work: WorkItem,
+    memory_limit_mb: Option<usize>,
+) {
+    let integrity_manifest = dispatch.integrity_manifest.clone();
+    let strict_imports = dispatch.strict_imports;
+    let module_cache = dispatch.module_cache.clone();
+    let lockfile_path = dispatch.lockfile_path.clone();
+    let http_client = dispatch.http_client.clone();
+
+    std::thread::spawn(move || {
+        if work.request_id.is_some() || work.correlation_id.is_some() {
+            set_request_context(work.request_id.clone(), work.correlation_id.clone());
+        }
+
+        let WorkItem {
+            code,
+            js_params,
+            auth_context,
+            http_headers,
+            timeout_ms,
+            outbound_tx,
+            inbound_rx,
+            is_test_server,
+            action_code_cache,
+            request_id: _,
+            correlation_id: _,
+            span,
+        } = work;
+
+        create_and_run_current_thread(
+            async move {
+                let res = crate::runtime::execute_js(
+                    code,
+                    js_params,
+                    auth_context,
+                    http_headers,
+                    timeout_ms,
+                    memory_limit_mb,
+                    outbound_tx.clone(),
+                    inbound_rx,
+                    is_test_server,
+                    integrity_manifest,
+                    strict_imports,
+                    module_cache,
+                    action_code_cache,
+                    lockfile_path,
+                    http_client,
+                )
+                .await;
+                send_execution_result(&outbound_tx, res).await;
+            }
+            .instrument(span),
+        );
+    });
+}
+
+fn pool_size_from_env() -> usize {
+    std::env::var(POOL_SIZE_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_POOL_SIZE)
+}
+
+pub(crate) fn format_error(err: &anyhow::Error) -> String {
     if let Some(CoreError::Js(js_err)) = any_and_jserrorbox_downcast_ref::<CoreError>(err) {
         deno_runtime::fmt_errors::format_js_error(js_err)
     } else {
         format!("{err:#}")
     }
+}
+
+/// Convert a runtime `Result<()>` to the response message expected by the
+/// outbound stream and send it. Shared between the legacy cold path
+/// (`server::spawn_legacy`) and the pool path
+/// (`worker_pool::run_worker_thread`) so error formatting stays identical
+/// across both.
+pub(crate) async fn send_execution_result(
+    outbound_tx: &flume::Sender<tonic::Result<ExecuteJsResponse>>,
+    res: Result<()>,
+) {
+    let response = match res {
+        Ok(()) => Ok(ExecutionResult {
+            success: true,
+            ..Default::default()
+        }
+        .into()),
+        Err(err) => {
+            // Return Tonic error as-is, otherwise return ExecutionResult
+            if let Some(status) = err.downcast_ref::<Status>() {
+                error!("{status:#}");
+                Err(status.clone())
+            } else {
+                Ok(ExecutionResult {
+                    success: false,
+                    error: format_error(&err),
+                }
+                .into())
+            }
+        }
+    };
+    let _ = outbound_tx
+        .send_async(response)
+        .inspect_err(|e| error!("failed to send execution result: {e:#}"))
+        .await;
 }
 
 pub async fn start_server<P, S>(
@@ -252,12 +465,15 @@ where
     P: Into<PathBuf>,
     S: std::future::Future<Output = ()>,
 {
-    unix::start_server(
-        Server::with_integrity(integrity_manifest, strict_imports, lockfile_path).into_service(),
-        socket_path,
-        shutdown_signal,
-    )
-    .await
+    let server = Server::with_integrity(integrity_manifest, strict_imports, lockfile_path);
+    // Spawn the warmup so it doesn't block socket bind. Worker threads do
+    // the slow V8 / Deno bootstrap concurrently with the rest of startup;
+    // the first few requests may miss the pool and fall back to legacy.
+    let pool = server.pool();
+    tokio::spawn(async move {
+        pool.warmup();
+    });
+    unix::start_server(server.into_service(), socket_path, shutdown_signal).await
 }
 
 pub async fn start_test_server<P, S>(socket_path: P, shutdown_signal: Option<S>) -> Result<()>
@@ -265,15 +481,20 @@ where
     P: Into<PathBuf>,
     S: std::future::Future<Output = ()>,
 {
-    unix::start_server(
-        Server::new_test_server().into_service(),
-        socket_path,
-        shutdown_signal,
-    )
-    .await
+    let server = Server::new_test_server();
+    let pool = server.pool();
+    tokio::spawn(async move {
+        pool.warmup();
+    });
+    unix::start_server(server.into_service(), socket_path, shutdown_signal).await
 }
 pub struct TestServer {
     pub socket_file: TempFile,
+    /// Snapshot of pool health counters; cloned at server construction
+    /// so integration tests can assert on hits / misses without poking
+    /// inside the running gRPC service.
+    pub pool_health: Arc<crate::worker_pool::PoolHealth>,
+    pub pool_target_size: usize,
 }
 
 impl TestServer {
@@ -281,21 +502,39 @@ impl TestServer {
         let socket_file = temp_file::empty();
         let socket_path = socket_file.path().to_path_buf();
 
-        std::thread::spawn(|| {
+        // Build the server on the test thread so we can capture the pool
+        // handle before moving the server into the runtime thread.
+        let server = Server::new_test_server();
+        let pool = server.pool();
+        let pool_health = pool.health();
+        let pool_target_size = pool.target_size();
+
+        std::thread::spawn(move || {
             create_and_run_current_thread(async move {
                 let signal = async {
                     let _ = tokio::signal::ctrl_c().await;
                 };
-                start_test_server(socket_path, Some(signal))
+                let warmup_pool = server.pool();
+                tokio::spawn(async move {
+                    warmup_pool.warmup();
+                });
+                unix::start_server(server.into_service(), socket_path, Some(signal))
                     .await
                     .expect("failed to start action server")
             });
         });
 
-        // Wait for startup
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        // Wait for startup AND for the pool to warm enough for tests that
+        // exercise warm hits. With pool=10 and a snapshot bootstrap of
+        // ~30-50 ms per worker, 200 ms is enough for at least a few to be
+        // ready. Tests that need every slot warm gate explicitly.
+        std::thread::sleep(std::time::Duration::from_millis(200));
 
-        Self { socket_file }
+        Self {
+            socket_file,
+            pool_health,
+            pool_target_size,
+        }
     }
 
     pub fn socket_path(&self) -> PathBuf {

--- a/lit-actions/server/worker_pool.rs
+++ b/lit-actions/server/worker_pool.rs
@@ -1,0 +1,552 @@
+//! Pool of pre-warmed `MainWorker` instances.
+//!
+//! Each pooled worker lives on its own OS thread, executes exactly one
+//! request, and is then dropped. The pool refills asynchronously: every
+//! successful acquire spawns one replacement.
+//!
+//! Pattern: Cloudflare Workers / Deno Deploy ("isolates are cheap to start
+//! from a snapshot, expensive to scrub for reuse, so don't reuse them").
+//!
+//! # Crash protection
+//!
+//! Bootstrap runs inside `std::panic::catch_unwind` so a Rust panic during
+//! V8 / Deno init won't take down the process. Aborts, segfaults, SIGTRAP
+//! and FFI undefined behaviour through V8 are NOT catchable here. The
+//! legacy cold path has the same exposure today (see `panic_in_op` ignored
+//! test in `lit-actions/tests/it.rs`).
+//!
+//! # Failure mode (half-open breaker)
+//!
+//! After `POOL_REFILL_FAILURE_LIMIT` consecutive bootstrap failures the
+//! breaker opens for `POOL_BREAKER_COOLDOWN`. While Open, `try_acquire`
+//! returns `None` so the dispatcher routes everything to the legacy cold
+//! path. After cooldown the breaker enters Half-Open and one trial refill
+//! is attempted. Success closes the breaker; failure re-opens it with a
+//! fresh cooldown.
+
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use deno_runtime::tokio_util::create_and_run_current_thread;
+use lit_actions_grpc::proto::{ExecuteJsRequest, ExecuteJsResponse};
+use lit_observability::channels::TracedReceiver;
+use lit_observability::logging::set_request_context;
+use tracing::{Instrument, Span, debug, error, warn};
+
+use crate::runtime::{self, ActionCodeCache, PoolSharedState};
+use crate::server;
+
+/// Refill failure threshold before the breaker opens.
+const POOL_REFILL_FAILURE_LIMIT: usize = 5;
+/// Initial backoff between refill attempts (doubled per consecutive failure).
+const POOL_REFILL_BACKOFF_BASE_MS: u64 = 50;
+/// Maximum backoff between refill attempts.
+const POOL_REFILL_BACKOFF_MAX_MS: u64 = 5_000;
+/// How long the breaker stays Open before transitioning to Half-Open.
+const POOL_BREAKER_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// One request handed off to a pre-warmed worker. Carries everything
+/// `execute_with_worker` needs plus the request-context fields the worker
+/// thread injects for log correlation.
+pub(crate) struct WorkItem {
+    pub code: String,
+    pub js_params: Option<serde_json::Value>,
+    pub auth_context: Option<serde_json::Value>,
+    pub http_headers: BTreeMap<String, String>,
+    pub timeout_ms: Option<u64>,
+    pub outbound_tx: flume::Sender<tonic::Result<ExecuteJsResponse>>,
+    pub inbound_rx: TracedReceiver<ExecuteJsRequest>,
+    pub is_test_server: bool,
+    pub action_code_cache: ActionCodeCache,
+    pub request_id: Option<String>,
+    pub correlation_id: Option<String>,
+    pub span: Span,
+}
+
+/// Send-side of a per-worker work channel. The channel is `bounded(1)`:
+/// each pre-warmed worker accepts exactly one work item and is then
+/// dropped, so a `TrySendError::Full` is an invariant violation.
+pub(crate) struct WorkerHandle {
+    pub work_tx: flume::Sender<WorkItem>,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum BreakerState {
+    Closed,
+    Open { opened_at: Instant },
+    HalfOpen,
+}
+
+/// Counters and breaker state. Public so tests and observability can peek.
+pub struct PoolHealth {
+    consecutive_refill_failures: AtomicUsize,
+    breaker: Mutex<BreakerState>,
+    full_errors: AtomicUsize,
+    disconnected_misses: AtomicUsize,
+    refill_failed: AtomicUsize,
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+}
+
+impl Default for PoolHealth {
+    fn default() -> Self {
+        Self {
+            consecutive_refill_failures: AtomicUsize::new(0),
+            breaker: Mutex::new(BreakerState::Closed),
+            full_errors: AtomicUsize::new(0),
+            disconnected_misses: AtomicUsize::new(0),
+            refill_failed: AtomicUsize::new(0),
+            hits: AtomicUsize::new(0),
+            misses: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl PoolHealth {
+    pub fn hits(&self) -> usize {
+        self.hits.load(Ordering::Relaxed)
+    }
+    pub fn misses(&self) -> usize {
+        self.misses.load(Ordering::Relaxed)
+    }
+    pub fn refill_failed(&self) -> usize {
+        self.refill_failed.load(Ordering::Relaxed)
+    }
+    pub fn full_errors(&self) -> usize {
+        self.full_errors.load(Ordering::Relaxed)
+    }
+    pub fn disconnected_misses(&self) -> usize {
+        self.disconnected_misses.load(Ordering::Relaxed)
+    }
+}
+
+pub struct WorkerPool {
+    target_size: usize,
+    shared: Arc<PoolSharedState>,
+    ready_tx: flume::Sender<WorkerHandle>,
+    ready_rx: flume::Receiver<WorkerHandle>,
+    health: Arc<PoolHealth>,
+}
+
+impl WorkerPool {
+    pub(crate) fn new(target_size: usize, shared: Arc<PoolSharedState>) -> Arc<Self> {
+        // Bound the channel at target_size so an over-eager refill loop
+        // can never grow the pool past target. `max(1)` avoids `bounded(0)`
+        // (rendezvous) when the pool is disabled (target_size == 0).
+        let (ready_tx, ready_rx) = flume::bounded(target_size.max(1));
+        Arc::new(Self {
+            target_size,
+            shared,
+            ready_tx,
+            ready_rx,
+            health: Arc::new(PoolHealth::default()),
+        })
+    }
+
+    pub fn target_size(&self) -> usize {
+        self.target_size
+    }
+
+    pub fn health(&self) -> Arc<PoolHealth> {
+        self.health.clone()
+    }
+
+    /// Spawn `target_size` worker threads. Idempotent in spirit; intended
+    /// to be called once at startup after the gRPC socket binds.
+    pub(crate) fn warmup(self: &Arc<Self>) {
+        if self.target_size == 0 {
+            debug!("worker pool warmup skipped: target_size = 0");
+            return;
+        }
+        debug!(
+            target_size = self.target_size,
+            "worker pool warmup starting"
+        );
+        for _ in 0..self.target_size {
+            self.spawn_worker();
+        }
+    }
+
+    /// Try to grab a pre-warmed worker. On hit, the pool spawns one
+    /// replacement asynchronously (drain-then-refill). On miss returns
+    /// `None`; caller must fall through to the legacy cold path.
+    pub(crate) fn try_acquire(self: &Arc<Self>) -> Option<WorkerHandle> {
+        if self.target_size == 0 {
+            return None;
+        }
+        if !self.breaker_allows_acquire() {
+            self.health.misses.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
+        match self.ready_rx.try_recv() {
+            Ok(handle) => {
+                self.health.hits.fetch_add(1, Ordering::Relaxed);
+                self.spawn_worker();
+                Some(handle)
+            }
+            Err(flume::TryRecvError::Empty) => {
+                self.health.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+            Err(flume::TryRecvError::Disconnected) => {
+                // Both ends are owned by this pool, so disconnect is
+                // unreachable. Log and treat as miss.
+                error!("pool ready channel disconnected — this is a bug");
+                self.health.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Note a `TrySendError::Full` from the dispatcher: under the
+    /// one-shot lifecycle this should never happen (the work channel is
+    /// `bounded(1)` and no work has been sent yet). Logged at WARN with a
+    /// separate counter so it's visible vs the normal Disconnected race.
+    pub(crate) fn note_full_error(&self) {
+        self.health.full_errors.fetch_add(1, Ordering::Relaxed);
+        warn!("pool worker work channel was full when handing off — invariant violation");
+    }
+
+    /// Note a `TrySendError::Disconnected` from the dispatcher: the worker
+    /// thread died between publishing its handle and the dispatcher
+    /// trying to hand it work. Counted at DEBUG: this is a normal-ish race.
+    pub(crate) fn note_disconnected(&self) {
+        self.health
+            .disconnected_misses
+            .fetch_add(1, Ordering::Relaxed);
+        debug!("pool worker handle disconnected before work could be sent");
+    }
+
+    fn breaker_allows_acquire(self: &Arc<Self>) -> bool {
+        let mut guard = match self.health.breaker.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match *guard {
+            BreakerState::Closed => true,
+            BreakerState::HalfOpen => false,
+            BreakerState::Open { opened_at } => {
+                if opened_at.elapsed() >= POOL_BREAKER_COOLDOWN {
+                    debug!("pool breaker cooldown elapsed; transitioning to half-open");
+                    *guard = BreakerState::HalfOpen;
+                    drop(guard);
+                    // One trial refill from this caller. Result will close
+                    // or re-open the breaker.
+                    self.spawn_worker();
+                }
+                false
+            }
+        }
+    }
+
+    fn record_refill_success(&self) {
+        self.health
+            .consecutive_refill_failures
+            .store(0, Ordering::Relaxed);
+        let mut guard = match self.health.breaker.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match *guard {
+            BreakerState::HalfOpen => {
+                debug!("pool breaker trial refill succeeded; closing breaker");
+                *guard = BreakerState::Closed;
+            }
+            BreakerState::Open { .. } => {
+                // Not expected on the success path: half-open is the only
+                // way a refill runs while the breaker is open. Treat
+                // conservatively as Closed.
+                *guard = BreakerState::Closed;
+            }
+            BreakerState::Closed => {}
+        }
+    }
+
+    fn record_refill_failure(&self, err: &dyn std::fmt::Display) {
+        self.health.refill_failed.fetch_add(1, Ordering::Relaxed);
+        let prev = self
+            .health
+            .consecutive_refill_failures
+            .fetch_add(1, Ordering::Relaxed);
+        let total_failures = prev + 1;
+        let mut guard = match self.health.breaker.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let was_half_open = matches!(*guard, BreakerState::HalfOpen);
+        if total_failures >= POOL_REFILL_FAILURE_LIMIT || was_half_open {
+            error!(
+                consecutive_failures = total_failures,
+                error = %err,
+                "pool refill breaker opening — pool degraded; falling back to legacy cold path until cooldown ({POOL_BREAKER_COOLDOWN:?})",
+            );
+            *guard = BreakerState::Open {
+                opened_at: Instant::now(),
+            };
+        } else {
+            warn!(
+                consecutive_failures = total_failures,
+                error = %err,
+                "pool worker bootstrap failed; will retry with backoff",
+            );
+        }
+    }
+
+    fn spawn_worker(self: &Arc<Self>) {
+        let pool = self.clone();
+        std::thread::spawn(move || {
+            run_worker_thread(pool);
+        });
+    }
+}
+
+fn run_worker_thread(pool: Arc<WorkerPool>) {
+    // Bootstrap is the panic surface: any V8 / Deno init issue lands here.
+    // catch_unwind protects against Rust panics; aborts/segfaults/SIGTRAP
+    // and FFI UB through V8 are NOT catchable here.
+    let bootstrap_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        runtime::build_worker_base(&pool.shared)
+    }));
+
+    let prepared = match bootstrap_result {
+        Ok(Ok(prepared)) => prepared,
+        Ok(Err(err)) => {
+            pool.record_refill_failure(&format_args!("{err:#}"));
+            schedule_replacement(&pool);
+            return;
+        }
+        Err(panic) => {
+            let msg = panic_message(&panic);
+            pool.record_refill_failure(&msg);
+            schedule_replacement(&pool);
+            return;
+        }
+    };
+
+    pool.record_refill_success();
+
+    let (work_tx, work_rx) = flume::bounded::<WorkItem>(1);
+    let handle = WorkerHandle { work_tx };
+
+    if pool.ready_tx.send(handle).is_err() {
+        // Pool was dropped before this worker could publish itself.
+        return;
+    }
+
+    // Block until either work arrives or the dispatcher gives up on this
+    // handle (drops it / panics).
+    let work = match work_rx.recv() {
+        Ok(work) => work,
+        Err(_) => {
+            // Dispatcher disconnected without sending work; just exit.
+            return;
+        }
+    };
+
+    // From here on we run a single request and drop the worker.
+    if work.request_id.is_some() || work.correlation_id.is_some() {
+        set_request_context(work.request_id.clone(), work.correlation_id.clone());
+    }
+
+    let WorkItem {
+        code,
+        js_params,
+        auth_context,
+        http_headers,
+        timeout_ms,
+        outbound_tx,
+        inbound_rx,
+        is_test_server,
+        action_code_cache,
+        request_id: _,
+        correlation_id: _,
+        span,
+    } = work;
+
+    let shared = pool.shared.clone();
+    let mut prepared = prepared;
+
+    create_and_run_current_thread(
+        async move {
+            // Per-request JS injection: namespace globals first (so user
+            // code sees Lit.*), PatchDeno + everything else is owned by
+            // execute_with_worker — preserves today's bootstrap order.
+            if let Err(err) = runtime::inject_lit_namespace(
+                &mut prepared.worker,
+                &auth_context,
+                &http_headers,
+            ) {
+                error!("pool worker failed to inject Lit namespace: {err:#}");
+                server::send_execution_result(&outbound_tx, Err(err)).await;
+                return;
+            }
+
+            let res = runtime::execute_with_worker(
+                prepared,
+                shared,
+                code,
+                js_params,
+                http_headers,
+                timeout_ms,
+                outbound_tx.clone(),
+                inbound_rx,
+                is_test_server,
+                action_code_cache,
+            )
+            .await;
+
+            server::send_execution_result(&outbound_tx, res).await;
+        }
+        .instrument(span),
+    );
+    // MainWorker dropped here; thread exits.
+}
+
+fn schedule_replacement(pool: &Arc<WorkerPool>) {
+    let failures = pool
+        .health
+        .consecutive_refill_failures
+        .load(Ordering::Relaxed)
+        .max(1);
+    // Exponential backoff, capped: 50ms, 100, 200, 400, 800, 1600, 3200, 5000ms.
+    // Shift bounded to 7 — shifting a u64 by >=64 bits is UB (panics in debug).
+    let backoff_ms =
+        (POOL_REFILL_BACKOFF_BASE_MS << failures.min(7)).min(POOL_REFILL_BACKOFF_MAX_MS);
+    let pool = pool.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(backoff_ms));
+        // Recheck breaker before issuing the replacement: if Open and not
+        // yet cooled down, skip — the breaker will issue a half-open trial
+        // when a request next arrives.
+        let allow = match pool.health.breaker.lock() {
+            Ok(g) => matches!(*g, BreakerState::Closed | BreakerState::HalfOpen),
+            Err(p) => matches!(
+                *p.into_inner(),
+                BreakerState::Closed | BreakerState::HalfOpen
+            ),
+        };
+        if !allow {
+            return;
+        }
+        pool.spawn_worker();
+    });
+}
+
+fn panic_message(panic: &Box<dyn Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+
+    use crate::cdn_module_loader::CdnModuleLoader;
+    use crate::runtime::DEFAULT_MEMORY_LIMIT_MB;
+
+    use super::*;
+
+    fn test_shared() -> Arc<PoolSharedState> {
+        Arc::new(PoolSharedState {
+            integrity_manifest: Arc::new(RwLock::new(HashMap::new())),
+            strict_imports: false,
+            module_cache: Arc::new(RwLock::new(HashMap::new())),
+            lockfile_path: None,
+            http_client: CdnModuleLoader::build_http_client(),
+            memory_limit_mb: DEFAULT_MEMORY_LIMIT_MB,
+        })
+    }
+
+    #[test]
+    fn try_acquire_returns_none_when_pool_disabled() {
+        let pool = WorkerPool::new(0, test_shared());
+        assert!(pool.try_acquire().is_none());
+        // Disabled pool short-circuits before counters: no hits, no misses.
+        assert_eq!(pool.health().hits(), 0);
+        assert_eq!(pool.health().misses(), 0);
+    }
+
+    #[test]
+    fn note_full_error_increments_full_counter() {
+        let pool = WorkerPool::new(0, test_shared());
+        pool.note_full_error();
+        pool.note_full_error();
+        assert_eq!(pool.health().full_errors(), 2);
+        assert_eq!(pool.health().disconnected_misses(), 0);
+    }
+
+    #[test]
+    fn note_disconnected_increments_disconnected_counter() {
+        let pool = WorkerPool::new(0, test_shared());
+        pool.note_disconnected();
+        assert_eq!(pool.health().disconnected_misses(), 1);
+        assert_eq!(pool.health().full_errors(), 0);
+    }
+
+    #[test]
+    fn breaker_opens_after_consecutive_failures() {
+        let pool = WorkerPool::new(1, test_shared());
+        for _ in 0..POOL_REFILL_FAILURE_LIMIT {
+            pool.record_refill_failure(&"synthetic bootstrap failure");
+        }
+        assert!(matches!(
+            *pool.health.breaker.lock().unwrap(),
+            BreakerState::Open { .. }
+        ));
+        assert_eq!(pool.health().refill_failed(), POOL_REFILL_FAILURE_LIMIT);
+        // Breaker open => try_acquire returns None and counts a miss.
+        assert!(pool.try_acquire().is_none());
+        assert_eq!(pool.health().misses(), 1);
+    }
+
+    #[test]
+    fn breaker_half_open_failure_reopens_with_fresh_cooldown() {
+        let pool = WorkerPool::new(1, test_shared());
+        // Manually park breaker in HalfOpen.
+        *pool.health.breaker.lock().unwrap() = BreakerState::HalfOpen;
+        // A single failure from HalfOpen MUST re-open even under the
+        // consecutive-failure threshold.
+        pool.record_refill_failure(&"trial bootstrap failure");
+        assert!(matches!(
+            *pool.health.breaker.lock().unwrap(),
+            BreakerState::Open { .. }
+        ));
+    }
+
+    #[test]
+    fn breaker_half_open_success_closes() {
+        let pool = WorkerPool::new(1, test_shared());
+        *pool.health.breaker.lock().unwrap() = BreakerState::HalfOpen;
+        pool.record_refill_success();
+        assert!(matches!(
+            *pool.health.breaker.lock().unwrap(),
+            BreakerState::Closed
+        ));
+    }
+
+    #[test]
+    fn record_refill_success_resets_failure_counter() {
+        let pool = WorkerPool::new(1, test_shared());
+        pool.record_refill_failure(&"first");
+        pool.record_refill_failure(&"second");
+        assert_eq!(
+            pool.health.consecutive_refill_failures.load(Ordering::Relaxed),
+            2
+        );
+        pool.record_refill_success();
+        assert_eq!(
+            pool.health.consecutive_refill_failures.load(Ordering::Relaxed),
+            0
+        );
+    }
+}

--- a/lit-actions/server/worker_pool.rs
+++ b/lit-actions/server/worker_pool.rs
@@ -411,9 +411,10 @@ fn schedule_replacement(pool: &Arc<WorkerPool>) {
         .load(Ordering::Relaxed)
         .max(1);
     // Exponential backoff, capped: 50ms, 100, 200, 400, 800, 1600, 3200, 5000ms.
+    // First failure (failures == 1) → BASE_MS << 0 = 50ms.
     // Shift bounded to 7 — shifting a u64 by >=64 bits is UB (panics in debug).
-    let backoff_ms =
-        (POOL_REFILL_BACKOFF_BASE_MS << failures.min(7)).min(POOL_REFILL_BACKOFF_MAX_MS);
+    let shift = (failures - 1).min(7);
+    let backoff_ms = (POOL_REFILL_BACKOFF_BASE_MS << shift).min(POOL_REFILL_BACKOFF_MAX_MS);
     let pool = pool.clone();
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_millis(backoff_ms));

--- a/lit-actions/server/worker_pool.rs
+++ b/lit-actions/server/worker_pool.rs
@@ -375,11 +375,9 @@ fn run_worker_thread(pool: Arc<WorkerPool>) {
             // Per-request JS injection: namespace globals first (so user
             // code sees Lit.*), PatchDeno + everything else is owned by
             // execute_with_worker — preserves today's bootstrap order.
-            if let Err(err) = runtime::inject_lit_namespace(
-                &mut prepared.worker,
-                &auth_context,
-                &http_headers,
-            ) {
+            if let Err(err) =
+                runtime::inject_lit_namespace(&mut prepared.worker, &auth_context, &http_headers)
+            {
                 error!("pool worker failed to inject Lit namespace: {err:#}");
                 server::send_execution_result(&outbound_tx, Err(err)).await;
                 return;
@@ -540,12 +538,16 @@ mod tests {
         pool.record_refill_failure(&"first");
         pool.record_refill_failure(&"second");
         assert_eq!(
-            pool.health.consecutive_refill_failures.load(Ordering::Relaxed),
+            pool.health
+                .consecutive_refill_failures
+                .load(Ordering::Relaxed),
             2
         );
         pool.record_refill_success();
         assert_eq!(
-            pool.health.consecutive_refill_failures.load(Ordering::Relaxed),
+            pool.health
+                .consecutive_refill_failures
+                .load(Ordering::Relaxed),
             0
         );
     }

--- a/lit-actions/tests/it.rs
+++ b/lit-actions/tests/it.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use anyhow::{Result, bail};
 use indoc::{formatdoc, indoc};
 use lit_actions_server::proto::execute_js_request::AesEncryptResponse;
+use lit_actions_server::worker_pool::PoolHealth;
 use lit_actions_server::{TestServer, init_v8, proto::*, unix};
 use pretty_assertions::assert_eq;
 use rstest::*;
@@ -832,3 +834,162 @@ async fn import_rewrite_no_imports(mut client: TestClient) {
     );
     assert!(client.received::<ExecutionResult>().success);
 }
+
+// =================================================================
+// Pre-warmed worker pool tests (CPL-265)
+// =================================================================
+
+/// Spin up a fresh server, hand back the pool counters, and a TestClient
+/// pointed at it. Server thread keeps running after the function returns;
+/// `pool_health` is a clone of the live counter `Arc`.
+fn pool_test_setup() -> (TestClient, Arc<PoolHealth>, usize) {
+    let server = TestServer::start();
+    let pool_health = server.pool_health.clone();
+    let pool_target = server.pool_target_size;
+    let client = TestClient::new(server.socket_file);
+    (client, pool_health, pool_target)
+}
+
+/// Coarse warmup wait. There's no "ready workers" counter today, so we
+/// just sleep long enough for snapshot-bootstrapped workers to land in
+/// the ready channel. With pool=10, 600ms is plenty under load.
+async fn wait_for_warmup(target: usize) {
+    if target == 0 {
+        return;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+}
+
+/// Pool hit on the warm path: after warmup, a request should be served by
+/// a pre-warmed worker (hits counter increments).
+#[tokio::test]
+async fn pool_warm_hit() {
+    let (mut client, pool_health, target) = pool_test_setup();
+    if target == 0 {
+        // Pool disabled (LIT_ACTIONS_POOL_SIZE=0) — nothing to assert.
+        return;
+    }
+
+    wait_for_warmup(target).await;
+
+    let hits_before = pool_health.hits();
+    client
+        .respond_with(PrintResponse {})
+        .execute_js(r#"async function main() { console.log("warm hit") }"#)
+        .await
+        .unwrap();
+
+    let _ = client.received::<PrintRequest>();
+    assert!(client.received::<ExecutionResult>().success);
+
+    let hits_after = pool_health.hits();
+    assert!(
+        hits_after > hits_before,
+        "expected pool hit (hits before={}, after={}, target={})",
+        hits_before,
+        hits_after,
+        target,
+    );
+}
+
+/// Custom `memory_limit` requests must bypass the pool (V8 heap limits are
+/// immutable post-bootstrap, so pre-warmed workers can't honour them).
+#[tokio::test]
+async fn pool_memory_limit_bypass() {
+    let (mut client, pool_health, target) = pool_test_setup();
+    if target == 0 {
+        return;
+    }
+
+    wait_for_warmup(target).await;
+
+    let hits_before = pool_health.hits();
+    let misses_before = pool_health.misses();
+    client
+        .respond_with(PrintResponse {})
+        .execute_js(ExecutionRequest {
+            code: r#"async function main() { console.log("custom limit") }"#.into(),
+            memory_limit: Some(64),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let _ = client.received::<PrintRequest>();
+    assert!(client.received::<ExecutionResult>().success);
+
+    let hits_after = pool_health.hits();
+    let misses_after = pool_health.misses();
+    assert_eq!(
+        hits_before, hits_after,
+        "custom memory_limit must not consume a pooled worker (hits should not increment)",
+    );
+    assert_eq!(
+        misses_before, misses_after,
+        "custom memory_limit must bypass the pool entirely (misses should not increment either)",
+    );
+}
+
+/// Concurrent execution: 20 in-flight requests against a pool of 10. Mix
+/// of pool hits and legacy fallbacks; all must succeed without deadlock.
+#[tokio::test]
+async fn pool_concurrent_exhaustion() {
+    use deno_runtime::deno_core::futures::future::join_all;
+
+    let server = TestServer::start();
+    let socket_path = server.socket_file.path().to_path_buf();
+    // Keep `server` alive until the end of the test so the socket file
+    // and runtime thread don't get torn down before requests complete.
+    let _server_keepalive = server;
+
+    let futures = (0..20).map(|i| {
+        let path = socket_path.clone();
+        async move { (i, raw_execute_no_op(&path).await) }
+    });
+
+    for (i, res) in join_all(futures).await {
+        res.unwrap_or_else(|e| panic!("request {i} failed: {e}"));
+    }
+}
+
+/// Minimal raw client helper for the concurrency test: dials the socket,
+/// runs an empty `nop` action, and returns. Used so concurrent tests
+/// don't share a single `TestClient` (which is sequential by design).
+async fn raw_execute_no_op(socket_path: &std::path::Path) -> Result<()> {
+    use lit_actions_server::proto::execute_js_response::Union as UnionResp;
+
+    let (outbound_tx, outbound_rx) = flume::bounded::<ExecuteJsRequest>(0);
+    let channel = unix::connect_to_socket(socket_path).await?;
+    let mut client = ActionClient::new(channel);
+
+    let req = ExecutionRequest {
+        code: "async function main() {}".into(),
+        ..Default::default()
+    };
+    let response = client
+        .execute_js(Request::new(outbound_rx.into_stream()))
+        .await?;
+    outbound_tx.send_async(req.into()).await?;
+
+    let mut stream = response.into_inner();
+    while let Some(resp) = stream.try_next().await? {
+        match resp.union {
+            Some(UnionResp::Result(res)) => {
+                if !res.success {
+                    bail!("execution failed: {}", res.error);
+                }
+                return Ok(());
+            }
+            Some(_) => bail!("unexpected op request from no-op action"),
+            None => {}
+        }
+    }
+    bail!("server closed connection without result")
+}
+
+/// Pool isolation: per-request `LoadedModules` must be a fresh `Arc` for
+/// each pooled worker. Tested at the unit level inside the runtime crate
+/// (see `runtime::tests::loaded_modules_arc_is_distinct_per_prepared_worker`)
+/// — kept here as a documentation marker so future readers find it.
+#[allow(dead_code)]
+fn pool_isolation_doc() {}


### PR DESCRIPTION
## Summary

- Adds a pool of pre-bootstrapped Deno `MainWorker` instances (default 10 via `LIT_ACTIONS_POOL_SIZE`, set to 0 to disable). Each pooled worker handles exactly one request and is then dropped; the pool refills asynchronously. Pattern: Cloudflare Workers / Deno Deploy — isolates are cheap to start from a snapshot, expensive to scrub for reuse.
- Bootstrap is split: warm-time builds the worker + module loader; request-time injects `LitNamespace.js`, then `PatchDeno.js`, wires op_state, runs the controller thread, executes user code, and clears the request context. `LoadedModules` is a single `Arc` shared between `CdnModuleLoader` and op_state per worker. Type-enforced one-shot lifecycle: `execute_with_worker(prepared: PreparedWorker, ...)` consumes by value.
- Bootstrap failures wrapped in `catch_unwind` with exponential backoff (50ms…5s, capped). After 5 consecutive failures a half-open circuit breaker opens for 60s; one trial refill on cooldown success closes it, failure re-opens with a fresh window. Custom-`memory_limit` requests bypass the pool (V8 `CreateParams::heap_limits` is immutable post-creation).

## Design notes

- Empty-code shortcut runs in `dispatch_execute_request` ahead of `try_acquire`, so an empty action never consumes a pre-warmed worker.
- `TrySendError::Full` (one-shot invariant violation) is counted separately from `TrySendError::Disconnected` (normal dead-handle event). Both fall back to the legacy cold path.
- `catch_unwind` cannot catch aborts / SIGTRAP / FFI UB through V8 — same exposure as today's legacy path. Documented in the module header.
- Tenant isolation is unit-tested via a `#[cfg(test)] PreparedWorker::loaded_modules_for_test` accessor that asserts two pre-warmed workers never share a `LoadedModules` `Arc`.

## Test plan

- [x] `LIT_ACTIONS_POOL_SIZE=10 cargo test -p lit-actions-server` — 74 passed
- [x] `LIT_ACTIONS_POOL_SIZE=10 cargo test -p lit-actions-tests --test integration` — 25 passed
- [x] `LIT_ACTIONS_POOL_SIZE=0 cargo test -p lit-actions-server` — 74 passed
- [x] `LIT_ACTIONS_POOL_SIZE=0 cargo test -p lit-actions-tests --test integration` — 25 passed
- [x] 7 new worker_pool unit tests (breaker open/half-open/close, full vs disconnected counters, disabled pool)
- [x] 3 new pool integration tests (`pool_warm_hit`, `pool_memory_limit_bypass`, `pool_concurrent_exhaustion`)
- [x] `LoadedModules` Arc-identity unit test in `runtime.rs`
- [x] Existing protections preserved: `lit_namespace_protection`, `oom`, `timeout` all green under both pool=10 and pool=0

## Rollback

Set `LIT_ACTIONS_POOL_SIZE=0` to disable the pool entirely (every request goes through the legacy cold path).

## Out of scope

- Reusing `MainWorker` across requests (rejected by ticket — one-shot is the safety property).
- Dynamic pool sizing.
- `ExecuteJsParams` struct refactor (deferred to follow-up; `execute_with_worker` keeps today's signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)