### PR TITLE
feat(CPL-275): offer API mode + ChainSecured mode in dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docker-compose.deploy.yml
 dstack-cache/
 CLAUDE.MD
 .gstack/
+.gstack-design-audit/

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -51,6 +51,27 @@ export interface CreateWalletResponse {
   wallet_address: string;
 }
 
+/**
+ * Returned by `/create_wallet_with_signature`. The client must follow up with an on-chain `registerWalletDerivation(adminHash, wallet_address, derivation_path, name, description)` call signed by the same wallet — until that lands, the PKP exists in MPC but is not registered to any account.
+ */
+export interface CreateWalletWithSignatureResponse {
+  wallet_address: string;
+  /** 0x-prefixed lowercase hex (uint256). Pass through verbatim to `registerWalletDerivation`'s `derivationPath` arg. */
+  derivation_path: string;
+}
+
+/**
+ * ChainSecured wallet creation. The client builds a SIWE-style message and signs it with their wallet; the server verifies the signature, mints a PKP via DStack MPC, and returns the new wallet address + derivation path so the client can register it on-chain via `registerWalletDerivation`.
+
+V1 does not maintain a server-side nonce store. The server enforces a ±5-minute window on the message's `Issued At` timestamp, which is the only replay protection. Worst-case replay just mints an extra PKP (compute cost only — registration still requires a separate wallet signature on-chain).
+ */
+export interface CreateWalletWithSignatureRequest {
+  /** EIP-191 plaintext message that was signed. Must contain `Address: 0x…`, `Chain ID: <u64>`, and `Issued At: <unix-seconds>` lines (case-sensitive prefixes). */
+  message: string;
+  /** 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign). */
+  signature: string;
+}
+
 export interface LitActionResponse {
   response: unknown;
   logs: string;
@@ -398,6 +419,10 @@ export type CreateWalletHeaders = {
 };
 
 export type CreateWalletDefault = CreateWalletResponse | ErrMessage;
+
+export type CreateWalletWithSignatureDefault =
+  | CreateWalletWithSignatureResponse
+  | ErrMessage;
 
 export type LitActionHeaders = {
   /**
@@ -846,6 +871,45 @@ export class LitApiServerClient {
       response,
       data,
       operationId: "create_wallet",
+    };
+  }
+
+  createWalletWithSignature(
+    createWalletWithSignatureRequest: CreateWalletWithSignatureRequest,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: CreateWalletWithSignatureDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(this.cleanBaseUrl + `/create_wallet_with_signature`);
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(createWalletWithSignatureRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "create_wallet_with_signature",
     };
   }
 

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -91,7 +91,7 @@ contract WritesFacet {
         if (!SecurityLib.isApiPayerOrOwner(msg.sender)) {
             if (managed) {
                 revert AppStorage.InvalidRequest(
-                    "unprivileged accounts must be unmanaged"
+                    "ChainSecured accounts must be unmanaged."
                 );
             }
             if (
@@ -99,12 +99,12 @@ contract WritesFacet {
                 uint256(keccak256(abi.encodePacked(msg.sender)))
             ) {
                 revert AppStorage.InvalidRequest(
-                    "unprivileged apiKeyHash must equal keccak256 of sender"
+                    "ChainSecured apiKeyHash must equal the keccak256 of the sender."
                 );
             }
             if (adminWalletAddress != msg.sender) {
                 revert AppStorage.InvalidRequest(
-                    "unprivileged adminWalletAddress must equal sender"
+                    "ChainSecured adminWalletAddress must equal the sender."
                 );
             }
         }

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -26,6 +26,12 @@ use ethers::types::{Address, H160, U256};
 use tracing::instrument;
 
 /// Create a new account. `initial_balance` is stored on the account's apiKey (AccountConfig.accountApiKey.balance).
+#[instrument(
+    name = "accounts::new_account",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn new_account(
     signer_pool: Arc<SignerPool>,
     api_key: &str,
@@ -50,6 +56,12 @@ pub async fn new_account(
 /// Check whether an account exists and is mutable. Uses an api_payer address as the
 /// simulated caller (msg.sender) because accountExistsAndIsMutable requires the
 /// caller to be an api_payer (for managed accounts) or the creator.
+#[instrument(
+    name = "accounts::account_exists",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn account_exists(api_key: &str) -> Result<bool> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
@@ -69,6 +81,12 @@ pub async fn account_exists(api_key: &str) -> Result<bool> {
 /// `permitted_actions` and `wallets` are keccak256 hashes (U256). Use `keccak256(action_ipfs_cid)` and `keccak256(pkp_public_key)` to produce them.
 /// `all_wallets_permitted` and `all_actions_permitted` match AccountConfig.sol Group fields.
 #[allow(clippy::too_many_arguments)]
+#[instrument(
+    name = "accounts::add_group",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn add_group(
     signer_pool: Arc<SignerPool>,
     api_key: &str,
@@ -112,6 +130,12 @@ pub async fn add_group(
 }
 
 /// Create a new action entry with name, description, and IPFS CID hash in the account's actionMetadata mapping.
+#[instrument(
+    name = "accounts::add_action",
+    level = "debug",
+    skip_all,
+    err
+)]
 pub async fn add_action(
     signer_pool: Arc<SignerPool>,
     api_key: &str,

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -26,12 +26,7 @@ use ethers::types::{Address, H160, U256};
 use tracing::instrument;
 
 /// Create a new account. `initial_balance` is stored on the account's apiKey (AccountConfig.accountApiKey.balance).
-#[instrument(
-    name = "accounts::new_account",
-    level = "debug",
-    skip_all,
-    err
-)]
+#[instrument(name = "accounts::new_account", level = "debug", skip_all, err)]
 pub async fn new_account(
     signer_pool: Arc<SignerPool>,
     api_key: &str,
@@ -56,12 +51,7 @@ pub async fn new_account(
 /// Check whether an account exists and is mutable. Uses an api_payer address as the
 /// simulated caller (msg.sender) because accountExistsAndIsMutable requires the
 /// caller to be an api_payer (for managed accounts) or the creator.
-#[instrument(
-    name = "accounts::account_exists",
-    level = "debug",
-    skip_all,
-    err
-)]
+#[instrument(name = "accounts::account_exists", level = "debug", skip_all, err)]
 pub async fn account_exists(api_key: &str) -> Result<bool> {
     let contract = get_read_only_account_config_contract().await?;
     let account_api_key_hash = api_key_hash(api_key);
@@ -81,12 +71,7 @@ pub async fn account_exists(api_key: &str) -> Result<bool> {
 /// `permitted_actions` and `wallets` are keccak256 hashes (U256). Use `keccak256(action_ipfs_cid)` and `keccak256(pkp_public_key)` to produce them.
 /// `all_wallets_permitted` and `all_actions_permitted` match AccountConfig.sol Group fields.
 #[allow(clippy::too_many_arguments)]
-#[instrument(
-    name = "accounts::add_group",
-    level = "debug",
-    skip_all,
-    err
-)]
+#[instrument(name = "accounts::add_group", level = "debug", skip_all, err)]
 pub async fn add_group(
     signer_pool: Arc<SignerPool>,
     api_key: &str,
@@ -130,12 +115,7 @@ pub async fn add_group(
 }
 
 /// Create a new action entry with name, description, and IPFS CID hash in the account's actionMetadata mapping.
-#[instrument(
-    name = "accounts::add_action",
-    level = "debug",
-    skip_all,
-    err
-)]
+#[instrument(name = "accounts::add_action", level = "debug", skip_all, err)]
 pub async fn add_action(
     signer_pool: Arc<SignerPool>,
     api_key: &str,

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -7,9 +7,9 @@ use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
     AddUsageApiKeyRequest, CreateWalletWithSignatureRequest, DeleteActionRequest,
-    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest, RemovePkpFromGroupRequest,
+    RemoveUsageApiKeyRequest, UpdateActionMetadataRequest, UpdateGroupRequest,
+    UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,
@@ -245,12 +245,13 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
 
 /// Recovers the EIP-191 personal-sign signer for `message`.
 fn recover_eip191_signer(message: &str, signature_hex: &str) -> Result<H160, ApiStatus> {
-    let sig: EthSignature = signature_hex
-        .trim()
-        .parse()
-        .map_err(|e: ethers::core::types::SignatureError| {
-            ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid signature hex")
-        })?;
+    let sig: EthSignature =
+        signature_hex
+            .trim()
+            .parse()
+            .map_err(|e: ethers::core::types::SignatureError| {
+                ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid signature hex")
+            })?;
     sig.recover(message.as_bytes().to_vec())
         .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))
 }

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -6,15 +6,15 @@ use crate::config::GLOBAL_NODE_CONFIG;
 use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest,
-    RemoveGroupRequest, RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest,
-    UpdateActionMetadataRequest, UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest,
-    UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, CreateWalletWithSignatureRequest, DeleteActionRequest,
+    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
+    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
+    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,
-    ChainConfigKeysResponse, CreateWalletResponse, ListMetadataItem, NewAccountResponse,
-    NodeChainConfigResponse, WalletItem,
+    ChainConfigKeysResponse, CreateWalletResponse, CreateWalletWithSignatureResponse,
+    ListMetadataItem, NewAccountResponse, NodeChainConfigResponse, WalletItem,
 };
 use crate::dstack::v1::get_client_key;
 use crate::stripe::StripeState;
@@ -25,6 +25,7 @@ use crate::utils::parse_with_hash::{
 };
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
+use ethers::core::types::Signature as EthSignature;
 use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{H160, U256};
 use ipfs_hasher::IpfsHasher;
@@ -160,6 +161,157 @@ pub async fn create_wallet(
 
     Ok(CreateWalletResponse {
         wallet_address: bytes_to_0x_hex(wallet_address.as_bytes()),
+    })
+}
+
+/// V1 SIWE-lite. ChainSecured users have no api key, so we authenticate
+/// PKP minting with a wallet signature instead. The server only mints —
+/// the client follows up with `registerWalletDerivation` signed by the
+/// same wallet to register the PKP on-chain.
+///
+/// Replay: ±5-minute timestamp window, no nonce store. Worst case is an
+/// extra unregistered PKP (compute cost only).
+const SIWE_TIMESTAMP_SKEW_SECONDS: i64 = 300;
+
+/// Parsed shape of a `create_wallet_with_signature` SIWE message.
+struct ParsedCreateWalletSiwe {
+    address: H160,
+    chain_id: u64,
+    issued_at: i64,
+}
+
+/// Parses a `create_wallet_with_signature` message. Required lines (case-sensitive):
+///   `Address: 0x…`
+///   `Chain ID: <u64>`
+///   `Issued At: <unix-seconds>`
+/// Other lines are ignored so callers can include domain/statement framing.
+fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, ApiStatus> {
+    let mut address: Option<H160> = None;
+    let mut chain_id: Option<u64> = None;
+    let mut issued_at: Option<i64> = None;
+    for line in message.lines() {
+        if let Some(v) = line.strip_prefix("Address:") {
+            let trimmed = v.trim();
+            let bytes = hex_to_bytes(trimmed.trim_start_matches("0x")).map_err(|_| {
+                ApiStatus::bad_request(
+                    anyhow::anyhow!("Address line not valid hex"),
+                    "Address line not valid hex",
+                )
+            })?;
+            if bytes.len() != 20 {
+                return Err(ApiStatus::bad_request(
+                    anyhow::anyhow!("Address must be 20 bytes"),
+                    "Address must be 20 bytes",
+                ));
+            }
+            address = Some(H160::from_slice(&bytes));
+        } else if let Some(v) = line.strip_prefix("Chain ID:") {
+            chain_id = Some(v.trim().parse::<u64>().map_err(|_| {
+                ApiStatus::bad_request(
+                    anyhow::anyhow!("Chain ID line not a u64"),
+                    "Chain ID line not a u64",
+                )
+            })?);
+        } else if let Some(v) = line.strip_prefix("Issued At:") {
+            issued_at = Some(v.trim().parse::<i64>().map_err(|_| {
+                ApiStatus::bad_request(
+                    anyhow::anyhow!("Issued At line not a unix timestamp"),
+                    "Issued At line not a unix timestamp",
+                )
+            })?);
+        }
+    }
+    Ok(ParsedCreateWalletSiwe {
+        address: address.ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("Missing Address line"),
+                "Missing Address line",
+            )
+        })?,
+        chain_id: chain_id.ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("Missing Chain ID line"),
+                "Missing Chain ID line",
+            )
+        })?,
+        issued_at: issued_at.ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("Missing Issued At line"),
+                "Missing Issued At line",
+            )
+        })?,
+    })
+}
+
+/// Recovers the EIP-191 personal-sign signer for `message`.
+fn recover_eip191_signer(message: &str, signature_hex: &str) -> Result<H160, ApiStatus> {
+    let sig: EthSignature = signature_hex
+        .trim()
+        .parse()
+        .map_err(|e: ethers::core::types::SignatureError| {
+            ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid signature hex")
+        })?;
+    sig.recover(message.as_bytes().to_vec())
+        .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))
+}
+
+pub async fn create_wallet_with_signature(
+    req: Json<CreateWalletWithSignatureRequest>,
+) -> Result<CreateWalletWithSignatureResponse, ApiStatus> {
+    let parsed = parse_create_wallet_siwe(&req.message)?;
+    let signer = recover_eip191_signer(&req.message, &req.signature)?;
+    if signer != parsed.address {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Signature does not match claimed address"),
+            "Signature does not match claimed address",
+        ));
+    }
+
+    let node_config = GLOBAL_NODE_CONFIG
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))
+        .map_err(|e| ApiStatus::internal_server_error(e, "GLOBAL_NODE_CONFIG missing"))?;
+    let expected_chain_id = node_config.chain.info().chain_id;
+    if parsed.chain_id != expected_chain_id {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Chain ID mismatch: message says {}, server is on {}",
+                parsed.chain_id,
+                expected_chain_id
+            ),
+            "Chain ID mismatch",
+        ));
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| {
+            ApiStatus::internal_server_error(
+                anyhow::anyhow!(e),
+                "System clock is before the Unix epoch",
+            )
+        })?
+        .as_secs() as i64;
+    if (now - parsed.issued_at).abs() > SIWE_TIMESTAMP_SKEW_SECONDS {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Issued At {} is outside the ±{}s window from now ({})",
+                parsed.issued_at,
+                SIWE_TIMESTAMP_SKEW_SECONDS,
+                now
+            ),
+            "Signed message timestamp is too old or too far in the future",
+        ));
+    }
+
+    tracing::info!(
+        "create_wallet_with_signature: minting PKP for ChainSecured signer {:?}",
+        signer
+    );
+    let (_public_key, wallet_address, _secret, derivation_u256) = create_new_wallet().await?;
+    Ok(CreateWalletWithSignatureResponse {
+        wallet_address: bytes_to_0x_hex(wallet_address.as_bytes()),
+        derivation_path: format!("0x{:x}", derivation_u256),
     })
 }
 

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -9,9 +9,9 @@ use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
     AddUsageApiKeyRequest, CreateWalletWithSignatureRequest, DeleteActionRequest,
-    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest, RemovePkpFromGroupRequest,
+    RemoveUsageApiKeyRequest, UpdateActionMetadataRequest, UpdateGroupRequest,
+    UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -8,15 +8,15 @@ use crate::core::v1::helpers::api_status::{ApiResult, ErrMessage};
 use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest,
-    RemoveGroupRequest, RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest,
-    UpdateActionMetadataRequest, UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest,
-    UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, CreateWalletWithSignatureRequest, DeleteActionRequest,
+    NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
+    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
+    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
     AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,
-    ChainConfigKeysResponse, CreateWalletResponse, ListMetadataItem, NewAccountResponse,
-    NodeChainConfigResponse, WalletItem,
+    ChainConfigKeysResponse, CreateWalletResponse, CreateWalletWithSignatureResponse,
+    ListMetadataItem, NewAccountResponse, NodeChainConfigResponse, WalletItem,
 };
 use crate::stripe::StripeState;
 use rocket::State;
@@ -182,6 +182,16 @@ pub(super) async fn create_wallet(
                 .await,
         )
         .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/create_wallet_with_signature", format = "json", data = "<req>")]
+pub(super) async fn create_wallet_with_signature(
+    req: Json<CreateWalletWithSignatureRequest>,
+) -> OpenApiResponse<CreateWalletWithSignatureResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(account_management::create_wallet_with_signature(req).await).into(),
     }
 }
 

--- a/lit-api-server/src/core/v1/endpoints/mod.rs
+++ b/lit-api-server/src/core/v1/endpoints/mod.rs
@@ -19,6 +19,7 @@ pub fn routes_with_spec() -> (Vec<Route>, OpenApi) {
         new_account,
         account_exists,
         create_wallet,
+        create_wallet_with_signature,
         lit_action,
         get_lit_action_ipfs_id,
         add_group,

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -172,6 +172,26 @@ pub struct ConfirmPaymentRequest {
     pub payment_intent_id: String,
 }
 
+/// ChainSecured wallet creation. The client builds a SIWE-style message
+/// and signs it with their wallet; the server verifies the signature, mints
+/// a PKP via DStack MPC, and returns the new wallet address + derivation
+/// path so the client can register it on-chain via `registerWalletDerivation`.
+///
+/// V1 does not maintain a server-side nonce store. The server enforces a
+/// ±5-minute window on the message's `Issued At` timestamp, which is the
+/// only replay protection. Worst-case replay just mints an extra PKP
+/// (compute cost only — registration still requires a separate wallet
+/// signature on-chain).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CreateWalletWithSignatureRequest {
+    /// EIP-191 plaintext message that was signed. Must contain
+    /// `Address: 0x…`, `Chain ID: <u64>`, and `Issued At: <unix-seconds>`
+    /// lines (case-sensitive prefixes).
+    pub message: String,
+    /// 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign).
+    pub signature: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EncryptRequest {
     pub api_key: String,

--- a/lit-api-server/src/core/v1/models/response.rs
+++ b/lit-api-server/src/core/v1/models/response.rs
@@ -17,6 +17,18 @@ pub struct CreateWalletResponse {
     pub wallet_address: String,
 }
 
+/// Returned by `/create_wallet_with_signature`. The client must follow up with
+/// an on-chain `registerWalletDerivation(adminHash, wallet_address, derivation_path, name, description)`
+/// call signed by the same wallet — until that lands, the PKP exists in MPC but
+/// is not registered to any account.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CreateWalletWithSignatureResponse {
+    pub wallet_address: String,
+    /// 0x-prefixed lowercase hex (uint256). Pass through verbatim to
+    /// `registerWalletDerivation`'s `derivationPath` arg.
+    pub derivation_path: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct LitActionResponse {
     pub response: serde_json::Value,

--- a/lit-static/account_config_full_abi.js
+++ b/lit-static/account_config_full_abi.js
@@ -353,6 +353,10 @@ export function isAbiDriftDevOverrideEnabled() {
     const s = v.trim().toLowerCase();
     return s === '1' || s === 'true' || s === 'yes' || s === 'on';
   }
+  if (typeof location !== 'undefined' && location.hostname) {
+    const h = location.hostname;
+    if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]') return true;
+  }
   return false;
 }
 

--- a/lit-static/account_config_full_abi.js
+++ b/lit-static/account_config_full_abi.js
@@ -341,6 +341,11 @@ export const ACCOUNT_CONFIG_DEPLOYMENTS = Object.freeze({});
  * has no pinned bytecode hash yet (local anvil, a fresh testnet deploy, etc.).
  * Browser-only: checks `window` / `globalThis` for a truthy flag.
  *
+ * Auto-enables on `localhost`, `127.0.0.1`, and `[::1]` so a contributor doing
+ * `python -m http.server` against a local anvil isn't blocked by drift checks.
+ * On any other hostname (including LAN IPs and *.local), the override is
+ * strictly opt-in via `window.LIT_ACCOUNT_CONFIG_ALLOW_UNPINNED_DEPLOYMENTS`.
+ *
  * Shipping dashboards MUST either populate ACCOUNT_CONFIG_DEPLOYMENTS with the
  * target (chainId, address) entries or pass them via `deployments` option;
  * otherwise sovereign writes hard-fail. See _verifyAbiIntegrity.

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -363,6 +363,11 @@ export class LitNodeSimpleApiClient {
    * @param {import('ethers').Signer} [options.signer] - Pre-connected signer for sovereign writes. May be set later via connectSigner().
    */
   constructor({ baseUrl = 'http://localhost:8000', mode = 'api', rpcUrl, contractAddress, chainId, deployments, signer, adminHashOverride } = {}) {
+    if (typeof baseUrl !== 'string') {
+      throw new Error(
+        `LitNodeSimpleApiClient: baseUrl must be a string, got ${typeof baseUrl} (${JSON.stringify(baseUrl)})`,
+      );
+    }
     const base = baseUrl.replace(/\/$/, '');
     this.baseUrl = `${base}/core/v1`;
     this.mode = mode;

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -930,7 +930,7 @@ export class LitNodeSimpleApiClient {
         ],
         ...(sovereignLifecycle ?? {}),
       });
-      return { success: true, api_key: newUsageKey, hash: usageHash, transaction_hash: txHash };
+      return { success: true, usage_api_key: newUsageKey, hash: usageHash, transaction_hash: txHash };
     }
     const body = {
       name,
@@ -1397,8 +1397,13 @@ export class LitNodeSimpleApiClient {
     const res = await fetch(`${this.baseUrl}/get_node_chain_config`);
     const cfg = await parseResponse(res, 'get_node_chain_config');
     if (!cfg.rpc_url && cfg.chain_id != null && cfg.is_evm) {
-      const rpcUrl = await resolveRpcUrlFromChainlist(cfg.chain_id);
-      if (rpcUrl) cfg.rpc_url = rpcUrl;
+      // Anvil isn't on chainlist; fall back to the local default.
+      if (Number(cfg.chain_id) === 31337) {
+        cfg.rpc_url = 'http://127.0.0.1:8545';
+      } else {
+        const rpcUrl = await resolveRpcUrlFromChainlist(cfg.chain_id);
+        if (rpcUrl) cfg.rpc_url = rpcUrl;
+      }
     }
     return cfg;
   }

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -718,6 +718,14 @@ export class LitNodeSimpleApiClient {
       if (!this.signer) {
         throw new Error('createWallet (sovereign): wallet signer not connected');
       }
+      // _verifyAbiIntegrity populates this.chainId from the RPC if it wasn't
+      // passed at construction. Run it before composing the SIWE message so
+      // the server sees a real "Chain ID:" line instead of "null" — the
+      // registerWalletDerivation step does the same verify, so this is free.
+      await this._verifyAbiIntegrity();
+      if (this.chainId == null) {
+        throw new Error('createWallet (sovereign): chainId could not be resolved from RPC');
+      }
       const signerAddress = await this.signer.getAddress();
       const issuedAt = Math.floor(Date.now() / 1000);
       const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -612,15 +612,21 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
       const hash = await this._adminHash(apiKey);
-      // accountExistsAndIsMutable has an msg.sender check (caller must be an
-      // api_payer). The server-side path spoofs this by setting `.from(api_payer)`
-      // on the eth_call. For sovereign reads we take the same approach: fetch
-      // api_payers via the same contract and use the first one as the from address.
-      const payers = await contract.api_payers();
-      if (!payers || payers.length === 0) {
-        throw new Error('account_exists (sovereign): no api_payers configured on contract');
+      // accountExistsAndIsMutable is msg.sender-gated. For unmanaged
+      // (ChainSecured) accounts only the wallet that owns the account passes;
+      // for managed accounts an api_payer passes. Use the connected signer
+      // when available (covers ChainSecured), fall back to api_payer.
+      let from;
+      if (this.signer) {
+        from = await this.signer.getAddress();
+      } else {
+        const payers = await contract.api_payers();
+        if (!payers || payers.length === 0) {
+          throw new Error('account_exists (sovereign): no api_payers configured on contract');
+        }
+        from = payers[0];
       }
-      return await contract.accountExistsAndIsMutable.staticCall(hash, { from: payers[0] });
+      return await contract.accountExistsAndIsMutable.staticCall(hash, { from });
     }
     const res = await fetch(`${this.baseUrl}/account_exists`, {
       headers: headersWithApiKey(apiKey),
@@ -634,7 +640,12 @@ export class LitNodeSimpleApiClient {
    * flow where the dashboard computes `keccak256(abi.encodePacked(address))`
    * before it has (or needs) an apiKey string.
    *
-   * Uses the same api_payer spoofing pattern as `accountExists` sovereign.
+   * `accountExistsAndIsMutable` is gated by msg.sender. For unmanaged
+   * (ChainSecured) accounts the contract requires `msg.sender ==
+   * account.adminWalletAddress` — i.e., the user's own wallet. Spoofing
+   * api_payer here would falsely return false for ChainSecured accounts.
+   * If a signer is connected we use its address; otherwise we fall back to
+   * api_payer for the managed-account case.
    *
    * @param {string} apiKeyHashHex - 0x-prefixed 32-byte hex
    * @returns {Promise<boolean>}
@@ -644,11 +655,17 @@ export class LitNodeSimpleApiClient {
       throw new Error('accountExistsByHash requires sovereign mode');
     }
     const contract = await this._getViewContract();
-    const payers = await contract.api_payers();
-    if (!payers || payers.length === 0) {
-      throw new Error('accountExistsByHash: no api_payers configured on contract');
+    let from;
+    if (this.signer) {
+      from = await this.signer.getAddress();
+    } else {
+      const payers = await contract.api_payers();
+      if (!payers || payers.length === 0) {
+        throw new Error('accountExistsByHash: no api_payers configured on contract');
+      }
+      from = payers[0];
     }
-    return await contract.accountExistsAndIsMutable.staticCall(apiKeyHashHex, { from: payers[0] });
+    return await contract.accountExistsAndIsMutable.staticCall(apiKeyHashHex, { from });
   }
 
   /**
@@ -671,13 +688,59 @@ export class LitNodeSimpleApiClient {
   }
 
   /**
-   * GET /core/v1/create_wallet
-   * Creates a wallet for the given API key and returns the wallet address.
-   * API key via X-Api-Key or Authorization: Bearer header.
-   * @param {string} apiKey - API key (from getApiKey)
+   * Creates a wallet for the given account.
+   *
+   * API mode (default): GET /core/v1/create_wallet — server mints + registers
+   * the PKP on-chain (api_payer pays gas, account is billed $0.01).
+   *
+   * ChainSecured mode: two wallet popups.
+   *   1. Sign a SIWE-style message proving wallet ownership; server verifies
+   *      and mints the PKP via DStack MPC (no on-chain write).
+   *   2. Wallet calls `registerWalletDerivation(adminHash, pkpAddress,
+   *      derivationPath, name, description)` to register the PKP on-chain.
+   *
+   * Backward-compat: legacy `createWallet(apiKey)` (bare string) still works.
+   *
+   * @param {string|Object} options - apiKey string (legacy) or options bag.
+   * @param {string} [options.apiKey]
+   * @param {string} [options.name='Wallet']
+   * @param {string} [options.description='Wallet']
+   * @param {Object} [options.sovereignLifecycle] - injected by the dashboard Proxy
    * @returns {Promise<CreateWalletResponse>}
    */
-  async createWallet(apiKey) {
+  async createWallet(options = {}) {
+    if (typeof options === 'string') {
+      options = { apiKey: options };
+    }
+    const { apiKey, name = 'Wallet', description = 'Wallet', sovereignLifecycle } = options;
+
+    if (this.mode === 'sovereign') {
+      if (!this.signer) {
+        throw new Error('createWallet (sovereign): wallet signer not connected');
+      }
+      const signerAddress = await this.signer.getAddress();
+      const issuedAt = Math.floor(Date.now() / 1000);
+      const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';
+      const message = `${host} wants you to create a new wallet for ChainSecured account.\n\nAddress: ${signerAddress}\nChain ID: ${this.chainId}\nIssued At: ${issuedAt}`;
+      const signature = await this.signer.signMessage(message);
+      const res = await fetch(`${this.baseUrl}/create_wallet_with_signature`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      const minted = await parseResponse(res, 'create_wallet_with_signature');
+      const { wallet_address, derivation_path } = minted;
+
+      const contract = await this._getWriteContract();
+      const adminHash = await this._adminHash(apiKey);
+      const { txHash } = await runContractWrite({
+        contract, method: 'registerWalletDerivation',
+        args: [adminHash, wallet_address, derivation_path, name, description],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { wallet_address, transaction_hash: txHash };
+    }
+
     const res = await fetch(`${this.baseUrl}/create_wallet`, {
       headers: headersWithApiKey(apiKey),
     });

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -362,7 +362,7 @@ export class LitNodeSimpleApiClient {
    * @param {Object} [options.deployments] - Optional override map `{ "<chainId>:<address>": { runtimeBytecodeKeccak } }` for drift pinning.
    * @param {import('ethers').Signer} [options.signer] - Pre-connected signer for sovereign writes. May be set later via connectSigner().
    */
-  constructor({ baseUrl = 'http://localhost:8000', mode = 'api', rpcUrl, contractAddress, chainId, deployments, signer } = {}) {
+  constructor({ baseUrl = 'http://localhost:8000', mode = 'api', rpcUrl, contractAddress, chainId, deployments, signer, adminHashOverride } = {}) {
     const base = baseUrl.replace(/\/$/, '');
     this.baseUrl = `${base}/core/v1`;
     this.mode = mode;
@@ -371,6 +371,11 @@ export class LitNodeSimpleApiClient {
     this.chainId = chainId ?? null;
     this.deployments = mergeDeployments(deployments);
     this.signer = signer ?? null;
+    // When set (e.g. ChainSecured login: keccak256(abi.encodePacked(address))),
+    // `_adminHash(apiKey)` returns this and ignores the apiKey argument.
+    // Leave null for API-mode and legacy sovereign API-key sessions, which
+    // still derive the identity hash from the api key string itself.
+    this.adminHashOverride = adminHashOverride ?? null;
     this._viewContractPromise = null;
     this._writeContract = null;
     this._driftCheckPromise = null;
@@ -510,6 +515,25 @@ export class LitNodeSimpleApiClient {
   }
 
   /**
+   * Resolve the 32-byte `apiKeyHash` used as the account identity on-chain.
+   * ChainSecured sessions set `adminHashOverride = keccak256(abi.encodePacked(address))`
+   * at login; API-key sessions (API mode or legacy sovereign) leave it null
+   * and this falls through to `_apiKeyHash(apiKey)`.
+   *
+   * IMPORTANT: only call this at identity sites (the "whose account is it"
+   * hash). Content hashes for actionIpfsCid and pkp addresses must keep
+   * calling `_apiKeyHash(value)` directly so the override does not corrupt
+   * them.
+   *
+   * @param {string} apiKey - apiKey string; may be empty for ChainSecured sessions.
+   * @returns {Promise<string>} 0x-prefixed 32-byte hex.
+   */
+  async _adminHash(apiKey) {
+    if (this.adminHashOverride) return this.adminHashOverride;
+    return this._apiKeyHash(apiKey);
+  }
+
+  /**
    * POST /core/v1/new_account
    * Creates a new account; server generates API key and wallet. Returns api_key and wallet_address.
    * @param {NewAccountOptions} options
@@ -530,6 +554,49 @@ export class LitNodeSimpleApiClient {
   }
 
   /**
+   * Contract: WritesFacet.newChainSecuredAccount(string, string).
+   * Creates a ChainSecured (unmanaged, wallet-signed) account. The connected
+   * signer address IS the admin; on-chain, apiKeyHash = keccak256(abi.encodePacked(msg.sender)).
+   *
+   * Sovereign mode only. Requires a connected signer + the chain drift check
+   * to pass. Reverts on collision (existing account for this wallet).
+   *
+   * @param {Object} options
+   * @param {string} options.accountName
+   * @param {string} options.accountDescription
+   * @param {Object} [options.sovereignLifecycle] - injected by the dashboard Proxy
+   * @returns {Promise<{wallet_address: string, api_key_hash: string, transaction_hash: string}>}
+   */
+  async newChainSecuredAccount({ accountName, accountDescription, sovereignLifecycle } = {}) {
+    if (this.mode !== 'sovereign') {
+      throw new Error('newChainSecuredAccount requires sovereign mode');
+    }
+    const contract = await this._getWriteContract();
+    const ethers = await loadEthers();
+    const signerAddress = await this.signer.getAddress();
+    const apiKeyHash = ethers.solidityPackedKeccak256(['address'], [signerAddress]);
+    try {
+      const { txHash } = await runContractWrite({
+        contract, method: 'newChainSecuredAccount',
+        args: [accountName ?? '', accountDescription ?? ''],
+        ...(sovereignLifecycle ?? {}),
+      });
+      return { wallet_address: signerAddress, api_key_hash: apiKeyHash, transaction_hash: txHash };
+    } catch (err) {
+      const msg = err?.decoded || err?.message || '';
+      if (msg.includes('AccountAlreadyExists')) {
+        const friendly = new Error(
+          'An account already exists for this wallet address. Connect a different wallet or log in with your existing account.',
+        );
+        friendly.cause = err;
+        friendly.accountAlreadyExists = true;
+        throw friendly;
+      }
+      throw err;
+    }
+  }
+
+  /**
    * GET /core/v1/account_exists
    * Checks whether an account exists and is mutable for the given API key (contract: accountExistsAndIsMutable).
    * API key via X-Api-Key or Authorization: Bearer header.
@@ -539,7 +606,7 @@ export class LitNodeSimpleApiClient {
   async accountExists(apiKey) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       // accountExistsAndIsMutable has an msg.sender check (caller must be an
       // api_payer). The server-side path spoofs this by setting `.from(api_payer)`
       // on the eth_call. For sovereign reads we take the same approach: fetch
@@ -554,6 +621,48 @@ export class LitNodeSimpleApiClient {
       headers: headersWithApiKey(apiKey),
     });
     return parseResponse(res, 'account_exists');
+  }
+
+  /**
+   * Sovereign-only variant of `accountExists` that takes a pre-computed
+   * apiKeyHash (0x-prefixed uint256 hex). Used by the ChainSecured login
+   * flow where the dashboard computes `keccak256(abi.encodePacked(address))`
+   * before it has (or needs) an apiKey string.
+   *
+   * Uses the same api_payer spoofing pattern as `accountExists` sovereign.
+   *
+   * @param {string} apiKeyHashHex - 0x-prefixed 32-byte hex
+   * @returns {Promise<boolean>}
+   */
+  async accountExistsByHash(apiKeyHashHex) {
+    if (this.mode !== 'sovereign') {
+      throw new Error('accountExistsByHash requires sovereign mode');
+    }
+    const contract = await this._getViewContract();
+    const payers = await contract.api_payers();
+    if (!payers || payers.length === 0) {
+      throw new Error('accountExistsByHash: no api_payers configured on contract');
+    }
+    return await contract.accountExistsAndIsMutable.staticCall(apiKeyHashHex, { from: payers[0] });
+  }
+
+  /**
+   * Public wrapper around `_verifyAbiIntegrity` that uses a read-only provider
+   * (no wallet required) and returns a non-throwing result. Safe to call
+   * post-wallet-connect to drive the drift banner.
+   *
+   * @returns {Promise<{ok: true} | {ok: false, reason: string}>}
+   */
+  async checkAbiDrift() {
+    if (this.mode !== 'sovereign') {
+      return { ok: true };
+    }
+    try {
+      await this._verifyAbiIntegrity();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: err?.message || String(err) };
+    }
   }
 
   /**
@@ -613,7 +722,7 @@ export class LitNodeSimpleApiClient {
   async addGroup({ apiKey, groupName, groupDescription = '', pkpIdsPermitted = [], cidHashesPermitted = [], sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const name = groupName ?? '';
       const description = groupDescription ?? '';
       // staticCall first to pre-fetch the new group_id without burning a tx.
@@ -654,7 +763,7 @@ export class LitNodeSimpleApiClient {
   async addAction({ apiKey, actionIpfsCid, name, description, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const actionHash = await this._apiKeyHash(actionIpfsCid);
       const { txHash } = await runContractWrite({
         contract, method: 'addAction',
@@ -681,7 +790,7 @@ export class LitNodeSimpleApiClient {
   async addActionToGroup({ apiKey, groupId, actionIpfsCid, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const actionHash = await this._apiKeyHash(actionIpfsCid);
       const { txHash } = await runContractWrite({
         contract, method: 'addActionToGroup',
@@ -711,7 +820,7 @@ export class LitNodeSimpleApiClient {
   async addPkpToGroup({ apiKey, groupId, pkpId, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'addPkpToGroup',
         args: [hash, BigInt(groupId), pkpId],
@@ -740,7 +849,7 @@ export class LitNodeSimpleApiClient {
   async removePkpFromGroup({ apiKey, groupId, pkpId, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'removePkpFromGroup',
         args: [hash, BigInt(groupId), pkpId],
@@ -784,7 +893,7 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const ethers = await loadEthers();
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       // Sovereign mode has no server-side Stripe billing: balance starts at 0
       // and can't be topped up without API mode. Caller may pass expiration
       // (uint256 seconds timestamp; 0 = never) and balance explicitly.
@@ -862,7 +971,7 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const ethers = await loadEthers();
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
       // setUsageApiKey is an upsert; existing expiration/balance are
       // overwritten. Sovereign callers should fetch current values via
@@ -920,7 +1029,7 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const ethers = await loadEthers();
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
       const { txHash } = await runContractWrite({
         contract, method: 'removeUsageApiKey',
@@ -943,7 +1052,7 @@ export class LitNodeSimpleApiClient {
   async removeGroup({ apiKey, groupId, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'removeGroup',
         args: [hash, BigInt(groupId)],
@@ -969,7 +1078,7 @@ export class LitNodeSimpleApiClient {
   async updateGroup({ apiKey, groupId, name, description, pkpIdsPermitted = [], cidHashesPermitted = [], sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'updateGroup',
         args: [hash, BigInt(groupId), name ?? '', description ?? '', cidHashesPermitted, pkpIdsPermitted],
@@ -1001,7 +1110,7 @@ export class LitNodeSimpleApiClient {
   async deleteAction({ apiKey, hashedCid, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'removeAction',
         args: [hash, hashedCid],
@@ -1027,7 +1136,7 @@ export class LitNodeSimpleApiClient {
   async removeActionFromGroup({ apiKey, groupId, hashedCid, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const { txHash } = await runContractWrite({
         contract, method: 'removeActionFromGroup',
         args: [hash, BigInt(groupId), hashedCid],
@@ -1056,7 +1165,7 @@ export class LitNodeSimpleApiClient {
   async updateActionMetadata({ apiKey, hashedCid, name, description, groupId = 0, sovereignLifecycle } = {}) {
     if (this.mode === 'sovereign') {
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       // groupId === 0 means "account-level action metadata" per contract convention.
       const { txHash } = await runContractWrite({
         contract, method: 'updateActionMetadata',
@@ -1088,7 +1197,7 @@ export class LitNodeSimpleApiClient {
     if (this.mode === 'sovereign') {
       const ethers = await loadEthers();
       const contract = await this._getWriteContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const usageHash = ethers.keccak256(ethers.toUtf8Bytes(usageApiKey));
       const { txHash } = await runContractWrite({
         contract, method: 'updateUsageApiKeyMetadata',
@@ -1119,7 +1228,7 @@ export class LitNodeSimpleApiClient {
   async listApiKeys({ apiKey, pageNumber = '0', pageSize = '10' }) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const rows = await contract.listApiKeys(hash, pageNumber, pageSize);
       return rows.map((r) => ({
         id: r.metadata.id.toString(),
@@ -1156,7 +1265,7 @@ export class LitNodeSimpleApiClient {
   async listGroups({ apiKey, pageNumber = '0', pageSize = '10' }) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const rows = await contract.listGroups(hash, pageNumber, pageSize);
       return rows.map((r) => ({
         id: r.id.toString(),
@@ -1183,7 +1292,7 @@ export class LitNodeSimpleApiClient {
   async listWallets({ apiKey, pageNumber = '0', pageSize = '10' }) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const rows = await contract.listPkps(hash, pageNumber, pageSize);
       return rows.map((r) => ({
         id: r.id.toString(),
@@ -1211,7 +1320,7 @@ export class LitNodeSimpleApiClient {
   async listWalletsInGroup({ apiKey, groupId, pageNumber = '0', pageSize = '10' }) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       const rows = await contract.listWalletsInGroup(hash, groupId, pageNumber, pageSize);
       return rows.map((r) => ({
         id: r.id.toString(),
@@ -1245,7 +1354,7 @@ export class LitNodeSimpleApiClient {
   async listActions({ apiKey, groupId, pageNumber = '0', pageSize = '10' }) {
     if (this.mode === 'sovereign') {
       const contract = await this._getViewContract();
-      const hash = await this._apiKeyHash(apiKey);
+      const hash = await this._adminHash(apiKey);
       // Match server semantics: group IDs start at 1, so groupId==0 means
       // "account-level listing", not "group zero". listActionsInGroup with 0
       // can revert (GroupDoesNotExist) or return wrong data.

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -132,8 +132,13 @@ CSS hides the wrong-mode-only elements:
 
 ```css
 body.is-chainsecured .sidebar-link[data-scroll="action-runner"] { display: none; }
-body.is-chainsecured #section-billing { display: none; }
+body.is-chainsecured #section-action-runner { display: none; }
 ```
+
+Billing (balance, Add Funds, no-funds warning, billing banners) is **not**
+mode-conditional. Stripe credit funds action runs in both modes. ChainSecured
+only changes how admin operations are signed (wallet vs API key), not how
+runs are paid for.
 
 Do not hide via JS-set inline styles. CSS-only toggles are easier to audit
 and survive page reloads.

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -123,22 +123,24 @@ Radii:
 
 ## Mode-conditional UI
 
-The dashboard hides features by mode using body classes:
+The dashboard exposes the same surface in both modes. Body classes are
+available for future gating but no features are currently hidden by mode:
 
 - `body.has-api-key` — set after successful API-mode login.
 - `body.is-chainsecured` — set after successful wallet connect.
 
-CSS hides the wrong-mode-only elements:
-
-```css
-body.is-chainsecured .sidebar-link[data-scroll="action-runner"] { display: none; }
-body.is-chainsecured #section-action-runner { display: none; }
-```
+Action Runner, Wallets, Actions, and Usage Keys all render in both modes.
+ChainSecured admin operations (add action, mint usage key) are signed by the
+connected wallet via the AccountConfig contract. ChainSecured users execute
+Lit Actions by pasting a usage API key they minted from the contract.
 
 Billing (balance, Add Funds, no-funds warning, billing banners) is **not**
 mode-conditional. Stripe credit funds action runs in both modes. ChainSecured
-only changes how admin operations are signed (wallet vs API key), not how
+only changes how admin writes are authorized (wallet vs API key), not how
 runs are paid for.
+
+Validation guards must use `isAuthenticated()`, not `!apiKey` — ChainSecured
+users authenticate via wallet and have no account-level api key.
 
 Do not hide via JS-set inline styles. CSS-only toggles are easier to audit
 and survive page reloads.

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -1,4 +1,4 @@
-# Lit Express Dashboard — Design System
+# Chipotle Dashboard — Design System
 
 What this document is: the source of truth for how the dashboard looks and behaves.
 Edit when the system actually changes. Do not edit to describe aspirational state.
@@ -112,8 +112,20 @@ Radii:
 ### Login mode cards
 
 - Side-by-side on desktop, stacked on mobile.
-- API mode card carries the `RECOMMENDED` badge — primary path.
-- Each card: icon, title, tagline, body, CTA.
+- API mode card carries the `RECOMMENDED` badge (filled primary) — primary path.
+- ChainSecured card carries the `WALLET REQUIRED` badge (muted, neutral fill)
+  to set expectation.
+- Neither card has a default highlight; both start with the same neutral
+  `--border` ring. Hover or focus-within either card → that card gets the
+  primary ring while the sibling stays neutral. The badges carry which is
+  recommended vs which requires a wallet, so the highlight follows intent
+  instead of pre-selecting one.
+- Each card's CTA (Log in / Create account / Connect wallet / Connect wallet
+  & create) shares the same shape (full-width, btn-block padding) but its
+  color follows the card's selected state: neutral outlined at rest, primary
+  blue when the card is hovered or focus-within. The btn-primary vs
+  btn-outline class no longer drives color here — the parent card does.
+- Each card: badge, icon, title, tagline, body, CTA.
 - Help glyph next to "ChainSecured" → tooltip defining the term.
 
 ### Help disclosure (`details.help-details`)

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -1,0 +1,165 @@
+# Lit Express Dashboard — Design System
+
+What this document is: the source of truth for how the dashboard looks and behaves.
+Edit when the system actually changes. Do not edit to describe aspirational state.
+
+## Voice
+
+Functional, calm, builder-to-builder. The dashboard is a control surface for an
+API. It should feel like an SDK with a UI on top, not a marketing page.
+
+- Verbs over nouns in CTAs. "Create your first usage key", not "Get started".
+- Define jargon on first appearance. "ChainSecured" is not self-explanatory.
+- No exclamation points. No emoji. No celebratory copy.
+- Errors say what failed and what to do next. They do not apologize.
+
+## Color tokens
+
+All color is driven by CSS custom properties on `:root` (light) and
+`[data-theme="dark"]` (dark). Hard-coded hex values are a bug.
+
+| Token | Light | Dark |
+|---|---|---|
+| `--primary` | `#3c50e0` | `#6366f1` |
+| `--primary-hover` | `#5a67d8` | `#818cf8` |
+| `--text` | `#1e293b` | `#f1f5f9` |
+| `--text-muted` | `#64748b` | `#94a3b8` |
+| `--body-bg` | `#f1f5f9` | `#0f172a` |
+| `--card-bg` | `#ffffff` | `#1e293b` |
+| `--border` | `#e2e8f0` | `#334155` |
+| `--bg-muted` | `#f3f4f6` | `#1e293b` |
+| `--danger` | `#dc2626` | `#f87171` |
+| `--success` | `#16a34a` | `#4ade80` |
+| `--shadow` | light shadow | darker shadow |
+
+Sidebar has its own scoped tokens (`--sidebar-bg`, `--sidebar-text`, etc.) so
+the sidebar can stay light when the rest goes dark, or vice versa.
+
+When tinting the primary color (e.g., empty-state icon backgrounds), use rgba
+with the same RGB as `--primary` so the alpha is the only knob:
+
+- Light tint: `rgba(60, 80, 224, 0.08)`
+- Dark tint: `rgba(99, 102, 241, 0.15)`
+
+## Typography
+
+- Body: `"Inter", system-ui, -apple-system, sans-serif`, 14px base, 1.5 line-height.
+- Mono: `"JetBrains Mono", ui-monospace, ...` for keys, hashes, addresses.
+- Form controls inherit (`font-family: inherit`) — never let browsers pick.
+
+Scale (semantic, not pixel-perfect):
+
+| Use | Size | Weight |
+|---|---|---|
+| Login title | 28px | 700 |
+| Topbar title | 20px | 600 |
+| Section h2 | 18px | 600 |
+| Card title | 0.9375rem (15px) | 600 |
+| Body | 14px | 400-500 |
+| Small / labels | 0.8125rem (13px) | 400-500 |
+| Caption | 12px | 500 |
+
+## Spacing
+
+8px grid. Use multiples: 4, 8, 12, 16, 20, 24, 32. Avoid arbitrary numbers.
+
+Radii:
+
+- `--radius` = 8px (most surfaces)
+- `--radius-lg` = 12px (cards, hero blocks, empty-state icon containers)
+
+## Components
+
+### Buttons
+
+- `.btn` base. Modifiers: `.btn-primary`, `.btn-outline`, `.btn-sm`, `.btn-block`.
+- Primary CTA: solid `--primary` background, white text.
+- Outline: transparent background, primary border + text.
+- Min height 44px on mobile (`max-width: 768px` media query). Desktop can be 36-40px.
+
+### Cards
+
+- Background `--card-bg`, border `1px solid --border`, radius `--radius-lg`,
+  shadow `--shadow`. Inner padding 1.5rem (24px).
+- Use sparingly. Stacking cards inside cards is a smell.
+
+### Stat cards (`stat-card`)
+
+- Anchor element (`<a>`), not div, so they navigate to their section.
+- Layout: icon left (44px square, brand-tinted bg), value + label stacked right.
+- Click → smooth-scroll to section + sets sidebar active state.
+
+### Empty states (`empty-state`)
+
+- Centered: 48px brand-tinted icon, title (15px / 600), body (13px / muted, 320px max-width).
+- Section-specific copy. Tell the user what the thing is and how to start.
+- Toggle visibility via `style.display = 'none' | ''` from JS, not class swap,
+  so existing handlers keep working.
+
+### Sidebar link (`sidebar-link`)
+
+- Icon (lucide-style 18px SVG) + text label.
+- States: default, `:hover`, `.is-active`.
+- Active state: brand color text, soft hover bg, 3px brand bar on the left edge.
+- Active state is set by IntersectionObserver scroll-spy (`app.js initSidebar`).
+
+### Mode badge (topbar `topbar-mode-badge`)
+
+- Click toggles a `.topbar-mode-popover` that explains the current mode.
+- Different copy per mode. ChainSecured popover lists which features are hidden.
+- Closes on outside click and Escape.
+
+### Login mode cards
+
+- Side-by-side on desktop, stacked on mobile.
+- API mode card carries the `RECOMMENDED` badge — primary path.
+- Each card: icon, title, tagline, body, CTA.
+- Help glyph next to "ChainSecured" → tooltip defining the term.
+
+### Help disclosure (`details.help-details`)
+
+- Native `<details>` for collapsible explanations (e.g., the dev-doc Instructions block).
+- Default closed. The summary acts as the button.
+
+## Mode-conditional UI
+
+The dashboard hides features by mode using body classes:
+
+- `body.has-api-key` — set after successful API-mode login.
+- `body.is-chainsecured` — set after successful wallet connect.
+
+CSS hides the wrong-mode-only elements:
+
+```css
+body.is-chainsecured .sidebar-link[data-scroll="action-runner"] { display: none; }
+body.is-chainsecured #section-billing { display: none; }
+```
+
+Do not hide via JS-set inline styles. CSS-only toggles are easier to audit
+and survive page reloads.
+
+## Accessibility
+
+- All focusable elements get `:focus-visible` outlines (`outline: 2px solid var(--primary)`).
+  Keyboard-only — mouse clicks do not trigger the ring.
+- Decorative SVGs use `aria-hidden="true"`. Meaningful SVGs get `<title>` or `aria-label`.
+- Touch targets ≥ 44px on mobile. Anything below is a bug.
+- Popovers use `aria-expanded`, `aria-haspopup`, and `aria-hidden` on the panel.
+- Modals use `role="dialog"` and trap focus.
+
+## Adding a new section
+
+1. Add a `<section id="section-{name}" class="dashboard-section">` in `index.html`.
+2. Add it to `MAIN_SECTION_IDS` in `app.js` (top of file).
+3. Add a sidebar link with matching `data-scroll="{name}"` and a lucide icon.
+4. If it has an empty state, follow the `empty-state` pattern (icon + title + body).
+5. If the section is mode-conditional, gate via `body.is-chainsecured` CSS rule.
+
+## Don'ts
+
+- No new CSS frameworks. We have what we need.
+- No inline styles for color, spacing, or typography. Use tokens.
+- No icon libraries. Inline SVG, lucide-style stroke 2.
+- No animations longer than 200ms. Snappy beats smooth.
+- No new fonts.
+- No "TODO" comments in shipped CSS — file an issue or fix it.

--- a/lit-static/dapps/dashboard/actions.js
+++ b/lit-static/dapps/dashboard/actions.js
@@ -2,7 +2,7 @@
  * IPFS Actions — table rendering, CRUD.
  */
 
-import { getEffectiveApiKey, getClient, getActionsStore, setActionsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
+import { getEffectiveApiKey, isAuthenticated, getClient, getActionsStore, setActionsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
 import { escapeHtml, showStatus, hideStatus, showActionProgress, closeActionProgress, openModal, closeModal, confirmDelete, formatError, logError, ICON_PENCIL, ICON_TRASH } from './ui-utils.js';
 
 // ----- Table rendering -----
@@ -48,7 +48,7 @@ export function renderActionsTable(items) {
 
 export async function loadActions() {
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('actions-status');
   const btn = document.getElementById('btn-load-actions');
   if (btn) btn.disabled = true;
@@ -154,7 +154,7 @@ async function confirmAndRemoveAction(item) {
   const confirmed = await confirmDelete(msg);
   if (!confirmed) return;
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('actions-status');
   try {
     showActionProgress('Deleting action', `Deleting action CID "${cid}".`);

--- a/lit-static/dapps/dashboard/actions.js
+++ b/lit-static/dapps/dashboard/actions.js
@@ -86,7 +86,11 @@ function openAddActionModal() {
     const name = document.getElementById('modal-action-name').value.trim() || undefined;
     const desc = document.getElementById('modal-action-desc').value.trim() || undefined;
     const apiKey = getEffectiveApiKey();
-    if (!apiKey || !cid) {
+    if (!isAuthenticated()) {
+      showStatus('actions-status', 'Log in first.', 'error');
+      return;
+    }
+    if (!cid) {
       showStatus('actions-status', 'Fill in the IPFS CID.', 'error');
       return;
     }
@@ -124,7 +128,11 @@ function openEditActionModal(item) {
     const name = document.getElementById('modal-edit-action-name').value.trim();
     const desc = document.getElementById('modal-edit-action-desc').value.trim();
     const apiKey = getEffectiveApiKey();
-    if (!apiKey || !cid || !name) {
+    if (!isAuthenticated()) {
+      showStatus('actions-status', 'Log in first.', 'error');
+      return;
+    }
+    if (!cid || !name) {
       showStatus('actions-status', 'Fill Name.', 'error');
       return;
     }

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -3,7 +3,7 @@
  * Imports all feature modules and orchestrates initialization.
  */
 
-import { getApiKey, setTheme, getTheme, setApiKey, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI, clearOverrideState } from './auth.js';
+import { isAuthenticated, setTheme, getTheme, logOut, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI } from './auth.js';
 import { initModalClose, initConfirmClose, showStatus, hideStatus, logError } from './ui-utils.js';
 import { initBilling } from './billing.js';
 import { initGroups, loadGroups } from './groups.js';
@@ -15,8 +15,7 @@ import { initActionRunner } from './runner.js';
 // ----- Preload all tables (with error visibility) -----
 
 async function preloadAllTables() {
-  const apiKey = getApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   const results = await Promise.allSettled([
     loadGroups(),
     loadWallets(),
@@ -142,8 +141,7 @@ function initHeader() {
     signoutBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       closeAccountDropdown();
-      clearOverrideState();
-      setApiKey('');
+      logOut();
     });
   }
 }

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -73,6 +73,12 @@ function setActionRunnerVisible(visible) {
   });
 }
 
+function setActiveSidebarLink(id) {
+  document.querySelectorAll('.sidebar-link[data-scroll]').forEach((a) => {
+    a.classList.toggle('is-active', a.getAttribute('data-scroll') === id);
+  });
+}
+
 function initSidebar() {
   document.querySelectorAll('.sidebar-link[data-scroll]').forEach((a) => {
     a.addEventListener('click', (e) => {
@@ -80,15 +86,45 @@ function initSidebar() {
       const id = a.getAttribute('data-scroll');
       if (id === ACTION_RUNNER_ID) {
         setActionRunnerVisible(true);
-        const el = document.getElementById('section-' + id);
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
       } else {
         setActionRunnerVisible(false);
-        const el = document.getElementById('section-' + id);
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
+      const el = document.getElementById('section-' + id);
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setActiveSidebarLink(id);
     });
   });
+
+  // Scroll-spy: highlight sidebar link for whichever section is in view.
+  const sections = MAIN_SECTION_IDS
+    .map((id) => document.getElementById('section-' + id))
+    .filter(Boolean);
+  if (sections.length === 0 || !('IntersectionObserver' in window)) return;
+
+  const visible = new Map();
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        visible.set(entry.target.id, entry.intersectionRatio);
+      } else {
+        visible.delete(entry.target.id);
+      }
+    });
+    if (visible.size === 0) return;
+    let bestId = null;
+    let bestRatio = -1;
+    visible.forEach((ratio, sectionId) => {
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        bestId = sectionId;
+      }
+    });
+    if (bestId) setActiveSidebarLink(bestId.replace(/^section-/, ''));
+  }, {
+    rootMargin: '-80px 0px -55% 0px',
+    threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
+  });
+  sections.forEach((el) => observer.observe(el));
 }
 
 // ----- Header (theme toggle, account dropdown, sign out) -----

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -80,7 +80,9 @@ function setActiveSidebarLink(id) {
 }
 
 function initSidebar() {
-  document.querySelectorAll('.sidebar-link[data-scroll]').forEach((a) => {
+  // Bind to any element with data-scroll (sidebar links, stat cards, empty-state CTAs).
+  // Active-link styling stays sidebar-only via setActiveSidebarLink's selector.
+  document.querySelectorAll('[data-scroll]').forEach((a) => {
     a.addEventListener('click', (e) => {
       e.preventDefault();
       const id = a.getAttribute('data-scroll');

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -398,16 +398,46 @@ function renderModeBadge() {
   }
   const isChainSecured = mode === 'sovereign' && !!getChainSecuredWallet();
   const modeLabel = isChainSecured ? 'ChainSecured mode' : 'API mode';
-  const tooltip = isChainSecured
-    ? 'Writes are wallet-signed transactions on-chain.'
-    : 'Writes go through the Lit Express API.';
+  const popoverContent = isChainSecured
+    ? `<strong>ChainSecured mode</strong>
+       <p>Your wallet is the account identity. Writes are signed on-chain as transactions you authorize in your wallet.</p>
+       <p class="mode-popover-hidden">Hidden in this mode: Action Runner, Billing.</p>`
+    : `<strong>API mode</strong>
+       <p>Writes go through the Lit Express API using your account API key. Fastest path, no wallet popups.</p>`;
   let pillHtml = '';
   if (isChainSecured) {
     const wallet = getChainSecuredWallet();
     const trunc = `${wallet.slice(0, 6)}\u2026${wallet.slice(-4)}`;
     pillHtml = ` <button type="button" class="topbar-wallet-pill" id="topbar-wallet-pill" title="Copy wallet address" data-wallet="${escapeHtml(wallet)}">${escapeHtml(trunc)}</button>`;
   }
-  host.innerHTML = `<span class="topbar-mode-badge" title="${escapeHtml(tooltip)}">${escapeHtml(modeLabel)}</span>${pillHtml}`;
+  host.innerHTML = `<span class="topbar-mode-badge-wrap">
+      <button type="button" class="topbar-mode-badge" id="topbar-mode-badge" aria-haspopup="dialog" aria-expanded="false">${escapeHtml(modeLabel)}</button>
+      <div class="topbar-mode-popover" id="topbar-mode-popover" role="dialog" aria-label="${escapeHtml(modeLabel)} details" hidden>${popoverContent}</div>
+    </span>${pillHtml}`;
+  const badgeBtn = document.getElementById('topbar-mode-badge');
+  const popover = document.getElementById('topbar-mode-popover');
+  if (badgeBtn && popover) {
+    const close = () => {
+      popover.hidden = true;
+      badgeBtn.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('click', onDocClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+    const onDocClick = (ev) => {
+      if (!badgeBtn.contains(ev.target) && !popover.contains(ev.target)) close();
+    };
+    const onKeyDown = (ev) => { if (ev.key === 'Escape') close(); };
+    badgeBtn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const open = popover.hidden;
+      popover.hidden = !open;
+      badgeBtn.setAttribute('aria-expanded', String(open));
+      if (open) {
+        document.addEventListener('click', onDocClick, true);
+        document.addEventListener('keydown', onKeyDown, true);
+      }
+    });
+  }
   const pill = document.getElementById('topbar-wallet-pill');
   if (pill) {
     pill.addEventListener('click', async () => {

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -419,7 +419,7 @@ function renderModeBadge() {
   const popoverContent = isChainSecured
     ? `<strong>ChainSecured mode</strong>
        <p>Your wallet is the account identity. Writes are signed on-chain as transactions you authorize in your wallet.</p>
-       <p class="mode-popover-hidden">Hidden in this mode: Action Runner, Billing.</p>`
+       <p class="mode-popover-hidden">Hidden in this mode: Action Runner. Funding still uses your account billing.</p>`
     : `<strong>API mode</strong>
        <p>Writes go through the Lit Express API using your account API key. Fastest path, no wallet popups.</p>`;
   let pillHtml = '';

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -331,10 +331,28 @@ export function updateStatCards() {
   const elGroups = document.getElementById('stat-groups');
   const elWallets = document.getElementById('stat-wallets');
   const elActions = document.getElementById('stat-actions');
-  if (elUsageKeys) elUsageKeys.textContent = (typeof _stats.usageKeys === 'number') ? _stats.usageKeys : getUsageKeysStore().length;
+  const usageKeysVal = (typeof _stats.usageKeys === 'number') ? _stats.usageKeys : getUsageKeysStore().length;
+  if (elUsageKeys) elUsageKeys.textContent = usageKeysVal;
   if (elGroups) elGroups.textContent = (typeof _stats.groups === 'number') ? _stats.groups : '—';
   if (elWallets) elWallets.textContent = (typeof _stats.wallets === 'number') ? _stats.wallets : '—';
   if (elActions) elActions.textContent = (typeof _stats.actions === 'number') ? _stats.actions : '—';
+
+  // Empty hero ↔ stats grid swap. Only swap once all four stores have resolved
+  // to numbers, otherwise we'd flash the hero during initial load.
+  const allResolved = typeof _stats.groups === 'number'
+    && typeof _stats.wallets === 'number'
+    && typeof _stats.actions === 'number';
+  const allZero = allResolved
+    && usageKeysVal === 0
+    && _stats.groups === 0
+    && _stats.wallets === 0
+    && _stats.actions === 0;
+  const heroEl = document.getElementById('overview-empty-state');
+  const statsEl = document.getElementById('stats-row');
+  if (heroEl && statsEl) {
+    heroEl.hidden = !allZero;
+    statsEl.hidden = allZero;
+  }
 }
 
 // ----- Module-scoped state (replaces window._*) -----

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -273,7 +273,7 @@ async function ensureSovereignSigner(client) {
  * onState: surfaces tx status in a non-dismissible progress banner.
  */
 async function buildSovereignLifecycle(client, sdkMethodName) {
-  const [{ showTxPreview }, { describeState, TX_STATES }] = await Promise.all([
+  const [{ showTxPreview }, { TX_STATES }] = await Promise.all([
     import('./tx_preview_modal.js'),
     import('../../tx_lifecycle.js'),
   ]);
@@ -287,7 +287,13 @@ async function buildSovereignLifecycle(client, sdkMethodName) {
     onPreview: (contractMethod, contractArgs) =>
       showTxPreview(contractMethod, contractArgs, meta),
     onState: (state, payload) => {
-      if (state === TX_STATES.SIGNING) {
+      // Preview modal owns the screen during PREPARING/PREVIEWING. Close any
+      // pre-existing action-overlay that a dashboard handler opened before
+      // calling the SDK (otherwise it stacks above and blocks the Confirm
+      // button). It is re-opened on SIGNING below.
+      if (state === TX_STATES.PREPARING || state === TX_STATES.PREVIEWING) {
+        closeActionProgress();
+      } else if (state === TX_STATES.SIGNING) {
         showActionProgress(sdkMethodName, 'Open your wallet to sign the transaction…');
       } else if (state === TX_STATES.PENDING) {
         showActionProgress(sdkMethodName, `Broadcast — ${payload?.txHash?.slice(0, 10)}… waiting for inclusion.`);
@@ -295,8 +301,6 @@ async function buildSovereignLifecycle(client, sdkMethodName) {
         showActionProgress(sdkMethodName, `Included — waiting for ${payload?.target} confirmations.`);
       } else if (state === TX_STATES.CONFIRMED || state === TX_STATES.FAILED || state === TX_STATES.REORGED) {
         closeActionProgress();
-      } else {
-        showActionProgress(sdkMethodName, describeState(state));
       }
     },
   };
@@ -419,7 +423,7 @@ function renderModeBadge() {
   const popoverContent = isChainSecured
     ? `<strong>ChainSecured mode</strong>
        <p>Your wallet is the account identity. Writes are signed on-chain as transactions you authorize in your wallet.</p>
-       <p class="mode-popover-hidden">Hidden in this mode: Action Runner. Funding still uses your account billing.</p>`
+       <p class="mode-popover-hidden">Action runs use a usage API key from your account. Funding still uses your account billing.</p>`
     : `<strong>API mode</strong>
        <p>Writes go through the Lit Express API using your account API key. Fastest path, no wallet popups.</p>`;
   let pillHtml = '';

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -9,6 +9,8 @@ const STORAGE_KEY_THEME = 'accountconfig_theme';
 const STORAGE_KEY_USAGE_OVERRIDE = 'accountconfig_usage_key_override';
 const STORAGE_KEY_OVERRIDE_ENABLED = 'accountconfig_usage_override_enabled';
 const STORAGE_KEY_MODE = 'accountconfig_mode';
+const STORAGE_KEY_CHAINSECURED_WALLET = 'accountconfig_chainsecured_wallet';
+const STORAGE_KEY_CHAINSECURED_HASH = 'accountconfig_chainsecured_hash';
 export const LIST_PAGE_SIZE = '20';
 
 /**
@@ -19,6 +21,7 @@ export const LIST_PAGE_SIZE = '20';
  * Keep in sync with branched writes in core_sdk.js.
  */
 const SOVEREIGN_WRITE_METHODS = new Set([
+  'newChainSecuredAccount',
   'addGroup', 'removeGroup', 'updateGroup',
   'addAction', 'deleteAction', 'addActionToGroup', 'removeActionFromGroup', 'updateActionMetadata',
   'addPkpToGroup', 'removePkpFromGroup',
@@ -36,9 +39,7 @@ export function setMode(mode) {
   if (mode === 'sovereign') sessionStorage.setItem(STORAGE_KEY_MODE, 'sovereign');
   else sessionStorage.removeItem(STORAGE_KEY_MODE);
   // Invalidate cached client so the next getClient() rebuilds with the new mode.
-  _clientInstance = null;
-  _clientBaseUrl = null;
-  _clientMode = null;
+  resetClient();
 }
 
 // ----- API key session -----
@@ -52,6 +53,60 @@ export function setApiKey(v) {
   else sessionStorage.removeItem(STORAGE_KEY_API);
   import('./billing.js').then((m) => m.resetBillingAvailability()).catch(() => {});
   updateAuthUI();
+}
+
+// ----- ChainSecured session (wallet-backed) -----
+
+export function getChainSecuredWallet() {
+  return sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_WALLET) || '';
+}
+
+export function getChainSecuredHash() {
+  return sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_HASH) || '';
+}
+
+/**
+ * Persist a ChainSecured login: wallet address + precomputed apiKeyHash.
+ * Pushes the hash onto the cached SDK client's `adminHashOverride` so the
+ * 20 identity sites in core_sdk.js use the wallet-derived hash instead of
+ * hashing an (empty) api key string.
+ */
+export async function setChainSecuredSession({ walletAddress, apiKeyHash }) {
+  if (walletAddress) sessionStorage.setItem(STORAGE_KEY_CHAINSECURED_WALLET, walletAddress);
+  else sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_WALLET);
+  if (apiKeyHash) sessionStorage.setItem(STORAGE_KEY_CHAINSECURED_HASH, apiKeyHash);
+  else sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_HASH);
+  if (_clientInstance) _clientInstance.adminHashOverride = apiKeyHash || null;
+  updateAuthUI();
+}
+
+/** Clears ChainSecured session markers and the client cache. */
+export function clearChainSecuredSession() {
+  sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_WALLET);
+  sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_HASH);
+  resetClient();
+}
+
+/** True if the user has any authenticated session — api key OR ChainSecured. */
+export function isAuthenticated() {
+  return !!getApiKey() || (getMode() === 'sovereign' && !!getChainSecuredWallet());
+}
+
+/** Full sign-out: clears api-key, ChainSecured session, and the client cache. */
+export function logOut() {
+  sessionStorage.removeItem(STORAGE_KEY_API);
+  sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_WALLET);
+  sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_HASH);
+  clearOverrideState();
+  resetClient();
+  updateAuthUI();
+}
+
+/** Invalidate the cached SDK client; next getClient() rebuilds fresh. */
+export function resetClient() {
+  _clientInstance = null;
+  _clientBaseUrl = null;
+  _clientMode = null;
 }
 
 /** Returns the usage API key override if set, otherwise the account API key. */
@@ -143,6 +198,12 @@ export async function getClient() {
       opts.contractAddress = cfg.contract_address;
       if (cfg.chain_id != null) opts.chainId = Number(cfg.chain_id);
     }
+    // Re-apply any active ChainSecured adminHash override so freshly-built
+    // clients resume with wallet-derived identity.
+    if (mode === 'sovereign') {
+      const chainSecuredHash = getChainSecuredHash();
+      if (chainSecuredHash) opts.adminHashOverride = chainSecuredHash;
+    }
     const client = createClient(opts);
     _clientInstance = new Proxy(client, {
       get(target, prop) {
@@ -150,8 +211,14 @@ export async function getClient() {
         if (typeof val !== 'function') return val;
         return async function (...args) {
           const apiKey = (args[0] && typeof args[0] === 'object' && args[0].apiKey) || args[0];
-          const keyPreview = typeof apiKey === 'string' ? apiKey.substring(0, 6) + '\u2026' : '(none)';
-          console.log(`[dashboard:${mode}] ${prop} \u2192 ${baseUrl} | key: ${keyPreview}`);
+          let authPreview;
+          if (mode === 'sovereign' && target.adminHashOverride) {
+            const wallet = getChainSecuredWallet();
+            authPreview = wallet ? `wallet: ${wallet.slice(0, 6)}\u2026${wallet.slice(-4)}` : `hash: ${target.adminHashOverride.slice(0, 10)}\u2026`;
+          } else {
+            authPreview = typeof apiKey === 'string' ? `key: ${apiKey.substring(0, 6)}\u2026` : 'auth: (none)';
+          }
+          console.log(`[dashboard:${mode}] ${prop} \u2192 ${baseUrl} | ${authPreview}`);
 
           // Sovereign-mode writes: auto-inject lifecycle (wallet connect +
           // preview modal + tx status banner) unless caller already supplied
@@ -301,11 +368,76 @@ let _onAuthReady = null;
 export function setOnAuthReady(fn) { _onAuthReady = fn; }
 
 function updateAuthUI() {
-  const hasKey = !!getApiKey();
-  document.body.classList.toggle('has-api-key', hasKey);
+  const authed = isAuthenticated();
+  const isChainSecured = authed && getMode() === 'sovereign' && !!getChainSecuredWallet();
+  // Keep the legacy `has-api-key` hook — it's what existing CSS gates the
+  // dashboard shell on. `is-chainsecured` toggles ChainSecured-specific UI
+  // (hides Action Runner + Billing, shows owner pill, etc.).
+  document.body.classList.toggle('has-api-key', authed);
+  document.body.classList.toggle('is-chainsecured', isChainSecured);
+  renderModeBadge();
   import('./billing.js').then((m) => m.refreshBillingUI()).catch(() => {});
-  if (hasKey && _onAuthReady) {
+  if (authed && _onAuthReady) {
     _onAuthReady();
+  }
+}
+
+/**
+ * Paint the topbar mode badge + (ChainSecured only) owner wallet pill.
+ * Called on every `updateAuthUI` pass. ChainSecured pill paints from session
+ * immediately; on-chain reconciliation via `getAccountWalletAddress` runs
+ * async and overwrites if the chain disagrees.
+ */
+function renderModeBadge() {
+  const host = document.querySelector('.topbar-title');
+  if (!host) return;
+  const mode = getMode();
+  if (!isAuthenticated()) {
+    host.innerHTML = '&nbsp;';
+    return;
+  }
+  const isChainSecured = mode === 'sovereign' && !!getChainSecuredWallet();
+  const modeLabel = isChainSecured ? 'ChainSecured mode' : 'API mode';
+  const tooltip = isChainSecured
+    ? 'Writes are wallet-signed transactions on-chain.'
+    : 'Writes go through the Lit Express API.';
+  let pillHtml = '';
+  if (isChainSecured) {
+    const wallet = getChainSecuredWallet();
+    const trunc = `${wallet.slice(0, 6)}\u2026${wallet.slice(-4)}`;
+    pillHtml = ` <button type="button" class="topbar-wallet-pill" id="topbar-wallet-pill" title="Copy wallet address" data-wallet="${escapeHtml(wallet)}">${escapeHtml(trunc)}</button>`;
+  }
+  host.innerHTML = `<span class="topbar-mode-badge" title="${escapeHtml(tooltip)}">${escapeHtml(modeLabel)}</span>${pillHtml}`;
+  const pill = document.getElementById('topbar-wallet-pill');
+  if (pill) {
+    pill.addEventListener('click', async () => {
+      const { copyToClipboard } = await import('./ui-utils.js');
+      await copyToClipboard(pill.dataset.wallet, pill);
+    });
+  }
+}
+
+/**
+ * Start the wallet-change watcher once. Logs out if the user disconnects the
+ * wallet or switches to a different account mid-session.
+ */
+let _walletWatchStarted = false;
+async function ensureWalletWatch() {
+  if (_walletWatchStarted) return;
+  _walletWatchStarted = true;
+  try {
+    const { onWalletChange } = await import('../../wallet_connect.js');
+    onWalletChange((snap) => {
+      if (getMode() !== 'sovereign' || !getChainSecuredWallet()) return;
+      const expected = getChainSecuredWallet().toLowerCase();
+      if (!snap.connected) {
+        logOut();
+      } else if (snap.address && snap.address.toLowerCase() !== expected) {
+        logOut();
+      }
+    });
+  } catch (e) {
+    console.warn('[auth] onWalletChange wiring failed:', e);
   }
 }
 
@@ -325,22 +457,17 @@ export function keyPreview(key) {
 
 export function initLogin() {
   const apiKeyInput = document.getElementById('login-api-key');
+  // Null-deref guard (TODOS.md:3-9) — pages that don't host the login form
+  // still import this module via app.js; skip wiring when the form is absent.
+  if (!apiKeyInput) {
+    // If a session already exists, surface the authed state on any page that
+    // imports auth (e.g. monitor's shared topbar) and return.
+    if (isAuthenticated()) updateAuthUI();
+    return;
+  }
   if (getApiKey()) apiKeyInput.value = '';
 
-  // Sovereign-mode toggle — reflects the current session mode and persists on change.
-  const modeToggle = document.getElementById('login-mode-sovereign');
-  const modeLabel = document.getElementById('login-mode-label');
-  if (modeToggle) {
-    modeToggle.checked = getMode() === 'sovereign';
-    const syncLabel = () => {
-      if (modeLabel) modeLabel.textContent = modeToggle.checked ? 'Sovereign mode' : 'API mode';
-    };
-    syncLabel();
-    modeToggle.addEventListener('change', () => {
-      setMode(modeToggle.checked ? 'sovereign' : 'api');
-      syncLabel();
-    });
-  }
+  ensureWalletWatch();
 
   const tabExisting = document.getElementById('login-tab-existing');
   const tabNew = document.getElementById('login-tab-new');
@@ -360,6 +487,7 @@ export function initLogin() {
   tabExisting?.addEventListener('click', () => switchLoginTab(true));
   tabNew?.addEventListener('click', () => switchLoginTab(false));
 
+  // ----- Card A (Existing): API-key login -----
   document.getElementById('btn-login').addEventListener('click', async () => {
     const key = (apiKeyInput.value || '').trim();
     if (!key) {
@@ -370,6 +498,7 @@ export function initLogin() {
     const btn = document.getElementById('btn-login');
     btn.disabled = true;
     try {
+      setMode('api');
       const client = await getClient();
       const exists = await client.accountExists(key);
       if (exists) {
@@ -386,11 +515,18 @@ export function initLogin() {
     }
   });
 
+  // ----- Card B (Existing): ChainSecured wallet login -----
+  const btnLoginWallet = document.getElementById('btn-login-wallet');
+  if (btnLoginWallet) {
+    btnLoginWallet.addEventListener('click', () => loginWithWallet(btnLoginWallet));
+  }
+
   // If a session already exists, trigger the auth-ready flow on load
-  if (getApiKey()) {
+  if (isAuthenticated()) {
     updateAuthUI();
   }
 
+  // ----- Card A (New): managed account creation -----
   document.getElementById('btn-create-account').addEventListener('click', async () => {
     const name = document.getElementById('new-account-name').value.trim();
     const desc = document.getElementById('new-account-desc').value.trim();
@@ -411,6 +547,7 @@ export function initLogin() {
         'Creating account',
         'Creating a new Lit Express account and returning an API key.'
       );
+      setMode('api');
       const client = await getClient();
       const res = await client.newAccount({ accountName: name, accountDescription: desc, email: email || undefined });
       setApiKey(res.api_key);
@@ -425,6 +562,109 @@ export function initLogin() {
       btn.disabled = false;
     }
   });
+
+  // ----- Card B (New): ChainSecured account creation -----
+  const btnCreateChainSecured = document.getElementById('btn-create-chainsecured');
+  if (btnCreateChainSecured) {
+    btnCreateChainSecured.addEventListener('click', () => createChainSecuredAccount(btnCreateChainSecured));
+  }
+}
+
+/**
+ * Card B (Existing) click handler. Error ordering matters here — we prefetch
+ * chain config BEFORE popping MetaMask so a failed API server doesn't waste a
+ * wallet-connect. Same rule applies to newChainSecuredAccount.
+ */
+async function loginWithWallet(btn) {
+  hideStatus('login-status');
+  btn.disabled = true;
+  const prevMode = getMode();
+  try {
+    setMode('sovereign');
+    // Prefetch chain config via getClient() sovereign bootstrap — throws
+    // BEFORE wallet popup on unreachable API server.
+    const client = await getClient();
+    const { connectEoa } = await import('../../wallet_connect.js');
+    const ethers = await loadEthersLocal();
+    const { address } = await connectEoa();
+    const apiKeyHash = ethers.solidityPackedKeccak256(['address'], [address]);
+    const exists = await client.accountExistsByHash(apiKeyHash);
+    if (!exists) {
+      setMode(prevMode); // revert
+      showStatus(
+        'login-status',
+        'No ChainSecured account found for this wallet. Sign up in the New User tab.',
+        'error',
+      );
+      return;
+    }
+    await setChainSecuredSession({ walletAddress: address, apiKeyHash });
+    showStatus('login-status', 'Connected. Wallet is the account admin.', 'success');
+    runPostConnectDriftCheck(client).catch((e) => logError('drift-check', e));
+  } catch (e) {
+    setMode(prevMode);
+    logError('login-wallet', e);
+    showStatus('login-status', 'Error: ' + formatError(e), 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+/**
+ * Card B (New) click handler. Creates a ChainSecured account via the
+ * WritesFacet.newChainSecuredAccount path; the Proxy injects the
+ * sovereignLifecycle (wallet connect + preview modal + tx banner).
+ */
+async function createChainSecuredAccount(btn) {
+  const name = (document.getElementById('new-chainsecured-name')?.value || '').trim();
+  const desc = (document.getElementById('new-chainsecured-desc')?.value || '').trim();
+  hideStatus('login-status');
+  if (!name) {
+    showStatus('login-status', 'Enter an account name.', 'error');
+    return;
+  }
+  btn.disabled = true;
+  const prevMode = getMode();
+  try {
+    setMode('sovereign');
+    const client = await getClient();
+    // Proxy auto-runs ensureSovereignSigner → wallet-connect before the tx.
+    const res = await client.newChainSecuredAccount({ accountName: name, accountDescription: desc });
+    await setChainSecuredSession({ walletAddress: res.wallet_address, apiKeyHash: res.api_key_hash });
+    showChainSecuredBanner(res.wallet_address);
+    const nameEl = document.getElementById('new-chainsecured-name');
+    const descEl = document.getElementById('new-chainsecured-desc');
+    if (nameEl) nameEl.value = '';
+    if (descEl) descEl.value = '';
+    runPostConnectDriftCheck(client).catch((e) => logError('drift-check', e));
+  } catch (e) {
+    setMode(prevMode);
+    logError('create-chainsecured', e);
+    showStatus('login-status', 'Error: ' + formatError(e), 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function loadEthersLocal() {
+  if (typeof globalThis !== 'undefined' && globalThis.ethers) return globalThis.ethers;
+  const mod = await import(/* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/ethers@6.13.0/dist/ethers.min.js');
+  const e = mod.ethers ?? mod.default ?? mod;
+  if (typeof globalThis !== 'undefined') globalThis.ethers = e;
+  return e;
+}
+
+async function runPostConnectDriftCheck(client) {
+  if (typeof client.checkAbiDrift !== 'function') return;
+  const result = await client.checkAbiDrift();
+  const banner = document.getElementById('abi-drift-banner');
+  if (!banner) return;
+  if (!result.ok) {
+    banner.textContent = 'ABI drift detected — on-chain contract does not match this dashboard build. Writes are disabled. Reason: ' + result.reason;
+    banner.style.display = '';
+  } else {
+    banner.style.display = 'none';
+  }
 }
 
 function showNewAccountBanner(apiKey) {
@@ -440,5 +680,35 @@ function showNewAccountBanner(apiKey) {
     const { copyToClipboard } = await import('./ui-utils.js');
     await copyToClipboard(apiKey, copyBtn);
   };
+  dismissBtn.onclick = () => { banner.style.display = 'none'; };
+}
+
+/**
+ * ChainSecured post-creation success banner. Re-uses the `new-account-banner`
+ * DOM when present; swaps the copy target from apiKey to wallet address and
+ * removes the "save this key" phrasing (there is no key).
+ */
+function showChainSecuredBanner(walletAddress) {
+  const banner = document.getElementById('new-account-banner');
+  const keyEl = document.getElementById('new-account-key-text');
+  const copyBtn = document.getElementById('new-account-copy-btn');
+  const dismissBtn = document.getElementById('new-account-dismiss-btn');
+  if (!banner || !keyEl || !copyBtn || !dismissBtn) return;
+  const body = banner.querySelector('.new-account-banner-body');
+  if (body) {
+    body.innerHTML = `<strong>Account created.</strong> Connected wallet <code class="mono">${escapeHtml(walletAddress)}</code> is the admin. No API key to copy \u2014 your wallet signs all writes.
+      <div class="new-account-key-row">
+        <code id="new-account-key-text" class="new-account-key mono">${escapeHtml(walletAddress)}</code>
+        <button type="button" id="new-account-copy-btn" class="btn btn-sm btn-outline">Copy</button>
+      </div>`;
+  }
+  banner.style.display = '';
+  const freshCopy = document.getElementById('new-account-copy-btn');
+  if (freshCopy) {
+    freshCopy.onclick = async () => {
+      const { copyToClipboard } = await import('./ui-utils.js');
+      await copyToClipboard(walletAddress, freshCopy);
+    };
+  }
   dismissBtn.onclick = () => { banner.style.display = 'none'; };
 }

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -88,9 +88,19 @@ export function clearChainSecuredSession() {
   resetClient();
 }
 
-/** True if the user has any authenticated session — api key OR ChainSecured. */
+/** True if the user has any authenticated session — api key OR ChainSecured.
+ *  ChainSecured requires BOTH wallet + admin hash; if only one is present the
+ *  session is half-written (e.g. mid-login crash) and we clear it so the
+ *  caller can re-auth instead of hashing an empty api key against the wrong
+ *  on-chain identity. */
 export function isAuthenticated() {
-  return !!getApiKey() || (getMode() === 'sovereign' && !!getChainSecuredWallet());
+  if (getApiKey()) return true;
+  if (getMode() !== 'sovereign') return false;
+  const hasWallet = !!getChainSecuredWallet();
+  const hasHash = !!sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_HASH);
+  if (hasWallet && hasHash) return true;
+  if (hasWallet || hasHash) clearChainSecuredSession();
+  return false;
 }
 
 /** Full sign-out: clears api-key, ChainSecured session, and the client cache. */
@@ -426,7 +436,7 @@ function renderModeBadge() {
        <p>Your wallet is the account identity. Writes are signed on-chain as transactions you authorize in your wallet.</p>
        <p class="mode-popover-hidden">Action runs use a usage API key from your account. Funding still uses your account billing.</p>`
     : `<strong>API mode</strong>
-       <p>Writes go through the Lit Express API using your account API key. Fastest path, no wallet popups.</p>`;
+       <p>Writes go through the Chipotle API using your account API key. Fastest path, no wallet popups.</p>`;
   let pillHtml = '';
   if (isChainSecured) {
     const wallet = getChainSecuredWallet();

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -22,6 +22,7 @@ export const LIST_PAGE_SIZE = '20';
  */
 const SOVEREIGN_WRITE_METHODS = new Set([
   'newChainSecuredAccount',
+  'createWallet',
   'addGroup', 'removeGroup', 'updateGroup',
   'addAction', 'deleteAction', 'addActionToGroup', 'removeActionFromGroup', 'updateActionMetadata',
   'addPkpToGroup', 'removePkpFromGroup',
@@ -638,7 +639,12 @@ async function loginWithWallet(btn) {
     const client = await getClient();
     const { connectEoa } = await import('../../wallet_connect.js');
     const ethers = await loadEthersLocal();
-    const { address } = await connectEoa();
+    const { signer, address } = await connectEoa();
+    // Attach the signer before the existence check: accountExistsAndIsMutable
+    // is msg.sender-gated and only the wallet that owns an unmanaged
+    // (ChainSecured) account passes. Without this, the SDK falls back to
+    // api_payer and the contract returns false for valid ChainSecured accounts.
+    client.connectSigner(signer);
     const apiKeyHash = ethers.solidityPackedKeccak256(['address'], [address]);
     const exists = await client.accountExistsByHash(apiKeyHash);
     if (!exists) {

--- a/lit-static/dapps/dashboard/groups.js
+++ b/lit-static/dapps/dashboard/groups.js
@@ -2,7 +2,7 @@
  * Groups — CRUD, table rendering, multi-select builders.
  */
 
-import { getEffectiveApiKey, getClient, getGroupsStore, setGroupsStore, getWalletsStore, getActionsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
+import { getEffectiveApiKey, isAuthenticated, getClient, getGroupsStore, setGroupsStore, getWalletsStore, getActionsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
 import { escapeHtml, showStatus, hideStatus, showActionProgress, closeActionProgress, openModal, closeModal, confirmDelete, formatError, logError, ICON_PENCIL, ICON_TRASH } from './ui-utils.js';
 
 // ----- Multi-select builders -----
@@ -140,7 +140,7 @@ export function renderGroupsTable(items) {
 
 export async function loadGroups() {
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('groups-status');
   const btn = document.getElementById('btn-load-groups');
   if (btn) btn.disabled = true;
@@ -169,7 +169,7 @@ async function confirmAndRemoveGroup(item) {
   const confirmed = await confirmDelete(msg);
   if (!confirmed) return;
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('groups-status');
   try {
     showActionProgress('Deleting group', `Deleting group "${escapeHtml(label)}".`);
@@ -230,7 +230,7 @@ function openGroupModal(item = null) {
     const pkpIdsPermitted = getSelectedStringValues('modal-group-pkp-ids');
     const cidHashesPermitted = getSelectedStringValues('modal-group-cid-hashes');
     const apiKey = getEffectiveApiKey();
-    if (!apiKey) {
+    if (!isAuthenticated()) {
       showStatus('groups-status', 'Log in first.', 'error');
       return;
     }

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -40,7 +40,7 @@
             <div class="login-card">
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
               <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
-              <p class="login-card-tagline">Best if you want self-custody. Your wallet signs every write.</p>
+              <p class="login-card-tagline">Best if you want self-custody. Your wallet signs every write &mdash; the API is only used to call an action.</p>
               <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account.</p>
               <button type="button" id="btn-login-wallet" class="btn btn-outline btn-block">Connect wallet</button>
               <p class="form-hint" style="margin-top: 0.75rem;">Your wallet address is the account identity.</p>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -17,17 +17,20 @@
     <section id="page-login" class="login-page">
       <div class="login-container">
         <h1 class="login-title">Lit Express Dashboard</h1>
-        <p class="login-subtitle">Sign in or create an account to manage a Lit Express Node account.</p>
+        <p class="login-subtitle">Sign in to manage your account, or create a new one to get started.</p>
         <div id="login-status" class="status info" style="display: none;"></div>
-        <div class="login-tabs" role="tablist" aria-label="Login or create account">
-          <button type="button" class="login-tab is-active" role="tab" id="login-tab-existing" aria-selected="true" aria-controls="login-panel-existing" data-tab="existing">Existing User</button>
-          <button type="button" class="login-tab" role="tab" id="login-tab-new" aria-selected="false" aria-controls="login-panel-new" data-tab="new">New User</button>
+        <div class="login-tabs" role="tablist" aria-label="Sign in or create account">
+          <button type="button" class="login-tab is-active" role="tab" id="login-tab-existing" aria-selected="true" aria-controls="login-panel-existing" data-tab="existing">Sign in</button>
+          <button type="button" class="login-tab" role="tab" id="login-tab-new" aria-selected="false" aria-controls="login-panel-new" data-tab="new">Create account</button>
         </div>
         <div id="login-panel-existing" class="login-tab-panel is-active" role="tabpanel" aria-labelledby="login-tab-existing">
           <div class="login-cards">
-            <div class="login-card">
+            <div class="login-card login-card-recommended">
+              <span class="login-card-recommended-badge">Recommended</span>
+              <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></div>
               <h3 class="login-card-title">API mode</h3>
-              <p class="form-hint" style="margin-bottom: 1rem;">Log in with an account API key. All writes go through the Lit Express API.</p>
+              <p class="login-card-tagline">Best if you want the fastest start. One key, no wallet needed.</p>
+              <p class="form-hint" style="margin-bottom: 1rem;">Writes go through the Lit Express API.</p>
               <div class="form-group">
                 <label for="login-api-key">API key</label>
                 <input type="password" id="login-api-key" class="input" placeholder="Paste your API key">
@@ -35,17 +38,22 @@
               <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
             </div>
             <div class="login-card">
-              <h3 class="login-card-title">ChainSecured mode</h3>
-              <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account. Writes are previewed then submitted as wallet-signed on-chain transactions.</p>
-              <button type="button" id="btn-login-wallet" class="btn btn-primary btn-block">Connect wallet</button>
-              <p class="form-hint" style="margin-top: 0.75rem;">Your wallet address is the account identity. No API key is involved.</p>
+              <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
+              <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
+              <p class="login-card-tagline">Best if you want self-custody. Your wallet signs every write.</p>
+              <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account.</p>
+              <button type="button" id="btn-login-wallet" class="btn btn-outline btn-block">Connect wallet</button>
+              <p class="form-hint" style="margin-top: 0.75rem;">Your wallet address is the account identity.</p>
             </div>
           </div>
         </div>
         <div id="login-panel-new" class="login-tab-panel" role="tabpanel" aria-labelledby="login-tab-new" hidden>
           <div class="login-cards">
-            <div class="login-card">
+            <div class="login-card login-card-recommended">
+              <span class="login-card-recommended-badge">Recommended</span>
+              <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></div>
               <h3 class="login-card-title">API mode</h3>
+              <p class="login-card-tagline">Best if you want the fastest start. We manage the account; you get a key.</p>
               <p class="form-hint" style="margin-bottom: 1rem;">Creates a managed account and returns a new API key. Store it securely.</p>
               <div class="form-group">
                 <label for="new-account-email">Email</label>
@@ -62,8 +70,10 @@
               <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
             </div>
             <div class="login-card">
-              <h3 class="login-card-title">ChainSecured mode</h3>
-              <p class="form-hint" style="margin-bottom: 1rem;">Creates an unmanaged account owned by the connected wallet. Writes are wallet-signed on-chain.</p>
+              <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
+              <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
+              <p class="login-card-tagline">Best if you want self-custody. The connected wallet owns the account.</p>
+              <p class="form-hint" style="margin-bottom: 1rem;">Creates an unmanaged account owned by the connected wallet.</p>
               <div class="form-group">
                 <label for="new-chainsecured-name">Account name</label>
                 <input type="text" id="new-chainsecured-name" class="input" placeholder="My account">
@@ -72,7 +82,7 @@
                 <label for="new-chainsecured-desc">Account description</label>
                 <input type="text" id="new-chainsecured-desc" class="input" placeholder="Optional">
               </div>
-              <button type="button" id="btn-create-chainsecured" class="btn btn-primary btn-block">Connect wallet &amp; create</button>
+              <button type="button" id="btn-create-chainsecured" class="btn btn-outline btn-block">Connect wallet &amp; create</button>
             </div>
           </div>
         </div>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -88,28 +88,28 @@
         <nav class="sidebar-nav">
           <span class="sidebar-menu-label">MENU</span>
           <a href="#overview" class="sidebar-link" data-scroll="overview">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/></svg></span>
             <span class="sidebar-link-text">Overview</span>
           </a>
           <a href="#usage-keys" class="sidebar-link" data-scroll="usage-keys">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></span>
             <span class="sidebar-link-text">Usage API Keys</span>
           </a>
           <a href="#groups" class="sidebar-link" data-scroll="groups">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
             <span class="sidebar-link-text">Groups</span>
           </a>
           <a href="#actions" class="sidebar-link" data-scroll="actions">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
             <span class="sidebar-link-text">IPFS Actions</span>
           </a>
           <a href="#wallets" class="sidebar-link" data-scroll="wallets">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1"/><path d="M3 5v14a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4"/></svg></span>
             <span class="sidebar-link-text">Wallets</span>
           </a>
           <hr>
           <a href="#action-runner" class="sidebar-link" data-scroll="action-runner">
-            <span class="sidebar-link-icon">◇</span>
+            <span class="sidebar-link-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg></span>
             <span class="sidebar-link-text">Action Runner</span>
           </a>
         </nav>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -171,8 +171,18 @@
             <p>This environment is not configured to accept payments. You should migrate towards using the production system as there are no uptime or state guarantees available for test systems.</p>
           </div>
 
+          <!-- Empty state (shown when account has no keys/groups/wallets/actions) -->
+          <div id="overview-empty-state" class="overview-empty-state" hidden>
+            <div class="overview-empty-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg>
+            </div>
+            <h2 class="overview-empty-title">You're all set. Now create your first key.</h2>
+            <p class="overview-empty-body">Usage API keys authorize and pay for Lit Action runs. Create one to start tracking activity here.</p>
+            <a href="#usage-keys" class="btn btn-primary" data-scroll="usage-keys">Create your first usage key</a>
+          </div>
+
           <!-- Stat cards -->
-          <div class="stats-row">
+          <div class="stats-row" id="stats-row">
             <div class="stat-card">
               <span class="stat-value" id="stat-usage-keys">—</span>
               <span class="stat-label">Usage API Keys</span>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -269,7 +269,11 @@
                     <thead><tr><th>Name</th><th>Description</th><th>Permissions</th><th>Expiration</th><th class="th-actions"></th></tr></thead>
                     <tbody id="usage-keys-tbody"></tbody>
                   </table>
-                  <p id="usage-keys-empty" class="empty-state" style="display: none;">No usage API keys.</p>
+                  <div id="usage-keys-empty" class="empty-state" style="display: none;">
+                    <span class="empty-state-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></span>
+                    <p class="empty-state-title">No usage API keys yet</p>
+                    <p class="empty-state-body">Create a key to authorize and track Lit Action runs.</p>
+                  </div>
                 </div>
                 <div class="table-add-row">
                   <button type="button" id="btn-add-usage-key" class="btn btn-primary">Add</button>
@@ -294,7 +298,11 @@
                     <thead><tr><th>Name</th><th>Description</th><th class="th-actions"></th></tr></thead>
                     <tbody id="groups-tbody"></tbody>
                   </table>
-                  <p id="groups-empty" class="empty-state" style="display: none;">No groups.</p>
+                  <div id="groups-empty" class="empty-state" style="display: none;">
+                    <span class="empty-state-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                    <p class="empty-state-title">No groups yet</p>
+                    <p class="empty-state-body">Groups bundle action CIDs and wallet permissions per app or use case.</p>
+                  </div>
                 </div>
                 <div class="table-add-row">
                   <button type="button" id="btn-add-group" class="btn btn-primary">Add</button>
@@ -321,7 +329,11 @@
                     <thead><tr><th>Name</th><th>Hashed CID</th><th>Description</th><th class="th-actions"></th></tr></thead>
                     <tbody id="actions-tbody"></tbody>
                   </table>
-                  <p id="actions-empty" class="empty-state" style="display: none;">No actions found.</p>
+                  <div id="actions-empty" class="empty-state" style="display: none;">
+                    <span class="empty-state-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                    <p class="empty-state-title">No actions yet</p>
+                    <p class="empty-state-body">Add an IPFS CID to allow it to run inside a group.</p>
+                  </div>
                 </div>
                 <div class="table-add-row">
                   <button type="button" id="btn-add-action" class="btn btn-primary">Add</button>
@@ -346,7 +358,11 @@
                     <thead><tr><th>Description</th><th>PkpId (Address)</th></tr></thead>
                     <tbody id="wallets-tbody"></tbody>
                   </table>
-                  <p id="wallets-empty" class="empty-state" style="display: none;">No wallets.</p>
+                  <div id="wallets-empty" class="empty-state" style="display: none;">
+                    <span class="empty-state-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1"/><path d="M3 5v14a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4"/></svg></span>
+                    <p class="empty-state-title">No wallets yet</p>
+                    <p class="empty-state-body">Add a PKP wallet to restrict which signers can run actions in a group.</p>
+                  </div>
                 </div>
                 <div class="table-add-row">
                   <button type="button" id="btn-add-wallet" class="btn btn-primary">Add</button>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -231,26 +231,26 @@
                 </div>
               </div>
             </div>
-            <div class="card">
-              <div class="card-header">
-                <h3 class="card-title">Instructions</h3>
-              </div>
-              <div class="card-body">
-                <div id="no-funds-warning" class="no-funds-warning" role="alert" style="display: none;">
-                  <strong>No funds available</strong>
-                  <p>Your account has no credit balance. Please <a href="#" id="no-funds-add-funds">add funds</a> for Lit Actions to work.</p>
-                </div>
-                <div class="instructions-block">
-                  <p>You can control access to the Lit Actions run by this node in the following ways:</p>
-                  <ul>
-                    <li><strong>Groups</strong> — Create groups for different categories of actions (e.g. by app or use case). Each group can have its own set of allowed IPFS action CIDs and wallet (PKP) restrictions.</li>
-                    <li><strong>Usage API keys</strong> — Create usage API keys and assign them to pay for Lit Action runs. Use different keys per client or app to track and limit spending. Add keys in the <strong>Usage API Keys</strong> section and use them when calling the node.  <strong>Note: </strong> your account api key can be also be used as a usage api key, but can not be rotated or removed, so this is not recommended.</li>
-                    <li><strong>Wallet restrictions</strong> — For any group, you can restrict which wallets (PKPs) are allowed to run actions in that group. Add or remove PKPs in the <strong>Wallets</strong> section (Add PKP to group / Remove PKP from group). You can also set a group to allow all wallets, if you do not need this limit.</li>
-                  </ul>
-                  <p>In short: create groups, add the IPFS action CIDs and (optionally) the wallets allowed for each group, then use usage API keys to authorize and pay for runs.</p>
-                </div>
-              </div>
+            <div id="no-funds-warning" class="no-funds-warning" role="alert" style="display: none;">
+              <strong>No funds available</strong>
+              <p>Your account has no credit balance. Please <a href="#" id="no-funds-add-funds">add funds</a> for Lit Actions to work.</p>
             </div>
+            <details class="help-details">
+              <summary class="help-details-summary">
+                <span class="help-details-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+                <span>How does this work?</span>
+                <span class="help-details-chevron" aria-hidden="true">▾</span>
+              </summary>
+              <div class="instructions-block">
+                <p>You control access to Lit Actions run by this node three ways:</p>
+                <ul>
+                  <li><strong>Groups</strong> — Categories of actions (by app or use case). Each group has its own allowed IPFS action CIDs and wallet (PKP) restrictions.</li>
+                  <li><strong>Usage API keys</strong> — Authorize and pay for Lit Action runs. Use different keys per client to track and limit spending.</li>
+                  <li><strong>Wallet restrictions</strong> — Limit which wallets (PKPs) can run actions in a group, or open it to all wallets.</li>
+                </ul>
+                <p>Workflow: create a group, add action CIDs and (optionally) allowed wallets, then issue usage API keys to authorize and pay for runs.</p>
+              </div>
+            </details>
           </section>
 
           <!-- Usage API Keys -->

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -39,7 +39,7 @@
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></div>
               <h3 class="login-card-title">API mode</h3>
               <p class="login-card-tagline">Best if you want the fastest start. One key, no wallet needed.</p>
-              <p class="form-hint" style="margin-bottom: 1rem;">Writes go through the Lit Express API.</p>
+              <p class="form-hint" style="margin-bottom: 1rem;">Writes go through the Chipotle API.</p>
               <div class="form-group">
                 <label for="login-api-key">API key</label>
                 <input type="password" id="login-api-key" class="input" placeholder="Paste your API key">
@@ -49,7 +49,7 @@
             <div class="login-card">
               <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
-              <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
+              <h3 class="login-card-title">ChainSecured mode <button type="button" class="login-card-help" aria-label="What is ChainSecured? Your wallet is the key. Writes are signed on-chain — no API key shared." data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</button></h3>
               <p class="login-card-tagline">Best if you want self-custody. Your wallet signs every write &mdash; the API is only used to call an action.</p>
               <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account. Your wallet address is the account identity.</p>
               <button type="button" id="btn-login-wallet" class="btn btn-outline btn-block">Connect wallet</button>
@@ -81,7 +81,7 @@
             <div class="login-card">
               <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
-              <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
+              <h3 class="login-card-title">ChainSecured mode <button type="button" class="login-card-help" aria-label="What is ChainSecured? Your wallet is the key. Writes are signed on-chain — no API key shared." data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</button></h3>
               <p class="login-card-tagline">Best if you want self-custody. The connected wallet owns the account.</p>
               <p class="form-hint" style="margin-bottom: 1rem;">Creates an unmanaged account owned by the connected wallet.</p>
               <div class="form-group">
@@ -252,7 +252,7 @@
                 <span class="help-details-chevron" aria-hidden="true">▾</span>
               </summary>
               <div class="instructions-block">
-                <p>You control access to Lit Actions run by this node three ways:</p>
+                <p>You control access to Lit Actions run by this node in three ways:</p>
                 <ul>
                   <li><strong>Groups</strong> — Categories of actions (by app or use case). Each group has its own allowed IPFS action CIDs and wallet (PKP) restrictions.</li>
                   <li><strong>Usage API keys</strong> — Authorize and pay for Lit Action runs. Use different keys per client to track and limit spending.</li>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -183,22 +183,34 @@
 
           <!-- Stat cards -->
           <div class="stats-row" id="stats-row">
-            <div class="stat-card">
-              <span class="stat-value" id="stat-usage-keys">—</span>
-              <span class="stat-label">Usage API Keys</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-value" id="stat-groups">—</span>
-              <span class="stat-label">Groups</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-value" id="stat-wallets">—</span>
-              <span class="stat-label">Wallets</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-value" id="stat-actions">—</span>
-              <span class="stat-label">IPFS CIDs</span>
-            </div>
+            <a href="#usage-keys" class="stat-card" data-scroll="usage-keys">
+              <span class="stat-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></span>
+              <span class="stat-card-text">
+                <span class="stat-value" id="stat-usage-keys">—</span>
+                <span class="stat-label">Usage API Keys</span>
+              </span>
+            </a>
+            <a href="#groups" class="stat-card" data-scroll="groups">
+              <span class="stat-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+              <span class="stat-card-text">
+                <span class="stat-value" id="stat-groups">—</span>
+                <span class="stat-label">Groups</span>
+              </span>
+            </a>
+            <a href="#wallets" class="stat-card" data-scroll="wallets">
+              <span class="stat-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1"/><path d="M3 5v14a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4"/></svg></span>
+              <span class="stat-card-text">
+                <span class="stat-value" id="stat-wallets">—</span>
+                <span class="stat-label">Wallets</span>
+              </span>
+            </a>
+            <a href="#actions" class="stat-card" data-scroll="actions">
+              <span class="stat-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+              <span class="stat-card-text">
+                <span class="stat-value" id="stat-actions">—</span>
+                <span class="stat-label">IPFS CIDs</span>
+              </span>
+            </a>
           </div>
 
           <!-- Overview / Instructions -->

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -24,35 +24,56 @@
           <button type="button" class="login-tab" role="tab" id="login-tab-new" aria-selected="false" aria-controls="login-panel-new" data-tab="new">New User</button>
         </div>
         <div id="login-panel-existing" class="login-tab-panel is-active" role="tabpanel" aria-labelledby="login-tab-existing">
-          <div class="login-card">
-            <div class="form-group">
-              <label for="login-api-key">API key</label>
-              <input type="password" id="login-api-key" class="input" placeholder="Paste your API key">
+          <div class="login-cards">
+            <div class="login-card">
+              <h3 class="login-card-title">API mode</h3>
+              <p class="form-hint" style="margin-bottom: 1rem;">Log in with an account API key. All writes go through the Lit Express API.</p>
+              <div class="form-group">
+                <label for="login-api-key">API key</label>
+                <input type="password" id="login-api-key" class="input" placeholder="Paste your API key">
+              </div>
+              <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
             </div>
-            <div class="form-group" style="display:flex; align-items:center; gap:0.75rem;">
-              <input type="checkbox" id="login-mode-sovereign">
-              <label for="login-mode-sovereign" id="login-mode-label" class="form-hint" style="margin:0; cursor:pointer;">API mode</label>
+            <div class="login-card">
+              <h3 class="login-card-title">ChainSecured mode</h3>
+              <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account. Writes are previewed then submitted as wallet-signed on-chain transactions.</p>
+              <button type="button" id="btn-login-wallet" class="btn btn-primary btn-block">Connect wallet</button>
+              <p class="form-hint" style="margin-top: 0.75rem;">Your wallet address is the account identity. No API key is involved.</p>
             </div>
-            <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
-            <p class="form-hint">Log in verifies the API key. Sovereign mode reads directly from the AccountConfig contract over RPC; writes are previewed, then submitted as wallet-signed transactions from your connected browser wallet.</p>
           </div>
         </div>
         <div id="login-panel-new" class="login-tab-panel" role="tabpanel" aria-labelledby="login-tab-new" hidden>
-          <div class="login-card">
-            <p class="form-hint" style="margin-bottom: 1rem;">Creates an account on Lit Express Node and returns a new API key. Store it securely.</p>
-            <div class="form-group">
-              <label for="new-account-email">Email</label>
-              <input type="email" id="new-account-email" class="input" placeholder="you@example.com" required>
+          <div class="login-cards">
+            <div class="login-card">
+              <h3 class="login-card-title">API mode</h3>
+              <p class="form-hint" style="margin-bottom: 1rem;">Creates a managed account and returns a new API key. Store it securely.</p>
+              <div class="form-group">
+                <label for="new-account-email">Email</label>
+                <input type="email" id="new-account-email" class="input" placeholder="you@example.com" required>
+              </div>
+              <div class="form-group">
+                <label for="new-account-name">Account name</label>
+                <input type="text" id="new-account-name" class="input" placeholder="My account">
+              </div>
+              <div class="form-group">
+                <label for="new-account-desc">Account description</label>
+                <input type="text" id="new-account-desc" class="input" placeholder="Optional">
+              </div>
+              <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
             </div>
-            <div class="form-group">
-              <label for="new-account-name">Account name</label>
-              <input type="text" id="new-account-name" class="input" placeholder="My account">
+            <div class="login-card">
+              <h3 class="login-card-title">ChainSecured mode</h3>
+              <p class="form-hint" style="margin-bottom: 1rem;">Creates an unmanaged account owned by the connected wallet. Writes are wallet-signed on-chain.</p>
+              <div class="form-group">
+                <label for="new-chainsecured-name">Account name</label>
+                <input type="text" id="new-chainsecured-name" class="input" placeholder="My account">
+              </div>
+              <div class="form-group">
+                <label for="new-chainsecured-desc">Account description</label>
+                <input type="text" id="new-chainsecured-desc" class="input" placeholder="Optional">
+              </div>
+              <button type="button" id="btn-create-chainsecured" class="btn btn-primary btn-block">Connect wallet &amp; create</button>
             </div>
-            <div class="form-group">
-              <label for="new-account-desc">Account description</label>
-              <input type="text" id="new-account-desc" class="input" placeholder="Optional">
-            </div>
-            <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
           </div>
         </div>
       </div>
@@ -119,6 +140,9 @@
         </header>
 
         <div class="dashboard-content">
+          <!-- ABI drift banner (post-wallet-connect, sovereign only) -->
+          <div id="abi-drift-banner" class="abi-drift-banner" role="alert" style="display:none;"></div>
+
           <!-- New account API key banner (shown once after account creation) -->
           <div id="new-account-banner" class="new-account-banner" style="display:none;" role="alert" aria-live="assertive">
             <div class="new-account-banner-body">

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -16,12 +16,21 @@
     <!-- Login (standalone when not authenticated) -->
     <section id="page-login" class="login-page">
       <div class="login-container">
-        <h1 class="login-title">Lit Express Dashboard</h1>
+        <h1 class="login-title">Chipotle Dashboard</h1>
         <p class="login-subtitle">Sign in to manage your account, or create a new one to get started.</p>
         <div id="login-status" class="status info" style="display: none;"></div>
-        <div class="login-tabs" role="tablist" aria-label="Sign in or create account">
-          <button type="button" class="login-tab is-active" role="tab" id="login-tab-existing" aria-selected="true" aria-controls="login-panel-existing" data-tab="existing">Sign in</button>
-          <button type="button" class="login-tab" role="tab" id="login-tab-new" aria-selected="false" aria-controls="login-panel-new" data-tab="new">Create account</button>
+        <div class="login-mode">
+          <span class="login-mode-label" id="login-mode-label">I would like to:</span>
+          <div class="login-tabs" role="tablist" aria-labelledby="login-mode-label">
+            <button type="button" class="login-tab is-active" role="tab" id="login-tab-existing" aria-selected="true" aria-controls="login-panel-existing" data-tab="existing">
+              <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>Sign in</span>
+            </button>
+            <button type="button" class="login-tab" role="tab" id="login-tab-new" aria-selected="false" aria-controls="login-panel-new" data-tab="new">
+              <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>Create account</span>
+            </button>
+          </div>
         </div>
         <div id="login-panel-existing" class="login-tab-panel is-active" role="tabpanel" aria-labelledby="login-tab-existing">
           <div class="login-cards">
@@ -38,12 +47,12 @@
               <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
             </div>
             <div class="login-card">
+              <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
               <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
               <p class="login-card-tagline">Best if you want self-custody. Your wallet signs every write &mdash; the API is only used to call an action.</p>
-              <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account.</p>
+              <p class="form-hint" style="margin-bottom: 1rem;">Connect the wallet that owns the account. Your wallet address is the account identity.</p>
               <button type="button" id="btn-login-wallet" class="btn btn-outline btn-block">Connect wallet</button>
-              <p class="form-hint" style="margin-top: 0.75rem;">Your wallet address is the account identity.</p>
             </div>
           </div>
         </div>
@@ -70,6 +79,7 @@
               <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
             </div>
             <div class="login-card">
+              <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
               <h3 class="login-card-title">ChainSecured mode <span class="login-card-help" tabindex="0" aria-label="What is ChainSecured?" data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</span></h3>
               <p class="login-card-tagline">Best if you want self-custody. The connected wallet owns the account.</p>
@@ -93,7 +103,7 @@
     <div id="dashboard-wrap" class="dashboard-wrap">
       <aside class="sidebar">
         <div class="sidebar-brand">
-          <span class="sidebar-brand-text">Lit Express Dashboard</span>
+          <span class="sidebar-brand-text">Chipotle Dashboard</span>
         </div>
         <nav class="sidebar-nav">
           <span class="sidebar-menu-label">MENU</span>

--- a/lit-static/dapps/dashboard/keys.js
+++ b/lit-static/dapps/dashboard/keys.js
@@ -2,7 +2,7 @@
  * Usage API Keys — table rendering, CRUD, permission summary.
  */
 
-import { getEffectiveApiKey, getClient, getUsageKeysStore, setUsageKeysStore, getGroupsStore, setStat, updateStatCards, maskApiKey, LIST_PAGE_SIZE } from './auth.js';
+import { getEffectiveApiKey, isAuthenticated, getClient, getUsageKeysStore, setUsageKeysStore, getGroupsStore, setStat, updateStatCards, maskApiKey, LIST_PAGE_SIZE } from './auth.js';
 import { escapeHtml, showStatus, hideStatus, showActionProgress, closeActionProgress, openModal, closeModal, confirmDelete, copyToClipboard, formatError, logError, ICON_PENCIL, ICON_TRASH, ICON_COPY } from './ui-utils.js';
 import { buildGroupMultiSelect, attachGroupMultiSelectLogic, updateMultiSelectSummary, getSelectedGroupIds } from './groups.js';
 
@@ -107,7 +107,7 @@ export function renderUsageKeysTable() {
 
 export async function loadUsageKeys() {
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return [];
+  if (!isAuthenticated()) return [];
   hideStatus('overview-status-usage-keys');
   const btn = document.getElementById('btn-load-usage-keys');
   if (btn) btn.disabled = true;
@@ -203,7 +203,7 @@ function openUsageKeyModal(item = null) {
     const name = document.getElementById('modal-usage-name').value.trim() || 'Usage Key';
     const description = document.getElementById('modal-usage-desc').value.trim() || '';
     const apiKey = getEffectiveApiKey();
-    if (!apiKey) {
+    if (!isAuthenticated()) {
       showStatus('overview-status-usage-keys', 'Log in first.', 'error');
       return;
     }
@@ -301,7 +301,7 @@ async function confirmAndRemoveUsageKey(item) {
   const confirmed = await confirmDelete(msg);
   if (!confirmed) return;
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('overview-status-usage-keys');
   try {
     showActionProgress('Removing usage API key', `Removing usage API key "${masked}".`);

--- a/lit-static/dapps/dashboard/runner.js
+++ b/lit-static/dapps/dashboard/runner.js
@@ -2,7 +2,7 @@
  * Action Runner — CodeJar editor, execute Lit Actions, get IPFS CID.
  */
 
-import { getApiKey, getEffectiveApiKey, getClient, getBaseUrl } from './auth.js';
+import { getEffectiveApiKey, getClient, getBaseUrl, isAuthenticated } from './auth.js';
 import { hideStatus, formatError, logError } from './ui-utils.js';
 
 let _codeJarEditor = null;
@@ -42,16 +42,23 @@ export async function initActionRunner() {
   }
 
   btn.addEventListener('click', async () => {
-    const accountKey = getApiKey();
     const usageKeyEl = document.getElementById('action-runner-usage-key');
     const usageKey = usageKeyEl?.value?.trim() ?? '';
     const apiKey = usageKey || getEffectiveApiKey();
     const code = (getCode ? getCode() : (codeEl?.textContent ?? '')).trim();
     const paramsRaw = (getParams ? getParams() : (paramsEl?.textContent ?? '')).trim();
 
-    if (!accountKey) {
+    if (!isAuthenticated()) {
       hideStatus('action-runner-status');
       outputEl.textContent = 'Log in first to execute Lit Actions.';
+      outputEl.className = 'action-runner-output error';
+      return;
+    }
+    // ChainSecured has no account-level api key; users execute via a usage key
+    // they minted from the contract. API mode falls back to the account key.
+    if (!apiKey) {
+      hideStatus('action-runner-status');
+      outputEl.textContent = 'Paste a Usage API Key above to execute Lit Actions.';
       outputEl.className = 'action-runner-output error';
       return;
     }

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -67,6 +67,25 @@ a:hover {
   text-decoration: underline;
 }
 
+/* Keyboard focus ring (only shows for keyboard users via :focus-visible) */
+button:focus-visible,
+a:focus-visible,
+[role="tab"]:focus-visible,
+summary:focus-visible,
+.stat-card:focus-visible,
+.sidebar-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 0;
+}
+
 /* ----- Login page (standalone) ----- */
 .login-page {
   min-height: 100vh;

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -1758,7 +1758,42 @@ textarea.input.textarea-sm {
 .empty-state {
   color: var(--text-muted);
   font-size: 0.875rem;
-  margin: 0.5rem 0 0;
+  margin: 0;
+  padding: 2rem 1.25rem;
+  text-align: center;
+}
+
+.empty-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(60, 80, 224, 0.08);
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+}
+
+[data-theme="dark"] .empty-state-icon {
+  background: rgba(99, 102, 241, 0.15);
+}
+
+.empty-state-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 0.25rem;
+}
+
+.empty-state-body {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 320px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.5;
 }
 
 .mono {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -790,14 +790,10 @@ body.has-api-key .dashboard-wrap {
   border-color: rgba(248, 113, 113, 0.35);
 }
 
-/* ChainSecured mode: hide Action Runner + Billing surfaces. */
+/* ChainSecured mode hides Action Runner only. Billing (Stripe credit) is
+   still the funding path for action runs regardless of admin auth mode. */
 body.is-chainsecured .sidebar-link[data-scroll="action-runner"],
-body.is-chainsecured #section-action-runner,
-body.is-chainsecured #billing-balance-display,
-body.is-chainsecured #btn-add-funds,
-body.is-chainsecured #billing-disabled-banner,
-body.is-chainsecured #billing-not-required,
-body.is-chainsecured #no-funds-warning {
+body.is-chainsecured #section-action-runner {
   display: none !important;
 }
 

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -73,7 +73,30 @@ body {
 
 .login-container {
   width: 100%;
-  max-width: 420px;
+  max-width: 820px;
+}
+
+.login-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.login-cards > .login-card {
+  background: var(--card-bg, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-bottom: 0;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 768px) {
+  .login-cards {
+    grid-template-columns: 1fr;
+  }
 }
 
 .login-title {
@@ -489,6 +512,78 @@ body.has-api-key .dashboard-wrap {
   font-weight: 700;
   margin: 0;
   color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.topbar-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: rgba(60, 80, 224, 0.12);
+  color: var(--primary, #3c50e0);
+  border: 1px solid rgba(60, 80, 224, 0.25);
+  cursor: help;
+}
+
+[data-theme="dark"] .topbar-mode-badge {
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.topbar-wallet-pill {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.topbar-wallet-pill:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+
+[data-theme="dark"] .topbar-wallet-pill:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.abi-drift-banner {
+  padding: 0.75rem 1rem;
+  margin: 0 0 1rem;
+  border-radius: var(--radius);
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  color: #b91c1c;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+[data-theme="dark"] .abi-drift-banner {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+/* ChainSecured mode: hide Action Runner + Billing surfaces. */
+body.is-chainsecured .sidebar-link[data-scroll="action-runner"],
+body.is-chainsecured #section-action-runner,
+body.is-chainsecured #billing-balance-display,
+body.is-chainsecured #btn-add-funds,
+body.is-chainsecured #billing-disabled-banner,
+body.is-chainsecured #billing-not-required,
+body.is-chainsecured #no-funds-warning {
+  display: none !important;
 }
 
 .btn-topbar {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -421,6 +421,23 @@ body.has-api-key .dashboard-wrap {
   color: var(--primary);
 }
 
+.sidebar-link.is-active {
+  color: var(--primary);
+  background: var(--sidebar-link-hover-bg);
+  position: relative;
+}
+
+.sidebar-link.is-active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--primary);
+}
+
 /* ----- Main content ----- */
 .dashboard-main {
   flex: 1;

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -1105,6 +1105,58 @@ body.is-chainsecured #no-funds-warning {
   margin-bottom: 0;
 }
 
+/* ----- Collapsible help / details disclosure ----- */
+.help-details {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  margin-bottom: 1rem;
+}
+
+.help-details-summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 0.85rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: var(--text);
+  user-select: none;
+}
+
+.help-details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.help-details-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.help-details-chevron {
+  margin-left: auto;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  transition: transform 0.15s;
+}
+
+.help-details[open] .help-details-chevron {
+  transform: rotate(180deg);
+}
+
+.help-details[open] .help-details-summary {
+  border-bottom: 1px solid var(--border);
+}
+
+.help-details > .instructions-block {
+  padding: 1rem 1.25rem;
+}
+
 /* ----- Forms ----- */
 .form-group {
   margin-bottom: 1rem;

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -191,13 +191,113 @@ a:hover {
   padding: 0;
   margin-bottom: 0;
   box-shadow: none;
+  position: relative;
+}
+
+.login-cards > .login-card {
+  padding: 1.5rem 1.25rem 1.25rem;
+}
+
+.login-cards > .login-card.login-card-recommended {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary), var(--shadow);
+}
+
+.login-card-recommended-badge {
+  position: absolute;
+  top: -0.6rem;
+  left: 1.25rem;
+  background: var(--primary);
+  color: #fff;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  line-height: 1;
+}
+
+.login-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: rgba(60, 80, 224, 0.1);
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+}
+
+[data-theme="dark"] .login-card-icon {
+  background: rgba(99, 102, 241, 0.18);
 }
 
 .login-card-title {
-  font-size: 1rem;
+  font-size: 1.0625rem;
   font-weight: 600;
-  margin: 0 0 1rem;
+  margin: 0 0 0.25rem;
   color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.login-card-tagline {
+  font-size: 0.875rem;
+  color: var(--text);
+  margin: 0 0 0.75rem;
+  font-weight: 500;
+}
+
+.login-card-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg-muted);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  cursor: help;
+  position: relative;
+}
+
+.login-card-help:hover,
+.login-card-help:focus {
+  background: var(--primary);
+  color: #fff;
+  outline: none;
+}
+
+.login-card-help::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: var(--card-bg);
+  font-size: 0.75rem;
+  font-weight: 400;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  white-space: normal;
+  width: max-content;
+  max-width: 220px;
+  line-height: 1.4;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 10;
+}
+
+.login-card-help:hover::after,
+.login-card-help:focus::after {
+  opacity: 1;
 }
 
 .form-hint {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -67,6 +67,12 @@ a:hover {
   text-decoration: underline;
 }
 
+/* Anchors styled as buttons (e.g. <a class="btn btn-primary">) shouldn't pick
+   up the underline-on-hover from the global <a> rule above. */
+a.btn:hover {
+  text-decoration: none;
+}
+
 /* Keyboard focus ring (only shows for keyboard users via :focus-visible) */
 button:focus-visible,
 a:focus-visible,
@@ -345,8 +351,12 @@ select:focus-visible {
   color: var(--text-muted);
   font-size: 0.6875rem;
   font-weight: 600;
+  font-family: inherit;
   cursor: help;
   position: relative;
+  padding: 0;
+  border: none;
+  line-height: 1;
 }
 
 .login-card-help:hover,
@@ -354,6 +364,11 @@ select:focus-visible {
   background: var(--primary);
   color: #fff;
   outline: none;
+}
+
+.login-card-help:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .login-card-help::after {
@@ -841,17 +856,11 @@ body.has-api-key .dashboard-wrap {
   padding: 0.75rem 1rem;
   margin: 0 0 1rem;
   border-radius: var(--radius);
-  background: rgba(220, 38, 38, 0.08);
-  border: 1px solid rgba(220, 38, 38, 0.3);
-  color: #b91c1c;
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+  color: var(--danger);
   font-size: 0.875rem;
   font-weight: 500;
-}
-
-[data-theme="dark"] .abi-drift-banner {
-  background: rgba(248, 113, 113, 0.12);
-  color: #fca5a5;
-  border-color: rgba(248, 113, 113, 0.35);
 }
 
 

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -122,7 +122,7 @@ select:focus-visible {
   flex-direction: column;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   .login-cards {
     grid-template-columns: 1fr;
   }

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -57,6 +57,16 @@ body {
   font-size: 14px;
 }
 
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--primary-hover);
+  text-decoration: underline;
+}
+
 /* ----- Login page (standalone) ----- */
 .login-page {
   min-height: 100vh;

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -1555,3 +1555,15 @@ textarea.input.textarea-sm {
 .new-account-dismiss:hover {
   color: var(--text);
 }
+
+/* ----- Mobile touch targets ----- */
+@media (max-width: 768px) {
+  .btn,
+  .input,
+  .login-tab {
+    min-height: 44px;
+  }
+  .btn-sm {
+    min-height: 36px;
+  }
+}

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -790,12 +790,6 @@ body.has-api-key .dashboard-wrap {
   border-color: rgba(248, 113, 113, 0.35);
 }
 
-/* ChainSecured mode hides Action Runner only. Billing (Stripe credit) is
-   still the funding path for action runs regardless of admin auth mode. */
-body.is-chainsecured .sidebar-link[data-scroll="action-runner"],
-body.is-chainsecured #section-action-runner {
-  display: none !important;
-}
 
 .btn-topbar {
   padding: 0.5rem 1rem;

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -641,6 +641,11 @@ body.has-api-key .dashboard-wrap {
   gap: 0.5rem;
 }
 
+.topbar-mode-badge-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
 .topbar-mode-badge {
   display: inline-flex;
   align-items: center;
@@ -652,7 +657,57 @@ body.has-api-key .dashboard-wrap {
   background: rgba(60, 80, 224, 0.12);
   color: var(--primary, #3c50e0);
   border: 1px solid rgba(60, 80, 224, 0.25);
-  cursor: help;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+
+.topbar-mode-badge:hover {
+  background: rgba(60, 80, 224, 0.2);
+}
+
+.topbar-mode-popover {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  width: 280px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow), 0 10px 25px rgba(0, 0, 0, 0.15);
+  padding: 0.85rem 1rem;
+  z-index: 100;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: var(--text);
+}
+
+.topbar-mode-popover[hidden] {
+  display: none;
+}
+
+.topbar-mode-popover strong {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 0.4rem;
+  color: var(--text);
+}
+
+.topbar-mode-popover p {
+  margin: 0 0 0.4rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.topbar-mode-popover p:last-child {
+  margin-bottom: 0;
+}
+
+.topbar-mode-popover .mode-popover-hidden {
+  font-size: 0.75rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
 }
 
 [data-theme="dark"] .topbar-mode-badge {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -284,8 +284,22 @@ body.has-api-key .dashboard-wrap {
 }
 
 .sidebar-link-icon {
-  font-size: 0.5rem;
-  opacity: 0.7;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--sidebar-text);
+}
+
+.sidebar-link-icon svg {
+  display: block;
+}
+
+.sidebar-link:hover .sidebar-link-icon,
+.sidebar-link.is-active .sidebar-link-icon {
+  color: var(--primary);
 }
 
 /* ----- Main content ----- */

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -902,11 +902,42 @@ body.is-chainsecured #no-funds-warning {
   border-radius: var(--radius-lg);
   padding: 1.25rem;
   box-shadow: var(--shadow);
-  transition: box-shadow 0.15s;
+  transition: box-shadow 0.15s, transform 0.15s, border-color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+  color: inherit;
 }
 
 .stat-card:hover {
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  border-color: var(--primary);
+  transform: translateY(-1px);
+  text-decoration: none;
+  color: inherit;
+}
+
+.stat-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: rgba(60, 80, 224, 0.1);
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .stat-card-icon {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.stat-card-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .stat-value {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -143,57 +143,75 @@ select:focus-visible {
   font-size: 0.9375rem;
 }
 
-.login-tabs {
+.login-mode {
   display: flex;
-  gap: 0;
-  margin-bottom: 0;
-  border-bottom: 1px solid var(--border);
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.login-mode-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.login-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
   background: var(--card-bg);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  padding: 0.25rem 0.25rem 0 0.25rem;
-  box-shadow: var(--shadow);
   border: 1px solid var(--border);
-  border-bottom: none;
+  border-radius: 999px;
 }
 
 .login-tab {
-  flex: 1;
-  padding: 0.75rem 1rem;
-  font-size: 0.9375rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.875rem;
   font-weight: 500;
   color: var(--text-muted);
   background: transparent;
   border: none;
-  border-radius: var(--radius);
+  border-radius: 999px;
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
   font-family: inherit;
+  line-height: 1.2;
 }
 
 .login-tab:hover {
   color: var(--text);
-  background: rgba(0, 0, 0, 0.04);
-}
-
-[data-theme="dark"] .login-tab:hover {
-  background: rgba(255, 255, 255, 0.06);
 }
 
 .login-tab.is-active {
-  color: var(--primary);
-  background: rgba(60, 80, 224, 0.08);
+  color: #fff;
+  background: var(--primary);
+  font-weight: 600;
 }
 
-[data-theme="dark"] .login-tab.is-active {
-  background: rgba(99, 102, 241, 0.15);
+.login-tab-check {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  display: none;
+}
+
+.login-tab.is-active .login-tab-check {
+  display: inline-block;
 }
 
 .login-tab-panel {
   display: none;
   background: var(--card-bg);
   border: 1px solid var(--border);
-  border-top: none;
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
   padding: 1.5rem;
   margin-bottom: 1.25rem;
@@ -217,17 +235,52 @@ select:focus-visible {
   padding: 1.5rem 1.25rem 1.25rem;
 }
 
-.login-cards > .login-card.login-card-recommended {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 1px var(--primary), var(--shadow);
+/* Both cards start neutral (grey 1px border via .login-cards > .login-card).
+   The "Recommended" / "Wallet required" badges carry the differentiation.
+   Hover or focus-within → primary blue ring on that card; the sibling stays
+   neutral. Only one card is ever highlighted at a time. */
+.login-cards > .login-card {
+  transition: box-shadow 0.15s ease;
 }
 
-.login-card-recommended-badge {
+.login-cards > .login-card:hover,
+.login-cards > .login-card:focus-within {
+  box-shadow: 0 0 0 1px var(--primary), var(--shadow);
+  border-color: var(--primary);
+}
+
+/* Login card CTAs (Log in / Create account / Connect wallet) all share the
+   same shape; the color follows the card's selected state. At rest both
+   sides look like a neutral outlined button; the active card's button
+   turns primary blue, matching the box-shadow ring. */
+.login-cards > .login-card .btn-primary,
+.login-cards > .login-card .btn-outline {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.login-cards > .login-card:hover .btn-primary,
+.login-cards > .login-card:hover .btn-outline,
+.login-cards > .login-card:focus-within .btn-primary,
+.login-cards > .login-card:focus-within .btn-outline {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+/* Push the CTA to the bottom so all four login-page buttons line up
+   horizontally, regardless of how much body copy each card carries. */
+.login-cards > .login-card .btn-block {
+  margin-top: auto;
+}
+
+.login-card-recommended-badge,
+.login-card-required-badge {
   position: absolute;
   top: -0.6rem;
   left: 1.25rem;
-  background: var(--primary);
-  color: #fff;
   font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -235,6 +288,17 @@ select:focus-visible {
   padding: 0.2rem 0.55rem;
   border-radius: 9999px;
   line-height: 1;
+}
+
+.login-card-recommended-badge {
+  background: var(--primary);
+  color: #fff;
+}
+
+.login-card-required-badge {
+  background: var(--bg-muted);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
 }
 
 .login-card-icon {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -819,12 +819,62 @@ body.is-chainsecured #no-funds-warning {
   width: 100%;
 }
 
+/* ----- Overview empty state ----- */
+.overview-empty-state {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.overview-empty-state[hidden] {
+  display: none;
+}
+
+.overview-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: rgba(60, 80, 224, 0.1);
+  color: var(--primary);
+  margin-bottom: 1rem;
+}
+
+[data-theme="dark"] .overview-empty-icon {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.overview-empty-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--text);
+}
+
+.overview-empty-body {
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  margin: 0 auto 1.25rem;
+  max-width: 460px;
+  line-height: 1.5;
+}
+
 /* ----- Stat cards ----- */
 .stats-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1.25rem;
   margin-bottom: 1.5rem;
+}
+
+.stats-row[hidden] {
+  display: none;
 }
 
 .stat-card {

--- a/lit-static/dapps/dashboard/ui-utils.js
+++ b/lit-static/dapps/dashboard/ui-utils.js
@@ -14,13 +14,22 @@ export function classifyError(e) {
   const raw = (e && e.message) ? e.message : String(e);
   const lower = raw.toLowerCase();
 
-  if (lower.includes('unauthorized') || lower.includes('403') || lower.includes('401') || lower.includes('session') || lower.includes('expired')) {
+  // Auth: only specific phrases, not bare "session"/"expired" which collide with
+  // contract revert reasons and ethers messages that mention those words.
+  if (
+    /\bunauthorized\b/.test(lower) ||
+    /\b401\b/.test(lower) ||
+    /\b403\b/.test(lower) ||
+    lower.includes('session expired') ||
+    lower.includes('token expired') ||
+    lower.includes('api key')
+  ) {
     return { type: 'auth', message: 'Session expired — please log in again.' };
   }
-  if (lower.includes('failed to fetch') || lower.includes('networkerror') || lower.includes('network') || lower.includes('err_connection')) {
+  if (lower.includes('failed to fetch') || lower.includes('networkerror') || lower.includes('err_connection')) {
     return { type: 'network', message: 'Connection lost — check your network and try again.' };
   }
-  if (lower.includes('500') || lower.includes('internal server') || lower.includes('502') || lower.includes('503')) {
+  if (/\b500\b/.test(lower) || /\b502\b/.test(lower) || /\b503\b/.test(lower) || lower.includes('internal server')) {
     return { type: 'server', message: 'Something went wrong on the server. Please try again.' };
   }
   return { type: 'unknown', message: raw };

--- a/lit-static/dapps/dashboard/wallets.js
+++ b/lit-static/dapps/dashboard/wallets.js
@@ -83,7 +83,7 @@ function openAddWalletModal() {
     try {
       showActionProgress('Creating wallet', 'Creating and registering a new wallet for this account.');
       const client = await getClient();
-      const res = await client.createWallet(apiKey);
+      const res = await client.createWallet({ apiKey });
       await loadWallets();
       showStatus('wallets-status', 'Wallet created: ' + (res.wallet_address || ''), 'success');
     } catch (e) {

--- a/lit-static/dapps/dashboard/wallets.js
+++ b/lit-static/dapps/dashboard/wallets.js
@@ -2,7 +2,7 @@
  * Wallets — table rendering, CRUD.
  */
 
-import { getEffectiveApiKey, getClient, getWalletsStore, setWalletsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
+import { getEffectiveApiKey, isAuthenticated, getClient, getWalletsStore, setWalletsStore, setStat, updateStatCards, LIST_PAGE_SIZE } from './auth.js';
 import { escapeHtml, showStatus, hideStatus, showActionProgress, closeActionProgress, openModal, closeModal, copyToClipboard, formatError, logError } from './ui-utils.js';
 
 // ----- Table rendering -----
@@ -42,7 +42,7 @@ export function renderWalletsTable(items) {
 
 export async function loadWallets() {
   const apiKey = getEffectiveApiKey();
-  if (!apiKey) return;
+  if (!isAuthenticated()) return;
   hideStatus('wallets-status');
   const btn = document.getElementById('btn-load-wallets');
   if (btn) btn.disabled = true;
@@ -75,7 +75,7 @@ function openAddWalletModal() {
   document.getElementById('modal-cancel-btn').addEventListener('click', closeModal);
   document.getElementById('modal-add-btn').addEventListener('click', async () => {
     const apiKey = getEffectiveApiKey();
-    if (!apiKey) return;
+    if (!isAuthenticated()) return;
     const addBtn = document.getElementById('modal-add-btn');
     if (addBtn) addBtn.disabled = true;
     closeModal();


### PR DESCRIPTION
## Summary

Lets the dashboard log in / create accounts in either **API mode** (default — recommended) or **ChainSecured mode** (self-custody, wallet-signed writes), and adds the missing pieces ChainSecured needed to actually be usable.

- **Login redesign.** New segmented "I would like to: [Sign in / Create account]" pill toggle, two cards per state (API vs ChainSecured), neutral by default with hover/focus-within painting the active card primary blue. CTAs vertically aligned across all four cards. Rebrand "Lit Express" → "Chipotle".
- **ChainSecured wallet creation (the missing piece).** New `POST /core/v1/create_wallet_with_signature` endpoint: client signs an EIP-191 SIWE-style message, server verifies (address match + chain ID + ±5-min timestamp window) and mints the PKP via DStack MPC. Client follows up with on-chain `registerWalletDerivation`. Two wallet popups, no api_key required.
- **SDK alignment.** `createWallet` is now an options bag with a sovereign branch. `accountExists` / `accountExistsByHash` prefer the connected signer over `api_payer` when calling the msg.sender-gated `accountExistsAndIsMutable` — without this, valid ChainSecured accounts read as nonexistent.

## Test plan

- [ ] **API mode existing user:** sign in → dashboard loads, wallet creation flow works (single popup, server-side mint+register).
- [ ] **API mode new user:** create account → wallet created → dashboard.
- [ ] **ChainSecured existing user:** "Connect wallet" → dashboard loads. Try creating a wallet → 2 popups (SIWE sign + on-chain register), wallet appears in list.
- [ ] **ChainSecured new user:** "Connect wallet & create" → on-chain account creation popup → dashboard.
- [ ] **Replay window:** message timestamp >5min in past or future → server rejects with `Signed message timestamp is too old or too far in the future`.
- [ ] **Wrong-signer:** edit `Address:` line in message before signing → server rejects with `Signature does not match claimed address`.
- [ ] **Login UI:** toggle between Sign in / Create account is obvious; cards stay neutral until you hover; active card paints blue ring + blue button; all four CTAs line up horizontally on desktop and tablet widths.
- [ ] `cargo check --bin lit-api-server` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)