### PR TITLE
feat: add stripe_report CLI for per-client daily usage (CPL-269)

### DIFF
--- a/lit-api-server/src/bin/stripe_report.rs
+++ b/lit-api-server/src/bin/stripe_report.rs
@@ -117,9 +117,14 @@ async fn main() -> ExitCode {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
-    let since = now - (args.days as i64) * 86_400;
+    // Snap to UTC midnight so the Stripe query window, the rendered date
+    // columns, and the "last N days" label all refer to the same whole days.
+    // Without this the first bucket is partial (starts at `now`'s time-of-day)
+    // and we end up with N+1 date columns.
+    let today_start = now - now.rem_euclid(86_400);
+    let since = today_start - (args.days.saturating_sub(1) as i64) * 86_400;
     let since_date = stripe::unix_to_utc_date(since);
-    let until_date = stripe::unix_to_utc_date(now);
+    let until_date = stripe::unix_to_utc_date(today_start);
 
     eprintln!(
         "Fetching Stripe customers and balance transactions for {since_date} .. {until_date} ({} days) …",
@@ -227,7 +232,9 @@ fn csv_escape(s: &str) -> String {
     } else {
         s
     };
-    if s.contains(',') || s.contains('"') || s.contains('\n') {
+    // Quote on CR too, not just LF: a bare \r embedded in a field can otherwise
+    // confuse CSV consumers that treat it as a record separator.
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
         let escaped = s.replace('"', "\"\"");
         format!("\"{escaped}\"")
     } else {
@@ -482,7 +489,14 @@ fn parse_utc_date(s: &str) -> Option<i64> {
     let doy = (153 * mp + 2) / 5 + d as u64 - 1; // [0, 365]
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
     let days = era * 146_097 + doe as i64 - 719_468;
-    Some(days * 86_400)
+    let ts = days * 86_400;
+    // Reject impossible dates like 2026-02-31 by round-tripping: if the math
+    // silently normalized the components, the formatted timestamp won't match
+    // the input string.
+    if stripe::unix_to_utc_date(ts) != s {
+        return None;
+    }
+    Some(ts)
 }
 
 fn html_escape(s: &str) -> String {
@@ -600,6 +614,29 @@ mod tests {
         assert!(parse_utc_date("2026-13-01").is_none());
         assert!(parse_utc_date("2026-04-00").is_none());
         assert!(parse_utc_date("2026-04-21-01").is_none());
+    }
+
+    #[test]
+    fn parse_utc_date_rejects_impossible_calendar_days() {
+        // These would silently normalize without round-trip validation (e.g.
+        // Feb 31 → Mar 3), producing a wrong date range in the report.
+        assert!(parse_utc_date("2026-02-31").is_none());
+        assert!(parse_utc_date("2026-02-30").is_none());
+        assert!(parse_utc_date("2025-02-29").is_none()); // 2025 is not leap
+        assert!(parse_utc_date("2026-04-31").is_none()); // April has 30 days
+        // Actual leap day in a leap year must still parse.
+        assert!(parse_utc_date("2024-02-29").is_some());
+    }
+
+    #[test]
+    fn csv_escape_quotes_embedded_carriage_return() {
+        // Bare \r inside a field must be quoted so CSV consumers that treat
+        // \r as a record separator don't split the row.
+        let escaped = csv_escape("alice\rbob@example.com");
+        assert!(
+            escaped.starts_with('"') && escaped.ends_with('"'),
+            "expected quoted field, got {escaped:?}"
+        );
     }
 
     #[test]

--- a/lit-api-server/src/bin/stripe_report.rs
+++ b/lit-api-server/src/bin/stripe_report.rs
@@ -1,0 +1,659 @@
+//! `stripe_report` — download the last N days of Stripe billing data and
+//! emit a usage-per-day-per-client report.
+//!
+//! The binary reads `STRIPE_SECRET_KEY` and `STRIPE_PUBLISHABLE_KEY` from the
+//! environment (same as the running API server), lists every Stripe customer,
+//! fetches each customer's balance transactions in the window, buckets them by
+//! UTC date and client, and writes:
+//!
+//!   • `<out>.csv`  — one row per (date, customer) with charge count + totals
+//!   • `<out>.html` — a self-contained pivot table (rows = clients, cols = days)
+//!
+//! Intended to be run out-of-band from an operator's machine; we deliberately
+//! keep the Stripe secret key off the public HTTP surface.
+//!
+//! Usage:
+//!   stripe_report                             # last 30 days → ./stripe-report.{csv,html}
+//!   stripe_report --days 7                    # last 7 days
+//!   stripe_report --out /tmp/april            # writes /tmp/april.csv and /tmp/april.html
+//!   stripe_report --csv-only                  # skip the HTML file
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use lit_api_server::stripe::{
+    self, ReportBalanceTx, ReportCustomer, ReportRow, aggregate_report_rows, cents_to_display,
+};
+
+const DEFAULT_DAYS: u32 = 30;
+const DEFAULT_OUT: &str = "stripe-report";
+
+struct Args {
+    days: u32,
+    out: String,
+    csv_only: bool,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut days = DEFAULT_DAYS;
+    let mut out = DEFAULT_OUT.to_string();
+    let mut csv_only = false;
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--days" => {
+                let v = it
+                    .next()
+                    .ok_or_else(|| "--days requires a value".to_string())?;
+                days = v
+                    .parse::<u32>()
+                    .map_err(|_| format!("--days: not a positive integer: {v}"))?;
+                if days == 0 {
+                    return Err("--days must be >= 1".to_string());
+                }
+            }
+            "--out" => {
+                out = it
+                    .next()
+                    .ok_or_else(|| "--out requires a value".to_string())?;
+            }
+            "--csv-only" => csv_only = true,
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(Args {
+        days,
+        out,
+        csv_only,
+    })
+}
+
+fn print_help() {
+    println!(
+        "stripe_report — download recent Stripe usage as CSV + HTML.
+
+USAGE:
+    stripe_report [OPTIONS]
+
+OPTIONS:
+    --days <N>       Window size in days (default: {DEFAULT_DAYS}).
+    --out <PATH>     Output path prefix (default: {DEFAULT_OUT}).
+                     Writes <PATH>.csv and <PATH>.html.
+    --csv-only       Skip the HTML file.
+    -h, --help       Show this message.
+
+ENVIRONMENT:
+    STRIPE_SECRET_KEY       (required) Stripe secret key.
+    STRIPE_PUBLISHABLE_KEY  (required) Stripe publishable key.
+"
+    );
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            eprintln!("run with --help for usage");
+            return ExitCode::from(2);
+        }
+    };
+
+    let Some(stripe_state) = stripe::init() else {
+        eprintln!(
+            "error: STRIPE_SECRET_KEY and/or STRIPE_PUBLISHABLE_KEY are not set; nothing to report."
+        );
+        return ExitCode::from(1);
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let since = now - (args.days as i64) * 86_400;
+    let since_date = stripe::unix_to_utc_date(since);
+    let until_date = stripe::unix_to_utc_date(now);
+
+    eprintln!(
+        "Fetching Stripe customers and balance transactions for {since_date} .. {until_date} ({} days) …",
+        args.days
+    );
+
+    let customers = match stripe::list_all_customers(&stripe_state).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: list_all_customers failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    eprintln!("  {} customers", customers.len());
+
+    let mut transactions: Vec<ReportBalanceTx> = Vec::new();
+    for (i, c) in customers.iter().enumerate() {
+        match stripe::list_balance_transactions_since(&stripe_state, &c.id, since).await {
+            Ok(txs) => {
+                if !txs.is_empty() {
+                    eprintln!(
+                        "  [{}/{}] {} ({}): {} txs",
+                        i + 1,
+                        customers.len(),
+                        c.id,
+                        c.wallet_address.as_deref().unwrap_or("-"),
+                        txs.len()
+                    );
+                }
+                transactions.extend(txs);
+            }
+            Err(e) => {
+                eprintln!(
+                    "  [{}/{}] {}: list_balance_transactions failed: {e}",
+                    i + 1,
+                    customers.len(),
+                    c.id
+                );
+            }
+        }
+    }
+    eprintln!("  {} transactions total", transactions.len());
+
+    let rows = aggregate_report_rows(&customers, &transactions);
+
+    let csv_path = format!("{}.csv", args.out);
+    if let Err(e) = std::fs::write(&csv_path, render_csv(&rows)) {
+        eprintln!("error: writing {csv_path}: {e}");
+        return ExitCode::from(1);
+    }
+    eprintln!("Wrote {csv_path} ({} rows)", rows.len());
+
+    if !args.csv_only {
+        let html = render_html(&rows, &customers, &since_date, &until_date, args.days);
+        let html_path = format!("{}.html", args.out);
+        if let Err(e) = std::fs::write(&html_path, html) {
+            eprintln!("error: writing {html_path}: {e}");
+            return ExitCode::from(1);
+        }
+        eprintln!("Wrote {html_path}");
+    }
+
+    print_stdout_summary(&rows);
+
+    ExitCode::SUCCESS
+}
+
+// ─── CSV ─────────────────────────────────────────────────────────────────────
+
+fn render_csv(rows: &[ReportRow]) -> String {
+    let mut out = String::from(
+        "date,customer_id,wallet_address,email,charges_count,charges_cents,credits_cents\n",
+    );
+    for r in rows {
+        writeln!(
+            &mut out,
+            "{},{},{},{},{},{},{}",
+            csv_escape(&r.date),
+            csv_escape(&r.customer_id),
+            csv_escape(r.wallet_address.as_deref().unwrap_or("")),
+            csv_escape(r.email.as_deref().unwrap_or("")),
+            r.charges_count,
+            r.charges_cents,
+            r.credits_cents,
+        )
+        .expect("writeln! to String cannot fail");
+    }
+    out
+}
+
+fn csv_escape(s: &str) -> String {
+    // Guard against CSV formula injection: a cell starting with =, +, -, @,
+    // tab, or CR is executed as a formula by Excel / Sheets / LibreOffice.
+    // A malicious customer-controlled field (e.g. email) could otherwise run
+    // code or exfiltrate data when the report is opened. Prefix with a
+    // single quote to force text interpretation.
+    let needs_prefix = matches!(
+        s.chars().next(),
+        Some('=') | Some('+') | Some('-') | Some('@') | Some('\t') | Some('\r')
+    );
+    let prefixed;
+    let s: &str = if needs_prefix {
+        prefixed = format!("'{s}");
+        &prefixed
+    } else {
+        s
+    };
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        let escaped = s.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    } else {
+        s.to_string()
+    }
+}
+
+// ─── Summary to stdout ───────────────────────────────────────────────────────
+
+fn print_stdout_summary(rows: &[ReportRow]) {
+    let mut total_cents: i64 = 0;
+    let mut total_charges: u64 = 0;
+    let mut per_customer: BTreeMap<String, (i64, u64)> = BTreeMap::new();
+    for r in rows {
+        total_cents += r.charges_cents;
+        total_charges += r.charges_count;
+        let e = per_customer.entry(r.customer_id.clone()).or_insert((0, 0));
+        e.0 += r.charges_cents;
+        e.1 += r.charges_count;
+    }
+    println!();
+    println!(
+        "Total usage: {} across {} charge(s), {} client(s)",
+        cents_to_display(total_cents),
+        total_charges,
+        per_customer.len()
+    );
+}
+
+// ─── HTML ────────────────────────────────────────────────────────────────────
+
+/// Render a self-contained HTML file with a pivot table
+/// (rows = clients, columns = days in the window).
+fn render_html(
+    rows: &[ReportRow],
+    customers: &[ReportCustomer],
+    since_date: &str,
+    until_date: &str,
+    days: u32,
+) -> String {
+    // Columns: every date in the window [since, until] inclusive.
+    let all_dates: Vec<String> = enumerate_dates(since_date, until_date);
+    // Also include any extra dates that appear in rows (defensive, in case of
+    // clock skew between Stripe and the local machine).
+    let mut date_set: BTreeSet<String> = all_dates.iter().cloned().collect();
+    for r in rows {
+        date_set.insert(r.date.clone());
+    }
+    let dates: Vec<String> = date_set.into_iter().collect();
+
+    // Rows: one per (customer_id).
+    #[derive(Default)]
+    struct ClientAgg {
+        wallet: Option<String>,
+        email: Option<String>,
+        per_day_cents: BTreeMap<String, i64>,
+        per_day_count: BTreeMap<String, u64>,
+        total_cents: i64,
+        total_charges: u64,
+    }
+    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> = customers
+        .iter()
+        .map(|c| (c.id.as_str(), c))
+        .collect();
+    let mut clients: BTreeMap<String, ClientAgg> = BTreeMap::new();
+    for r in rows {
+        let agg = clients.entry(r.customer_id.clone()).or_default();
+        if agg.wallet.is_none() {
+            agg.wallet = r
+                .wallet_address
+                .clone()
+                .or_else(|| customer_by_id.get(r.customer_id.as_str()).and_then(|c| c.wallet_address.clone()));
+        }
+        if agg.email.is_none() {
+            agg.email = r
+                .email
+                .clone()
+                .or_else(|| customer_by_id.get(r.customer_id.as_str()).and_then(|c| c.email.clone()));
+        }
+        agg.per_day_cents
+            .entry(r.date.clone())
+            .and_modify(|v| *v += r.charges_cents)
+            .or_insert(r.charges_cents);
+        agg.per_day_count
+            .entry(r.date.clone())
+            .and_modify(|v| *v += r.charges_count)
+            .or_insert(r.charges_count);
+        agg.total_cents += r.charges_cents;
+        agg.total_charges += r.charges_count;
+    }
+
+    let mut column_totals_cents: BTreeMap<String, i64> = BTreeMap::new();
+    let mut column_totals_count: BTreeMap<String, u64> = BTreeMap::new();
+    for agg in clients.values() {
+        for (d, v) in &agg.per_day_cents {
+            *column_totals_cents.entry(d.clone()).or_insert(0) += v;
+        }
+        for (d, v) in &agg.per_day_count {
+            *column_totals_count.entry(d.clone()).or_insert(0) += v;
+        }
+    }
+    let grand_total_cents: i64 = column_totals_cents.values().sum();
+    let grand_total_count: u64 = column_totals_count.values().sum();
+
+    // Sort clients by total_cents descending so the top spenders are at the top.
+    let mut client_list: Vec<(&String, &ClientAgg)> = clients.iter().collect();
+    client_list.sort_by(|a, b| b.1.total_cents.cmp(&a.1.total_cents).then(a.0.cmp(b.0)));
+
+    let mut html = String::new();
+    writeln!(&mut html, "<!DOCTYPE html>").unwrap();
+    writeln!(&mut html, "<html lang=\"en\"><head><meta charset=\"utf-8\">").unwrap();
+    writeln!(
+        &mut html,
+        "<title>Stripe Usage Report — {} to {}</title>",
+        html_escape(since_date),
+        html_escape(until_date)
+    )
+    .unwrap();
+    writeln!(&mut html, "<style>{STYLES}</style></head><body>").unwrap();
+    writeln!(&mut html, "<h1>Stripe Usage Report</h1>").unwrap();
+    writeln!(
+        &mut html,
+        "<p class=\"subtitle\">Last {days} days · {} → {} UTC · {} client(s) · {} across {} charge(s)</p>",
+        html_escape(since_date),
+        html_escape(until_date),
+        client_list.len(),
+        html_escape(&cents_to_display(grand_total_cents)),
+        grand_total_count,
+    )
+    .unwrap();
+
+    if client_list.is_empty() {
+        writeln!(
+            &mut html,
+            "<p class=\"empty\">No charges recorded in this window.</p></body></html>"
+        )
+        .unwrap();
+        return html;
+    }
+
+    writeln!(&mut html, "<div class=\"scroll\"><table>").unwrap();
+    // Header: client | each day | total
+    write!(&mut html, "<thead><tr><th class=\"sticky\">Client</th>").unwrap();
+    for d in &dates {
+        write!(&mut html, "<th>{}</th>", html_escape(d)).unwrap();
+    }
+    writeln!(&mut html, "<th class=\"total\">Total</th></tr></thead>").unwrap();
+    writeln!(&mut html, "<tbody>").unwrap();
+    for (cid, agg) in &client_list {
+        write!(&mut html, "<tr><td class=\"sticky client\">").unwrap();
+        if let Some(w) = &agg.wallet {
+            write!(&mut html, "<code>{}</code>", html_escape(w)).unwrap();
+        } else {
+            write!(&mut html, "<code>{}</code>", html_escape(cid)).unwrap();
+        }
+        if let Some(e) = &agg.email {
+            write!(&mut html, "<br><span class=\"muted\">{}</span>", html_escape(e)).unwrap();
+        }
+        write!(&mut html, "</td>").unwrap();
+        for d in &dates {
+            let cents = agg.per_day_cents.get(d).copied().unwrap_or(0);
+            let count = agg.per_day_count.get(d).copied().unwrap_or(0);
+            write_cell(&mut html, cents, count, false);
+        }
+        write_cell(&mut html, agg.total_cents, agg.total_charges, true);
+        writeln!(&mut html, "</tr>").unwrap();
+    }
+    // Totals row
+    write!(
+        &mut html,
+        "<tr class=\"totals-row\"><td class=\"sticky\">Total</td>"
+    )
+    .unwrap();
+    for d in &dates {
+        let cents = column_totals_cents.get(d).copied().unwrap_or(0);
+        let count = column_totals_count.get(d).copied().unwrap_or(0);
+        write_cell(&mut html, cents, count, false);
+    }
+    write_cell(&mut html, grand_total_cents, grand_total_count, true);
+    writeln!(&mut html, "</tr>").unwrap();
+    writeln!(&mut html, "</tbody></table></div></body></html>").unwrap();
+
+    html
+}
+
+/// Render one pivot cell showing the dollar amount and the charge count.
+/// `total` flips on the bold/highlighted styling used for the totals row/column.
+fn write_cell(html: &mut String, cents: i64, count: u64, total: bool) {
+    let class = if total { "total" } else { "" };
+    if cents == 0 && count == 0 {
+        // Keep the zero placeholder visually quiet.
+        let z_class = if total { "total zero" } else { "zero" };
+        write!(html, "<td class=\"{z_class}\">·</td>").expect("write to String cannot fail");
+        return;
+    }
+    write!(
+        html,
+        "<td class=\"{class}\">{}<br><span class=\"count\">{}\u{00a0}call{}</span></td>",
+        html_escape(&cents_to_display(cents)),
+        count,
+        if count == 1 { "" } else { "s" },
+    )
+    .expect("write to String cannot fail");
+}
+
+/// Build the inclusive list of `YYYY-MM-DD` dates from `from` to `to`.
+/// Falls back to just `[from, to]` if either string is malformed.
+fn enumerate_dates(from: &str, to: &str) -> Vec<String> {
+    let Some(from_ts) = parse_utc_date(from) else {
+        return vec![from.to_string(), to.to_string()];
+    };
+    let Some(to_ts) = parse_utc_date(to) else {
+        return vec![from.to_string(), to.to_string()];
+    };
+    let mut out = Vec::new();
+    let mut ts = from_ts;
+    while ts <= to_ts {
+        out.push(stripe::unix_to_utc_date(ts));
+        ts += 86_400;
+    }
+    out
+}
+
+/// Parse `YYYY-MM-DD` (UTC midnight) → Unix seconds.  `None` on malformed input.
+///
+/// Inverse of `stripe::unix_to_utc_date` for dates in [1970-01-01, 9999-12-31].
+fn parse_utc_date(s: &str) -> Option<i64> {
+    let mut parts = s.split('-');
+    let y: i64 = parts.next()?.parse().ok()?;
+    let m: u32 = parts.next()?.parse().ok()?;
+    let d: u32 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    // Inverse of civil_from_days: days_from_civil.
+    let y_adj = if m <= 2 { y - 1 } else { y };
+    let era = if y_adj >= 0 { y_adj } else { y_adj - 399 } / 400;
+    let yoe = (y_adj - era * 400) as u64; // [0, 399]
+    let mp = if m > 2 { m - 3 } else { m + 9 } as u64; // [0, 11]
+    let doy = (153 * mp + 2) / 5 + d as u64 - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    let days = era * 146_097 + doe as i64 - 719_468;
+    Some(days * 86_400)
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+const STYLES: &str = r#"
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 2rem; color: #1a1a1a; }
+h1 { margin-bottom: 0.25rem; }
+.subtitle { color: #555; margin-top: 0; margin-bottom: 1.5rem; }
+.scroll { overflow-x: auto; border: 1px solid #e5e5e5; border-radius: 8px; }
+table { border-collapse: collapse; font-size: 0.85rem; width: 100%; }
+th, td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #eee; text-align: right; white-space: nowrap; }
+th { background: #fafafa; font-weight: 600; position: sticky; top: 0; z-index: 1; }
+th:first-child, td.sticky { text-align: left; position: sticky; left: 0; background: #fff; z-index: 2; }
+thead th:first-child { z-index: 3; background: #fafafa; }
+td.client code { font-size: 0.75rem; background: #f3f3f3; padding: 1px 4px; border-radius: 3px; }
+td.zero { color: #ccc; text-align: center; }
+.count { display: block; color: #888; font-size: 0.7rem; font-variant-numeric: tabular-nums; }
+.totals-row .count, td.total .count { color: #555; }
+td.total, th.total { font-weight: 600; background: #fafafa; }
+.muted { color: #777; font-size: 0.75rem; }
+.totals-row { font-weight: 600; background: #fafafa; }
+.empty { color: #777; }
+"#;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mkrow(date: &str, customer_id: &str, charges_cents: i64) -> ReportRow {
+        ReportRow {
+            date: date.to_string(),
+            customer_id: customer_id.to_string(),
+            wallet_address: None,
+            email: None,
+            charges_count: if charges_cents == 0 { 0 } else { 1 },
+            charges_cents,
+            credits_cents: 0,
+        }
+    }
+
+    #[test]
+    fn csv_has_header_and_rows() {
+        let rows = vec![mkrow("2026-04-21", "cus_a", 5)];
+        let csv = render_csv(&rows);
+        assert!(csv.starts_with("date,customer_id,wallet_address,email,"));
+        assert!(csv.contains("2026-04-21,cus_a,,,1,5,0"));
+    }
+
+    #[test]
+    fn csv_escapes_commas_and_quotes() {
+        let mut row = mkrow("2026-04-21", "cus_a", 5);
+        row.email = Some(r#"a,"b"@example.com"#.to_string());
+        let csv = render_csv(&[row]);
+        assert!(csv.contains(r#""a,""b""@example.com""#));
+    }
+
+    #[test]
+    fn csv_escape_neutralizes_formula_injection() {
+        // A malicious customer sets their email to a formula. The field must
+        // not be executed as a formula when the CSV is opened in Excel.
+        for payload in [
+            "=cmd|'/C calc'!A0",
+            "+1+1",
+            "-2+3",
+            "@SUM(A1:A9)",
+            "\tTAB_PREFIX",
+            "\rCR_PREFIX",
+        ] {
+            let escaped = csv_escape(payload);
+            // Result must either start with a single quote (inside a quoted
+            // cell or bare) or with `"'` for wrapped cells. Either way, the
+            // leading formula-trigger character is defused.
+            let stripped = escaped.trim_start_matches('"');
+            assert!(
+                stripped.starts_with('\''),
+                "payload {payload:?} not defused: got {escaped:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn csv_escape_leaves_benign_fields_alone() {
+        assert_eq!(csv_escape("cus_abc123"), "cus_abc123");
+        assert_eq!(csv_escape("0x1234"), "0x1234");
+        assert_eq!(csv_escape("alice@example.com"), "alice@example.com");
+    }
+
+    #[test]
+    fn parse_utc_date_roundtrip() {
+        for ts in [0_i64, 1_776_470_400, 1_709_164_800, 946_684_800] {
+            let s = stripe::unix_to_utc_date(ts);
+            let back = parse_utc_date(&s).unwrap();
+            assert_eq!(back, ts, "roundtrip failed for ts={ts} ({s})");
+        }
+    }
+
+    #[test]
+    fn parse_utc_date_bad_input() {
+        assert!(parse_utc_date("not-a-date").is_none());
+        assert!(parse_utc_date("2026-13-01").is_none());
+        assert!(parse_utc_date("2026-04-00").is_none());
+        assert!(parse_utc_date("2026-04-21-01").is_none());
+    }
+
+    #[test]
+    fn enumerate_dates_inclusive() {
+        let dates = enumerate_dates("2026-04-20", "2026-04-22");
+        assert_eq!(dates, vec!["2026-04-20", "2026-04-21", "2026-04-22"]);
+    }
+
+    #[test]
+    fn enumerate_dates_single_day() {
+        let dates = enumerate_dates("2026-04-20", "2026-04-20");
+        assert_eq!(dates, vec!["2026-04-20"]);
+    }
+
+    #[test]
+    fn html_empty_rows_still_renders() {
+        let html = render_html(&[], &[], "2026-04-01", "2026-04-02", 2);
+        assert!(html.contains("No charges recorded"));
+        assert!(html.contains("<html"));
+        assert!(html.contains("</html>"));
+    }
+
+    #[test]
+    fn html_contains_pivot_table() {
+        let rows = vec![
+            mkrow("2026-04-21", "cus_a", 500),
+            mkrow("2026-04-22", "cus_a", 300),
+            mkrow("2026-04-22", "cus_b", 100),
+        ];
+        let html = render_html(&rows, &[], "2026-04-21", "2026-04-22", 2);
+        assert!(html.contains("cus_a"));
+        assert!(html.contains("cus_b"));
+        // Per-day amounts.
+        assert!(html.contains("$5.00"));
+        assert!(html.contains("$3.00"));
+        assert!(html.contains("$1.00"));
+        // Per-day counts (1 call each in the test data).
+        assert!(html.contains("1\u{00a0}call</span>"));
+        // Per-client totals: cus_a = $8.00 / 2 calls; cus_b = $1.00 / 1 call.
+        assert!(html.contains("$8.00"));
+        // Column total for 2026-04-22: $4.00 across 2 calls.
+        assert!(html.contains("$4.00"));
+        assert!(html.contains("2\u{00a0}calls</span>"));
+        // Subtitle reports the grand-total count.
+        assert!(html.contains("across 3 charge(s)"));
+    }
+
+    #[test]
+    fn html_zero_cells_render_placeholder() {
+        // cus_a has activity only on 2026-04-21; the 2026-04-22 cell must be the
+        // muted placeholder (no "0 calls" line).
+        let rows = vec![mkrow("2026-04-21", "cus_a", 100)];
+        let html = render_html(&rows, &[], "2026-04-21", "2026-04-22", 2);
+        assert!(html.contains("class=\"zero\">·</td>"));
+        assert!(!html.contains("0\u{00a0}call"));
+    }
+
+    #[test]
+    fn html_escapes_injected_content() {
+        let mut row = mkrow("2026-04-21", "cus_a", 5);
+        row.wallet_address = Some("<script>alert(1)</script>".to_string());
+        let html = render_html(&[row], &[], "2026-04-21", "2026-04-21", 1);
+        assert!(!html.contains("<script>alert(1)</script>"));
+        assert!(html.contains("&lt;script&gt;"));
+    }
+}

--- a/lit-api-server/src/bin/stripe_report.rs
+++ b/lit-api-server/src/bin/stripe_report.rs
@@ -288,24 +288,24 @@ fn render_html(
         total_cents: i64,
         total_charges: u64,
     }
-    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> = customers
-        .iter()
-        .map(|c| (c.id.as_str(), c))
-        .collect();
+    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> =
+        customers.iter().map(|c| (c.id.as_str(), c)).collect();
     let mut clients: BTreeMap<String, ClientAgg> = BTreeMap::new();
     for r in rows {
         let agg = clients.entry(r.customer_id.clone()).or_default();
         if agg.wallet.is_none() {
-            agg.wallet = r
-                .wallet_address
-                .clone()
-                .or_else(|| customer_by_id.get(r.customer_id.as_str()).and_then(|c| c.wallet_address.clone()));
+            agg.wallet = r.wallet_address.clone().or_else(|| {
+                customer_by_id
+                    .get(r.customer_id.as_str())
+                    .and_then(|c| c.wallet_address.clone())
+            });
         }
         if agg.email.is_none() {
-            agg.email = r
-                .email
-                .clone()
-                .or_else(|| customer_by_id.get(r.customer_id.as_str()).and_then(|c| c.email.clone()));
+            agg.email = r.email.clone().or_else(|| {
+                customer_by_id
+                    .get(r.customer_id.as_str())
+                    .and_then(|c| c.email.clone())
+            });
         }
         agg.per_day_cents
             .entry(r.date.clone())
@@ -338,7 +338,11 @@ fn render_html(
 
     let mut html = String::new();
     writeln!(&mut html, "<!DOCTYPE html>").unwrap();
-    writeln!(&mut html, "<html lang=\"en\"><head><meta charset=\"utf-8\">").unwrap();
+    writeln!(
+        &mut html,
+        "<html lang=\"en\"><head><meta charset=\"utf-8\">"
+    )
+    .unwrap();
     writeln!(
         &mut html,
         "<title>Stripe Usage Report — {} to {}</title>",
@@ -384,7 +388,12 @@ fn render_html(
             write!(&mut html, "<code>{}</code>", html_escape(cid)).unwrap();
         }
         if let Some(e) = &agg.email {
-            write!(&mut html, "<br><span class=\"muted\">{}</span>", html_escape(e)).unwrap();
+            write!(
+                &mut html,
+                "<br><span class=\"muted\">{}</span>",
+                html_escape(e)
+            )
+            .unwrap();
         }
         write!(&mut html, "</td>").unwrap();
         for d in &dates {

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -867,10 +867,8 @@ pub fn aggregate_report_rows(
     transactions: &[ReportBalanceTx],
 ) -> Vec<ReportRow> {
     use std::collections::BTreeMap;
-    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> = customers
-        .iter()
-        .map(|c| (c.id.as_str(), c))
-        .collect();
+    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> =
+        customers.iter().map(|c| (c.id.as_str(), c)).collect();
     // BTreeMap so output is sorted by (date, customer_id) deterministically.
     let mut buckets: BTreeMap<(String, String), ReportRow> = BTreeMap::new();
     for tx in transactions {

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -715,6 +715,7 @@ pub async fn list_all_customers(state: &StripeState) -> Result<Vec<ReportCustome
                 .get("metadata")
                 .and_then(|m| m.get("wallet_address"))
                 .and_then(|v| v.as_str())
+                .filter(|s| !s.trim().is_empty())
                 .map(|s| s.to_string());
             let email = c
                 .get("email")
@@ -782,8 +783,21 @@ pub async fn list_balance_transactions_since(
             let Some(id) = tx.get("id").and_then(|v| v.as_str()) else {
                 continue;
             };
-            let amount = tx.get("amount").and_then(|v| v.as_i64()).unwrap_or(0);
-            let created = tx.get("created").and_then(|v| v.as_i64()).unwrap_or(0);
+            // Don't silently default missing amount/created to 0 — that would
+            // bucket malformed transactions into 1970-01-01 with $0 and skew
+            // the report. Skip with a warning instead.
+            let Some(amount) = tx.get("amount").and_then(|v| v.as_i64()) else {
+                tracing::warn!(
+                    "stripe_report: skipping tx {id} for customer {customer_id}: missing/invalid 'amount' field"
+                );
+                continue;
+            };
+            let Some(created) = tx.get("created").and_then(|v| v.as_i64()) else {
+                tracing::warn!(
+                    "stripe_report: skipping tx {id} for customer {customer_id}: missing/invalid 'created' field"
+                );
+                continue;
+            };
             let description = tx
                 .get("description")
                 .and_then(|v| v.as_str())

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -659,6 +659,245 @@ pub fn cents_to_display(cents: i64) -> String {
     format!("${}.{:02}", cents / 100, cents.abs() % 100)
 }
 
+// ─── Reporting helpers ────────────────────────────────────────────────────────
+//
+// These helpers power the `stripe_report` binary.  They are not used by the
+// running API server — they are pub so that other crates in the workspace
+// (and the binary) can reuse the authenticated HTTP client and the same
+// customer-to-wallet mapping convention.
+
+/// One Stripe customer as returned by `list_customers`.
+#[derive(Debug, Clone)]
+pub struct ReportCustomer {
+    pub id: String,
+    pub wallet_address: Option<String>,
+    pub email: Option<String>,
+}
+
+/// One customer balance transaction as returned by `list_balance_transactions_since`.
+///
+/// `created` is a Unix timestamp in seconds.  `amount` is in the currency's minor unit
+/// (cents for USD): positive = charge (debit to the customer's credit balance),
+/// negative = credit (top-up).
+#[derive(Debug, Clone)]
+pub struct ReportBalanceTx {
+    pub id: String,
+    pub customer_id: String,
+    pub amount: i64,
+    pub created: i64,
+    pub description: String,
+}
+
+/// Page over `GET /v1/customers` and return every customer, 100 at a time.
+pub async fn list_all_customers(state: &StripeState) -> Result<Vec<ReportCustomer>> {
+    let mut out = Vec::new();
+    let mut starting_after: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("limit", "100")];
+        if let Some(cursor) = starting_after.as_deref() {
+            query.push(("starting_after", cursor));
+        }
+        let resp = stripe_get(state, "customers", &query).await?;
+        let data = resp
+            .body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if data.is_empty() {
+            break;
+        }
+        for c in &data {
+            let Some(id) = c.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let wallet = c
+                .get("metadata")
+                .and_then(|m| m.get("wallet_address"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let email = c
+                .get("email")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            out.push(ReportCustomer {
+                id: id.to_string(),
+                wallet_address: wallet,
+                email,
+            });
+        }
+        let has_more = resp
+            .body
+            .get("has_more")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !has_more {
+            break;
+        }
+        // Cursor must come from the raw response's last item, not from `out`.
+        // If every item in a page failed the id guard above, `out.last()` would
+        // not advance and we would re-request the same page forever.
+        let next_cursor = data
+            .last()
+            .and_then(|c| c.get("id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        match next_cursor {
+            Some(c) => starting_after = Some(c),
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch all customer balance transactions created at or after `since_unix`
+/// (seconds since epoch), paginating 100 at a time.
+pub async fn list_balance_transactions_since(
+    state: &StripeState,
+    customer_id: &str,
+    since_unix: i64,
+) -> Result<Vec<ReportBalanceTx>> {
+    let path = format!("customers/{customer_id}/balance_transactions");
+    let since_str = since_unix.to_string();
+    let mut out = Vec::new();
+    let mut starting_after: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> =
+            vec![("limit", "100"), ("created[gte]", since_str.as_str())];
+        if let Some(cursor) = starting_after.as_deref() {
+            query.push(("starting_after", cursor));
+        }
+        let resp = stripe_get(state, &path, &query).await?;
+        let data = resp
+            .body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if data.is_empty() {
+            break;
+        }
+        for tx in &data {
+            let Some(id) = tx.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let amount = tx.get("amount").and_then(|v| v.as_i64()).unwrap_or(0);
+            let created = tx.get("created").and_then(|v| v.as_i64()).unwrap_or(0);
+            let description = tx
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            out.push(ReportBalanceTx {
+                id: id.to_string(),
+                customer_id: customer_id.to_string(),
+                amount,
+                created,
+                description,
+            });
+        }
+        let has_more = resp
+            .body
+            .get("has_more")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !has_more {
+            break;
+        }
+        // See note in list_all_customers: derive the cursor from the raw response,
+        // not from `out`, so a fully-filtered page can't stall the loop.
+        let next_cursor = data
+            .last()
+            .and_then(|c| c.get("id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        match next_cursor {
+            Some(c) => starting_after = Some(c),
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+/// Convert a Unix timestamp (seconds, UTC) to a `YYYY-MM-DD` date string.
+///
+/// Pure function — no external deps (avoids pulling `chrono` into the server crate).
+pub fn unix_to_utc_date(ts: i64) -> String {
+    // Days since 1970-01-01 (Thursday), floor.
+    let days = ts.div_euclid(86_400);
+    // Convert to (year, month, day) using Howard Hinnant's civil_from_days algorithm.
+    // https://howardhinnant.github.io/date_algorithms.html#civil_from_days
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let year = if m <= 2 { y + 1 } else { y };
+    format!("{year:04}-{m:02}-{d:02}")
+}
+
+/// One row of the per-day-per-client usage report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportRow {
+    pub date: String,
+    pub customer_id: String,
+    pub wallet_address: Option<String>,
+    pub email: Option<String>,
+    /// Number of positive-amount balance transactions (charges) on this day.
+    pub charges_count: u64,
+    /// Sum of positive amounts in cents (debits to the customer's credit balance).
+    pub charges_cents: i64,
+    /// Sum of absolute value of negative amounts in cents (credits / top-ups).
+    pub credits_cents: i64,
+}
+
+/// Aggregate a flat list of balance transactions into one row per
+/// (date, customer_id) pair.
+///
+/// `customers` provides wallet/email lookup by customer id.  Transactions whose
+/// `customer_id` is not present in `customers` are still bucketed but have
+/// `wallet_address` and `email` set to `None`.
+pub fn aggregate_report_rows(
+    customers: &[ReportCustomer],
+    transactions: &[ReportBalanceTx],
+) -> Vec<ReportRow> {
+    use std::collections::BTreeMap;
+    let customer_by_id: std::collections::HashMap<&str, &ReportCustomer> = customers
+        .iter()
+        .map(|c| (c.id.as_str(), c))
+        .collect();
+    // BTreeMap so output is sorted by (date, customer_id) deterministically.
+    let mut buckets: BTreeMap<(String, String), ReportRow> = BTreeMap::new();
+    for tx in transactions {
+        let date = unix_to_utc_date(tx.created);
+        let key = (date.clone(), tx.customer_id.clone());
+        let row = buckets.entry(key).or_insert_with(|| {
+            let cust = customer_by_id.get(tx.customer_id.as_str()).copied();
+            ReportRow {
+                date: date.clone(),
+                customer_id: tx.customer_id.clone(),
+                wallet_address: cust.and_then(|c| c.wallet_address.clone()),
+                email: cust.and_then(|c| c.email.clone()),
+                charges_count: 0,
+                charges_cents: 0,
+                credits_cents: 0,
+            }
+        });
+        if tx.amount > 0 {
+            row.charges_count += 1;
+            row.charges_cents += tx.amount;
+        } else if tx.amount < 0 {
+            row.credits_cents += -tx.amount;
+        }
+    }
+    buckets.into_values().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -789,5 +1028,100 @@ mod tests {
     fn balance_refresh_preserves_multiple_decrements() {
         // Multiple charges: cache decremented to -950, Stripe still at -1000.
         assert!(!should_update_balance_cache(Some(-950), -1000));
+    }
+
+    // ── Reporting helpers ────────────────────────────────────────────────────
+
+    #[test]
+    fn unix_to_utc_date_epoch() {
+        assert_eq!(unix_to_utc_date(0), "1970-01-01");
+    }
+
+    #[test]
+    fn unix_to_utc_date_known_values() {
+        // 2026-04-21 00:00:00 UTC = 1_776_729_600
+        assert_eq!(unix_to_utc_date(1_776_729_600), "2026-04-21");
+        // 2026-04-21 23:59:59 UTC
+        assert_eq!(unix_to_utc_date(1_776_729_600 + 86_399), "2026-04-21");
+        // 2026-04-22 00:00:00 UTC
+        assert_eq!(unix_to_utc_date(1_776_729_600 + 86_400), "2026-04-22");
+    }
+
+    #[test]
+    fn unix_to_utc_date_leap_year() {
+        // 2024-02-29 is a leap day.  1709164800 = 2024-02-29 00:00:00 UTC
+        assert_eq!(unix_to_utc_date(1_709_164_800), "2024-02-29");
+        assert_eq!(unix_to_utc_date(1_709_251_199), "2024-02-29");
+        assert_eq!(unix_to_utc_date(1_709_251_200), "2024-03-01");
+    }
+
+    fn tx(customer_id: &str, amount: i64, created: i64) -> ReportBalanceTx {
+        ReportBalanceTx {
+            id: format!("tx_{customer_id}_{created}_{amount}"),
+            customer_id: customer_id.to_string(),
+            amount,
+            created,
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn aggregate_report_rows_empty() {
+        assert!(aggregate_report_rows(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn aggregate_report_rows_buckets_by_day_and_customer() {
+        let customers = vec![
+            ReportCustomer {
+                id: "cus_a".to_string(),
+                wallet_address: Some("0xA".to_string()),
+                email: None,
+            },
+            ReportCustomer {
+                id: "cus_b".to_string(),
+                wallet_address: Some("0xB".to_string()),
+                email: Some("b@example.com".to_string()),
+            },
+        ];
+        let day1 = 1_776_729_600; // 2026-04-21 00:00:00 UTC
+        let day2 = day1 + 86_400; // 2026-04-22 00:00:00 UTC
+        let txs = vec![
+            tx("cus_a", 1, day1 + 10),
+            tx("cus_a", 1, day1 + 20),
+            tx("cus_a", 1, day2 + 5),
+            tx("cus_b", 5, day1 + 1),
+            tx("cus_b", -500, day1 + 2), // top-up credit
+        ];
+        let rows = aggregate_report_rows(&customers, &txs);
+        assert_eq!(rows.len(), 3);
+        // Sorted by (date, customer_id) ascending.
+        assert_eq!(rows[0].date, "2026-04-21");
+        assert_eq!(rows[0].customer_id, "cus_a");
+        assert_eq!(rows[0].charges_count, 2);
+        assert_eq!(rows[0].charges_cents, 2);
+        assert_eq!(rows[0].credits_cents, 0);
+        assert_eq!(rows[0].wallet_address.as_deref(), Some("0xA"));
+        assert_eq!(rows[1].date, "2026-04-21");
+        assert_eq!(rows[1].customer_id, "cus_b");
+        assert_eq!(rows[1].charges_count, 1);
+        assert_eq!(rows[1].charges_cents, 5);
+        assert_eq!(rows[1].credits_cents, 500);
+        assert_eq!(rows[1].email.as_deref(), Some("b@example.com"));
+        assert_eq!(rows[2].date, "2026-04-22");
+        assert_eq!(rows[2].customer_id, "cus_a");
+        assert_eq!(rows[2].charges_count, 1);
+    }
+
+    #[test]
+    fn aggregate_report_rows_unknown_customer_still_bucketed() {
+        let day1 = 1_776_729_600; // 2026-04-21 00:00:00 UTC
+        let txs = vec![tx("cus_unknown", 3, day1)];
+        let rows = aggregate_report_rows(&[], &txs);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].customer_id, "cus_unknown");
+        assert_eq!(rows[0].wallet_address, None);
+        assert_eq!(rows[0].email, None);
+        assert_eq!(rows[0].charges_cents, 3);
     }
 }

--- a/scripts/stripe_report.sh
+++ b/scripts/stripe_report.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Wrapper for the stripe_report CLI (CPL-269).
+#
+# Usage:
+#   STRIPE_SECRET_KEY=sk_live_...  \
+#   STRIPE_PUBLISHABLE_KEY=pk_live_...  \
+#   ./scripts/stripe_report.sh [--days N] [--out PATH] [--csv-only]
+#
+# Defaults: --days 30, --out ./stripe-report (writes .csv and .html).
+#
+# Requires `cargo` on PATH. Runs the release build for speed.
+
+set -euo pipefail
+
+if [[ -z "${STRIPE_SECRET_KEY:-}" || -z "${STRIPE_PUBLISHABLE_KEY:-}" ]]; then
+  echo "error: STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY must be set in the environment." >&2
+  echo "       export them before running, e.g.:" >&2
+  echo "         export STRIPE_SECRET_KEY=sk_live_..." >&2
+  echo "         export STRIPE_PUBLISHABLE_KEY=pk_live_..." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT/lit-api-server"
+
+exec cargo run --release --bin stripe_report -- "$@"


### PR DESCRIPTION
## Summary

Closes CPL-269. Adds a CLI that downloads the last 30 days of Stripe activity and renders a per-client, per-day usage report as both CSV and a self-contained HTML pivot table.

- New helpers in `lit-api-server/src/stripe.rs`: paginated `list_all_customers`, `list_balance_transactions_since`, a pure-Rust `unix_to_utc_date` (no chrono), and `aggregate_report_rows` that buckets by `(date, customer_id)`.
- New binary `lit-api-server/src/bin/stripe_report.rs` that fetches data, renders both dollar value and call count per cell, emits sticky-first-column HTML, and applies formula-injection-safe CSV escaping (`=`, `+`, `-`, `@`, tab, CR prefixes get neutralized).
- 6 unit tests for the helpers, 12 for the binary.

## How to run

```bash
export STRIPE_SECRET_KEY=sk_live_...
export STRIPE_PUBLISHABLE_KEY=pk_live_...
cargo run -p lit-api-server --bin stripe_report -- --days 30 --out stripe-report
open stripe-report.html
```

Flags: `--days N` (default 30), `--out PATH` (default `stripe-report`), `--csv-only`.

## Why a CLI, not an HTTP endpoint

No admin-auth concept exists server-side, and cross-customer billing data is sensitive. The CLI keeps the Stripe secret off the network and off any node.

## Test plan

- [x] `cargo test -p lit-api-server` — 195 lib tests + 12 bin tests pass
- [x] `cargo clippy --all-targets` clean
- [ ] Run against live Stripe account, verify CSV opens cleanly in Excel / Sheets and HTML renders the pivot correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)