### PR TITLE
feat(CPL-283): use connected wallet's RPC in ChainSecured mode

### DIFF
--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -105,12 +105,11 @@ Every subsequent management call (`addGroup`, `addAction`,
 The Core SDK is constructed with `mode: 'sovereign'`, an RPC URL, and the
 on-chain `AccountConfig` contract address. Reads call the contract
 directly; writes are wallet-signed and submitted via the connected signer.
-Once a signer with a provider is attached (any
-`ethers.BrowserProvider`-derived signer, including the one from
-`new ethers.BrowserProvider(window.ethereum).getSigner()`), the SDK
-routes reads through the wallet's provider instead of `rpcUrl`. The
-`rpcUrl` constructor option is the fallback used for reads that happen
-before a signer is attached.
+Once a signer with a provider is attached (any ethers v6 signer that
+carries a provider — for example, a `JsonRpcSigner` returned by
+`BrowserProvider.getSigner()`), the SDK routes reads through that
+provider instead of `rpcUrl`. The `rpcUrl` constructor option is the
+fallback used for reads that happen before a signer is attached.
 
 ```javascript
 import { LitNodeSimpleApiClient } from './core_sdk.js';

--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -105,6 +105,12 @@ Every subsequent management call (`addGroup`, `addAction`,
 The Core SDK is constructed with `mode: 'sovereign'`, an RPC URL, and the
 on-chain `AccountConfig` contract address. Reads call the contract
 directly; writes are wallet-signed and submitted via the connected signer.
+Once a signer with a provider is attached (any
+`ethers.BrowserProvider`-derived signer, including the one from
+`new ethers.BrowserProvider(window.ethereum).getSigner()`), the SDK
+routes reads through the wallet's provider instead of `rpcUrl`. The
+`rpcUrl` constructor option is the fallback used for reads that happen
+before a signer is attached.
 
 ```javascript
 import { LitNodeSimpleApiClient } from './core_sdk.js';
@@ -150,9 +156,12 @@ on the client (the dashboard does this automatically at login),
 account-level `apiKey` is required in ChainSecured mode.
 
 Call `GET /get_node_chain_config` (no auth required) for the live
-`contract_address` and `chain_id`. The RPC URL is not returned by the API —
-supply your own Base RPC endpoint (any public Base RPC works, e.g.
-`https://mainnet.base.org` or `https://base-rpc.publicnode.com`).
+`contract_address` and `chain_id`. The RPC URL is not returned by the API
+— supply your own Base RPC endpoint as the `rpcUrl` fallback (any public
+Base RPC works, e.g. `https://mainnet.base.org` or
+`https://base-rpc.publicnode.com`). Once your signer is attached the SDK
+prefers the wallet's RPC, so this fallback only matters for the brief
+window before `connectSigner(signer)` runs.
 
 ## Using the dashboard
 

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -356,11 +356,11 @@ export class LitNodeSimpleApiClient {
    * @param {Object} options
    * @param {string} [options.baseUrl='http://localhost:8000'] - Base URL of the API
    * @param {'api'|'sovereign'} [options.mode='api'] - Read-path mode. See module docblock.
-   * @param {string} [options.rpcUrl] - RPC URL for sovereign reads. Required when mode === 'sovereign'.
+   * @param {string} [options.rpcUrl] - RPC URL fallback for sovereign reads when no signer-with-provider is attached. Required when mode === 'sovereign'.
    * @param {string} [options.contractAddress] - AccountConfig contract address. Required when mode === 'sovereign'.
    * @param {number} [options.chainId] - Expected chain ID. Used for drift pinning + wallet chain guard. Optional; auto-detected from RPC when omitted.
    * @param {Object} [options.deployments] - Optional override map `{ "<chainId>:<address>": { runtimeBytecodeKeccak } }` for drift pinning.
-   * @param {import('ethers').Signer} [options.signer] - Pre-connected signer for sovereign writes. May be set later via connectSigner().
+   * @param {import('ethers').Signer} [options.signer] - Pre-connected signer for sovereign writes. May be set later via connectSigner(). When the signer carries its own provider (e.g. ethers.BrowserProvider), reads use it instead of `rpcUrl` (CPL-283).
    */
   constructor({ baseUrl = 'http://localhost:8000', mode = 'api', rpcUrl, contractAddress, chainId, deployments, signer, adminHashOverride } = {}) {
     if (typeof baseUrl !== 'string') {
@@ -376,6 +376,11 @@ export class LitNodeSimpleApiClient {
     this.chainId = chainId ?? null;
     this.deployments = mergeDeployments(deployments);
     this.signer = signer ?? null;
+    // ChainSecured-mode read provider. Populated from `signer.provider` when
+    // a wallet signer is attached (CPL-283), so reads route through the
+    // wallet's RPC instead of `this.rpcUrl`. Falls back to a JsonRpcProvider
+    // built from `this.rpcUrl` when no wallet is connected yet.
+    this.provider = signer?.provider ?? null;
     // When set (e.g. ChainSecured login: keccak256(abi.encodePacked(address))),
     // `_adminHash(apiKey)` returns this and ignores the apiKey argument.
     // Leave null for API-mode and legacy sovereign API-key sessions, which
@@ -385,9 +390,12 @@ export class LitNodeSimpleApiClient {
     this._writeContract = null;
     this._driftCheckPromise = null;
 
-    if (mode === 'sovereign' && (!rpcUrl || !contractAddress)) {
+    if (mode === 'sovereign' && !contractAddress) {
+      throw new Error('LitNodeSimpleApiClient: sovereign mode requires contractAddress');
+    }
+    if (mode === 'sovereign' && !rpcUrl && !this.provider) {
       throw new Error(
-        'LitNodeSimpleApiClient: sovereign mode requires rpcUrl and contractAddress',
+        'LitNodeSimpleApiClient: sovereign mode requires rpcUrl, or a signer whose provider can be used for reads (CPL-283)',
       );
     }
   }
@@ -400,6 +408,14 @@ export class LitNodeSimpleApiClient {
   connectSigner(signer) {
     this.signer = signer;
     this._writeContract = null;
+    // Adopt the wallet's provider for reads (CPL-283). Drop cached read
+    // artifacts so the next read rebinds to the new provider instead of the
+    // stale JsonRpcProvider built from `this.rpcUrl`.
+    if (signer?.provider) {
+      this.provider = signer.provider;
+      this._viewContractPromise = null;
+      this._driftCheckPromise = null;
+    }
   }
 
   /**
@@ -430,7 +446,7 @@ export class LitNodeSimpleApiClient {
     if (!this._driftCheckPromise) {
       this._driftCheckPromise = (async () => {
         const ethers = await loadEthers();
-        const provider = new ethers.JsonRpcProvider(this.rpcUrl);
+        const provider = this.provider ?? new ethers.JsonRpcProvider(this.rpcUrl);
         const [code, network] = await Promise.all([
           provider.getCode(this.contractAddress),
           provider.getNetwork(),
@@ -501,7 +517,7 @@ export class LitNodeSimpleApiClient {
     if (!this._viewContractPromise) {
       this._viewContractPromise = (async () => {
         const ethers = await loadEthers();
-        const provider = new ethers.JsonRpcProvider(this.rpcUrl);
+        const provider = this.provider ?? new ethers.JsonRpcProvider(this.rpcUrl);
         return new ethers.Contract(this.contractAddress, ACCOUNT_CONFIG_VIEW_ABI, provider);
       })();
     }

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -13,8 +13,10 @@
  *                           `connectSigner(signer)` has been called; without a
  *                           signer, write methods throw.
  *
- * In sovereign mode the constructor requires `rpcUrl` + `contractAddress`, or
- * the dashboard can call `getNodeChainConfig()` first and pass the values in.
+ * In sovereign mode the constructor requires `contractAddress` plus either
+ * `rpcUrl` or a signer that carries its own provider (any ethers v6 signer
+ * with `signer.provider` set). The dashboard typically calls
+ * `getNodeChainConfig()` first and passes the values in.
  */
 
 import { ACCOUNT_CONFIG_VIEW_ABI } from './account_config_view_abi.js';
@@ -344,7 +346,7 @@ export class LitNodeSimpleApiClient {
    * @param {Object} options
    * @param {string} [options.baseUrl='http://localhost:8000'] - Base URL of the API
    * @param {'api'|'sovereign'} [options.mode='api'] - Read-path mode. See module docblock.
-   * @param {string} [options.rpcUrl] - RPC URL fallback for sovereign reads when no signer-with-provider is attached. Required when mode === 'sovereign'.
+   * @param {string} [options.rpcUrl] - RPC URL fallback for sovereign reads when no signer-with-provider is attached. Required for sovereign mode unless `signer` (or a later `connectSigner()` call) supplies a provider.
    * @param {string} [options.contractAddress] - AccountConfig contract address. Required when mode === 'sovereign'.
    * @param {number} [options.chainId] - Expected chain ID. Used for drift pinning + wallet chain guard. Optional; auto-detected from RPC when omitted.
    * @param {Object} [options.deployments] - Optional override map `{ "<chainId>:<address>": { runtimeBytecodeKeccak } }` for drift pinning.
@@ -383,7 +385,7 @@ export class LitNodeSimpleApiClient {
     }
     if (mode === 'sovereign' && !rpcUrl && !this.provider) {
       throw new Error(
-        'LitNodeSimpleApiClient: sovereign mode requires rpcUrl, or a signer whose provider can be used for reads (CPL-283)',
+        'LitNodeSimpleApiClient: sovereign mode requires rpcUrl, or a signer whose provider can be used for reads',
       );
     }
   }
@@ -394,13 +396,16 @@ export class LitNodeSimpleApiClient {
    * @param {import('ethers').Signer} signer - ethers v6 Signer
    */
   connectSigner(signer) {
+    const nextProvider = signer?.provider ?? null;
+    const providerChanged = nextProvider !== this.provider;
     this.signer = signer;
     this._writeContract = null;
-    // Adopt the wallet's provider for reads (CPL-283). Drop cached read
-    // artifacts so the next read rebinds to the new provider instead of the
-    // stale JsonRpcProvider built from `this.rpcUrl`.
-    if (signer?.provider) {
-      this.provider = signer.provider;
+    // Adopt the wallet's provider for reads (CPL-283), or fall back to the
+    // `rpcUrl` JsonRpcProvider when the new signer has none / signer is null.
+    // Reset cached read artifacts on any provider change so the next read
+    // rebinds rather than keeping the previous wallet's provider.
+    if (providerChanged) {
+      this.provider = nextProvider;
       this._viewContractPromise = null;
       this._driftCheckPromise = null;
     }

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -265,7 +265,10 @@ export async function getClient() {
     if (mode === 'sovereign') {
       // Bootstrap contract address + chain id via the server config endpoint.
       // RPC URL is sourced from `getChainSecuredRpcUrl()` (default or user
-      // override under Account → RPC URL, per CPL-276), not the API.
+      // override under Account → RPC URL, per CPL-276), not the API. This is
+      // the fallback for reads that happen before a wallet signer is attached
+      // — once `connectSigner(signer)` runs, the SDK switches to the wallet's
+      // own provider for reads (CPL-283).
       const bootstrap = createClient({ baseUrl });
       const cfg = await bootstrap.getNodeChainConfig();
       if (!cfg || !cfg.contract_address) {

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -248,7 +248,7 @@
                 <h3 class="card-title">ChainSecured RPC URL</h3>
               </div>
               <div class="card-body">
-                <p class="form-hint" style="margin-bottom: 0.75rem;">Default: <code class="mono" id="chainsecured-rpc-default">https://base-rpc.publicnode.com</code>. Point the dashboard at your own RPC if you'd prefer.</p>
+                <p class="form-hint" style="margin-bottom: 0.75rem;">Once your wallet is connected the dashboard reads through your wallet's RPC. This URL is the fallback for reads that happen before the wallet attaches (e.g. right after page reload). Default: <code class="mono" id="chainsecured-rpc-default">https://base-rpc.publicnode.com</code>.</p>
                 <div style="display:flex;align-items:center;gap:0.5rem;">
                   <input type="text" id="chainsecured-rpc-input" class="input" style="flex:1;font-family:'JetBrains Mono',monospace;font-size:0.8125rem;" placeholder="https://base-rpc.publicnode.com" aria-label="ChainSecured RPC URL">
                   <button type="button" id="chainsecured-rpc-apply" class="btn btn-primary btn-sm">Apply</button>


### PR DESCRIPTION
## Summary

In ChainSecured (sovereign) mode, the SDK now routes reads through the connected wallet's provider instead of a separately-configured RPC URL.

**Before:** Reads (view contract calls, ABI drift bytecode check) always went through `new ethers.JsonRpcProvider(rpcUrl)` — either the user override (CPL-276) or the default (`https://base-rpc.publicnode.com`). The wallet's provider (`ethers.BrowserProvider(window.ethereum)`) was discarded after `connectSigner(signer)`.

**After:** When a wallet signer with a provider is attached, the SDK captures `signer.provider` and uses it for subsequent sovereign reads. The `rpcUrl` constructor option becomes the fallback for reads that happen before a signer is attached (e.g. on page reload, before the user reconnects their wallet).

## Changes

- **`lit-static/core_sdk.js`** — Track `this.provider` (init from `signer?.provider`). In `connectSigner()`, capture `signer.provider` and reset `_viewContractPromise` + `_driftCheckPromise` so the next read rebinds. In `_verifyAbiIntegrity` and `_getViewContract`, prefer `this.provider ?? new JsonRpcProvider(this.rpcUrl)`. Constructor now allows omitting `rpcUrl` if a signer-with-provider is supplied.
- **`lit-static/dapps/dashboard/auth.js`** — Comment around `getClient()` notes the wallet RPC takeover. No functional change (rpcUrl is still passed; it's now the fallback).
- **`lit-static/dapps/dashboard/index.html`** — RPC URL panel hint copy reframed: it's the fallback for reads before wallet attach.
- **`docs/management/account_modes.mdx`** — Documents that the wallet's provider takes over after `connectSigner`, and `rpcUrl` is the pre-attach fallback.

## Why this is safe

Wallet-disconnect / chain-switch teardown is already handled by the existing `onWalletChange` watcher in `auth.js` (calls `logOut()` → `resetClient()`), so no stale `this.provider` survives a wallet event. The drift-check is invalidated when a new signer attaches, so it re-runs against the wallet's provider on the next write.

## Out of scope

- Removing the user-configurable RPC URL panel entirely (CPL-276) — kept as fallback for power users.
- Rebuilding the SDK client mid-session on wallet `chainChanged` (the existing `switchChain` flow re-derives the signer and the dashboard tears down the client on disconnect).

## Test plan

- [ ] Log in to ChainSecured mode with a wallet on Base. Confirm subsequent admin reads use the wallet's RPC (visible in browser devtools network tab — requests should hit your wallet's RPC, not `base-rpc.publicnode.com`).
- [ ] Log out and reload the page. Confirm read requests fall back to the configured RPC URL until you re-connect the wallet.
- [ ] Set a custom RPC URL via Account → RPC URL. Reload. Confirm pre-wallet-connect reads use the override; post-wallet-connect reads use the wallet.
- [ ] Switch chains in the wallet. Confirm the dashboard logs out cleanly (existing behavior, not regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)