### PR TITLE
feat: call-before-send for sovereign contract writes (CPL-271)

### DIFF
--- a/lit-api-server/src/accounts/signable_contract.rs
+++ b/lit-api-server/src/accounts/signable_contract.rs
@@ -115,6 +115,22 @@ pub async fn send_transaction<T: ethers::abi::Detokenize>(
     signer_address: H160,
     client: Arc<SigningClient>,
 ) -> Result<bool> {
+    // Call-before-send: dry-run via eth_call so any revert surfaces as a
+    // decoded, human-readable error before we broadcast. No nonce is
+    // consumed and no gas is spent on a failed simulation — callers upstream
+    // get e.g. `Contract error: NotGroupOwner(...)` instead of a generic
+    // post-broadcast failure.
+    if let Err(sim_err) = function_call.call().await {
+        let decoded = decode_contract_revert(&sim_err);
+        // Log-and-ignore release errors so the decoded revert is always the
+        // message the caller sees; the stale-lease sweep will reclaim the
+        // signer if the release channel is dead.
+        if let Err(release_err) = signer_pool.release(signer_address).await {
+            tracing::warn!("signer release after sim failure failed: {release_err}");
+        }
+        return Err(anyhow::anyhow!("Simulation failed: {decoded}"));
+    }
+
     // First attempt.  The Ok arm returns early so the PendingTransaction's borrow of
     // `function_call` is fully consumed before we ever reach the nonce-resync path below;
     // this lets the borrow checker accept the later mutable borrow of `function_call.tx`.

--- a/lit-api-server/src/accounts/signer_pool.rs
+++ b/lit-api-server/src/accounts/signer_pool.rs
@@ -8,6 +8,7 @@ use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{H160, U256};
 use ethers_providers::Middleware;
 
+use crate::accounts::decode_revert::decode_contract_revert;
 use crate::accounts::signable_contract::{
     SigningClient, get_admin_api_payer_contract, get_admin_api_signer,
     get_read_only_account_config_contract,
@@ -262,6 +263,16 @@ async fn set_api_payers(entries: Vec<SigningPoolEntry>) -> Result<()> {
     tracing::info!("signer_pool: setting api payers: {:?}", api_payers);
 
     let function_call = contract.set_api_payers(api_payers);
+
+    // Call-before-send: dry-run to surface a decoded revert reason before
+    // broadcasting the admin transaction.
+    if let Err(sim_err) = function_call.call().await {
+        let decoded = decode_contract_revert(&sim_err);
+        return Err(anyhow::anyhow!(
+            "Failed to set api payers (simulation): {decoded}"
+        ));
+    }
+
     let tx = function_call.send().await;
 
     if let Err(e) = tx {

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -20,7 +20,13 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
+pub const LIT_ACTIONS_SOCKET: &str = "/tmp/lit_actions.sock";
+
+/// Wrapper around the lit-actions socket path so it can be injected via
+/// Rocket managed state. Tests build the rocket with a path guaranteed not to
+/// exist so the reachability probe is hermetic; production wires in the real
+/// `/tmp/lit_actions.sock`.
+pub struct LitActionsSocketPath(pub PathBuf);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HealthResponse {
@@ -39,18 +45,20 @@ async fn health(
     grpc_pool: &State<GrpcClientPool<tonic::transport::Channel>>,
     cpu_monitor: &State<CpuOverloadMonitor>,
     stripe_state: &State<Option<Arc<StripeState>>>,
+    socket_path: &State<LitActionsSocketPath>,
 ) -> (Status, Json<HealthResponse>) {
+    let socket_key = socket_path.0.to_string_lossy();
     // Check if we have a pooled gRPC connection to lit-actions.  If not, try
     // to connect (1s timeout via connect_to_socket).  This avoids the deadlock
     // where NLB marks the node unhealthy → no traffic → lazy connection never
     // established → stays unhealthy.  A successful connect also populates the
     // pool so subsequent probes are a cheap HashMap lookup.
-    let lit_actions_reachable = if grpc_pool.get_connection(LIT_ACTIONS_SOCKET).await.is_some() {
+    let lit_actions_reachable = if grpc_pool.get_connection(&socket_key).await.is_some() {
         true
     } else {
-        match unix::connect_to_socket(PathBuf::from(LIT_ACTIONS_SOCKET)).await {
+        match unix::connect_to_socket(socket_path.0.clone()).await {
             Ok(channel) => {
-                grpc_pool.add_connection(LIT_ACTIONS_SOCKET, channel).await;
+                grpc_pool.add_connection(&socket_key, channel).await;
                 true
             }
             Err(_) => false,
@@ -94,10 +102,19 @@ mod tests {
     ) -> rocket::Rocket<rocket::Build> {
         let pool = GrpcClientPool::<tonic::transport::Channel>::new();
         let monitor = CpuOverloadMonitor::new_with_flag(Arc::new(AtomicBool::new(overloaded)));
+        // Use a path guaranteed not to exist so the lit-actions reachability
+        // probe is hermetic — otherwise the test inherits whatever
+        // /tmp/lit_actions.sock happens to be on the host (e.g. a real
+        // lit-actions process running for local dev), which would flip the
+        // expected "unreachable" result to "reachable".
+        let socket = LitActionsSocketPath(PathBuf::from(
+            "/tmp/lit_actions_test_nonexistent_socket_path.sock",
+        ));
         rocket::build()
             .manage(pool)
             .manage(monitor)
             .manage(stripe_state)
+            .manage(socket)
             .mount("/", routes![health])
     }
 

--- a/lit-api-server/src/core/v1/health.rs
+++ b/lit-api-server/src/core/v1/health.rs
@@ -94,7 +94,31 @@ mod tests {
     use crate::core::v1::guards::cpu_overload::CpuOverloadMonitor;
     use rocket::local::asynchronous::Client;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    /// Build a per-test socket path under `temp_dir()` keyed by PID + a
+    /// monotonic counter, then assert it doesn't already exist. This keeps
+    /// the lit-actions reachability probe hermetic across concurrent test
+    /// runs and across machines where the previously-used hardcoded path
+    /// might (in theory) be created by something else.
+    fn unique_nonexistent_socket_path() -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "lit_actions_test_{}_{}_{}.sock",
+            std::process::id(),
+            n,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        assert!(
+            !path.exists(),
+            "test socket path collided with existing file: {path:?}"
+        );
+        path
+    }
 
     fn build_rocket(
         overloaded: bool,
@@ -102,14 +126,12 @@ mod tests {
     ) -> rocket::Rocket<rocket::Build> {
         let pool = GrpcClientPool::<tonic::transport::Channel>::new();
         let monitor = CpuOverloadMonitor::new_with_flag(Arc::new(AtomicBool::new(overloaded)));
-        // Use a path guaranteed not to exist so the lit-actions reachability
-        // probe is hermetic — otherwise the test inherits whatever
+        // Per-test path under temp_dir() so the lit-actions reachability probe
+        // is hermetic — otherwise the test would inherit whatever
         // /tmp/lit_actions.sock happens to be on the host (e.g. a real
         // lit-actions process running for local dev), which would flip the
         // expected "unreachable" result to "reachable".
-        let socket = LitActionsSocketPath(PathBuf::from(
-            "/tmp/lit_actions_test_nonexistent_socket_path.sock",
-        ));
+        let socket = LitActionsSocketPath(unique_nonexistent_socket_path());
         rocket::build()
             .manage(pool)
             .manage(monitor)

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -358,7 +358,10 @@ fn build_rocket(
         .manage(signer_pool)
         .manage(chain_config)
         .manage(cpu_monitor)
-        .manage(stripe_state);
+        .manage(stripe_state)
+        .manage(core::v1::health::LitActionsSocketPath(
+            std::path::PathBuf::from(core::v1::health::LIT_ACTIONS_SOCKET),
+        ));
 
     // /attestation at root — per Phala Get Attestation
     r = r

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -616,20 +616,15 @@ export class LitNodeSimpleApiClient {
       const hash = await this._apiKeyHash(apiKey);
       const name = groupName ?? '';
       const description = groupDescription ?? '';
-      // staticCall first to pre-fetch the new group_id without burning a tx.
-      let groupId = null;
-      try {
-        groupId = await contract.addGroup.staticCall(hash, name, description, cidHashesPermitted, pkpIdsPermitted);
-      } catch (e) {
-        // staticCall revert will surface again on the real call; proceed and
-        // let runContractWrite produce a decoded error.
-      }
-      const { txHash } = await runContractWrite({
+      // runContractWrite's call-before-send simulation returns the new group_id
+      // (addGroup's return value) as `simulatedResult`, so we can surface it
+      // without a separate staticCall.
+      const { txHash, simulatedResult } = await runContractWrite({
         contract, method: 'addGroup',
         args: [hash, name, description, cidHashesPermitted, pkpIdsPermitted],
         ...(sovereignLifecycle ?? {}),
       });
-      return { success: true, group_id: groupId != null ? groupId.toString() : null, transaction_hash: txHash };
+      return { success: true, group_id: simulatedResult != null ? simulatedResult.toString() : null, transaction_hash: txHash };
     }
     const body = {
       group_name: groupName ?? '',

--- a/lit-static/tx_lifecycle.js
+++ b/lit-static/tx_lifecycle.js
@@ -152,7 +152,7 @@ function extractRevertData(err) {
  * @param {Object} [options.overrides] - ethers tx overrides (gasLimit, value, etc.)
  * @param {number} [options.confirmations=1] - confirmations to wait for before marking confirmed
  * @param {(state: string, payload?: Object) => void} [options.onState] - called on every state transition
- * @param {() => Promise<boolean>} [options.onPreview] - user-preview gate; must resolve true to proceed
+ * @param {(method: string, args: any[]) => Promise<boolean>} [options.onPreview] - user-preview gate; must resolve true to proceed
  * @returns {Promise<{receipt: Object, txHash: string, simulatedResult: any}>}
  *   `simulatedResult` is the eth_call return value from the pre-send
  *   simulation — useful for write methods that return a value that is not

--- a/lit-static/tx_lifecycle.js
+++ b/lit-static/tx_lifecycle.js
@@ -4,6 +4,9 @@
  *
  * States (monotonic, with only `confirmed|failed|reorged` as terminal):
  *   preparing    → building calldata, validating mode/signer/chain
+ *   simulating   → eth_call dry-run (call-before-send) to surface reverts
+ *                  with a decoded, human-readable reason before the wallet
+ *                  popup is shown. No gas is spent on a failed simulation.
  *   previewing   → awaiting user's in-dashboard preview/confirm click
  *   signing      → wallet popup is open (user must confirm in wallet)
  *   pending      → tx broadcast to mempool; hash known; waiting for 1 conf
@@ -22,6 +25,7 @@ import { ACCOUNT_CONFIG_ERROR_ABI } from './account_config_full_abi.js';
 
 export const TX_STATES = Object.freeze({
   PREPARING: 'preparing',
+  SIMULATING: 'simulating',
   PREVIEWING: 'previewing',
   SIGNING: 'signing',
   PENDING: 'pending',
@@ -149,7 +153,10 @@ function extractRevertData(err) {
  * @param {number} [options.confirmations=1] - confirmations to wait for before marking confirmed
  * @param {(state: string, payload?: Object) => void} [options.onState] - called on every state transition
  * @param {() => Promise<boolean>} [options.onPreview] - user-preview gate; must resolve true to proceed
- * @returns {Promise<{receipt: Object, txHash: string}>}
+ * @returns {Promise<{receipt: Object, txHash: string, simulatedResult: any}>}
+ *   `simulatedResult` is the eth_call return value from the pre-send
+ *   simulation — useful for write methods that return a value that is not
+ *   emitted in logs (e.g. `addGroup` returning the new group_id).
  * @throws {Error} with { state: 'failed'|'reorged', cause, decoded } on failure
  */
 export async function runContractWrite({
@@ -178,6 +185,13 @@ export async function runContractWrite({
       throw new Error(`tx_lifecycle: contract has no method "${method}"`);
     }
 
+    // Call-before-send: dry-run via eth_call so any revert surfaces as a
+    // decoded, human-readable error before we show the preview modal or open
+    // the wallet. A failure here throws into the catch below with no gas
+    // spent and no signature prompt.
+    emit(TX_STATES.SIMULATING, { method, args });
+    const simulatedResult = await contract[method].staticCall(...args, overrides);
+
     if (onPreview) {
       emit(TX_STATES.PREVIEWING, { method, args });
       const ok = await onPreview(method, args);
@@ -202,7 +216,7 @@ export async function runContractWrite({
     }
 
     emit(TX_STATES.CONFIRMED, { txHash: tx.hash, receipt });
-    return { receipt, txHash: tx.hash };
+    return { receipt, txHash: tx.hash, simulatedResult };
   } catch (err) {
     const decoded = decodeContractRevert(err);
     const finalState = err?.reorg ? TX_STATES.REORGED : TX_STATES.FAILED;
@@ -222,6 +236,7 @@ export async function runContractWrite({
 export function describeState(state) {
   switch (state) {
     case TX_STATES.PREPARING: return 'Preparing transaction…';
+    case TX_STATES.SIMULATING: return 'Simulating transaction…';
     case TX_STATES.PREVIEWING: return 'Awaiting your confirmation…';
     case TX_STATES.SIGNING: return 'Awaiting wallet signature…';
     case TX_STATES.PENDING: return 'Broadcast — waiting for inclusion…';


### PR DESCRIPTION
## Summary

Ticket: [CPL-271](https://linear.app/lit-protocol/issue/CPL-271)

When a sovereign contract write is going to revert, surface a decoded human-readable error (e.g. `Contract error: NotGroupOwner(...)`) before we broadcast the transaction. No gas is spent, no nonce is consumed, and on the client no wallet popup is shown.

Implemented both server-side (Rust, ethers-rs) and client-side (JS, ethers v6).

## Changes

### Client (`lit-static`)
- `tx_lifecycle.js`: added `SIMULATING` state. `runContractWrite` now does `contract[method].staticCall(...args, overrides)` before the preview modal / wallet popup. The simulation's return value is exposed as `simulatedResult`.
- `core_sdk.js`: `addGroup` reads `simulatedResult` for the new `group_id` instead of running its own manual `staticCall`.

### Server (`lit-api-server`)
- `accounts/signable_contract.rs::send_transaction`: pre-send `function_call.call().await` dry-run. On failure, release the signer (log-and-ignore release errors so the decoded revert is always the surfaced message) and return `anyhow!("Simulation failed: {decoded}")`.
- `accounts/signer_pool.rs::set_api_payers`: same pre-send dry-run for the admin-path write that bypasses `send_transaction`.
- `rebalance_entries` intentionally left alone — raw ETH transfer, no contract ABI.

### Test hermeticity fix (`health.rs`, `main.rs`)
- Parameterized the hardcoded `/tmp/lit_actions.sock` path via a `LitActionsSocketPath` Rocket managed-state newtype so `health_reports_lit_actions_unreachable_when_no_socket` is hermetic. Previously, a real lit-actions socket on the dev machine would flip the expected "unreachable" result to "reachable" and fail the test. Production wiring unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 195 unit + 14 binary tests pass
- [x] Health test now passes with a live lit-actions socket on the host
- [ ] Trigger a known-revert condition against a deployed AccountConfig (e.g. `addGroup` with a duplicate name) and verify the error surfaces as the decoded custom error string — rather than a generic post-broadcast failure — in both the JS dashboard and a direct Rust API call
- [ ] Verify success-path latency is unchanged apart from one extra eth_call roundtrip per write

🤖 Generated with [Claude Code](https://claude.com/claude-code)