### PR TITLE
feat: sovereign newAccount + hybrid createWallet (CPL-267 Phase 2 scaffolding)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -92,6 +92,42 @@
   **Branch:** GTC6244/k6-api-key-security-tests
   **Noticed:** 2026-03-26
 
+## CPL-267 Phase 2: newAccount access control for sovereign self-serve
+
+**What:** Relax the `OnlyApiPayerOrOwner` guard on `AccountConfig.newAccount` so a user-owned wallet can create an unmanaged (`managed=false`) self-sovereign account. Today the check blocks every non-api_payer caller, which is correct for server-managed accounts but blocks the whole Phase 2 direct-write path.
+
+**Why:** Without this, sovereign `newAccount` always reverts with `OnlyApiPayerOrOwner(0x…)`. The client-side SDK branch is already wired and decoded end-to-end (see `core_sdk.js::newAccount` sovereign branch on `feature/cpl-267-phase-2-sovereign-accounts`); only the contract gate stands in the way.
+
+**How to fix:** Add a branch in `AccountConfig.newAccount`: if `managed == false` and `creatorWalletAddress == msg.sender`, skip the api_payer check. Keep managed accounts behind the existing guard. Consider rate-limiting per-address to avoid spam.
+
+**Priority:** P1 (blocks Phase 2 demo)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-phase-2-sovereign-accounts
+
+## CPL-267 Phase 2: POST /prepare_sovereign_wallet TEE-prepare endpoint
+
+**What:** Add a new endpoint that generates a PKP inside the TEE, persists derivation metadata, and returns `{ pkp_id, derivation_path, expires_at }`. Hybrid `createWallet` in sovereign mode calls this first, then the user signs `registerWalletDerivation` on-chain to finalize.
+
+**Why:** PKPs must be generated inside the TEE (the user's browser can't mint one). But registration should land on-chain from the user's wallet so the server is not in the trust boundary for account linkage. Without this endpoint, sovereign `createWallet` 404s at step 1.
+
+**How to fix:** New endpoint `/core/v1/prepare_sovereign_wallet` accepting `{ api_key }`, generating a PKP in TEE, storing `{ pkp_id → { derivation_path, expires_at, registered: false } }` in persistent state, returning pkp_id + derivation_path. Pair with the "GC orphan prepared wallet keys" TODO.
+
+**Priority:** P1 (blocks Phase 2 createWallet)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-phase-2-sovereign-accounts
+
+## CPL-267 Phase 2: API → sovereign conversion dashboard UX
+
+**What:** Add a one-way "convert this account to sovereign" flow in the dashboard. Requires a wallet-connect step, an explicit confirmation modal explaining consequences (server can no longer act on your behalf; all admin ops need your wallet signature; Lit Action billing continues), and a contract write that flips `managed` to `false` for the account.
+
+**Why:** Users who currently run API-mode accounts can't migrate today without manually rotating. One-way conversion is the sanctioned path; pairing it with an explanatory modal prevents support tickets and accidental lockouts.
+
+**How to fix:** Need a contract function like `setAccountManaged(hash, false)` gated to the current owner. Dashboard adds a "Convert to sovereign" button in account settings that runs through the preview+confirm pipeline like any other sovereign write.
+
+**Priority:** P2 (nice-to-have for Phase 2 ship; parallel to contract work)
+
+**Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-phase-2-sovereign-accounts
+
 ## CPL-267 Sovereign Mode: blockchain_cache needs `invalidate_for_account_hash(hash)` primitive
 
 **What:** Add `invalidate_for_account_hash(api_key_hash: Bytes32)` to `lit-api-server/src/accounts/blockchain_cache.rs`. Existing invalidation functions (`invalidate_for_account`, `invalidate_for_key`) take raw api_key and hash internally, but the Phase 3 event listener only has the hashed apiKeyHash from chain event topics.

--- a/TODOS.md
+++ b/TODOS.md
@@ -110,7 +110,7 @@
 
 **Why:** PKPs must be generated inside the TEE (the user's browser can't mint one). But registration should land on-chain from the user's wallet so the server is not in the trust boundary for account linkage. Without this endpoint, sovereign `createWallet` 404s at step 1.
 
-**How to fix:** New endpoint `/core/v1/prepare_sovereign_wallet` accepting `{ api_key }`, generating a PKP in TEE, storing `{ pkp_id → { derivation_path, expires_at, registered: false } }` in persistent state, returning pkp_id + derivation_path. Pair with the "GC orphan prepared wallet keys" TODO.
+**How to fix:** New endpoint `/core/v1/prepare_sovereign_wallet` authenticating via the existing `X-Api-Key` / `Authorization: Bearer` headers (same shape as other account-scoped endpoints; the SDK sends an empty JSON body). Generate a PKP in TEE, store `{ pkp_id → { derivation_path, expires_at, registered: false } }` in persistent state, return `{ pkp_id, derivation_path, expires_at }`. Pair with the "GC orphan prepared wallet keys" TODO.
 
 **Priority:** P1 (blocks Phase 2 createWallet)
 

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -510,12 +510,47 @@ export class LitNodeSimpleApiClient {
   }
 
   /**
-   * POST /core/v1/new_account
-   * Creates a new account; server generates API key and wallet. Returns api_key and wallet_address.
-   * @param {NewAccountOptions} options
+   * POST /core/v1/new_account  (api mode)
+   *   Creates a new account; server generates API key and wallet.
+   *
+   * contract.newAccount(hash, managed=false, name, description, creator)  (sovereign mode)
+   *   User generates their own API key client-side, hashes it locally, and
+   *   submits a tx from their wallet. managed=false flags the account as
+   *   self-sovereign (server billing still applies to Lit Action execution).
+   *
+   *   BLOCKER: today `newAccount` has an OnlyApiPayerOrOwner guard on the
+   *   contract, so a random user wallet reverts. Phase 2 requires a contract
+   *   change that relaxes this for unmanaged self-sovereign accounts. See
+   *   TODOS.md "CPL-267 Phase 2: newAccount access control for sovereign
+   *   self-serve".
+   *
+   * @param {NewAccountOptions & { sovereignLifecycle?: Object }} options
    * @returns {Promise<NewAccountResponse>}
    */
-  async newAccount({ accountName, accountDescription, email }) {
+  async newAccount({ accountName, accountDescription, email, sovereignLifecycle } = {}) {
+    if (this.mode === 'sovereign') {
+      const ethers = await loadEthers();
+      const randBytes = new Uint8Array(32);
+      crypto.getRandomValues(randBytes);
+      const apiKey = 'lk_' + Array.from(randBytes, (b) => b.toString(16).padStart(2, '0')).join('');
+      const hash = ethers.keccak256(ethers.toUtf8Bytes(apiKey));
+      const contract = await this._getWriteContract();
+      const creator = await this.signer.getAddress();
+      const { txHash } = await runContractWrite({
+        contract, method: 'newAccount',
+        args: [hash, false, accountName ?? '', accountDescription ?? '', creator],
+        ...(sovereignLifecycle ?? {}),
+      });
+      // Email is not surfaced on-chain; if it ever needs to be linked, that
+      // belongs in an off-chain account-registry service keyed by hash.
+      return {
+        success: true,
+        api_key: apiKey,
+        account_hash: hash,
+        creator_wallet_address: creator,
+        transaction_hash: txHash,
+      };
+    }
     const body = {
       account_name: accountName,
       account_description: accountDescription ?? '',
@@ -557,17 +592,100 @@ export class LitNodeSimpleApiClient {
   }
 
   /**
-   * GET /core/v1/create_wallet
-   * Creates a wallet for the given API key and returns the wallet address.
-   * API key via X-Api-Key or Authorization: Bearer header.
-   * @param {string} apiKey - API key (from getApiKey)
+   * Create a wallet (PKP) for the account.
+   *
+   * Accepts either a bare apiKey string (backwards compat with GET /core/v1/create_wallet)
+   * or an options object: { apiKey, name?, description?, sovereignLifecycle? }.
+   *
+   * api mode      : GET /core/v1/create_wallet — server generates PKP end-to-end.
+   *
+   * sovereign mode: hybrid flow. The TEE still has to generate the key (the
+   *   user's browser can't mint a PKP) but registration happens on-chain via a
+   *   user-signed tx. Two round-trips:
+   *     1) POST /core/v1/prepare_sovereign_wallet { api_key } → { pkp_id, derivation_path }
+   *        Server generates and holds the key in TEE state, returns metadata.
+   *     2) contract.registerWalletDerivation(hash, pkp_id, derivation_path, name, description)
+   *        User signs; tx settles; server listener finalizes persistence.
+   *
+   *   BLOCKER: step 1 endpoint does not exist yet. See TODOS.md
+   *   "CPL-267 Phase 2: POST /prepare_sovereign_wallet TEE-prepare endpoint".
+   *   Without it, sovereign createWallet will 404. Standalone registration via
+   *   `registerWalletDerivation` is available if the caller has pkp_id +
+   *   derivation_path from elsewhere.
+   *
+   * @param {string | { apiKey: string, name?: string, description?: string, sovereignLifecycle?: Object }} arg
    * @returns {Promise<CreateWalletResponse>}
    */
-  async createWallet(apiKey) {
+  async createWallet(arg) {
+    const opts = typeof arg === 'string' ? { apiKey: arg } : (arg ?? {});
+    const { apiKey, name = '', description = '', sovereignLifecycle } = opts;
+
+    if (this.mode === 'sovereign') {
+      // Step 1: server-side TEE prepare.
+      const prepRes = await fetch(`${this.baseUrl}/prepare_sovereign_wallet`, {
+        method: 'POST',
+        headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+        body: JSON.stringify({}),
+      });
+      if (!prepRes.ok) {
+        if (prepRes.status === 404) {
+          throw new Error(
+            'Sovereign createWallet is not yet available: the server /prepare_sovereign_wallet endpoint is not deployed. ' +
+            'Track progress in TODOS.md ("CPL-267 Phase 2: prepare_sovereign_wallet").',
+          );
+        }
+        throw new Error(`prepare_sovereign_wallet failed with HTTP ${prepRes.status}`);
+      }
+      const prep = await prepRes.json();
+      if (!prep?.pkp_id || prep.derivation_path == null) {
+        throw new Error('prepare_sovereign_wallet response missing pkp_id or derivation_path');
+      }
+
+      // Step 2: on-chain registration, user-signed.
+      const contract = await this._getWriteContract();
+      const hash = await this._apiKeyHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'registerWalletDerivation',
+        args: [hash, prep.pkp_id, BigInt(prep.derivation_path), name, description],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return {
+        success: true,
+        wallet_address: prep.pkp_id,
+        derivation_path: String(prep.derivation_path),
+        transaction_hash: txHash,
+      };
+    }
+
     const res = await fetch(`${this.baseUrl}/create_wallet`, {
       headers: headersWithApiKey(apiKey),
     });
     return parseResponse(res, 'create_wallet');
+  }
+
+  /**
+   * Register an existing server-prepared PKP derivation on-chain.
+   *
+   * Exposed for advanced callers who already have pkp_id + derivation_path
+   * from a bespoke server flow and just need the on-chain registration leg.
+   * Regular dashboard users should call createWallet() which does both steps.
+   *
+   * sovereign mode only. Throws in api mode (registration is implicit there).
+   *
+   * @param {{ apiKey: string, pkpId: string, derivationPath: string|number|bigint, name?: string, description?: string, sovereignLifecycle?: Object }} options
+   */
+  async registerWalletDerivation({ apiKey, pkpId, derivationPath, name = '', description = '', sovereignLifecycle } = {}) {
+    if (this.mode !== 'sovereign') {
+      throw new Error('registerWalletDerivation is sovereign-mode only; in api mode use createWallet instead.');
+    }
+    const contract = await this._getWriteContract();
+    const hash = await this._apiKeyHash(apiKey);
+    const { txHash } = await runContractWrite({
+      contract, method: 'registerWalletDerivation',
+      args: [hash, pkpId, BigInt(derivationPath), name, description],
+      ...(sovereignLifecycle ?? {}),
+    });
+    return { success: true, transaction_hash: txHash };
   }
 
   /**

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -529,11 +529,10 @@ export class LitNodeSimpleApiClient {
    */
   async newAccount({ accountName, accountDescription, email, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
-      const ethers = await loadEthers();
       const randBytes = new Uint8Array(32);
       crypto.getRandomValues(randBytes);
       const apiKey = 'lk_' + Array.from(randBytes, (b) => b.toString(16).padStart(2, '0')).join('');
-      const hash = ethers.keccak256(ethers.toUtf8Bytes(apiKey));
+      const hash = await this._apiKeyHash(apiKey);
       const contract = await this._getWriteContract();
       const creator = await this.signer.getAddress();
       const { txHash } = await runContractWrite({
@@ -602,8 +601,10 @@ export class LitNodeSimpleApiClient {
    * sovereign mode: hybrid flow. The TEE still has to generate the key (the
    *   user's browser can't mint a PKP) but registration happens on-chain via a
    *   user-signed tx. Two round-trips:
-   *     1) POST /core/v1/prepare_sovereign_wallet { api_key } → { pkp_id, derivation_path }
-   *        Server generates and holds the key in TEE state, returns metadata.
+   *     1) POST /core/v1/prepare_sovereign_wallet → { pkp_id, derivation_path }
+   *        Auth: X-Api-Key / Authorization header (same as other account-scoped
+   *        endpoints). Request body is an empty JSON object. Server generates
+   *        and holds the key in TEE state, returns metadata.
    *     2) contract.registerWalletDerivation(hash, pkp_id, derivation_path, name, description)
    *        User signs; tx settles; server listener finalizes persistence.
    *
@@ -630,11 +631,12 @@ export class LitNodeSimpleApiClient {
       if (!prepRes.ok) {
         if (prepRes.status === 404) {
           throw new Error(
-            'Sovereign createWallet is not yet available: the server /prepare_sovereign_wallet endpoint is not deployed. ' +
+            'Sovereign createWallet is not yet available: the server ' +
+            `${this.baseUrl}/prepare_sovereign_wallet endpoint is not deployed. ` +
             'Track progress in TODOS.md ("CPL-267 Phase 2: prepare_sovereign_wallet").',
           );
         }
-        throw new Error(`prepare_sovereign_wallet failed with HTTP ${prepRes.status}`);
+        throw new Error(`POST ${this.baseUrl}/prepare_sovereign_wallet failed with HTTP ${prepRes.status}`);
       }
       const prep = await prepRes.json();
       if (!prep?.pkp_id || prep.derivation_path == null) {

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -23,6 +23,8 @@ const SOVEREIGN_WRITE_METHODS = new Set([
   'addAction', 'deleteAction', 'addActionToGroup', 'removeActionFromGroup', 'updateActionMetadata',
   'addPkpToGroup', 'removePkpFromGroup',
   'addUsageApiKey', 'updateUsageApiKey', 'removeUsageApiKey', 'updateUsageApiKeyMetadata',
+  // Phase 2 additions: direct account + wallet writes.
+  'newAccount', 'createWallet', 'registerWalletDerivation',
 ]);
 
 // ----- Mode (api | sovereign) -----

--- a/lit-static/dapps/dashboard/tx_preview_modal.js
+++ b/lit-static/dapps/dashboard/tx_preview_modal.js
@@ -33,8 +33,8 @@ const METHOD_LABELS = {
   setUsageApiKey: 'Create/update usage API key',
   removeUsageApiKey: 'Delete usage API key',
   updateUsageApiKeyMetadata: 'Update usage API key metadata',
-  newAccount: 'Create account',
-  registerWalletDerivation: 'Register wallet',
+  newAccount: 'Create account (sovereign)',
+  registerWalletDerivation: 'Register wallet on-chain',
 };
 
 /**
@@ -61,6 +61,9 @@ const ARG_LABELS = {
   balance: 'Starting balance',
   creatorWalletAddress: 'Creator wallet',
   derivationPath: 'Derivation path',
+  managed: 'Server-managed account',
+  accountName: 'Account name',
+  accountDescription: 'Account description',
 };
 
 function prettifyMethod(name) {

--- a/lit-static/dapps/dashboard/wallets.js
+++ b/lit-static/dapps/dashboard/wallets.js
@@ -83,7 +83,7 @@ function openAddWalletModal() {
     try {
       showActionProgress('Creating wallet', 'Creating and registering a new wallet for this account.');
       const client = await getClient();
-      const res = await client.createWallet(apiKey);
+      const res = await client.createWallet({ apiKey });
       await loadWallets();
       showStatus('wallets-status', 'Wallet created: ' + (res.wallet_address || ''), 'success');
     } catch (e) {


### PR DESCRIPTION
> Draft. Stacked on #310 (CPL-267 Phase 1). Do not merge before Phase 1.
> Blocks on a contract change + a new server endpoint (see TODOS.md).

## Summary

Wires the client side of Phase 2 self-sovereign account management. Three new sovereign write paths added to the SDK and the dashboard Proxy, plus three TODOS entries for the contract and server changes that have to land before this can actually execute end-to-end.

**What ships:**
- **`newAccount` sovereign branch** — user generates an `lk_` API key locally, hashes it, submits a tx with `managed=false` and `creator=signer.address`. Today the on-chain `OnlyApiPayerOrOwner` guard blocks this; our revert decoder surfaces the reason clearly.
- **`registerWalletDerivation`** — new standalone SDK method for advanced callers who already have `pkp_id` + `derivation_path` from a bespoke server flow. Sovereign-only; throws in api mode.
- **`createWallet` hybrid** — `POST /prepare_sovereign_wallet` (TEE generates PKP, returns `pkp_id + derivation_path`) followed by a user-signed `registerWalletDerivation`. The prepare endpoint doesn't exist yet; the SDK 404-catches with a pointer to TODOS.md.
- **Dashboard Proxy** — auto-injects `sovereignLifecycle` for `newAccount`, `createWallet`, and `registerWalletDerivation`. `wallets.js` updated to pass the object form of `createWallet` so the Proxy sees its args.
- **Preview modal labels** — method + arg labels for the new writes.

**What is explicitly blocked (tracked in TODOS.md):**
1. **Contract change:** relax `newAccount`'s access-control for `managed=false` self-serve. P1.
2. **Server endpoint:** `POST /core/v1/prepare_sovereign_wallet` TEE-prepare + persistent state for orphan GC. P1.
3. **Conversion UX:** API → sovereign one-way conversion flow needs a `setAccountManaged(hash, false)` contract function + a confirmation modal. P2.

## Test plan

- [x] Node smoke: `newAccount` generates `lk_` key (67 chars), hashes with keccak256, calls contract with `managed=false`, creator = signer address
- [x] Node smoke: `registerWalletDerivation` passes `derivationPath` as bigint, pkpId as address
- [x] Node smoke: hybrid `createWallet` POSTs prepare → then calls `registerWalletDerivation` with server-returned pkp_id + derivation_path
- [x] Node smoke: `registerWalletDerivation` in api mode throws
- [x] Node smoke: `createWallet` with 404 prep surfaces the blocker message
- [ ] Browser test: wallet connects on "Create account" flow, preview modal shows `Create account (sovereign)` with decoded args, wallet prompt fires, tx reverts with `OnlyApiPayerOrOwner(0x…)` — **expected until contract change lands**
- [ ] Browser test: once contract change ships, full newAccount → login → first write flow
- [ ] Browser test: once `/prepare_sovereign_wallet` ships, full `createWallet` hybrid flow

## Review notes

Stacked on #310. Phase 1 is the load-bearing work; this PR is ~170 lines of surface-level plumbing on top. Safe to review in isolation but don't merge until Phase 1 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)