### PR TITLE
feat(CPL-276): dApp RPC config for ChainSecured

### DIFF
--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -135,11 +135,16 @@ Radii:
 
 ## Mode-conditional UI
 
-The dashboard exposes the same surface in both modes. Body classes are
-available for future gating but no features are currently hidden by mode:
+The dashboard exposes the same core surface in both modes. Body classes drive
+mode-specific gating via CSS:
 
 - `body.has-api-key` — set after successful API-mode login.
 - `body.is-chainsecured` — set after successful wallet connect.
+
+Mode-conditional elements use the `.is-chainsecured-only` class — hidden in API
+mode via `body:not(.is-chainsecured) .is-chainsecured-only { display: none }`.
+Today this gates the **ChainSecured RPC URL** override (Account → RPC URL),
+which is meaningless in API mode.
 
 Action Runner, Wallets, Actions, and Usage Keys all render in both modes.
 ChainSecured admin operations (add action, mint usage key) are signed by the

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -3,7 +3,7 @@
  * Imports all feature modules and orchestrates initialization.
  */
 
-import { isAuthenticated, setTheme, getTheme, logOut, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI } from './auth.js';
+import { isAuthenticated, setTheme, getTheme, logOut, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI, setChainSecuredRpcUrl, toggleChainSecuredRpcPanel, updateChainSecuredRpcUrlUI } from './auth.js';
 import { initModalClose, initConfirmClose, showStatus, hideStatus, logError } from './ui-utils.js';
 import { initBilling } from './billing.js';
 import { initGroups, loadGroups } from './groups.js';
@@ -57,6 +57,43 @@ function initUsageKeyOverride() {
     });
   }
   updateUsageKeyOverrideUI();
+}
+
+// ----- ChainSecured RPC URL UI (CPL-276) -----
+
+function initChainSecuredRpc() {
+  const input = document.getElementById('chainsecured-rpc-input');
+  const applyBtn = document.getElementById('chainsecured-rpc-apply');
+  const resetBtn = document.getElementById('chainsecured-rpc-reset');
+  if (applyBtn) {
+    applyBtn.addEventListener('click', () => {
+      const val = (input?.value || '').trim();
+      if (!val) {
+        showStatus('overview-status', 'Enter an RPC URL.', 'error');
+        return;
+      }
+      try {
+        const u = new URL(val);
+        if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error('not http');
+      } catch {
+        showStatus('overview-status', 'Enter a valid http(s) RPC URL.', 'error');
+        return;
+      }
+      setChainSecuredRpcUrl(val);
+      hideStatus('overview-status');
+      showStatus('overview-status', 'RPC URL updated. Dashboard will use this RPC for ChainSecured reads and writes.', 'success');
+      preloadAllTables();
+    });
+  }
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      setChainSecuredRpcUrl('');
+      hideStatus('overview-status');
+      showStatus('overview-status', 'RPC URL reset to default.', 'success');
+      preloadAllTables();
+    });
+  }
+  updateChainSecuredRpcUrlUI();
 }
 
 // ----- Sidebar scroll -----
@@ -174,6 +211,15 @@ function initHeader() {
     });
   }
 
+  const toggleRpcBtn = document.getElementById('toggle-chainsecured-rpc-btn');
+  if (toggleRpcBtn) {
+    toggleRpcBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      closeAccountDropdown();
+      toggleChainSecuredRpcPanel();
+    });
+  }
+
   const signoutBtn = document.getElementById('account-signout-btn');
   if (signoutBtn) {
     signoutBtn.addEventListener('click', (e) => {
@@ -190,6 +236,7 @@ setOnAuthReady(() => {
   updateStatCards();
   preloadAllTables();
   updateUsageKeyOverrideUI();
+  updateChainSecuredRpcUrlUI();
 });
 
 // ----- Init -----
@@ -221,6 +268,7 @@ function init() {
   initHeader();
   initBilling();
   initUsageKeyOverride();
+  initChainSecuredRpc();
 }
 
 init();

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -11,6 +11,10 @@ const STORAGE_KEY_OVERRIDE_ENABLED = 'accountconfig_usage_override_enabled';
 const STORAGE_KEY_MODE = 'accountconfig_mode';
 const STORAGE_KEY_CHAINSECURED_WALLET = 'accountconfig_chainsecured_wallet';
 const STORAGE_KEY_CHAINSECURED_HASH = 'accountconfig_chainsecured_hash';
+const STORAGE_KEY_CHAINSECURED_RPC = 'accountconfig_chainsecured_rpc_url';
+const STORAGE_KEY_CHAINSECURED_RPC_PANEL = 'accountconfig_chainsecured_rpc_panel_visible';
+const DEFAULT_CHAINSECURED_RPC_URL_REMOTE = 'https://base-rpc.publicnode.com';
+const DEFAULT_CHAINSECURED_RPC_URL_LOCAL = 'http://127.0.0.1:8545';
 export const LIST_PAGE_SIZE = '20';
 
 /**
@@ -174,11 +178,72 @@ export function clearOverrideState() {
   setUsageKeyOverride('');
 }
 
+// ----- ChainSecured RPC URL override (CPL-276) -----
+
+/** True when the dashboard is served from a localhost origin. Shared by
+ *  `getBaseUrl()` and `getDefaultChainSecuredRpcUrl()`. */
+function isLocalhostOrigin() {
+  return typeof location !== 'undefined' && !!location.origin && location.origin.indexOf('localhost') !== -1;
+}
+
+/** Default RPC URL when no user override is set: local Anvil on localhost,
+ *  public Base RPC everywhere else. */
+export function getDefaultChainSecuredRpcUrl() {
+  return isLocalhostOrigin() ? DEFAULT_CHAINSECURED_RPC_URL_LOCAL : DEFAULT_CHAINSECURED_RPC_URL_REMOTE;
+}
+
+/** Effective RPC URL for ChainSecured reads/writes — user override or default. */
+export function getChainSecuredRpcUrl() {
+  return sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_RPC) || getDefaultChainSecuredRpcUrl();
+}
+
+export function hasChainSecuredRpcOverride() {
+  return !!sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_RPC);
+}
+
+/** Persist (or clear, on falsy) the user-supplied RPC URL.
+ *  Forces a fresh SDK client so its JsonRpcProvider rebinds to the new RPC. */
+export function setChainSecuredRpcUrl(v) {
+  if (v) sessionStorage.setItem(STORAGE_KEY_CHAINSECURED_RPC, v);
+  else sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_RPC);
+  resetClient();
+  updateChainSecuredRpcUrlUI();
+}
+
+export function isChainSecuredRpcPanelVisible() {
+  return sessionStorage.getItem(STORAGE_KEY_CHAINSECURED_RPC_PANEL) === 'true';
+}
+
+export function toggleChainSecuredRpcPanel() {
+  const next = !isChainSecuredRpcPanelVisible();
+  if (next) sessionStorage.setItem(STORAGE_KEY_CHAINSECURED_RPC_PANEL, 'true');
+  else sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_RPC_PANEL);
+  updateChainSecuredRpcUrlUI();
+}
+
+export function updateChainSecuredRpcUrlUI() {
+  const card = document.getElementById('chainsecured-rpc-card');
+  const input = document.getElementById('chainsecured-rpc-input');
+  const toggleBtn = document.getElementById('toggle-chainsecured-rpc-btn');
+  const resetBtn = document.getElementById('chainsecured-rpc-reset');
+  const defaultEl = document.getElementById('chainsecured-rpc-default');
+  const visible = isChainSecuredRpcPanelVisible();
+  const hasOverride = hasChainSecuredRpcOverride();
+  const defaultUrl = getDefaultChainSecuredRpcUrl();
+  if (card) card.style.display = visible ? '' : 'none';
+  if (input) {
+    input.value = getChainSecuredRpcUrl();
+    input.placeholder = defaultUrl;
+  }
+  if (defaultEl) defaultEl.textContent = defaultUrl;
+  if (resetBtn) resetBtn.style.display = hasOverride ? '' : 'none';
+  if (toggleBtn) toggleBtn.textContent = hasOverride ? '✓ RPC URL' : 'RPC URL';
+}
+
 // ----- Base URL -----
 
 export function getBaseUrl() {
-  if (typeof location !== 'undefined' && location.origin && location.origin.indexOf('localhost') !== -1)
-    return 'http://localhost:8000';
+  if (isLocalhostOrigin()) return 'http://localhost:8000';
   return '__LIT_API_BASE_URL__';
 }
 
@@ -198,14 +263,15 @@ export async function getClient() {
     const { createClient } = await import('../../core_sdk.js');
     const opts = { baseUrl, mode };
     if (mode === 'sovereign') {
-      // Bootstrap RPC + contract address via the server config endpoint
-      // (explicitly stays on the API path per CPL-267 plan).
+      // Bootstrap contract address + chain id via the server config endpoint.
+      // RPC URL is sourced from `getChainSecuredRpcUrl()` (default or user
+      // override under Account → RPC URL, per CPL-276), not the API.
       const bootstrap = createClient({ baseUrl });
       const cfg = await bootstrap.getNodeChainConfig();
-      if (!cfg || !cfg.rpc_url || !cfg.contract_address) {
-        throw new Error('Node chain config missing rpc_url or contract_address');
+      if (!cfg || !cfg.contract_address) {
+        throw new Error('Node chain config missing contract_address');
       }
-      opts.rpcUrl = cfg.rpc_url;
+      opts.rpcUrl = getChainSecuredRpcUrl();
       opts.contractAddress = cfg.contract_address;
       if (cfg.chain_id != null) opts.chainId = Number(cfg.chain_id);
     }

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -153,6 +153,7 @@
               </button>
               <div class="account-dropdown-panel" id="account-dropdown-panel" role="menu" aria-hidden="true">
                 <button type="button" class="account-dropdown-item" id="toggle-usage-override-btn" role="menuitem">Usage Key Override</button>
+                <button type="button" class="account-dropdown-item is-chainsecured-only" id="toggle-chainsecured-rpc-btn" role="menuitem">RPC URL</button>
                 <button type="button" class="account-dropdown-item account-dropdown-signout" id="account-signout-btn" role="menuitem">Sign out</button>
               </div>
             </div>
@@ -238,6 +239,19 @@
                   <input type="password" id="usage-key-override-input" class="input" style="flex:1;font-family:'JetBrains Mono',monospace;font-size:0.8125rem;" placeholder="Paste a usage API key to override… " aria-label="Usage API key override">
                   <button type="button" id="usage-key-override-apply" class="btn btn-primary btn-sm">Apply</button>
                   <button type="button" id="usage-key-override-clear" class="btn btn-outline btn-sm">Clear</button>
+                </div>
+              </div>
+            </div>
+            <div class="card is-chainsecured-only" id="chainsecured-rpc-card" style="display:none;">
+              <div class="card-header">
+                <h3 class="card-title">ChainSecured RPC URL</h3>
+              </div>
+              <div class="card-body">
+                <p class="form-hint" style="margin-bottom: 0.75rem;">Default: <code class="mono" id="chainsecured-rpc-default">https://base-rpc.publicnode.com</code>. Point the dashboard at your own RPC if you'd prefer.</p>
+                <div style="display:flex;align-items:center;gap:0.5rem;">
+                  <input type="text" id="chainsecured-rpc-input" class="input" style="flex:1;font-family:'JetBrains Mono',monospace;font-size:0.8125rem;" placeholder="https://base-rpc.publicnode.com" aria-label="ChainSecured RPC URL">
+                  <button type="button" id="chainsecured-rpc-apply" class="btn btn-primary btn-sm">Apply</button>
+                  <button type="button" id="chainsecured-rpc-reset" class="btn btn-outline btn-sm">Reset</button>
                 </div>
               </div>
             </div>

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -746,6 +746,11 @@ body.has-api-key .dashboard-wrap {
   background: rgba(248, 113, 113, 0.12);
 }
 
+/* Mode-conditional UI: hide ChainSecured-only items in API mode (CPL-276). */
+body:not(.is-chainsecured) .is-chainsecured-only {
+  display: none !important;
+}
+
 .topbar-title {
   font-size: 1.25rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- ChainSecured mode now defaults to `https://base-rpc.publicnode.com` (or local Anvil `http://127.0.0.1:8545` when served from a localhost origin) instead of pulling `rpc_url` from the API config endpoint. The API call still supplies `contract_address` and `chain_id`.
- New **Account → RPC URL** setting (visible only in ChainSecured mode) opens an override card on the Overview. Apply validates http(s) URLs and forces a fresh SDK client so the ethers `JsonRpcProvider` rebinds; Reset clears the override.
- Mode-gating uses a new `.is-chainsecured-only` class hidden in API mode via `body:not(.is-chainsecured)`. `DESIGN.md` updated to document the pattern.

## Implementation notes
- Storage keys follow the existing `accountconfig_*` sessionStorage convention. Override + panel-visibility flag are independent (clearing the override on toggle would have surprised users who set it once and want to hide the panel).
- Extracted `isLocalhostOrigin()` helper used by both `getBaseUrl()` and `getDefaultChainSecuredRpcUrl()` — single source of truth for localhost detection.
- The setter calls `resetClient()` so the next `getClient()` rebuilds. Cached `_clientInstance` plus the bootstrap fetch for `contract_address`/`chain_id` are unchanged.

## Pre-Landing Review
0 critical, 9 informational. 3 auto-fixed (DRY localhost helper, comment URL drift, DESIGN.md staleness). 6 skipped — false positive (#3) or established-pattern matches (#1, #4, #5, #6, #8). Full report in `/review` output.

## Test plan
- [ ] In production-like deployment: log in via ChainSecured mode → verify default RPC is `base-rpc.publicnode.com`, dashboard reads/writes work against Base.
- [ ] Open Account → RPC URL → set a custom Base RPC → Apply → verify subsequent reads route through it (devtools network tab).
- [ ] Reset → verify it falls back to the default and the SDK client is rebuilt.
- [ ] Switch to API mode → verify the menu item and override card are hidden.
- [ ] Local dev (anvil): hit dashboard at `http://localhost:8000` → verify default shows `http://127.0.0.1:8545`.
- [ ] Edge: paste a non-http(s) URL → Apply → expect inline validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)