### PR TITLE
feat: add crypto payment options to dashboard Stripe modal (CPL-274)

### DIFF
--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -5,7 +5,7 @@
 
 import { isAuthenticated, setTheme, getTheme, logOut, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI, setChainSecuredRpcUrl, toggleChainSecuredRpcPanel, updateChainSecuredRpcUrlUI, getMode, getApiKey, convertToChainSecured, changeChainSecuredOwnership } from './auth.js';
 import { initModalClose, initConfirmClose, showStatus, hideStatus, logError } from './ui-utils.js';
-import { initBilling } from './billing.js';
+import { initBilling, handleBillingReturn } from './billing.js';
 import { initGroups, loadGroups } from './groups.js';
 import { initKeys, loadUsageKeys } from './keys.js';
 import { initActions, loadActions } from './actions.js';
@@ -281,6 +281,7 @@ setOnAuthReady(() => {
   refreshConvertVisibility();
   refreshChangeOwnershipVisibility();
   updateChainSecuredRpcUrlUI();
+  handleBillingReturn();
 });
 
 // ----- Init -----

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -1,6 +1,11 @@
 /**
  * Billing — Stripe integration, payment flow.
  *
+ * Uses Stripe Payment Element which auto-renders whichever methods are
+ * enabled on the Stripe account (card, USDC, USDP, ETH, SOL). Crypto
+ * payments use a redirect flow; card payments complete inline when no
+ * additional action is required.
+ *
  * ChainSecured callers (CPL-285, CPL-286) authenticate to /billing/* with an
  * EIP-712 typed-data signature proving they hold the wallet's private key.
  * The wallet UI surfaces `primaryType: BillingAuth` and labelled fields so a
@@ -13,8 +18,7 @@
  * captured-credential snapshot — `clearBillingSession()` is called on logout
  * or wallet switch and aborts pending fetches; every post-await branch
  * re-checks `billingAuthKey() === captured` before mutating UI or calling
- * Stripe.confirmCardPayment so a mid-flight session change can never credit
- * the prior account.
+ * Stripe so a mid-flight session change can never credit the prior account.
  */
 
 import {
@@ -33,7 +37,10 @@ import {
 import { formatError, logError } from './ui-utils.js';
 
 let _stripe = null;
-let _stripeCard = null;
+let _publishableKey = null;
+let _elements = null;
+let _paymentElement = null;
+let _paymentIntentId = null;
 
 let _billingAvailable = null;
 let _billingCheckedAt = 0;
@@ -121,7 +128,8 @@ export async function checkBillingAvailable() {
   }
   try {
     const client = await getClient();
-    await client.getStripeConfig();
+    const cfg = await client.getStripeConfig();
+    _publishableKey = cfg.publishable_key;
     _billingAvailable = true;
   } catch (_) {
     _billingAvailable = false;
@@ -273,6 +281,61 @@ async function loadBillingBalance() {
   }
 }
 
+function setModalStep(step) {
+  const amountGroup = document.getElementById('billing-amount-group');
+  const paymentGroup = document.getElementById('billing-payment-group');
+  const continueBtn = document.getElementById('billing-continue-btn');
+  const payBtn = document.getElementById('billing-pay-btn');
+  const backBtn = document.getElementById('billing-back-btn');
+  if (step === 'amount') {
+    if (amountGroup) amountGroup.style.display = '';
+    if (paymentGroup) paymentGroup.style.display = 'none';
+    if (continueBtn) continueBtn.style.display = '';
+    if (payBtn) payBtn.style.display = 'none';
+    if (backBtn) backBtn.style.display = 'none';
+  } else {
+    if (amountGroup) amountGroup.style.display = 'none';
+    if (paymentGroup) paymentGroup.style.display = '';
+    if (continueBtn) continueBtn.style.display = 'none';
+    if (payBtn) payBtn.style.display = '';
+    if (backBtn) backBtn.style.display = '';
+  }
+}
+
+function setStatus(message, kind) {
+  const el = document.getElementById('billing-modal-status');
+  if (!el) return;
+  if (!message) {
+    el.style.display = 'none';
+    el.textContent = '';
+    return;
+  }
+  el.textContent = message;
+  el.className = 'status ' + (kind || 'info');
+  el.style.display = 'block';
+}
+
+function resetPaymentElement() {
+  if (_paymentElement) {
+    try { _paymentElement.unmount(); } catch (_) { /* ignore */ }
+    try { _paymentElement.destroy(); } catch (_) { /* ignore */ }
+  }
+  _paymentElement = null;
+  _elements = null;
+  _paymentIntentId = null;
+}
+
+async function ensureStripe() {
+  if (_stripe) return _stripe;
+  if (!_publishableKey) {
+    const client = await getClient();
+    const cfg = await client.getStripeConfig();
+    _publishableKey = cfg.publishable_key;
+  }
+  _stripe = Stripe(_publishableKey); // eslint-disable-line no-undef
+  return _stripe;
+}
+
 async function openAddFundsModal() {
   if (_billingAvailable === false) return;
   const overlay = document.getElementById('billing-modal-overlay');
@@ -280,58 +343,35 @@ async function openAddFundsModal() {
   overlay.classList.add('is-open');
   overlay.setAttribute('aria-hidden', 'false');
 
-  const statusEl = document.getElementById('billing-modal-status');
-  if (statusEl) { statusEl.style.display = 'none'; }
+  setStatus('');
+  setModalStep('amount');
+  resetPaymentElement();
 
-  const payBtn = document.getElementById('billing-pay-btn');
-  if (payBtn) payBtn.disabled = true;
-
-  if (!_stripe) {
-    try {
-      const client = await getClient();
-      const cfg = await client.getStripeConfig();
-      _stripe = Stripe(cfg.publishable_key); // eslint-disable-line no-undef
-      const elements = _stripe.elements();
-      _stripeCard = elements.create('card');
-      _stripeCard.mount('#stripe-card-element');
-    } catch (e) {
-      logError('stripe-init', e);
-      if (statusEl) {
-        statusEl.textContent = 'Billing not available: ' + formatError(e);
-        statusEl.className = 'status error';
-        statusEl.style.display = 'block';
-      }
-      return;
-    }
+  try {
+    await ensureStripe();
+  } catch (e) {
+    logError('stripe-init', e);
+    setStatus('Billing not available: ' + formatError(e), 'error');
+    return;
   }
 
   // Sovereign mode: prime the wallet-auth cache now (one EIP-712 typed-data
-  // popup) so the user's later Pay click — and the balance refresh that
-  // follows — flows without a second prompt. If they cancel the signature,
+  // popup) so the user's later Continue/Pay clicks — and the balance refresh
+  // that follows — flow without a second prompt. If they cancel the signature,
   // surface that in the modal status and leave the modal open so they can retry.
   if (getMode() === 'sovereign' && !hasValidWalletAuthCache()) {
-    if (statusEl) {
-      statusEl.textContent = 'Approve the wallet signature to enable billing for this session…';
-      statusEl.className = 'status info';
-      statusEl.style.display = 'block';
-    }
+    setStatus('Approve the wallet signature to enable billing for this session…', 'info');
     try {
       await getWalletAuthHeader();
-      if (statusEl) statusEl.style.display = 'none';
+      setStatus('');
     } catch (e) {
       logError('wallet-auth-prime', e);
-      if (statusEl) {
-        statusEl.textContent = 'Wallet signature required to fund a ChainSecured account: ' + formatError(e);
-        statusEl.className = 'status error';
-        statusEl.style.display = 'block';
-      }
+      setStatus('Wallet signature required to fund a ChainSecured account: ' + formatError(e), 'error');
       return;
     }
     // Now that we have a valid cache, surface the actual balance.
     loadBillingBalance();
   }
-
-  if (payBtn) payBtn.disabled = false;
 }
 
 function closeBillingModal() {
@@ -340,12 +380,202 @@ function closeBillingModal() {
     overlay.classList.remove('is-open');
     overlay.setAttribute('aria-hidden', 'true');
   }
+  resetPaymentElement();
+  setModalStep('amount');
+  setStatus('');
+}
+
+async function handleContinue() {
+  const apiKey = billingAuthKey();
+  if (!apiKey) return;
+
+  const amountInput = document.getElementById('billing-amount');
+  const amountCents = parseInt(amountInput?.value || '0', 10);
+  if (!amountCents || amountCents < 500) {
+    setStatus('Minimum amount is $5.00.', 'error');
+    return;
+  }
+
+  const continueBtn = document.getElementById('billing-continue-btn');
+  if (continueBtn) continueBtn.disabled = true;
+  setStatus('');
+
+  const ctrl = ensureAbortController();
+  try {
+    await ensureStripe();
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const client = await getClient();
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const opts = await billingRequestOptions(ctrl.signal);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const intent = await client.createPaymentIntent(apiKey, amountCents, opts);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    _paymentIntentId = intent.payment_intent_id;
+
+    _elements = _stripe.elements({ clientSecret: intent.client_secret });
+    // Suppress billing-address collection — credits are scoped to the
+    // account/wallet, not to a postal address. `address: 'never'` hides the
+    // address fields entirely; Stripe still gathers any name/email that a
+    // specific payment method strictly needs.
+    _paymentElement = _elements.create('payment', {
+      fields: { billingDetails: { address: 'never' } },
+    });
+    _paymentElement.mount('#stripe-payment-element');
+    setModalStep('payment');
+  } catch (e) {
+    if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
+    if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
+    logError('createPaymentIntent', e);
+    if (billingAuthKey() === apiKey) {
+      setStatus('Could not start payment: ' + formatError(e), 'error');
+    }
+  } finally {
+    if (continueBtn) continueBtn.disabled = false;
+  }
+}
+
+function handleBack() {
+  resetPaymentElement();
+  setStatus('');
+  setModalStep('amount');
+}
+
+async function handlePay() {
+  const apiKey = billingAuthKey();
+  if (!apiKey || !_stripe || !_elements || !_paymentIntentId) return;
+
+  const payBtn = document.getElementById('billing-pay-btn');
+  const backBtn = document.getElementById('billing-back-btn');
+  if (payBtn) payBtn.disabled = true;
+  if (backBtn) backBtn.disabled = true;
+  setStatus('');
+
+  const intentId = _paymentIntentId;
+  const ctrl = ensureAbortController();
+  // Stripe redirects to return_url for methods that require it (crypto);
+  // card payments complete inline when redirect: 'if_required' is set.
+  const returnUrl = window.location.origin + window.location.pathname;
+
+  try {
+    const result = await _stripe.confirmPayment({
+      elements: _elements,
+      confirmParams: {
+        return_url: returnUrl,
+        // We tell the Payment Element not to render address fields
+        // (`fields.billingDetails.address: 'never'`), so Stripe requires us
+        // to pass a billing-address country here for methods that need one
+        // (e.g. card AVS). Default to 'US'; crypto methods ignore this.
+        payment_method_data: {
+          billing_details: { address: { country: 'US' } },
+        },
+      },
+      redirect: 'if_required',
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message);
+    }
+
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) {
+      // Payment succeeded on Stripe but the session changed before we could
+      // credit. The PaymentIntent is settled against the prior wallet's
+      // Stripe customer; surface the intent ID for manual reconciliation.
+      setStatus('Payment processed — session changed before crediting. Reference: ' + intentId, 'info');
+      return;
+    }
+
+    try {
+      const client = await getClient();
+      if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+      // Re-fetch options in case the cached wallet-auth header expired during
+      // the Stripe.js round-trip.
+      const opts = await billingRequestOptions(ctrl.signal);
+      if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+      await client.confirmPayment(apiKey, intentId, opts);
+    } catch (confirmErr) {
+      if (confirmErr && (confirmErr.name === 'AbortError' || ctrl.signal.aborted)) return;
+      logError('confirmPayment', confirmErr, { intentId });
+      closeBillingModal();
+      showTopLevelStatus('Payment processed — credit pending. Reference: ' + intentId, 'info');
+      await loadBillingBalance();
+      return;
+    }
+
+    closeBillingModal();
+    await loadBillingBalance();
+  } catch (e) {
+    if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
+    if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
+    logError('payment', e, { intentId });
+    if (billingAuthKey() === apiKey) {
+      setStatus('Payment failed: ' + formatError(e), 'error');
+    }
+  } finally {
+    if (payBtn) payBtn.disabled = false;
+    if (backBtn) backBtn.disabled = false;
+  }
+}
+
+export async function handleBillingReturn() {
+  const params = new URLSearchParams(window.location.search);
+  const intentId = params.get('payment_intent');
+  const status = params.get('redirect_status');
+  if (!intentId || !status) return;
+
+  // Strip Stripe redirect params regardless of outcome so reloads don't retrigger.
+  const cleanUrl = window.location.origin + window.location.pathname + window.location.hash;
+  window.history.replaceState({}, '', cleanUrl);
+
+  const apiKey = billingAuthKey();
+  if (!apiKey) return;
+
+  // Stripe redirect_status values: `succeeded`, `processing`,
+  // `requires_payment_method`, `requires_action`, `failed`, `canceled`.
+  // For `succeeded` and `processing` we still call the backend so it can
+  // credit (succeeded) or record-pending (processing) — Stripe only flips
+  // crypto intents to `succeeded` after on-chain confirmation, but the
+  // settled state can arrive while the user is mid-redirect.
+  if (status !== 'succeeded' && status !== 'processing') {
+    showTopLevelStatus('Payment ' + status + '. Reference: ' + intentId, 'error');
+    return;
+  }
+
+  const ctrl = ensureAbortController();
+  try {
+    const client = await getClient();
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const opts = await billingRequestOptions(ctrl.signal);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    await client.confirmPayment(apiKey, intentId, opts);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    if (status === 'succeeded') {
+      showTopLevelStatus('Credits added to your account.', 'success');
+    } else {
+      showTopLevelStatus('Payment processing — credits will appear once settled. Reference: ' + intentId, 'info');
+    }
+    await loadBillingBalance();
+  } catch (e) {
+    if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
+    if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
+    logError('handleBillingReturn', e, { intentId });
+    showTopLevelStatus('Payment processed — credit pending. Reference: ' + intentId, 'info');
+  }
+}
+
+function showTopLevelStatus(message, kind) {
+  const el = document.getElementById('overview-status');
+  if (!el) return;
+  el.textContent = message;
+  el.className = 'status ' + (kind || 'info');
+  el.style.display = 'block';
 }
 
 export function initBilling() {
   const addFundsBtn = document.getElementById('btn-add-funds');
   const closeBtn = document.getElementById('billing-modal-close-btn');
   const cancelBtn = document.getElementById('billing-cancel-btn');
+  const continueBtn = document.getElementById('billing-continue-btn');
+  const backBtn = document.getElementById('billing-back-btn');
   const payBtn = document.getElementById('billing-pay-btn');
 
   if (addFundsBtn) addFundsBtn.addEventListener('click', openAddFundsModal);
@@ -353,97 +583,7 @@ export function initBilling() {
   if (noFundsLink) noFundsLink.addEventListener('click', (e) => { e.preventDefault(); openAddFundsModal(); });
   if (closeBtn) closeBtn.addEventListener('click', closeBillingModal);
   if (cancelBtn) cancelBtn.addEventListener('click', closeBillingModal);
-
-  if (payBtn) {
-    payBtn.addEventListener('click', async () => {
-      const apiKey = billingAuthKey();
-      if (!apiKey || !_stripe || !_stripeCard) return;
-
-      const amountInput = document.getElementById('billing-amount');
-      const amountCents = parseInt(amountInput.value, 10);
-      const statusEl = document.getElementById('billing-modal-status');
-
-      // Client-side validation: minimum $5.00
-      if (!amountCents || amountCents < 500) {
-        if (statusEl) {
-          statusEl.textContent = 'Minimum amount is $5.00.';
-          statusEl.className = 'status error';
-          statusEl.style.display = 'block';
-        }
-        return;
-      }
-
-      payBtn.disabled = true;
-      if (statusEl) { statusEl.style.display = 'none'; }
-
-      const ctrl = ensureAbortController();
-      let intentId = null;
-      try {
-        const client = await getClient();
-        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
-        const opts = await billingRequestOptions(ctrl.signal);
-        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
-        const intent = await client.createPaymentIntent(apiKey, amountCents, opts);
-        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) {
-          // Auth changed after intent was created — log but don't proceed.
-          // The PaymentIntent will simply expire unconfirmed.
-          logError('payment', new Error('session changed mid-flight, dropping intent'), { intentId: intent.payment_intent_id });
-          return;
-        }
-        intentId = intent.payment_intent_id;
-
-        const result = await _stripe.confirmCardPayment(intent.client_secret, {
-          payment_method: { card: _stripeCard },
-        });
-
-        if (result.error) {
-          throw new Error(result.error.message);
-        }
-
-        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) {
-          // Card was charged, but the session changed before we could call
-          // confirmPayment. The funds are reserved on the original wallet's
-          // Stripe customer; surface the intent ID for manual reconciliation.
-          if (statusEl) {
-            statusEl.textContent = 'Payment processed — session changed before crediting. Reference: ' + intent.payment_intent_id;
-            statusEl.className = 'status info';
-            statusEl.style.display = 'block';
-          }
-          return;
-        }
-
-        // Separate try for confirmPayment — card is already charged at this point
-        try {
-          // Re-fetch options in case the cached wallet-auth header expired during the Stripe.js round-trip.
-          const opts2 = await billingRequestOptions(ctrl.signal);
-          if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
-          await client.confirmPayment(apiKey, intent.payment_intent_id, opts2);
-        } catch (confirmErr) {
-          logError('confirmPayment', confirmErr, { intentId });
-          if (statusEl) {
-            statusEl.textContent = 'Payment processed — credit pending. Reference: ' + intent.payment_intent_id;
-            statusEl.className = 'status info';
-            statusEl.style.display = 'block';
-          }
-          closeBillingModal();
-          await loadBillingBalance();
-          return;
-        }
-
-        closeBillingModal();
-        await loadBillingBalance();
-      } catch (e) {
-        if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
-        if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
-        logError('payment', e, { intentId });
-        if (statusEl && billingAuthKey() === apiKey) {
-          statusEl.textContent = 'Payment failed: ' + formatError(e);
-          statusEl.className = 'status error';
-          statusEl.style.display = 'block';
-        }
-      } finally {
-        payBtn.disabled = false;
-      }
-    });
-  }
+  if (continueBtn) continueBtn.addEventListener('click', handleContinue);
+  if (backBtn) backBtn.addEventListener('click', handleBack);
+  if (payBtn) payBtn.addEventListener('click', handlePay);
 }

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -521,8 +521,8 @@
         <button type="button" class="modal-close" id="billing-modal-close-btn" aria-label="Close">&times;</button>
       </div>
       <div class="modal-body">
-        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Credits are used for API calls ($0.01 for management, $0.01 per second for Lit Action execution with a 1-second minimum).</p>
-        <div class="form-group">
+        <p style="margin-bottom:1rem;">Add credits to your account (minimum $5.00). Pay with card or crypto. Credits are used for API calls ($0.01 for management, $0.01 per second for Lit Action execution with a 1-second minimum).</p>
+        <div class="form-group" id="billing-amount-group">
           <label for="billing-amount">Amount (USD)</label>
           <select id="billing-amount" class="input">
             <option value="500">$5.00</option>
@@ -533,15 +533,17 @@
             <option value="20000">$200.00</option>
           </select>
         </div>
-        <div class="form-group">
-          <label>Card details</label>
-          <div id="stripe-card-element" style="padding:0.625rem 0.75rem;border:1px solid var(--border,#e5e7eb);border-radius:0.375rem;background:var(--input-bg,#fff);"></div>
+        <div class="form-group" id="billing-payment-group" style="display:none;">
+          <label>Payment method</label>
+          <div id="stripe-payment-element"></div>
         </div>
         <div id="billing-modal-status" class="status" style="display:none;"></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline" id="billing-cancel-btn">Cancel</button>
-        <button type="button" class="btn btn-primary" id="billing-pay-btn">Pay</button>
+        <button type="button" class="btn btn-outline" id="billing-back-btn" style="display:none;">Back</button>
+        <button type="button" class="btn btn-primary" id="billing-continue-btn">Continue</button>
+        <button type="button" class="btn btn-primary" id="billing-pay-btn" style="display:none;">Pay</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Switches the Add Funds modal in the dashboard from Stripe's Card Element to the **Payment Element**, which auto-renders whichever methods are enabled on the Stripe account (card + crypto: USDC, USDP, ETH, SOL). Backend billing endpoints already support crypto — this is a frontend-only change.

Linear: [CPL-274](https://linear.app/litprotocol/issue/CPL-274/add-crypto-payment-options-in-the-stripe-modal-in-the-dashboard-app)

### What changed
- **`lit-static/dapps/dashboard/index.html`** — Billing modal split into a two-step flow: amount selector + Continue (step 1), then Payment Element mount point + Back/Pay (step 2). `stripe-card-element` renamed to `stripe-payment-element`.
- **`lit-static/dapps/dashboard/billing.js`** — Rewrote the payment flow. Continue creates the PaymentIntent and mounts `elements({ clientSecret }).create('payment')`. Pay calls `stripe.confirmPayment({ elements, confirmParams: { return_url }, redirect: 'if_required' })` — card stays inline, crypto redirects to the wallet flow. Exports new `handleBillingReturn()` that detects `?payment_intent=…&redirect_status=…` on page load, calls the backend `confirm_payment` endpoint, and strips the query params.
- **`lit-static/dapps/dashboard/app.js`** — Imports and invokes `handleBillingReturn()` from the `setOnAuthReady` callback so the crypto-redirect return is processed once the API key is loaded.

### Why
The existing modal used `elements.create('card')` + `confirmCardPayment()`, which is card-only and doesn't surface Stripe's crypto options. The Payment Element approach is a minimal frontend refactor that unlocks card + crypto in one UI — no backend changes needed.

## Pre-Landing Review
No blocking issues found.

- **Security/data safety:** `return_url` is built from `window.location.origin + window.location.pathname` (no user input). Status display uses `textContent` (no XSS surface). No new credentials/tokens exposed.
- **Error handling:** `handleContinue`, `handlePay`, and `handleBillingReturn` all wrap network calls in try/catch. `confirmPayment`-backend failure preserves the prior "card charged, credit pending" fallback. URL params stripped before `confirm_payment` call so reloads don't retrigger.
- **Edge cases checked:** double-click on Continue/Pay (buttons disabled in-flight, re-enabled in `finally`); amount change mid-flow (Back fully unmounts the element, next Continue creates a fresh intent); repeated `handleBillingReturn` calls (URL cleaned first, subsequent fires no-op); Stripe account without crypto enabled (Payment Element gracefully shows card only).

## Test plan
Requires a dev backend with Stripe test keys and a Stripe account that has crypto payment methods enabled.

- [ ] Open dashboard → Add Funds → amount step shows with dropdown + Continue
- [ ] Pick \$5 → Continue → Payment Element renders with card (and crypto tabs if enabled)
- [ ] Back button returns to amount step (unmounts element; next Continue creates a fresh PaymentIntent)
- [ ] **Card path**: submit test card `4242…` → stays inline → balance updates → modal closes
- [ ] **Crypto path**: select crypto → connect wallet → approve → redirects out → returns to dashboard root → auth ready fires → `handleBillingReturn` calls `confirm_payment` → overview shows "Credits added" → balance refreshes
- [ ] Confirm that an unauthenticated user hitting `?payment_intent=…` silently strips the params without processing (no crash, no retry loop)

## Notes
- No unit tests exist for the vanilla-JS dashboard module — `node --check` passes on both JS files.
- Crypto docs at `docs/management/crypto.mdx` already describe the intended user flow and reference the Payment Element approach this PR implements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)