### PR TITLE
feat: sovereign-mode direct contract writes (CPL-267 Phase 1)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -92,6 +92,64 @@
   **Branch:** GTC6244/k6-api-key-security-tests
   **Noticed:** 2026-03-26
 
+## CPL-267 Sovereign Mode: blockchain_cache needs `invalidate_for_account_hash(hash)` primitive
+
+**What:** Add `invalidate_for_account_hash(api_key_hash: Bytes32)` to `lit-api-server/src/accounts/blockchain_cache.rs`. Existing invalidation functions (`invalidate_for_account`, `invalidate_for_key`) take raw api_key and hash internally, but the Phase 3 event listener only has the hashed apiKeyHash from chain event topics.
+
+**Why:** Blocker for Phase 3 event listener in CPL-267 sovereign mode. Without this primitive, listener can't invalidate cache entries for direct-write transactions.
+
+**How to fix:** Factor out the hash-based invalidation path from `invalidate_for_account` into a new public function. Existing callers keep their raw-key signature; listener calls the hash variant directly.
+
+**Priority:** P1 (blocks Phase 3)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
+
+## CPL-267 Sovereign Mode: GC orphan prepared wallet keys
+
+**What:** Add periodic cleanup sweep for TEE-prepared wallets that were never registered on-chain. After server generates a key for sovereign `createWallet` and returns derivation metadata, user wallet may abandon before signing `register_wallet_derivation`, leaving TEE with an un-tracked key.
+
+**Why:** Unbounded growth of orphan keys in TEE state. Also a minor security concern (keys exist with no on-chain accountability).
+
+**How to fix:** Track prepared-wallet state with timestamp in TEE persistent storage. Background task (every N hours) drops entries older than threshold (e.g., 24h) that have no on-chain derivation registered.
+
+**Priority:** P2 (not blocking ship, but required before external users)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
+
+## CPL-267 Sovereign Mode: Document cache staleness window
+
+**What:** SDK + dashboard docs should state: "After a sovereign-mode write, reads on other server instances may show stale data for up to N seconds (polling interval)."
+
+**Why:** Per-instance event listener (user chose over single-leader) means N independent views of chain state. Users hitting load-balanced servers can see brief staleness. Undocumented surprises become support tickets.
+
+**How to fix:** Add to SDK README + dashboard user docs. Also add dashboard banner when detected listener lag > 30s.
+
+**Priority:** P2 (pair with Phase 3 listener ship)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
+
+## CPL-267 Sovereign Mode: 6-month adoption re-evaluation
+
+**What:** At 6 months post-ship of sovereign mode, review adoption metrics. If <5% of active accounts have converted or started sovereign, open a design doc to evaluate: (a) pivot to Approach B signed intents, (b) sunset sovereign mode, (c) continue parallel.
+
+**Why:** Driver was internal alignment, not customer demand. Codex outside voice flagged whole approach as potentially wrong first proof. We rejected pivot now for philosophical reasons, but committed to data-driven re-evaluation.
+
+**Priority:** P3 (reminder, not urgent)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
+
+## CPL-267 Sovereign Mode: Billing bypass documentation
+
+**What:** Admin writes in sovereign mode bypass Stripe billing guards (user's wallet pays gas directly to chain). Lit Action execution still charges via Stripe. Document this split explicitly in SDK + billing page.
+
+**Why:** Billing logic is per-op today (see `stripe::` in lit-api-server); sovereign admin writes never hit those guards. Accounting split must be visible to ops and support, otherwise conversion-to-sovereign looks like "billing broken."
+
+**How to fix:** Add note to `billing.md` or equivalent. Add sovereign-mode label to Stripe dashboard for per-account identification.
+
+**Priority:** P3
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
+
 ## Completed
 ## Monitor: Keyboard Shortcuts
 - **What:** Add keyboard shortcuts to the Lit Node Monitor: R to refresh, F to fund all critical, S to toggle settings panel.

--- a/lit-static/account_config_full_abi.js
+++ b/lit-static/account_config_full_abi.js
@@ -324,7 +324,27 @@ export const ACCOUNT_CONFIG_FULL_ABI = [
  * Operators: regenerate hashes after any deployment with
  *   `cast keccak $(cast code <address> --rpc-url <rpc>)`.
  */
-export const ACCOUNT_CONFIG_DEPLOYMENTS = {};
+export const ACCOUNT_CONFIG_DEPLOYMENTS = Object.freeze({});
+
+/**
+ * Dev-only escape hatch for running sovereign mode against a deployment that
+ * has no pinned bytecode hash yet (local anvil, a fresh testnet deploy, etc.).
+ * Browser-only: checks `window` / `globalThis` for a truthy flag.
+ *
+ * Shipping dashboards MUST either populate ACCOUNT_CONFIG_DEPLOYMENTS with the
+ * target (chainId, address) entries or pass them via `deployments` option;
+ * otherwise sovereign writes hard-fail. See _verifyAbiIntegrity.
+ */
+export function isAbiDriftDevOverrideEnabled() {
+  const v = (typeof globalThis !== 'undefined' && globalThis.LIT_ACCOUNT_CONFIG_ALLOW_UNPINNED_DEPLOYMENTS)
+    ?? (typeof window !== 'undefined' && window.LIT_ACCOUNT_CONFIG_ALLOW_UNPINNED_DEPLOYMENTS);
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase();
+    return s === '1' || s === 'true' || s === 'yes' || s === 'on';
+  }
+  return false;
+}
 
 /**
  * Merge operator-provided deployments (e.g. from a build-time config or

--- a/lit-static/account_config_full_abi.js
+++ b/lit-static/account_config_full_abi.js
@@ -1,0 +1,338 @@
+/**
+ * AccountConfig full ABI bundle (view + admin writes + custom errors).
+ *
+ * Source of truth: lit-api-server/src/accounts/contracts/AccountConfig.json.
+ * This is the hand-maintained subset used for sovereign-mode direct contract
+ * calls. If the on-chain contract changes, (a) regenerate entries from the
+ * updated JSON, (b) bump ACCOUNT_CONFIG_ABI_VERSION, (c) update the pinned
+ * bytecode hash in ACCOUNT_CONFIG_DEPLOYMENTS for each affected chain.
+ *
+ * Drift detection:
+ * - `runtimeBytecodeKeccak` is the keccak256 of the deployed runtime bytecode
+ *   returned by eth_getCode for (chainId, address). Dashboard hard-blocks if
+ *   the live hash does not match the pinned value.
+ * - If a (chainId, address) pair has `runtimeBytecodeKeccak: null`, drift is
+ *   skipped (dev-only override; never ship null values to production).
+ */
+
+import { ACCOUNT_CONFIG_VIEW_ABI } from './account_config_view_abi.js';
+
+export const ACCOUNT_CONFIG_ABI_VERSION = '2026-04-21.1';
+
+const WRITE_FUNCTIONS = [
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+      { internalType: 'uint256[]', name: 'cidHashes', type: 'uint256[]' },
+      { internalType: 'address[]', name: 'pkpIds', type: 'address[]' },
+    ],
+    name: 'addGroup',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+    ],
+    name: 'removeGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+      { internalType: 'uint256[]', name: 'cidHashes', type: 'uint256[]' },
+      { internalType: 'address[]', name: 'pkpIds', type: 'address[]' },
+    ],
+    name: 'updateGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+    ],
+    name: 'updateGroupMetadata',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+      { internalType: 'uint256', name: 'actionHash', type: 'uint256' },
+    ],
+    name: 'addAction',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'actionHash', type: 'uint256' },
+    ],
+    name: 'removeAction',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'uint256', name: 'action', type: 'uint256' },
+    ],
+    name: 'addActionToGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'uint256', name: 'action', type: 'uint256' },
+    ],
+    name: 'removeActionFromGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'actionHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+    ],
+    name: 'updateActionMetadata',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'address', name: 'pkpId', type: 'address' },
+    ],
+    name: 'addPkpToGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'address', name: 'pkpId', type: 'address' },
+    ],
+    name: 'removePkpFromGroup',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'usageApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'expiration', type: 'uint256' },
+      { internalType: 'uint256', name: 'balance', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+      { internalType: 'bool', name: 'createGroups', type: 'bool' },
+      { internalType: 'bool', name: 'deleteGroups', type: 'bool' },
+      { internalType: 'bool', name: 'createPKPs', type: 'bool' },
+      { internalType: 'uint256[]', name: 'manageIPFSIdsInGroups', type: 'uint256[]' },
+      { internalType: 'uint256[]', name: 'addPkpToGroups', type: 'uint256[]' },
+      { internalType: 'uint256[]', name: 'removePkpFromGroups', type: 'uint256[]' },
+      { internalType: 'uint256[]', name: 'executeInGroups', type: 'uint256[]' },
+    ],
+    name: 'setUsageApiKey',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'usageApiKeyHash', type: 'uint256' },
+    ],
+    name: 'removeUsageApiKey',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'usageApiKeyHash', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+    ],
+    name: 'updateUsageApiKeyMetadata',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'bool', name: 'managed', type: 'bool' },
+      { internalType: 'string', name: 'accountName', type: 'string' },
+      { internalType: 'string', name: 'accountDescription', type: 'string' },
+      { internalType: 'address', name: 'creatorWalletAddress', type: 'address' },
+    ],
+    name: 'newAccount',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'address', name: 'pkpId', type: 'address' },
+      { internalType: 'uint256', name: 'derivationPath', type: 'uint256' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'description', type: 'string' },
+    ],
+    name: 'registerWalletDerivation',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
+const CUSTOM_ERRORS = [
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'AccountAlreadyExists', type: 'error' },
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'AccountDoesNotExist', type: 'error' },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'uint256', name: 'cidHash', type: 'uint256' },
+    ],
+    name: 'ActionDoesNotExist',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+    ],
+    name: 'GroupDoesNotExist',
+    type: 'error',
+  },
+  { inputs: [{ internalType: 'string', name: 'message', type: 'string' }], name: 'InvalidRequest', type: 'error' },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'address', name: 'sender', type: 'address' },
+    ],
+    name: 'NoAccountAccess',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+    ],
+    name: 'NotAllowedToAddPkpToGroup',
+    type: 'error',
+  },
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'NotAllowedToCreateGroup', type: 'error' },
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'NotAllowedToCreatePkp', type: 'error' },
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'NotAllowedToDeleteGroup', type: 'error' },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+    ],
+    name: 'NotAllowedToManageIPFSIdsInGroup',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+    ],
+    name: 'NotAllowedToRemovePkpFromGroup',
+    type: 'error',
+  },
+  { inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }], name: 'NotMasterAccount', type: 'error' },
+  { inputs: [{ internalType: 'address', name: 'caller', type: 'address' }], name: 'OnlyApiPayerOrOwner', type: 'error' },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'address', name: 'pkpId', type: 'address' },
+    ],
+    name: 'PkpDoesNotExist',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'usageApiKeyHash', type: 'uint256' },
+    ],
+    name: 'UsageApiKeyDoesNotExist',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+    ],
+    name: 'InsufficientBalance',
+    type: 'error',
+  },
+];
+
+export const ACCOUNT_CONFIG_WRITE_ABI = WRITE_FUNCTIONS;
+export const ACCOUNT_CONFIG_ERROR_ABI = CUSTOM_ERRORS;
+
+export const ACCOUNT_CONFIG_FULL_ABI = [
+  ...ACCOUNT_CONFIG_VIEW_ABI,
+  ...WRITE_FUNCTIONS,
+  ...CUSTOM_ERRORS,
+];
+
+/**
+ * Pinned per-deployment bytecode hashes. Hard-block on mismatch.
+ *
+ * Key format: `${chainId}:${contractAddress.toLowerCase()}`.
+ * Value.runtimeBytecodeKeccak: lowercase 0x-prefixed keccak256 of eth_getCode.
+ * Value.runtimeBytecodeKeccak === null: drift check DISABLED for this target
+ *   (dev/local override; do not ship null values to production dashboards).
+ *
+ * Operators: regenerate hashes after any deployment with
+ *   `cast keccak $(cast code <address> --rpc-url <rpc>)`.
+ */
+export const ACCOUNT_CONFIG_DEPLOYMENTS = {};
+
+/**
+ * Merge operator-provided deployments (e.g. from a build-time config or
+ * `window.ACCOUNT_CONFIG_DEPLOYMENTS`) with the pinned map.
+ */
+export function mergeDeployments(overrides) {
+  if (!overrides || typeof overrides !== 'object') return { ...ACCOUNT_CONFIG_DEPLOYMENTS };
+  return { ...ACCOUNT_CONFIG_DEPLOYMENTS, ...overrides };
+}
+
+export default ACCOUNT_CONFIG_FULL_ABI;

--- a/lit-static/account_config_view_abi.js
+++ b/lit-static/account_config_view_abi.js
@@ -1,0 +1,179 @@
+/**
+ * AccountConfig view-only ABI subset.
+ *
+ * Source of truth: lit-api-server/src/accounts/contracts/AccountConfig.json.
+ * Includes only view functions the dashboard/SDK needs to read in sovereign mode.
+ * State-mutating functions live in the full ABI bundle (added in Phase 1).
+ */
+
+export const ACCOUNT_CONFIG_VIEW_ABI = [
+  {
+    inputs: [{ internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' }],
+    name: 'accountExistsAndIsMutable',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listGroups',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'id', type: 'uint256' },
+          { internalType: 'string', name: 'name', type: 'string' },
+          { internalType: 'string', name: 'description', type: 'string' },
+        ],
+        internalType: 'struct AppStorage.Metadata[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listPkps',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'id', type: 'uint256' },
+          { internalType: 'address', name: 'pkpId', type: 'address' },
+          { internalType: 'string', name: 'name', type: 'string' },
+          { internalType: 'string', name: 'description', type: 'string' },
+        ],
+        internalType: 'struct AppStorage.PkpData[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listWalletsInGroup',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'id', type: 'uint256' },
+          { internalType: 'address', name: 'pkpId', type: 'address' },
+          { internalType: 'string', name: 'name', type: 'string' },
+          { internalType: 'string', name: 'description', type: 'string' },
+        ],
+        internalType: 'struct AppStorage.PkpData[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listActions',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'id', type: 'uint256' },
+          { internalType: 'string', name: 'name', type: 'string' },
+          { internalType: 'string', name: 'description', type: 'string' },
+        ],
+        internalType: 'struct AppStorage.Metadata[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'groupId', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listActionsInGroup',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'id', type: 'uint256' },
+          { internalType: 'string', name: 'name', type: 'string' },
+          { internalType: 'string', name: 'description', type: 'string' },
+        ],
+        internalType: 'struct AppStorage.Metadata[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'accountApiKeyHash', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageNumber', type: 'uint256' },
+      { internalType: 'uint256', name: 'pageSize', type: 'uint256' },
+    ],
+    name: 'listApiKeys',
+    outputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: 'uint256', name: 'id', type: 'uint256' },
+              { internalType: 'string', name: 'name', type: 'string' },
+              { internalType: 'string', name: 'description', type: 'string' },
+            ],
+            internalType: 'struct AppStorage.Metadata',
+            name: 'metadata',
+            type: 'tuple',
+          },
+          { internalType: 'uint256', name: 'apiKeyHash', type: 'uint256' },
+          { internalType: 'uint256', name: 'expiration', type: 'uint256' },
+          { internalType: 'uint256', name: 'balance', type: 'uint256' },
+          { internalType: 'uint256[]', name: 'executeInGroups', type: 'uint256[]' },
+          { internalType: 'bool', name: 'createGroups', type: 'bool' },
+          { internalType: 'bool', name: 'deleteGroups', type: 'bool' },
+          { internalType: 'bool', name: 'createPKPs', type: 'bool' },
+          { internalType: 'uint256[]', name: 'manageIPFSIdsInGroups', type: 'uint256[]' },
+          { internalType: 'uint256[]', name: 'addPkpToGroups', type: 'uint256[]' },
+          { internalType: 'uint256[]', name: 'removePkpFromGroups', type: 'uint256[]' },
+        ],
+        internalType: 'struct ViewsFacet.UsageApiKeyReturn[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'api_payers',
+    outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+export default ACCOUNT_CONFIG_VIEW_ABI;

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -4,7 +4,24 @@
  * Wrapper for the v1 API endpoints defined in lit-api-server.
  * Types match core/v1/models (request.rs, response.rs) and core/v1/endpoints.rs.
  * Routes are mounted at /core/v1/ (see src/main.rs).
+ *
+ * Modes:
+ *  - 'api'       (default): every call goes through lit-api-server over HTTP.
+ *  - 'sovereign'          : read methods call the AccountConfig contract directly
+ *                           via RPC (no server round-trip). Writes still use HTTP
+ *                           until Phase 1 adds the wallet-signed path.
+ *
+ * In sovereign mode the constructor requires `rpcUrl` + `contractAddress`, or
+ * the dashboard can call `getNodeChainConfig()` first and pass the values in.
  */
+
+import { ACCOUNT_CONFIG_VIEW_ABI } from './account_config_view_abi.js';
+import {
+  ACCOUNT_CONFIG_FULL_ABI,
+  ACCOUNT_CONFIG_ABI_VERSION,
+  mergeDeployments,
+} from './account_config_full_abi.js';
+import { runContractWrite, TX_STATES } from './tx_lifecycle.js';
 
 // --- Request types (match core/v1/models/request.rs) ---
 
@@ -310,14 +327,178 @@ export async function resolveRpcUrlFromChainlist(chainId) {
   }
 }
 
+const ETHERS_CDN_URL = 'https://cdn.jsdelivr.net/npm/ethers@6.13.0/dist/ethers.min.js';
+
+let _ethersPromise = null;
+/**
+ * Lazily load ethers v6 from CDN (once per page). Returns the ethers module.
+ * Works in the dashboard and monitor without adding a build step. In environments
+ * where ethers is already a global (e.g. when bundled alongside the SDK), it
+ * resolves to that instance.
+ */
+async function loadEthers() {
+  if (typeof globalThis !== 'undefined' && globalThis.ethers) return globalThis.ethers;
+  if (!_ethersPromise) {
+    _ethersPromise = import(/* @vite-ignore */ ETHERS_CDN_URL).then((mod) => {
+      const e = mod.ethers ?? mod.default ?? mod;
+      if (typeof globalThis !== 'undefined') globalThis.ethers = e;
+      return e;
+    });
+  }
+  return _ethersPromise;
+}
+
 export class LitNodeSimpleApiClient {
   /**
    * @param {Object} options
    * @param {string} [options.baseUrl='http://localhost:8000'] - Base URL of the API
+   * @param {'api'|'sovereign'} [options.mode='api'] - Read-path mode. See module docblock.
+   * @param {string} [options.rpcUrl] - RPC URL for sovereign reads. Required when mode === 'sovereign'.
+   * @param {string} [options.contractAddress] - AccountConfig contract address. Required when mode === 'sovereign'.
+   * @param {number} [options.chainId] - Expected chain ID. Used for drift pinning + wallet chain guard. Optional; auto-detected from RPC when omitted.
+   * @param {Object} [options.deployments] - Optional override map `{ "<chainId>:<address>": { runtimeBytecodeKeccak } }` for drift pinning.
+   * @param {import('ethers').Signer} [options.signer] - Pre-connected signer for sovereign writes. May be set later via connectSigner().
    */
-  constructor({ baseUrl = 'http://localhost:8000' } = {}) {
+  constructor({ baseUrl = 'http://localhost:8000', mode = 'api', rpcUrl, contractAddress, chainId, deployments, signer } = {}) {
     const base = baseUrl.replace(/\/$/, '');
     this.baseUrl = `${base}/core/v1`;
+    this.mode = mode;
+    this.rpcUrl = rpcUrl ?? null;
+    this.contractAddress = contractAddress ?? null;
+    this.chainId = chainId ?? null;
+    this.deployments = mergeDeployments(deployments);
+    this.signer = signer ?? null;
+    this._viewContractPromise = null;
+    this._writeContract = null;
+    this._driftCheckPromise = null;
+
+    if (mode === 'sovereign' && (!rpcUrl || !contractAddress)) {
+      throw new Error(
+        'LitNodeSimpleApiClient: sovereign mode requires rpcUrl and contractAddress',
+      );
+    }
+  }
+
+  /**
+   * Attach a signer to this client for sovereign-mode writes. Must be called
+   * (or passed via constructor) before any write method in sovereign mode.
+   * @param {import('ethers').Signer} signer - ethers v6 Signer
+   */
+  connectSigner(signer) {
+    this.signer = signer;
+    this._writeContract = null;
+  }
+
+  /**
+   * Throws unless sovereign mode is set up with a usable signer.
+   */
+  _assertSovereignWriteReady() {
+    if (this.mode !== 'sovereign') {
+      throw new Error('_assertSovereignWriteReady called outside sovereign mode');
+    }
+    if (!this.signer) {
+      throw new Error(
+        'LitNodeSimpleApiClient: sovereign write requires a connected signer. Call connectSigner(signer) first.',
+      );
+    }
+  }
+
+  /**
+   * Verify on-chain bytecode matches the pinned hash for (chainId, address).
+   * Hard-blocks sovereign writes on mismatch. Runs once per client instance;
+   * cached promise is reused for subsequent calls.
+   *
+   * Dev-override: if no entry exists for (chainId, address) in `deployments`,
+   * the check is skipped with a console warning. Shipping dashboards MUST
+   * provide pinned entries or users are vulnerable to ABI drift.
+   */
+  async _verifyAbiIntegrity() {
+    if (this.mode !== 'sovereign') return;
+    if (!this._driftCheckPromise) {
+      this._driftCheckPromise = (async () => {
+        const ethers = await loadEthers();
+        const provider = new ethers.JsonRpcProvider(this.rpcUrl);
+        const [code, network] = await Promise.all([
+          provider.getCode(this.contractAddress),
+          provider.getNetwork(),
+        ]);
+        const chainId = Number(network.chainId);
+        if (this.chainId == null) this.chainId = chainId;
+        if (!code || code === '0x') {
+          throw new Error(
+            `ABI drift check: no contract code at ${this.contractAddress} on chain ${chainId}. Aborting sovereign writes.`,
+          );
+        }
+        const liveHash = ethers.keccak256(code).toLowerCase();
+        const key = `${chainId}:${this.contractAddress.toLowerCase()}`;
+        const pinned = this.deployments[key];
+        if (!pinned) {
+          console.warn(
+            `[LitNodeSimpleApiClient] ABI drift check SKIPPED: no pinned entry for ${key}. Add one to ACCOUNT_CONFIG_DEPLOYMENTS or pass 'deployments' option before shipping to production. (ABI version: ${ACCOUNT_CONFIG_ABI_VERSION})`,
+          );
+          return;
+        }
+        if (pinned.runtimeBytecodeKeccak === null) {
+          // Explicit dev-only opt-out.
+          return;
+        }
+        if (pinned.runtimeBytecodeKeccak.toLowerCase() !== liveHash) {
+          throw new Error(
+            `ABI drift detected for ${key}: live bytecode hash ${liveHash} != pinned ${pinned.runtimeBytecodeKeccak.toLowerCase()}. Dashboard must be redeployed with a matching ABI bundle. (ABI version: ${ACCOUNT_CONFIG_ABI_VERSION})`,
+          );
+        }
+      })().catch((err) => {
+        // Surface the error on every retry (don't cache the failure forever).
+        this._driftCheckPromise = null;
+        throw err;
+      });
+    }
+    return this._driftCheckPromise;
+  }
+
+  /**
+   * Lazily build (and cache) a writeable ethers.Contract bound to the full
+   * ABI + connected signer. Runs the ABI drift check on first construction.
+   * @returns {Promise<Object>} ethers.Contract
+   */
+  async _getWriteContract() {
+    this._assertSovereignWriteReady();
+    if (!this._writeContract) {
+      await this._verifyAbiIntegrity();
+      const ethers = await loadEthers();
+      this._writeContract = new ethers.Contract(this.contractAddress, ACCOUNT_CONFIG_FULL_ABI, this.signer);
+    }
+    return this._writeContract;
+  }
+
+  /**
+   * Lazily build (and cache) a read-only ethers.Contract instance bound to the
+   * AccountConfig address. Uses the view-only ABI subset.
+   * @returns {Promise<Object>} ethers.Contract
+   */
+  async _getViewContract() {
+    if (this.mode !== 'sovereign') {
+      throw new Error('_getViewContract called outside sovereign mode');
+    }
+    if (!this._viewContractPromise) {
+      this._viewContractPromise = (async () => {
+        const ethers = await loadEthers();
+        const provider = new ethers.JsonRpcProvider(this.rpcUrl);
+        return new ethers.Contract(this.contractAddress, ACCOUNT_CONFIG_VIEW_ABI, provider);
+      })();
+    }
+    return this._viewContractPromise;
+  }
+
+  /**
+   * Keccak256 hash of an API key string, as uint256 — matches server-side
+   * `api_key_hash` in lit-api-server/src/utils/parse_with_hash.rs.
+   * @param {string} apiKey
+   * @returns {Promise<string>} 0x-prefixed 32-byte hex, passable as uint256.
+   */
+  async _apiKeyHash(apiKey) {
+    const ethers = await loadEthers();
+    return ethers.keccak256(ethers.toUtf8Bytes(apiKey));
   }
 
   /**
@@ -348,6 +529,19 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<boolean>}
    */
   async accountExists(apiKey) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      // accountExistsAndIsMutable has an msg.sender check (caller must be an
+      // api_payer). The server-side path spoofs this by setting `.from(api_payer)`
+      // on the eth_call. For sovereign reads we take the same approach: fetch
+      // api_payers via the same contract and use the first one as the from address.
+      const payers = await contract.api_payers();
+      if (!payers || payers.length === 0) {
+        throw new Error('account_exists (sovereign): no api_payers configured on contract');
+      }
+      return await contract.accountExistsAndIsMutable.staticCall(hash, { from: payers[0] });
+    }
     const res = await fetch(`${this.baseUrl}/account_exists`, {
       headers: headersWithApiKey(apiKey),
     });
@@ -408,7 +602,27 @@ export class LitNodeSimpleApiClient {
    * @param {AddGroupOptions} options
    * @returns {Promise<AddGroupResponse>} Response with `success` and `group_id`.
    */
-  async addGroup({ apiKey, groupName, groupDescription = '', pkpIdsPermitted = [], cidHashesPermitted = [] }) {
+  async addGroup({ apiKey, groupName, groupDescription = '', pkpIdsPermitted = [], cidHashesPermitted = [], sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const name = groupName ?? '';
+      const description = groupDescription ?? '';
+      // staticCall first to pre-fetch the new group_id without burning a tx.
+      let groupId = null;
+      try {
+        groupId = await contract.addGroup.staticCall(hash, name, description, cidHashesPermitted, pkpIdsPermitted);
+      } catch (e) {
+        // staticCall revert will surface again on the real call; proceed and
+        // let runContractWrite produce a decoded error.
+      }
+      const { txHash } = await runContractWrite({
+        contract, method: 'addGroup',
+        args: [hash, name, description, cidHashesPermitted, pkpIdsPermitted],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, group_id: groupId != null ? groupId.toString() : null, transaction_hash: txHash };
+    }
     const body = {
       group_name: groupName ?? '',
       group_description: groupDescription ?? '',
@@ -429,7 +643,18 @@ export class LitNodeSimpleApiClient {
    * @param {AddActionOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async addAction({ apiKey, actionIpfsCid, name, description }) {
+  async addAction({ apiKey, actionIpfsCid, name, description, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const actionHash = await this._apiKeyHash(actionIpfsCid);
+      const { txHash } = await runContractWrite({
+        contract, method: 'addAction',
+        args: [hash, name ?? '', description ?? '', actionHash],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, action_hash: actionHash, transaction_hash: txHash };
+    }
     const body = { action_ipfs_cid: actionIpfsCid, name: name ?? '', description: description ?? '' };
     const res = await fetch(`${this.baseUrl}/add_action`, {
       method: 'POST',
@@ -445,7 +670,18 @@ export class LitNodeSimpleApiClient {
    * @param {AddActionToGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async addActionToGroup({ apiKey, groupId, actionIpfsCid }) {
+  async addActionToGroup({ apiKey, groupId, actionIpfsCid, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const actionHash = await this._apiKeyHash(actionIpfsCid);
+      const { txHash } = await runContractWrite({
+        contract, method: 'addActionToGroup',
+        args: [hash, BigInt(groupId), actionHash],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       group_id: Number(groupId),
       action_ipfs_cid: actionIpfsCid,
@@ -464,7 +700,17 @@ export class LitNodeSimpleApiClient {
    * @param {AddPkpToGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async addPkpToGroup({ apiKey, groupId, pkpId }) {
+  async addPkpToGroup({ apiKey, groupId, pkpId, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'addPkpToGroup',
+        args: [hash, BigInt(groupId), pkpId],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       group_id: Number(groupId),
       pkp_id: pkpId,
@@ -483,7 +729,17 @@ export class LitNodeSimpleApiClient {
    * @param {RemovePkpFromGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async removePkpFromGroup({ apiKey, groupId, pkpId }) {
+  async removePkpFromGroup({ apiKey, groupId, pkpId, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'removePkpFromGroup',
+        args: [hash, BigInt(groupId), pkpId],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       group_id: Number(groupId),
       pkp_id: pkpId,
@@ -513,7 +769,47 @@ export class LitNodeSimpleApiClient {
     addPkpToGroups = [],
     removePkpFromGroups = [],
     executeInGroups = [],
-  }) {
+    expiration,
+    balance,
+    sovereignLifecycle,
+  } = {}) {
+    if (this.mode === 'sovereign') {
+      const ethers = await loadEthers();
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      // Sovereign mode has no server-side Stripe billing: balance starts at 0
+      // and can't be topped up without API mode. Caller may pass expiration
+      // (uint256 seconds timestamp; 0 = never) and balance explicitly.
+      const expirationVal = expiration != null ? BigInt(expiration) : 0n;
+      const balanceVal = balance != null ? BigInt(balance) : 0n;
+      // Client-generated secret: server-mode generates this server-side and
+      // returns it. Sovereign must mint it locally so the user can save the
+      // cleartext key before it leaves this browser.
+      const randBytes = new Uint8Array(32);
+      crypto.getRandomValues(randBytes);
+      const newUsageKey = 'lk_' + Array.from(randBytes, (b) => b.toString(16).padStart(2, '0')).join('');
+      const usageHash = ethers.keccak256(ethers.toUtf8Bytes(newUsageKey));
+      const { txHash } = await runContractWrite({
+        contract, method: 'setUsageApiKey',
+        args: [
+          hash,
+          usageHash,
+          expirationVal,
+          balanceVal,
+          name ?? '',
+          description ?? '',
+          canCreateGroups,
+          canDeleteGroups,
+          canCreatePkps,
+          manageIpfsIdsInGroups.map((n) => BigInt(n)),
+          addPkpToGroups.map((n) => BigInt(n)),
+          removePkpFromGroups.map((n) => BigInt(n)),
+          executeInGroups.map((n) => BigInt(n)),
+        ],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, api_key: newUsageKey, hash: usageHash, transaction_hash: txHash };
+    }
     const body = {
       name,
       description,
@@ -551,7 +847,41 @@ export class LitNodeSimpleApiClient {
     addPkpToGroups = [],
     removePkpFromGroups = [],
     executeInGroups = [],
-  }) {
+    expiration,
+    balance,
+    sovereignLifecycle,
+  } = {}) {
+    if (this.mode === 'sovereign') {
+      const ethers = await loadEthers();
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
+      // setUsageApiKey is an upsert; existing expiration/balance are
+      // overwritten. Sovereign callers should fetch current values via
+      // listApiKeys and pass them back if preservation is desired.
+      const expirationVal = expiration != null ? BigInt(expiration) : 0n;
+      const balanceVal = balance != null ? BigInt(balance) : 0n;
+      const { txHash } = await runContractWrite({
+        contract, method: 'setUsageApiKey',
+        args: [
+          hash,
+          usageHash,
+          expirationVal,
+          balanceVal,
+          name ?? '',
+          description ?? '',
+          canCreateGroups,
+          canDeleteGroups,
+          canCreatePkps,
+          manageIpfsIdsInGroups.map((n) => BigInt(n)),
+          addPkpToGroups.map((n) => BigInt(n)),
+          removePkpFromGroups.map((n) => BigInt(n)),
+          executeInGroups.map((n) => BigInt(n)),
+        ],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       usage_api_key: usageApiKey,
       name,
@@ -578,7 +908,19 @@ export class LitNodeSimpleApiClient {
    * @param {RemoveUsageApiKeyOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async removeUsageApiKey({ apiKey, usageApiKey }) {
+  async removeUsageApiKey({ apiKey, usageApiKey, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const ethers = await loadEthers();
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
+      const { txHash } = await runContractWrite({
+        contract, method: 'removeUsageApiKey',
+        args: [hash, usageHash],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       usage_api_key: usageApiKey,
     };
@@ -590,7 +932,17 @@ export class LitNodeSimpleApiClient {
     return parseResponse(res, 'remove_usage_api_key');
   }
 
-  async removeGroup({ apiKey, groupId }) {
+  async removeGroup({ apiKey, groupId, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'removeGroup',
+        args: [hash, BigInt(groupId)],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = { group_id: String(groupId) };
     const res = await fetch(`${this.baseUrl}/remove_group`, {
       method: 'POST',
@@ -606,7 +958,17 @@ export class LitNodeSimpleApiClient {
    * @param {UpdateGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async updateGroup({ apiKey, groupId, name, description, pkpIdsPermitted = [], cidHashesPermitted = [] }) {
+  async updateGroup({ apiKey, groupId, name, description, pkpIdsPermitted = [], cidHashesPermitted = [], sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'updateGroup',
+        args: [hash, BigInt(groupId), name ?? '', description ?? '', cidHashesPermitted, pkpIdsPermitted],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       group_id: Number(groupId),
       name: name ?? '',
@@ -628,7 +990,17 @@ export class LitNodeSimpleApiClient {
    * @param {DeleteActionOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async deleteAction({ apiKey, hashedCid }) {
+  async deleteAction({ apiKey, hashedCid, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'removeAction',
+        args: [hash, hashedCid],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = { hashed_cid: hashedCid };
     const res = await fetch(`${this.baseUrl}/delete_action`, {
       method: 'POST',
@@ -644,7 +1016,17 @@ export class LitNodeSimpleApiClient {
    * @param {RemoveActionFromGroupOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async removeActionFromGroup({ apiKey, groupId, hashedCid }) {
+  async removeActionFromGroup({ apiKey, groupId, hashedCid, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'removeActionFromGroup',
+        args: [hash, BigInt(groupId), hashedCid],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       group_id: Number(groupId),
       hashed_cid: hashedCid,
@@ -663,7 +1045,18 @@ export class LitNodeSimpleApiClient {
    * @param {UpdateActionMetadataOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async updateActionMetadata({ apiKey, hashedCid, name, description }) {
+  async updateActionMetadata({ apiKey, hashedCid, name, description, groupId = 0, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      // groupId === 0 means "account-level action metadata" per contract convention.
+      const { txHash } = await runContractWrite({
+        contract, method: 'updateActionMetadata',
+        args: [hash, hashedCid, BigInt(groupId), name ?? '', description ?? ''],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       hashed_cid: hashedCid,
       name: name ?? '',
@@ -683,7 +1076,19 @@ export class LitNodeSimpleApiClient {
    * @param {UpdateUsageApiKeyMetadataOptions} options
    * @returns {Promise<AccountOpResponse>}
    */
-  async updateUsageApiKeyMetadata({ apiKey, usageApiKey, name, description }) {
+  async updateUsageApiKeyMetadata({ apiKey, usageApiKey, name, description, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const ethers = await loadEthers();
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
+      const { txHash } = await runContractWrite({
+        contract, method: 'updateUsageApiKeyMetadata',
+        args: [hash, usageHash, name ?? '', description ?? ''],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { success: true, transaction_hash: txHash };
+    }
     const body = {
       usage_api_key: usageApiKey,
       name: name ?? '',
@@ -704,6 +1109,26 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<ApiKeyItem[]>}
    */
   async listApiKeys({ apiKey, pageNumber = '0', pageSize = '10' }) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const rows = await contract.listApiKeys(hash, pageNumber, pageSize);
+      return rows.map((r) => ({
+        id: r.metadata.id.toString(),
+        api_key_hash: '0x' + r.apiKeyHash.toString(16).padStart(64, '0'),
+        name: r.metadata.name,
+        description: r.metadata.description,
+        expiration: r.expiration.toString(),
+        balance: Number(r.balance),
+        can_create_groups: r.createGroups,
+        can_delete_groups: r.deleteGroups,
+        can_create_pkps: r.createPKPs,
+        can_manage_ipfs_ids_in_groups: r.manageIPFSIdsInGroups.map((n) => Number(n)),
+        can_add_pkp_to_groups: r.addPkpToGroups.map((n) => Number(n)),
+        can_remove_pkp_from_groups: r.removePkpFromGroups.map((n) => Number(n)),
+        can_execute_in_groups: r.executeInGroups.map((n) => Number(n)),
+      }));
+    }
     const params = new URLSearchParams({
       page_number: String(pageNumber),
       page_size: String(pageSize),
@@ -721,6 +1146,16 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<ListMetadataItem[]>}
    */
   async listGroups({ apiKey, pageNumber = '0', pageSize = '10' }) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const rows = await contract.listGroups(hash, pageNumber, pageSize);
+      return rows.map((r) => ({
+        id: r.id.toString(),
+        name: r.name,
+        description: r.description,
+      }));
+    }
     const params = new URLSearchParams({
       page_number: String(pageNumber),
       page_size: String(pageSize),
@@ -738,6 +1173,17 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<WalletItem[]>}
    */
   async listWallets({ apiKey, pageNumber = '0', pageSize = '10' }) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const rows = await contract.listPkps(hash, pageNumber, pageSize);
+      return rows.map((r) => ({
+        id: r.id.toString(),
+        name: r.name,
+        description: r.description,
+        wallet_address: r.pkpId,
+      }));
+    }
     const params = new URLSearchParams({
       page_number: String(pageNumber),
       page_size: String(pageSize),
@@ -755,6 +1201,17 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<WalletItem[]>}
    */
   async listWalletsInGroup({ apiKey, groupId, pageNumber = '0', pageSize = '10' }) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const rows = await contract.listWalletsInGroup(hash, groupId, pageNumber, pageSize);
+      return rows.map((r) => ({
+        id: r.id.toString(),
+        name: r.name,
+        description: r.description,
+        wallet_address: r.pkpId,
+      }));
+    }
     const params = new URLSearchParams({
       group_id: groupId,
       page_number: String(pageNumber),
@@ -778,6 +1235,18 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<ListMetadataItem[]>}
    */
   async listActions({ apiKey, groupId, pageNumber = '0', pageSize = '10' }) {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const rows = groupId !== undefined
+        ? await contract.listActionsInGroup(hash, groupId, pageNumber, pageSize)
+        : await contract.listActions(hash, pageNumber, pageSize);
+      return rows.map((r) => ({
+        id: r.id.toString(),
+        name: r.name,
+        description: r.description,
+      }));
+    }
     const entries = {
       page_number: String(pageNumber),
       page_size: String(pageSize),
@@ -814,6 +1283,10 @@ export class LitNodeSimpleApiClient {
    * @returns {Promise<string[]>}
    */
   async getApiPayers() {
+    if (this.mode === 'sovereign') {
+      const contract = await this._getViewContract();
+      return await contract.api_payers();
+    }
     const res = await fetch(`${this.baseUrl}/get_api_payers`);
     return parseResponse(res, 'get_api_payers');
   }
@@ -888,11 +1361,13 @@ export class LitNodeSimpleApiClient {
 
 /**
  * Factory for a default client (e.g. for script usage).
- * @param {string} [baseUrl='http://localhost:8000']
+ * Accepts either a string baseUrl or a full options object.
+ * @param {string|Object} [options='http://localhost:8000']
  * @returns {LitNodeSimpleApiClient}
  */
-export function createClient(baseUrl = 'http://localhost:8000') {
-  return new LitNodeSimpleApiClient({ baseUrl });
+export function createClient(options = 'http://localhost:8000') {
+  const opts = typeof options === 'string' ? { baseUrl: options } : options;
+  return new LitNodeSimpleApiClient(opts);
 }
 
 export default LitNodeSimpleApiClient;

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -7,9 +7,11 @@
  *
  * Modes:
  *  - 'api'       (default): every call goes through lit-api-server over HTTP.
- *  - 'sovereign'          : read methods call the AccountConfig contract directly
- *                           via RPC (no server round-trip). Writes still use HTTP
- *                           until Phase 1 adds the wallet-signed path.
+ *  - 'sovereign'          : reads call the AccountConfig contract directly via
+ *                           RPC (no server round-trip). Writes are submitted
+ *                           as wallet-signed contract transactions once
+ *                           `connectSigner(signer)` has been called; without a
+ *                           signer, write methods throw.
  *
  * In sovereign mode the constructor requires `rpcUrl` + `contractAddress`, or
  * the dashboard can call `getNodeChainConfig()` first and pass the values in.
@@ -20,6 +22,7 @@ import {
   ACCOUNT_CONFIG_FULL_ABI,
   ACCOUNT_CONFIG_ABI_VERSION,
   mergeDeployments,
+  isAbiDriftDevOverrideEnabled,
 } from './account_config_full_abi.js';
 import { runContractWrite, TX_STATES } from './tx_lifecycle.js';
 
@@ -408,9 +411,9 @@ export class LitNodeSimpleApiClient {
    * Hard-blocks sovereign writes on mismatch. Runs once per client instance;
    * cached promise is reused for subsequent calls.
    *
-   * Dev-override: if no entry exists for (chainId, address) in `deployments`,
-   * the check is skipped with a console warning. Shipping dashboards MUST
-   * provide pinned entries or users are vulnerable to ABI drift.
+   * Fail-closed: if no entry exists for (chainId, address), hard-block sovereign
+   * writes unless LIT_ACCOUNT_CONFIG_ALLOW_UNPINNED_DEPLOYMENTS is set (dev-only).
+   * Operators MUST populate ACCOUNT_CONFIG_DEPLOYMENTS or pass `deployments`.
    */
   async _verifyAbiIntegrity() {
     if (this.mode !== 'sovereign') return;
@@ -433,8 +436,13 @@ export class LitNodeSimpleApiClient {
         const key = `${chainId}:${this.contractAddress.toLowerCase()}`;
         const pinned = this.deployments[key];
         if (!pinned) {
+          if (!isAbiDriftDevOverrideEnabled()) {
+            throw new Error(
+              `ABI drift check: no pinned entry for ${key}. Add one to ACCOUNT_CONFIG_DEPLOYMENTS or pass 'deployments' option. To run against an unpinned deployment (dev only), set window.LIT_ACCOUNT_CONFIG_ALLOW_UNPINNED_DEPLOYMENTS = true. (ABI version: ${ACCOUNT_CONFIG_ABI_VERSION})`,
+            );
+          }
           console.warn(
-            `[LitNodeSimpleApiClient] ABI drift check SKIPPED: no pinned entry for ${key}. Add one to ACCOUNT_CONFIG_DEPLOYMENTS or pass 'deployments' option before shipping to production. (ABI version: ${ACCOUNT_CONFIG_ABI_VERSION})`,
+            `[LitNodeSimpleApiClient] ABI drift check SKIPPED (dev override): no pinned entry for ${key}. (ABI version: ${ACCOUNT_CONFIG_ABI_VERSION})`,
           );
           return;
         }
@@ -1238,7 +1246,11 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
       const hash = await this._apiKeyHash(apiKey);
-      const rows = groupId !== undefined
+      // Match server semantics: group IDs start at 1, so groupId==0 means
+      // "account-level listing", not "group zero". listActionsInGroup with 0
+      // can revert (GroupDoesNotExist) or return wrong data.
+      const inGroup = groupId !== undefined && Number(groupId) > 0;
+      const rows = inGroup
         ? await contract.listActionsInGroup(hash, groupId, pageNumber, pageSize)
         : await contract.listActions(hash, pageNumber, pageSize);
       return rows.map((r) => ({

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -8,7 +8,38 @@ const STORAGE_KEY_API = 'accountconfig_api_key';
 const STORAGE_KEY_THEME = 'accountconfig_theme';
 const STORAGE_KEY_USAGE_OVERRIDE = 'accountconfig_usage_key_override';
 const STORAGE_KEY_OVERRIDE_ENABLED = 'accountconfig_usage_override_enabled';
+const STORAGE_KEY_MODE = 'accountconfig_mode';
 export const LIST_PAGE_SIZE = '20';
+
+/**
+ * SDK methods that perform admin writes. In sovereign mode these get
+ * auto-injected with a sovereignLifecycle (wallet connect + preview modal +
+ * tx status banner) by the getClient() Proxy.
+ *
+ * Keep in sync with branched writes in core_sdk.js.
+ */
+const SOVEREIGN_WRITE_METHODS = new Set([
+  'addGroup', 'removeGroup', 'updateGroup',
+  'addAction', 'deleteAction', 'addActionToGroup', 'removeActionFromGroup', 'updateActionMetadata',
+  'addPkpToGroup', 'removePkpFromGroup',
+  'addUsageApiKey', 'updateUsageApiKey', 'removeUsageApiKey', 'updateUsageApiKeyMetadata',
+]);
+
+// ----- Mode (api | sovereign) -----
+
+/** @returns {'api'|'sovereign'} */
+export function getMode() {
+  return sessionStorage.getItem(STORAGE_KEY_MODE) === 'sovereign' ? 'sovereign' : 'api';
+}
+
+export function setMode(mode) {
+  if (mode === 'sovereign') sessionStorage.setItem(STORAGE_KEY_MODE, 'sovereign');
+  else sessionStorage.removeItem(STORAGE_KEY_MODE);
+  // Invalidate cached client so the next getClient() rebuilds with the new mode.
+  _clientInstance = null;
+  _clientBaseUrl = null;
+  _clientMode = null;
+}
 
 // ----- API key session -----
 
@@ -89,31 +120,115 @@ export function getBaseUrl() {
 
 let _clientInstance = null;
 let _clientBaseUrl = null;
+let _clientMode = null;
 
 export async function getClient() {
   const baseUrl = getBaseUrl();
-  if (_clientInstance && _clientBaseUrl === baseUrl) return _clientInstance;
+  const mode = getMode();
+  if (_clientInstance && _clientBaseUrl === baseUrl && _clientMode === mode) {
+    return _clientInstance;
+  }
   try {
     const { createClient } = await import('../../core_sdk.js');
-    const client = createClient(baseUrl);
+    const opts = { baseUrl, mode };
+    if (mode === 'sovereign') {
+      // Bootstrap RPC + contract address via the server config endpoint
+      // (explicitly stays on the API path per CPL-267 plan).
+      const bootstrap = createClient({ baseUrl });
+      const cfg = await bootstrap.getNodeChainConfig();
+      if (!cfg || !cfg.rpc_url || !cfg.contract_address) {
+        throw new Error('Node chain config missing rpc_url or contract_address');
+      }
+      opts.rpcUrl = cfg.rpc_url;
+      opts.contractAddress = cfg.contract_address;
+      if (cfg.chain_id != null) opts.chainId = Number(cfg.chain_id);
+    }
+    const client = createClient(opts);
     _clientInstance = new Proxy(client, {
       get(target, prop) {
         const val = target[prop];
         if (typeof val !== 'function') return val;
-        return function (...args) {
+        return async function (...args) {
           const apiKey = (args[0] && typeof args[0] === 'object' && args[0].apiKey) || args[0];
           const keyPreview = typeof apiKey === 'string' ? apiKey.substring(0, 6) + '\u2026' : '(none)';
-          console.log(`[dashboard] ${prop} \u2192 ${baseUrl} | key: ${keyPreview}`);
+          console.log(`[dashboard:${mode}] ${prop} \u2192 ${baseUrl} | key: ${keyPreview}`);
+
+          // Sovereign-mode writes: auto-inject lifecycle (wallet connect +
+          // preview modal + tx status banner) unless caller already supplied
+          // its own sovereignLifecycle.
+          if (mode === 'sovereign' && SOVEREIGN_WRITE_METHODS.has(prop) &&
+              args[0] && typeof args[0] === 'object' && !args[0].sovereignLifecycle) {
+            await ensureSovereignSigner(target);
+            const sovereignLifecycle = await buildSovereignLifecycle(target, prop);
+            args = [{ ...args[0], sovereignLifecycle }];
+          }
           return val.apply(target, args);
         };
       },
     });
     _clientBaseUrl = baseUrl;
+    _clientMode = mode;
     return _clientInstance;
   } catch (e) {
     logError('getClient', e);
     throw new Error('Unable to connect to API: ' + formatError(e));
   }
+}
+
+/**
+ * Lazy wallet-connect for sovereign writes. Prompts the user to connect a
+ * browser wallet (MetaMask et al.) on first sovereign write. Also enforces
+ * the chain guard against the SDK's expected chainId.
+ */
+async function ensureSovereignSigner(client) {
+  if (client.signer) return;
+  const { connectEoa, assertChain, switchChain } = await import('../../wallet_connect.js');
+  const { signer, chainId } = await connectEoa();
+  if (client.chainId != null && chainId !== client.chainId) {
+    try {
+      await switchChain(client.chainId);
+    } catch (err) {
+      throw new Error(
+        `Your wallet is on chain ${chainId} but this dashboard expects chain ${client.chainId}. Switch network in your wallet and retry.`,
+      );
+    }
+  }
+  client.connectSigner(signer);
+}
+
+/**
+ * Build the sovereignLifecycle hook set for a given SDK method invocation.
+ * onPreview: blocks on the tx preview modal (must resolve true to proceed).
+ * onState: surfaces tx status in a non-dismissible progress banner.
+ */
+async function buildSovereignLifecycle(client, sdkMethodName) {
+  const [{ showTxPreview }, { describeState, TX_STATES }] = await Promise.all([
+    import('./tx_preview_modal.js'),
+    import('../../tx_lifecycle.js'),
+  ]);
+  const signerAddress = client.signer ? await client.signer.getAddress() : null;
+  const meta = {
+    signerAddress,
+    chainId: client.chainId,
+    contractAddress: client.contractAddress,
+  };
+  return {
+    onPreview: (contractMethod, contractArgs) =>
+      showTxPreview(contractMethod, contractArgs, meta),
+    onState: (state, payload) => {
+      if (state === TX_STATES.SIGNING) {
+        showActionProgress(sdkMethodName, 'Open your wallet to sign the transaction…');
+      } else if (state === TX_STATES.PENDING) {
+        showActionProgress(sdkMethodName, `Broadcast — ${payload?.txHash?.slice(0, 10)}… waiting for inclusion.`);
+      } else if (state === TX_STATES.CONFIRMING) {
+        showActionProgress(sdkMethodName, `Included — waiting for ${payload?.target} confirmations.`);
+      } else if (state === TX_STATES.CONFIRMED || state === TX_STATES.FAILED || state === TX_STATES.REORGED) {
+        closeActionProgress();
+      } else {
+        showActionProgress(sdkMethodName, describeState(state));
+      }
+    },
+  };
 }
 
 // ----- Theme -----
@@ -207,6 +322,21 @@ export function keyPreview(key) {
 export function initLogin() {
   const apiKeyInput = document.getElementById('login-api-key');
   if (getApiKey()) apiKeyInput.value = '';
+
+  // Sovereign-mode toggle — reflects the current session mode and persists on change.
+  const modeToggle = document.getElementById('login-mode-sovereign');
+  const modeLabel = document.getElementById('login-mode-label');
+  if (modeToggle) {
+    modeToggle.checked = getMode() === 'sovereign';
+    const syncLabel = () => {
+      if (modeLabel) modeLabel.textContent = modeToggle.checked ? 'Sovereign mode' : 'API mode';
+    };
+    syncLabel();
+    modeToggle.addEventListener('change', () => {
+      setMode(modeToggle.checked ? 'sovereign' : 'api');
+      syncLabel();
+    });
+  }
 
   const tabExisting = document.getElementById('login-tab-existing');
   const tabNew = document.getElementById('login-tab-new');

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -182,8 +182,8 @@ export async function getClient() {
  */
 async function ensureSovereignSigner(client) {
   if (client.signer) return;
-  const { connectEoa, assertChain, switchChain } = await import('../../wallet_connect.js');
-  const { signer, chainId } = await connectEoa();
+  const { connectEoa, switchChain } = await import('../../wallet_connect.js');
+  let { signer, chainId } = await connectEoa();
   if (client.chainId != null && chainId !== client.chainId) {
     try {
       await switchChain(client.chainId);
@@ -192,6 +192,10 @@ async function ensureSovereignSigner(client) {
         `Your wallet is on chain ${chainId} but this dashboard expects chain ${client.chainId}. Switch network in your wallet and retry.`,
       );
     }
+    // switchChain rebinds window.ethereum to the new network; re-derive the
+    // signer from a fresh BrowserProvider so ethers caches the new chainId
+    // instead of signing against the previous network.
+    ({ signer } = await connectEoa());
   }
   client.connectSigner(signer);
 }

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.13.0/dist/ethers.umd.min.js"></script>
 </head>
 <body>
   <div class="app">
@@ -28,8 +29,12 @@
               <label for="login-api-key">API key</label>
               <input type="password" id="login-api-key" class="input" placeholder="Paste your API key">
             </div>
+            <div class="form-group" style="display:flex; align-items:center; gap:0.75rem;">
+              <input type="checkbox" id="login-mode-sovereign">
+              <label for="login-mode-sovereign" id="login-mode-label" class="form-hint" style="margin:0; cursor:pointer;">API mode</label>
+            </div>
             <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
-            <p class="form-hint">Log in verifies the API key with the server (account exists and is mutable).</p>
+            <p class="form-hint">Log in verifies the API key. Sovereign mode reads directly from the AccountConfig contract over RPC; writes still go through the server until Phase 1 ships wallet-signed transactions.</p>
           </div>
         </div>
         <div id="login-panel-new" class="login-tab-panel" role="tabpanel" aria-labelledby="login-tab-new" hidden>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -34,7 +34,7 @@
               <label for="login-mode-sovereign" id="login-mode-label" class="form-hint" style="margin:0; cursor:pointer;">API mode</label>
             </div>
             <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
-            <p class="form-hint">Log in verifies the API key. Sovereign mode reads directly from the AccountConfig contract over RPC; writes still go through the server until Phase 1 ships wallet-signed transactions.</p>
+            <p class="form-hint">Log in verifies the API key. Sovereign mode reads directly from the AccountConfig contract over RPC; writes are previewed, then submitted as wallet-signed transactions from your connected browser wallet.</p>
           </div>
         </div>
         <div id="login-panel-new" class="login-tab-panel" role="tabpanel" aria-labelledby="login-tab-new" hidden>

--- a/lit-static/dapps/dashboard/tx_preview_modal.js
+++ b/lit-static/dapps/dashboard/tx_preview_modal.js
@@ -165,11 +165,27 @@ export function showTxPreview(methodName, args, meta = {}) {
 
     openModal(prettifyMethod(methodName), bodyHTML, footerHTML);
 
-    const cleanup = (result) => {
+    // The generic modal (initModalClose) already wires #modal-close-btn and
+    // overlay-background clicks to closeModal(). Without our own handlers on
+    // those paths, closing via the X or backdrop would hide the modal but
+    // leave this Promise unresolved, hanging the write flow in PREVIEWING.
+    // Resolve false on any close path; closeModal() is idempotent.
+    let settled = false;
+    const overlay = document.getElementById('modal-overlay');
+    const closeBtn = document.getElementById('modal-close-btn');
+    const onOverlayClick = (e) => { if (e.target.id === 'modal-overlay') settle(false); };
+    const onCloseClick = () => settle(false);
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      overlay?.removeEventListener('click', onOverlayClick);
+      closeBtn?.removeEventListener('click', onCloseClick);
       closeModal();
       resolve(result);
     };
-    document.getElementById('tx-preview-cancel')?.addEventListener('click', () => cleanup(false), { once: true });
-    document.getElementById('tx-preview-confirm')?.addEventListener('click', () => cleanup(true), { once: true });
+    overlay?.addEventListener('click', onOverlayClick);
+    closeBtn?.addEventListener('click', onCloseClick);
+    document.getElementById('tx-preview-cancel')?.addEventListener('click', () => settle(false), { once: true });
+    document.getElementById('tx-preview-confirm')?.addEventListener('click', () => settle(true), { once: true });
   });
 }

--- a/lit-static/dapps/dashboard/tx_preview_modal.js
+++ b/lit-static/dapps/dashboard/tx_preview_modal.js
@@ -1,0 +1,175 @@
+/**
+ * Sovereign-mode transaction preview + confirm modal.
+ *
+ * Decision from CPL-267 plan-eng-review (Issue 5): "required preview+confirm
+ * modal before every wallet pop, decoded calldata + function name + account
+ * impact." This module renders that modal and returns a Promise that resolves
+ * true on confirm / false on cancel (wired as runContractWrite.onPreview).
+ *
+ * Required DOM (from index.html):
+ *   #modal-overlay, #modal-title, #modal-body, #modal-footer, #modal-close-btn
+ *   (existing generic modal, reused via openModal/closeModal)
+ */
+
+import { openModal, closeModal, escapeHtml } from './ui-utils.js';
+import { ACCOUNT_CONFIG_FULL_ABI } from '../../account_config_full_abi.js';
+
+/**
+ * Labels for each admin-write contract method, surfaced in the preview title.
+ * Fallback: prettify camelCase if the method is unknown.
+ */
+const METHOD_LABELS = {
+  addGroup: 'Create group',
+  removeGroup: 'Delete group',
+  updateGroup: 'Update group (full)',
+  updateGroupMetadata: 'Update group metadata',
+  addAction: 'Register action',
+  removeAction: 'Delete action',
+  addActionToGroup: 'Grant action to group',
+  removeActionFromGroup: 'Revoke action from group',
+  updateActionMetadata: 'Update action metadata',
+  addPkpToGroup: 'Grant PKP to group',
+  removePkpFromGroup: 'Revoke PKP from group',
+  setUsageApiKey: 'Create/update usage API key',
+  removeUsageApiKey: 'Delete usage API key',
+  updateUsageApiKeyMetadata: 'Update usage API key metadata',
+  newAccount: 'Create account',
+  registerWalletDerivation: 'Register wallet',
+};
+
+/**
+ * Friendly labels for the "apiKeyHash" / "accountApiKeyHash" input across
+ * methods — this is always the account identifier.
+ */
+const ARG_LABELS = {
+  apiKeyHash: 'Account (apiKeyHash)',
+  accountApiKeyHash: 'Account (apiKeyHash)',
+  usageApiKeyHash: 'Usage key hash',
+  actionHash: 'Action hash',
+  cidHashes: 'Action CID hashes',
+  pkpIds: 'PKP addresses',
+  pkpId: 'PKP address',
+  groupId: 'Group ID',
+  manageIPFSIdsInGroups: 'Can manage IPFS in groups',
+  addPkpToGroups: 'Can add PKPs to groups',
+  removePkpFromGroups: 'Can remove PKPs from groups',
+  executeInGroups: 'Can execute in groups',
+  createGroups: 'Can create groups',
+  deleteGroups: 'Can delete groups',
+  createPKPs: 'Can create PKPs',
+  expiration: 'Expires (unix s, 0=never)',
+  balance: 'Starting balance',
+  creatorWalletAddress: 'Creator wallet',
+  derivationPath: 'Derivation path',
+};
+
+function prettifyMethod(name) {
+  if (METHOD_LABELS[name]) return METHOD_LABELS[name];
+  return name.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+}
+
+function prettifyArg(name) {
+  if (ARG_LABELS[name]) return ARG_LABELS[name];
+  return name;
+}
+
+/**
+ * Best-effort human-readable rendering for an argument value.
+ */
+function formatArg(value) {
+  if (value == null) return '<em>(empty)</em>';
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '<em>(none)</em>';
+    return '<code>[' + value.map((v) => escapeHtml(String(v))).join(', ') + ']</code>';
+  }
+  if (typeof value === 'string') {
+    if (value.startsWith('0x') && value.length === 66) {
+      // 32-byte hash: show first+last
+      return '<code>' + escapeHtml(value.slice(0, 10)) + '…' + escapeHtml(value.slice(-6)) + '</code>';
+    }
+    if (value.startsWith('0x') && value.length === 42) {
+      // 20-byte address
+      return '<code>' + escapeHtml(value) + '</code>';
+    }
+    return escapeHtml(value);
+  }
+  return escapeHtml(String(value));
+}
+
+function findMethodInputs(methodName) {
+  const entry = ACCOUNT_CONFIG_FULL_ABI.find(
+    (i) => i.type === 'function' && i.name === methodName,
+  );
+  return entry?.inputs ?? [];
+}
+
+/**
+ * Show the preview modal. Resolves true on confirm, false on cancel.
+ *
+ * @param {string} methodName - contract function name (e.g. 'addGroup')
+ * @param {any[]} args - positional args in contract-ABI order
+ * @param {Object} [meta]
+ * @param {string} [meta.chainLabel] - "Base", "Base Sepolia", etc.
+ * @param {string} [meta.signerAddress] - 0x-prefixed signer
+ * @param {string} [meta.contractAddress] - target contract
+ * @returns {Promise<boolean>}
+ */
+export function showTxPreview(methodName, args, meta = {}) {
+  return new Promise((resolve) => {
+    const inputs = findMethodInputs(methodName);
+    const rows = inputs.map((input, idx) => {
+      const val = args[idx];
+      const label = prettifyArg(input.name);
+      return `<tr>
+        <th style="text-align:left;padding:4px 8px;vertical-align:top;font-weight:600">${escapeHtml(label)}</th>
+        <td style="padding:4px 8px;word-break:break-all">${formatArg(val)}</td>
+      </tr>`;
+    }).join('');
+
+    const metaRows = [];
+    if (meta.signerAddress) {
+      metaRows.push(`<tr><th style="text-align:left;padding:4px 8px">Signing wallet</th><td style="padding:4px 8px"><code>${escapeHtml(meta.signerAddress)}</code></td></tr>`);
+    }
+    if (meta.chainLabel || meta.chainId) {
+      metaRows.push(`<tr><th style="text-align:left;padding:4px 8px">Network</th><td style="padding:4px 8px">${escapeHtml(meta.chainLabel || `chain ${meta.chainId}`)}</td></tr>`);
+    }
+    if (meta.contractAddress) {
+      metaRows.push(`<tr><th style="text-align:left;padding:4px 8px">AccountConfig</th><td style="padding:4px 8px"><code>${escapeHtml(meta.contractAddress)}</code></td></tr>`);
+    }
+
+    const bodyHTML = `
+      <div style="display:grid;gap:12px">
+        <div>
+          <div style="font-size:13px;color:var(--muted,#888);margin-bottom:4px">Contract method</div>
+          <div style="font-weight:600"><code>${escapeHtml(methodName)}</code></div>
+        </div>
+        ${metaRows.length ? `<table style="width:100%;font-size:13px;border-collapse:collapse">${metaRows.join('')}</table>` : ''}
+        <div>
+          <div style="font-size:13px;color:var(--muted,#888);margin-bottom:4px">Arguments</div>
+          <table style="width:100%;font-size:13px;border-collapse:collapse;background:var(--bg-soft,#fafafa);border-radius:6px">
+            ${rows || '<tr><td style="padding:8px"><em>(no arguments)</em></td></tr>'}
+          </table>
+        </div>
+        <div style="font-size:12px;color:var(--muted,#888)">
+          After you confirm, your wallet will pop up to sign. You can still reject there.
+        </div>
+      </div>
+    `;
+
+    const footerHTML = `
+      <button type="button" class="btn btn-ghost" id="tx-preview-cancel">Cancel</button>
+      <button type="button" class="btn btn-primary" id="tx-preview-confirm">Confirm &amp; sign in wallet</button>
+    `;
+
+    openModal(prettifyMethod(methodName), bodyHTML, footerHTML);
+
+    const cleanup = (result) => {
+      closeModal();
+      resolve(result);
+    };
+    document.getElementById('tx-preview-cancel')?.addEventListener('click', () => cleanup(false), { once: true });
+    document.getElementById('tx-preview-confirm')?.addEventListener('click', () => cleanup(true), { once: true });
+  });
+}

--- a/lit-static/tx_lifecycle.js
+++ b/lit-static/tx_lifecycle.js
@@ -1,0 +1,234 @@
+/**
+ * Transaction lifecycle state machine + revert-reason decoder for
+ * sovereign-mode direct contract writes.
+ *
+ * States (monotonic, with only `confirmed|failed|reorged` as terminal):
+ *   preparing    → building calldata, validating mode/signer/chain
+ *   previewing   → awaiting user's in-dashboard preview/confirm click
+ *   signing      → wallet popup is open (user must confirm in wallet)
+ *   pending      → tx broadcast to mempool; hash known; waiting for 1 conf
+ *   confirming   → tx included in a block; waiting for target confirmations
+ *   confirmed    → TERMINAL. receipt.status === 1, target confirmations met.
+ *   failed       → TERMINAL. rejected, reverted, timed out, unparseable.
+ *   reorged      → TERMINAL. receipt became null after earlier inclusion.
+ *
+ * Revert parsing mirrors `lit-api-server/src/accounts/decode_revert.rs`:
+ *   1. Error(string) / Panic(uint256) (standard solidity reverts)
+ *   2. AccountConfig custom errors (from ACCOUNT_CONFIG_ERROR_ABI)
+ *   3. Unknown revert data (truncated hex)
+ */
+
+import { ACCOUNT_CONFIG_ERROR_ABI } from './account_config_full_abi.js';
+
+export const TX_STATES = Object.freeze({
+  PREPARING: 'preparing',
+  PREVIEWING: 'previewing',
+  SIGNING: 'signing',
+  PENDING: 'pending',
+  CONFIRMING: 'confirming',
+  CONFIRMED: 'confirmed',
+  FAILED: 'failed',
+  REORGED: 'reorged',
+});
+
+const TERMINAL_STATES = new Set([TX_STATES.CONFIRMED, TX_STATES.FAILED, TX_STATES.REORGED]);
+
+export function isTerminal(state) {
+  return TERMINAL_STATES.has(state);
+}
+
+const MAX_HEX_DISPLAY_BYTES = 64;
+
+function getEthers() {
+  if (typeof globalThis.ethers !== 'undefined') return globalThis.ethers;
+  throw new Error('tx_lifecycle: ethers is not loaded. Preload it before importing this module.');
+}
+
+/**
+ * Decode an Error(string) / Panic(uint256) revert payload. Returns null if
+ * the payload doesn't match those two standard selectors.
+ */
+function decodeStandardRevert(ethers, data) {
+  if (!data || data === '0x') return null;
+  const selector = data.slice(0, 10).toLowerCase();
+  try {
+    if (selector === '0x08c379a0') {
+      const [reason] = ethers.AbiCoder.defaultAbiCoder().decode(['string'], '0x' + data.slice(10));
+      return `Revert: ${reason}`;
+    }
+    if (selector === '0x4e487b71') {
+      const [code] = ethers.AbiCoder.defaultAbiCoder().decode(['uint256'], '0x' + data.slice(10));
+      return `Panic: 0x${code.toString(16).padStart(2, '0')}`;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Decode a custom-error revert payload via the AccountConfig error ABI.
+ * Returns null if the 4-byte selector doesn't match any known custom error.
+ */
+function decodeCustomError(ethers, data) {
+  if (!data || data === '0x' || data.length < 10) return null;
+  const iface = new ethers.Interface(ACCOUNT_CONFIG_ERROR_ABI);
+  try {
+    const parsed = iface.parseError(data);
+    if (!parsed) return null;
+    const argStr = parsed.args.map((a) => String(a)).join(', ');
+    return `Contract error: ${parsed.name}(${argStr})`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Top-level decoder. Accepts an ethers error (or any object with a nested
+ * `data` / `error.data` / `info.error.data` / `revert` / `cause` chain).
+ * Always returns a non-empty string; falls back to the error's message or
+ * `String(err)` if nothing else matches.
+ */
+export function decodeContractRevert(err) {
+  const ethers = getEthers();
+  const data = extractRevertData(err);
+
+  if (data) {
+    const std = decodeStandardRevert(ethers, data);
+    if (std) return std;
+
+    const custom = decodeCustomError(ethers, data);
+    if (custom) return custom;
+
+    if (data.length > 2 + MAX_HEX_DISPLAY_BYTES * 2) {
+      return `Unknown revert data (${(data.length - 2) / 2} bytes): ${data.slice(0, 2 + MAX_HEX_DISPLAY_BYTES * 2)}...`;
+    }
+    return `Unknown revert data: ${data}`;
+  }
+
+  if (err && typeof err === 'object') {
+    if (err.shortMessage) return err.shortMessage;
+    if (err.reason) return err.reason;
+    if (err.message) return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Walk the ethers v6 error graph looking for a 0x-hex revert payload. Ethers
+ * hides the payload in different slots depending on provider type; this
+ * tries every known location.
+ */
+function extractRevertData(err) {
+  if (!err) return null;
+  const candidates = [
+    err.data,
+    err.error?.data,
+    err.info?.error?.data,
+    err.revert?.data,
+    err.cause?.data,
+    err.cause?.error?.data,
+    err.cause?.info?.error?.data,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.startsWith('0x')) return c;
+    if (c && typeof c === 'object' && typeof c.data === 'string' && c.data.startsWith('0x')) return c.data;
+  }
+  if (err.cause) return extractRevertData(err.cause);
+  return null;
+}
+
+/**
+ * Run a sovereign-mode contract write end-to-end with lifecycle callbacks.
+ *
+ * @param {Object} options
+ * @param {import('ethers').Contract} options.contract - ethers v6 contract (already connected to a signer)
+ * @param {string} options.method - function name on the contract
+ * @param {any[]} options.args - positional args for the call
+ * @param {Object} [options.overrides] - ethers tx overrides (gasLimit, value, etc.)
+ * @param {number} [options.confirmations=1] - confirmations to wait for before marking confirmed
+ * @param {(state: string, payload?: Object) => void} [options.onState] - called on every state transition
+ * @param {() => Promise<boolean>} [options.onPreview] - user-preview gate; must resolve true to proceed
+ * @returns {Promise<{receipt: Object, txHash: string}>}
+ * @throws {Error} with { state: 'failed'|'reorged', cause, decoded } on failure
+ */
+export async function runContractWrite({
+  contract,
+  method,
+  args,
+  overrides = {},
+  confirmations = 1,
+  onState = () => {},
+  onPreview,
+}) {
+  let state = TX_STATES.PREPARING;
+  const emit = (next, payload) => {
+    state = next;
+    try {
+      onState(next, payload);
+    } catch (cbErr) {
+      console.warn('[tx_lifecycle] onState callback threw:', cbErr);
+    }
+  };
+
+  try {
+    emit(TX_STATES.PREPARING, { method, args });
+
+    if (typeof contract[method] !== 'function') {
+      throw new Error(`tx_lifecycle: contract has no method "${method}"`);
+    }
+
+    if (onPreview) {
+      emit(TX_STATES.PREVIEWING, { method, args });
+      const ok = await onPreview(method, args);
+      if (!ok) throw Object.assign(new Error('User cancelled at preview'), { userCancelled: true });
+    }
+
+    emit(TX_STATES.SIGNING, { method, args });
+    const tx = await contract[method](...args, overrides);
+
+    emit(TX_STATES.PENDING, { txHash: tx.hash, method });
+    const receipt = await tx.wait(1);
+    if (!receipt) {
+      throw Object.assign(new Error('Transaction receipt was null (possible reorg)'), { reorg: true });
+    }
+    if (receipt.status !== 1) {
+      throw Object.assign(new Error('Transaction reverted on-chain'), { receipt });
+    }
+
+    if (confirmations > 1) {
+      emit(TX_STATES.CONFIRMING, { txHash: tx.hash, confirmations: 1, target: confirmations });
+      await tx.wait(confirmations);
+    }
+
+    emit(TX_STATES.CONFIRMED, { txHash: tx.hash, receipt });
+    return { receipt, txHash: tx.hash };
+  } catch (err) {
+    const decoded = decodeContractRevert(err);
+    const finalState = err?.reorg ? TX_STATES.REORGED : TX_STATES.FAILED;
+    emit(finalState, { error: err, decoded });
+    const wrapped = new Error(decoded);
+    wrapped.cause = err;
+    wrapped.state = finalState;
+    wrapped.decoded = decoded;
+    wrapped.userCancelled = !!err?.userCancelled;
+    throw wrapped;
+  }
+}
+
+/**
+ * Human-readable state label for UI surfaces.
+ */
+export function describeState(state) {
+  switch (state) {
+    case TX_STATES.PREPARING: return 'Preparing transaction…';
+    case TX_STATES.PREVIEWING: return 'Awaiting your confirmation…';
+    case TX_STATES.SIGNING: return 'Awaiting wallet signature…';
+    case TX_STATES.PENDING: return 'Broadcast — waiting for inclusion…';
+    case TX_STATES.CONFIRMING: return 'Included — waiting for more confirmations…';
+    case TX_STATES.CONFIRMED: return 'Transaction confirmed.';
+    case TX_STATES.FAILED: return 'Transaction failed.';
+    case TX_STATES.REORGED: return 'Reorganized — resubmit may be required.';
+    default: return state;
+  }
+}

--- a/lit-static/wallet_connect.js
+++ b/lit-static/wallet_connect.js
@@ -110,13 +110,27 @@ export async function switchChain(targetChainId, addParams) {
       params: [{ chainId: hexId }],
     });
   } catch (err) {
-    // EIP-3326 error code 4902: chain not added. Try to add then re-switch.
+    // EIP-3326 error code 4902: chain not added. Add it, then re-issue switch.
+    // Some wallets auto-switch after add, others do not, so we always retry
+    // the switch and verify chainId afterwards.
     const code = err?.code ?? err?.data?.originalError?.code;
     if (code === 4902 && addParams) {
       await window.ethereum.request({
         method: 'wallet_addEthereumChain',
         params: [{ ...addParams, chainId: hexId }],
       });
+      try {
+        await window.ethereum.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: hexId }],
+        });
+      } catch (switchErr) {
+        // Some wallets return success from add + auto-switch internally; if
+        // this second switch throws 4902 or "already on chain", treat it as
+        // non-fatal and fall through to the network-verification step below.
+        const sc = switchErr?.code ?? switchErr?.data?.originalError?.code;
+        if (sc !== 4902 && sc !== -32602) throw switchErr;
+      }
     } else {
       throw err;
     }
@@ -127,11 +141,20 @@ export async function switchChain(targetChainId, addParams) {
   const provider = new ethers.BrowserProvider(window.ethereum);
   const signer = await provider.getSigner();
   const network = await provider.getNetwork();
+  const activeChainId = Number(network.chainId);
+  if (activeChainId !== Number(targetChainId)) {
+    throw Object.assign(
+      new Error(
+        `Chain switch did not take effect: wallet is on chain ${activeChainId}, expected ${targetChainId}. Switch network manually and retry.`,
+      ),
+      { wrongChain: true, actual: activeChainId, expected: Number(targetChainId) },
+    );
+  }
   _state = {
     ..._state,
     provider,
     signer,
-    chainId: Number(network.chainId),
+    chainId: activeChainId,
   };
   emit();
 }

--- a/lit-static/wallet_connect.js
+++ b/lit-static/wallet_connect.js
@@ -1,0 +1,203 @@
+/**
+ * Browser-wallet connect helpers for sovereign-mode direct contract writes.
+ *
+ * Scope (CPL-267 Phase 1):
+ *   - EOA / browser-injected providers only (MetaMask, Rabby, etc.).
+ *   - Chain-switching prompt (wallet_switchEthereumChain / wallet_addEthereumChain).
+ *   - Account-change + chain-change listener teardown on disconnect.
+ *
+ * Deferred to later Phase 1 sub-tasks:
+ *   - WalletConnect v2 / Safe Transaction Service integration (monitor app
+ *     already has a working EthereumProvider flow we'll lift from).
+ */
+
+function getEthers() {
+  if (typeof globalThis.ethers !== 'undefined') return globalThis.ethers;
+  throw new Error('wallet_connect: ethers is not loaded. Preload it before importing this module.');
+}
+
+const listeners = {
+  accountsChanged: null,
+  chainChanged: null,
+  disconnect: null,
+};
+
+let _state = {
+  provider: null,        // ethers.BrowserProvider
+  signer: null,          // ethers.Signer
+  address: null,
+  chainId: null,
+  source: null,          // 'eoa' for this Phase 1 pass
+};
+
+const subscribers = new Set();
+
+export function onWalletChange(fn) {
+  subscribers.add(fn);
+  return () => subscribers.delete(fn);
+}
+
+function emit() {
+  const snapshot = snapshotState();
+  for (const fn of subscribers) {
+    try { fn(snapshot); } catch (e) { console.warn('[wallet_connect] subscriber threw:', e); }
+  }
+}
+
+export function snapshotState() {
+  return {
+    connected: !!_state.signer,
+    address: _state.address,
+    chainId: _state.chainId,
+    source: _state.source,
+  };
+}
+
+export function getSigner() {
+  return _state.signer;
+}
+
+export function getProvider() {
+  return _state.provider;
+}
+
+/**
+ * Connect to window.ethereum (EOA). Throws if no injected provider or user
+ * rejects. Wires up accountsChanged / chainChanged / disconnect listeners.
+ *
+ * @returns {Promise<{signer: import('ethers').Signer, address: string, chainId: number}>}
+ */
+export async function connectEoa() {
+  const ethers = getEthers();
+  if (!window.ethereum) {
+    throw new Error('No browser wallet found. Install MetaMask (or another EIP-1193 wallet) and reload.');
+  }
+
+  const provider = new ethers.BrowserProvider(window.ethereum);
+  await provider.send('eth_requestAccounts', []);
+  const signer = await provider.getSigner();
+  const address = await signer.getAddress();
+  const network = await provider.getNetwork();
+
+  detachListeners();
+  attachListeners(window.ethereum);
+
+  _state = {
+    provider,
+    signer,
+    address,
+    chainId: Number(network.chainId),
+    source: 'eoa',
+  };
+  emit();
+  return { signer, address, chainId: _state.chainId };
+}
+
+/**
+ * Request a chain switch via EIP-3326. If the wallet doesn't know the chain,
+ * and `addParams` is provided, fall back to EIP-3085 wallet_addEthereumChain.
+ *
+ * @param {number} targetChainId
+ * @param {Object} [addParams] - EIP-3085 params for wallet_addEthereumChain fallback
+ */
+export async function switchChain(targetChainId, addParams) {
+  if (!window.ethereum) throw new Error('No browser wallet available to switch chains.');
+  const hexId = '0x' + Number(targetChainId).toString(16);
+
+  try {
+    await window.ethereum.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: hexId }],
+    });
+  } catch (err) {
+    // EIP-3326 error code 4902: chain not added. Try to add then re-switch.
+    const code = err?.code ?? err?.data?.originalError?.code;
+    if (code === 4902 && addParams) {
+      await window.ethereum.request({
+        method: 'wallet_addEthereumChain',
+        params: [{ ...addParams, chainId: hexId }],
+      });
+    } else {
+      throw err;
+    }
+  }
+
+  // Refresh state to pick up the new chain / signer.
+  const ethers = getEthers();
+  const provider = new ethers.BrowserProvider(window.ethereum);
+  const signer = await provider.getSigner();
+  const network = await provider.getNetwork();
+  _state = {
+    ..._state,
+    provider,
+    signer,
+    chainId: Number(network.chainId),
+  };
+  emit();
+}
+
+/**
+ * Guard: throw unless the wallet is on the expected chain. Caller should
+ * catch and invoke `switchChain(expectedChainId, addParams)` on failure.
+ */
+export function assertChain(expectedChainId) {
+  if (_state.chainId !== Number(expectedChainId)) {
+    throw Object.assign(
+      new Error(`Wallet is on chain ${_state.chainId}, expected ${expectedChainId}. Switch network and retry.`),
+      { wrongChain: true, actual: _state.chainId, expected: Number(expectedChainId) },
+    );
+  }
+}
+
+export function disconnect() {
+  detachListeners();
+  _state = { provider: null, signer: null, address: null, chainId: null, source: null };
+  emit();
+}
+
+function attachListeners(eth) {
+  listeners.accountsChanged = async (accounts) => {
+    if (!accounts || accounts.length === 0) {
+      disconnect();
+      return;
+    }
+    try {
+      const ethers = getEthers();
+      const provider = new ethers.BrowserProvider(eth);
+      const signer = await provider.getSigner();
+      _state = { ..._state, provider, signer, address: accounts[0] };
+      emit();
+    } catch (e) {
+      console.warn('[wallet_connect] accountsChanged handler failed:', e);
+      disconnect();
+    }
+  };
+  listeners.chainChanged = async (hexChainId) => {
+    const chainId = typeof hexChainId === 'string' ? parseInt(hexChainId, 16) : Number(hexChainId);
+    try {
+      const ethers = getEthers();
+      const provider = new ethers.BrowserProvider(eth);
+      const signer = _state.address ? await provider.getSigner() : null;
+      _state = { ..._state, provider, signer, chainId };
+      emit();
+    } catch (e) {
+      console.warn('[wallet_connect] chainChanged handler failed:', e);
+    }
+  };
+  listeners.disconnect = () => disconnect();
+
+  eth.on?.('accountsChanged', listeners.accountsChanged);
+  eth.on?.('chainChanged', listeners.chainChanged);
+  eth.on?.('disconnect', listeners.disconnect);
+}
+
+function detachListeners() {
+  const eth = window.ethereum;
+  if (!eth?.removeListener) return;
+  if (listeners.accountsChanged) eth.removeListener('accountsChanged', listeners.accountsChanged);
+  if (listeners.chainChanged) eth.removeListener('chainChanged', listeners.chainChanged);
+  if (listeners.disconnect) eth.removeListener('disconnect', listeners.disconnect);
+  listeners.accountsChanged = null;
+  listeners.chainChanged = null;
+  listeners.disconnect = null;
+}


### PR DESCRIPTION
## Summary

Wires the dashboard for direct AccountConfig writes from the user's own wallet when sovereign mode is enabled, preserving the existing API-server path for everyone else. Phase 1 of CPL-267 per the CEO plan (plan-eng-review cleared).

**What ships in this PR:**
- Full admin-write ABI bundle (16 write fns + 17 custom errors, ABI version pinned)
- ABI drift hard-block via keccak-hashed runtime bytecode per (chainId, contractAddress)
- Tx lifecycle state machine: `preparing → previewing → signing → pending → confirming → confirmed | failed | reorged`
- Revert decoder: `Error(string)` → `Panic(uint256)` → custom errors → hex fallback; walks the ethers v6 nested error graph
- Wallet connect (EOA, EIP-3326 chain switch + EIP-3085 add fallback, accountsChanged / chainChanged listener lifecycle)
- Required preview+confirm modal before every wallet pop, decoded calldata + arg labels from the full ABI
- 14 SDK write methods branched on `mode === 'sovereign'`; usage API keys generated client-side (contract only stores hash)
- Dashboard `getClient()` Proxy auto-injects the sovereign lifecycle, zero call-site changes in groups.js / actions.js / wallets.js / keys.js

**Deferred to Phase 1 follow-ups (intentional, per plan):**
- WalletConnect v2 / Safe Transaction Service integration
- Playwright + Synpress E2E harness for the 15+ writes
- Live-stack validation against real AccountConfig

**Out of scope (Phase 2+):**
- `newAccount` as direct contract write
- Hybrid `createWallet` with server-prepared key + `registerWalletDerivation`
- One-way API → sovereign account conversion

## Test plan

- [ ] Node-level smoke passed locally (ABI load, lifecycle states, revert decoding standard + custom + nested + hex fallback, Proxy auto-inject on writes only, runContractWrite state transitions on success/failure/cancel)
- [ ] Load dashboard in browser, flip sovereign toggle, confirm reads still work (Phase 0 path)
- [ ] Create a group in sovereign mode against local_test.sh stack + MetaMask — preview modal shows, wallet pops, tx confirms, group lists
- [ ] Delete a group in sovereign mode — same flow
- [ ] Revert path: attempt a write with a non-master wallet, confirm `NotMasterAccount(…)` decodes in the error banner
- [ ] Chain-switch path: connect wallet on wrong chain, confirm switch prompt fires and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)