### PR TITLE
feat(CPL-284): add sig-derived usage API key endpoint for ChainSecured mode

### DIFF
--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -282,7 +282,7 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 
 ### ChainSecured-mode HTTP endpoints
 
-Two HTTP endpoints back the ChainSecured (sovereign) flow. They sit alongside the on-chain writes — see [API mode vs ChainSecured mode](/management/account_modes) for the full SDK-side workflow and when to choose each mode.
+Three HTTP endpoints back the ChainSecured (sovereign) flow. They sit alongside the on-chain writes — see [API mode vs ChainSecured mode](/management/account_modes) for the full SDK-side workflow and when to choose each mode.
 
 #### `POST /create_wallet_with_signature`
 
@@ -342,6 +342,46 @@ curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/convert_to_chain_s
 ```
 
 See [API mode vs ChainSecured mode → Converting an API account to ChainSecured](/management/account_modes#converting-an-api-account-to-chainsecured) for the dashboard flow, the SDK wrapper (`client.convertToChainSecuredAccount`), and the post-conversion verification checklist.
+
+#### `POST /add_usage_api_key_with_signature`
+
+The ChainSecured counterpart to `/add_usage_api_key`. Mirrors `create_wallet_with_signature`: the server mints a usage-key wallet via DStack MPC after verifying a wallet-ownership signature, then returns the secret (base64-encoded) plus the wallet address and derivation path. The client follows up on-chain — only the admin wallet of a ChainSecured account can call `setUsageApiKey`, so the server cannot complete the attach for you.
+
+No API key required. Same ±5-minute `Issued At` window as `create_wallet_with_signature`. Worst-case replay just returns a fresh secret for an unattached wallet — equivalent to a freshly generated keypair until the admin wallet calls the on-chain follow-ups, so compute cost only.
+
+**Request body:**
+
+```json
+{
+  "message": "<EIP-191 plaintext>",
+  "signature": "0x<65-byte hex>"
+}
+```
+
+Same SIWE-lite shape as `create_wallet_with_signature`: `Address: 0x…`, `Chain ID: <u64>`, and `Issued At: <unix-seconds>` (case-sensitive, exactly one of each — duplicates are rejected). Other lines are ignored. Messages longer than 4 KiB are rejected.
+
+**Response:**
+
+```json
+{
+  "usage_api_key": "<base64 of 32 secret bytes>",
+  "wallet_address": "0x...",
+  "derivation_path": "0x..."
+}
+```
+
+The client must do two on-chain calls signed by the admin wallet to attach the new usage key:
+
+1. `registerWalletDerivation(adminHash, wallet_address, derivation_path, name, description)` — registers the PKP to the account.
+2. `setUsageApiKey(adminHash, keccak256(usage_api_key_bytes), expiration, balance, name, description, …permissions)` — attaches the usage key with its permission set.
+
+Until both land, the secret in `usage_api_key` is just a freshly minted keypair with no on-chain identity.
+
+```bash
+curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/add_usage_api_key_with_signature" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"chipotle.dev wants you to mint a usage API key for ChainSecured account.\n\nAddress: 0xabc...\nChain ID: 8453\nIssued At: 1745798400","signature":"0x..."}'
+```
 
 ---
 

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -213,6 +213,28 @@ export interface AddUsageApiKeyRequest {
 }
 
 /**
+ * Returned by `/add_usage_api_key_with_signature`. The client must follow up with on-chain `registerWalletDerivation(adminHash, wallet_address, derivation_path, name, description)` and `setUsageApiKey(adminHash, keccak256(usage_api_key), …)` — both signed by the admin wallet — to attach the usage key to the ChainSecured account.
+ */
+export interface AddUsageApiKeyWithSignatureResponse {
+  /** Base64-encoded 32-byte secret. Send as `X-Api-Key` / `Authorization: Bearer …` for usage requests; pass `keccak256(this)` to `setUsageApiKey`. */
+  usage_api_key: string;
+  /** 0x-prefixed lowercase hex EVM address of the minted PKP wallet. */
+  wallet_address: string;
+  /** 0x-prefixed lowercase hex (uint256). Pass through verbatim to `registerWalletDerivation`'s `derivationPath` arg. */
+  derivation_path: string;
+}
+
+/**
+ * ChainSecured usage-key minting. Mirrors `CreateWalletWithSignatureRequest`: the user proves wallet ownership with an EIP-191 personal_sign signature, the server mints a usage-key wallet via DStack MPC and returns the secret (as the usage API key) plus address + derivation path. The client follows up with on-chain `registerWalletDerivation` and `setUsageApiKey` signed by their admin wallet — only the admin wallet of a ChainSecured account can call `setUsageApiKey` (see AppStorage.accountExistsAndIsMutable).
+ */
+export interface AddUsageApiKeyWithSignatureRequest {
+  /** EIP-191 plaintext message that was signed. Same format as `create_wallet_with_signature`: `Address: 0x…`, `Chain ID: <u64>`, `Issued At: <unix-seconds>` (case-sensitive prefixes). */
+  message: string;
+  /** 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign). */
+  signature: string;
+}
+
+/**
  * Request for update_usage_api_key. Updates all permissions and metadata on an existing usage API key. API key via header.
  */
 export interface UpdateUsageApiKeyRequest {
@@ -529,6 +551,10 @@ export type AddUsageApiKeyHeaders = {
 };
 
 export type AddUsageApiKeyDefault = AddUsageApiKeyResponse | ErrMessage;
+
+export type AddUsageApiKeyWithSignatureDefault =
+  | AddUsageApiKeyWithSignatureResponse
+  | ErrMessage;
 
 export type UpdateUsageApiKeyHeaders = {
   /**
@@ -1444,6 +1470,47 @@ export class LitApiServerClient {
       response,
       data,
       operationId: "add_usage_api_key",
+    };
+  }
+
+  addUsageApiKeyWithSignature(
+    addUsageApiKeyWithSignatureRequest: AddUsageApiKeyWithSignatureRequest,
+    requestParameters?: Params,
+  ): {
+    response: Response;
+    data: AddUsageApiKeyWithSignatureDefault;
+    operationId: string;
+  } {
+    const k6url = new URL(
+      this.cleanBaseUrl + `/add_usage_api_key_with_signature`,
+    );
+    const mergedRequestParameters = this._mergeRequestParameters(
+      requestParameters || {},
+      this.commonRequestParameters,
+    );
+    const response = http.request(
+      "POST",
+      k6url.toString(),
+      JSON.stringify(addUsageApiKeyWithSignatureRequest),
+      {
+        ...mergedRequestParameters,
+        headers: {
+          ...mergedRequestParameters?.headers,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    let data;
+
+    try {
+      data = response.json();
+    } catch {
+      data = response.body;
+    }
+    return {
+      response,
+      data,
+      operationId: "add_usage_api_key_with_signature",
     };
   }
 

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -328,7 +328,12 @@ fn verify_chainsecured_siwe(message: &str, signature: &str) -> Result<H160, ApiS
             )
         })?
         .as_secs() as i64;
-    if (now - parsed.issued_at).abs() > SIWE_TIMESTAMP_SKEW_SECONDS {
+    // i128 subtraction: two i64s can never overflow into i128, and i128::abs
+    // is safe for any value produced by an i64 subtraction. Without this, a
+    // crafted `Issued At: i64::MIN` would wrap `(now - issued_at).abs()` back
+    // to a small/negative value and bypass the skew check in release builds.
+    let delta = (now as i128) - (parsed.issued_at as i128);
+    if delta.abs() > SIWE_TIMESTAMP_SKEW_SECONDS as i128 {
         return Err(ApiStatus::bad_request(
             anyhow::anyhow!(
                 "Issued At {} is outside the ±{}s window from now ({})",

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -421,55 +421,11 @@ pub async fn convert_to_chain_secured_account(
         ));
     }
 
-    let parsed = parse_chainsecured_siwe(&req.message)?;
-    if parsed.address != claimed_address {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!("Signed Address does not match new_admin_wallet_address"),
-            "Signed Address does not match new_admin_wallet_address",
-        ));
-    }
-    let signer = recover_eip191_signer(&req.message, &req.signature)?;
+    let signer = verify_chainsecured_siwe(&req.message, &req.signature)?;
     if signer != claimed_address {
         return Err(ApiStatus::bad_request(
             anyhow::anyhow!("Signature does not match new_admin_wallet_address"),
             "Signature does not match new_admin_wallet_address",
-        ));
-    }
-
-    let node_config = GLOBAL_NODE_CONFIG
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))
-        .map_err(|e| ApiStatus::internal_server_error(e, "GLOBAL_NODE_CONFIG missing"))?;
-    let expected_chain_id = node_config.chain.info().chain_id;
-    if parsed.chain_id != expected_chain_id {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!(
-                "Chain ID mismatch: message says {}, server is on {}",
-                parsed.chain_id,
-                expected_chain_id
-            ),
-            "Chain ID mismatch",
-        ));
-    }
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|e| {
-            ApiStatus::internal_server_error(
-                anyhow::anyhow!(e),
-                "System clock is before the Unix epoch",
-            )
-        })?
-        .as_secs() as i64;
-    if (now - parsed.issued_at).abs() > SIWE_TIMESTAMP_SKEW_SECONDS {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!(
-                "Issued At {} is outside the ±{}s window from now ({})",
-                parsed.issued_at,
-                SIWE_TIMESTAMP_SKEW_SECONDS,
-                now
-            ),
-            "Signed message timestamp is too old or too far in the future",
         ));
     }
 

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -6,15 +6,17 @@ use crate::config::GLOBAL_NODE_CONFIG;
 use crate::core::v1::helpers::api_status::ApiStatus;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, ConvertToChainSecuredAccountRequest, CreateWalletWithSignatureRequest,
-    DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, AddUsageApiKeyWithSignatureRequest, ConvertToChainSecuredAccountRequest,
+    CreateWalletWithSignatureRequest, DeleteActionRequest, NewAccountRequest,
+    RemoveActionFromGroupRequest, RemoveGroupRequest, RemovePkpFromGroupRequest,
+    RemoveUsageApiKeyRequest, UpdateActionMetadataRequest, UpdateGroupRequest,
+    UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
-    AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,
-    ChainConfigKeysResponse, CreateWalletResponse, CreateWalletWithSignatureResponse,
-    ListMetadataItem, NewAccountResponse, NodeChainConfigResponse, WalletItem,
+    AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse,
+    AddUsageApiKeyWithSignatureResponse, ApiKeyItem, ChainConfigKeysResponse, CreateWalletResponse,
+    CreateWalletWithSignatureResponse, ListMetadataItem, NewAccountResponse,
+    NodeChainConfigResponse, WalletItem,
 };
 use crate::dstack::v1::get_client_key;
 use crate::stripe::StripeState;
@@ -164,33 +166,52 @@ pub async fn create_wallet(
     })
 }
 
-/// V1 SIWE-lite. ChainSecured users have no api key, so we authenticate
-/// PKP minting with a wallet signature instead. The server only mints —
-/// the client follows up with `registerWalletDerivation` signed by the
-/// same wallet to register the PKP on-chain.
+/// V1 SIWE-lite. Shared by `create_wallet_with_signature` and
+/// `add_usage_api_key_with_signature` — both authenticate PKP minting
+/// with a wallet signature because ChainSecured users have no api key.
+/// The server only mints — the client follows up on-chain with
+/// `registerWalletDerivation` (and, for usage keys, `setUsageApiKey`)
+/// signed by the admin wallet (which may differ from the SIWE signer).
 ///
-/// Replay: ±5-minute timestamp window, no nonce store. Worst case is an
-/// extra unregistered PKP (compute cost only).
+/// Replay: ±5-minute timestamp window, no nonce store. Worst case on
+/// either endpoint is an extra unregistered PKP — the bytes the server
+/// returns are unattached on-chain until the admin wallet calls the
+/// follow-up txns, so they are equivalent to a freshly generated keypair
+/// until then. Compute cost only.
 const SIWE_TIMESTAMP_SKEW_SECONDS: i64 = 300;
 
-/// Parsed shape of a `create_wallet_with_signature` SIWE message.
-struct ParsedCreateWalletSiwe {
+/// Hard cap on the SIWE-lite message size to prevent unauthenticated callers
+/// from forcing the server to allocate / hash large strings before any cheap
+/// reject. 4 KiB is far above any legitimate three-line message.
+const MAX_SIWE_MESSAGE_LEN: usize = 4096;
+
+/// Parsed shape of a ChainSecured SIWE-lite message.
+struct ParsedChainsecuredSiwe {
     address: H160,
     chain_id: u64,
     issued_at: i64,
 }
 
-/// Parses a `create_wallet_with_signature` message. Required lines (case-sensitive):
+/// Parses a ChainSecured SIWE-lite message. Required lines (case-sensitive),
+/// each must appear exactly once:
 ///   `Address: 0x…`
 ///   `Chain ID: <u64>`
 ///   `Issued At: <unix-seconds>`
 /// Other lines are ignored so callers can include domain/statement framing.
-fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, ApiStatus> {
+/// Duplicate required lines are rejected (last-wins parsing would let a
+/// crafted message show one value to the wallet UI and another to the server).
+fn parse_chainsecured_siwe(message: &str) -> Result<ParsedChainsecuredSiwe, ApiStatus> {
     let mut address: Option<H160> = None;
     let mut chain_id: Option<u64> = None;
     let mut issued_at: Option<i64> = None;
     for line in message.lines() {
         if let Some(v) = line.strip_prefix("Address:") {
+            if address.is_some() {
+                return Err(ApiStatus::bad_request(
+                    anyhow::anyhow!("Duplicate Address line"),
+                    "Duplicate Address line",
+                ));
+            }
             let trimmed = v.trim();
             let bytes = hex_to_bytes(trimmed.trim_start_matches("0x")).map_err(|_| {
                 ApiStatus::bad_request(
@@ -206,6 +227,12 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
             }
             address = Some(H160::from_slice(&bytes));
         } else if let Some(v) = line.strip_prefix("Chain ID:") {
+            if chain_id.is_some() {
+                return Err(ApiStatus::bad_request(
+                    anyhow::anyhow!("Duplicate Chain ID line"),
+                    "Duplicate Chain ID line",
+                ));
+            }
             chain_id = Some(v.trim().parse::<u64>().map_err(|_| {
                 ApiStatus::bad_request(
                     anyhow::anyhow!("Chain ID line not a u64"),
@@ -213,6 +240,12 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
                 )
             })?);
         } else if let Some(v) = line.strip_prefix("Issued At:") {
+            if issued_at.is_some() {
+                return Err(ApiStatus::bad_request(
+                    anyhow::anyhow!("Duplicate Issued At line"),
+                    "Duplicate Issued At line",
+                ));
+            }
             issued_at = Some(v.trim().parse::<i64>().map_err(|_| {
                 ApiStatus::bad_request(
                     anyhow::anyhow!("Issued At line not a unix timestamp"),
@@ -221,7 +254,7 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
             })?);
         }
     }
-    Ok(ParsedCreateWalletSiwe {
+    Ok(ParsedChainsecuredSiwe {
         address: address.ok_or_else(|| {
             ApiStatus::bad_request(
                 anyhow::anyhow!("Missing Address line"),
@@ -256,17 +289,19 @@ fn recover_eip191_signer(message: &str, signature_hex: &str) -> Result<H160, Api
         .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))
 }
 
-pub async fn create_wallet_with_signature(
-    req: Json<CreateWalletWithSignatureRequest>,
-) -> Result<CreateWalletWithSignatureResponse, ApiStatus> {
-    let parsed = parse_create_wallet_siwe(&req.message)?;
-    let signer = recover_eip191_signer(&req.message, &req.signature)?;
-    if signer != parsed.address {
+/// Parses + verifies a ChainSecured SIWE-lite message and returns the recovered
+/// signer. Cheap rejects (length cap, parse, chain ID, timestamp window) run
+/// before the expensive ECDSA recovery so attacker traffic with stale or
+/// wrong-chain messages is dropped without doing crypto.
+fn verify_chainsecured_siwe(message: &str, signature: &str) -> Result<H160, ApiStatus> {
+    if message.len() > MAX_SIWE_MESSAGE_LEN {
         return Err(ApiStatus::bad_request(
-            anyhow::anyhow!("Signature does not match claimed address"),
-            "Signature does not match claimed address",
+            anyhow::anyhow!("Message exceeds {}-byte cap", MAX_SIWE_MESSAGE_LEN),
+            "Message too large",
         ));
     }
+
+    let parsed = parse_chainsecured_siwe(message)?;
 
     let node_config = GLOBAL_NODE_CONFIG
         .get()
@@ -305,12 +340,49 @@ pub async fn create_wallet_with_signature(
         ));
     }
 
+    let signer = recover_eip191_signer(message, signature)?;
+    if signer != parsed.address {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Signature does not match claimed address"),
+            "Signature does not match claimed address",
+        ));
+    }
+
+    Ok(signer)
+}
+
+pub async fn create_wallet_with_signature(
+    req: Json<CreateWalletWithSignatureRequest>,
+) -> Result<CreateWalletWithSignatureResponse, ApiStatus> {
+    let signer = verify_chainsecured_siwe(&req.message, &req.signature)?;
     tracing::info!(
         "create_wallet_with_signature: minting PKP for ChainSecured signer {:?}",
         signer
     );
     let (_public_key, wallet_address, _secret, derivation_u256) = create_new_wallet().await?;
     Ok(CreateWalletWithSignatureResponse {
+        wallet_address: bytes_to_0x_hex(wallet_address.as_bytes()),
+        derivation_path: format!("0x{:x}", derivation_u256),
+    })
+}
+
+/// ChainSecured usage API key: server only mints the wallet (PKP) gated by an
+/// EIP-191 wallet signature; the client follows up with on-chain
+/// `registerWalletDerivation` and `setUsageApiKey` signed by their admin
+/// wallet (api_payer cannot call setUsageApiKey for ChainSecured accounts —
+/// see AppStorage.accountExistsAndIsMutable).
+pub async fn add_usage_api_key_with_signature(
+    req: Json<AddUsageApiKeyWithSignatureRequest>,
+) -> Result<AddUsageApiKeyWithSignatureResponse, ApiStatus> {
+    let signer = verify_chainsecured_siwe(&req.message, &req.signature)?;
+    tracing::info!(
+        "add_usage_api_key_with_signature: minting usage-key PKP for ChainSecured signer {:?}",
+        signer
+    );
+    let (_public_key, wallet_address, secret, derivation_u256) = create_new_wallet().await?;
+    let usage_api_key = base64_light::base64_encode_bytes(&secret);
+    Ok(AddUsageApiKeyWithSignatureResponse {
+        usage_api_key,
         wallet_address: bytes_to_0x_hex(wallet_address.as_bytes()),
         derivation_path: format!("0x{:x}", derivation_u256),
     })
@@ -349,7 +421,7 @@ pub async fn convert_to_chain_secured_account(
         ));
     }
 
-    let parsed = parse_create_wallet_siwe(&req.message)?;
+    let parsed = parse_chainsecured_siwe(&req.message)?;
     if parsed.address != claimed_address {
         return Err(ApiStatus::bad_request(
             anyhow::anyhow!("Signed Address does not match new_admin_wallet_address"),

--- a/lit-api-server/src/core/v1/endpoints/account_management.rs
+++ b/lit-api-server/src/core/v1/endpoints/account_management.rs
@@ -8,15 +8,17 @@ use crate::core::v1::helpers::api_status::{ApiResult, ErrMessage};
 use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{
     AddActionRequest, AddActionToGroupRequest, AddGroupRequest, AddPkpToGroupRequest,
-    AddUsageApiKeyRequest, ConvertToChainSecuredAccountRequest, CreateWalletWithSignatureRequest,
-    DeleteActionRequest, NewAccountRequest, RemoveActionFromGroupRequest, RemoveGroupRequest,
-    RemovePkpFromGroupRequest, RemoveUsageApiKeyRequest, UpdateActionMetadataRequest,
-    UpdateGroupRequest, UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
+    AddUsageApiKeyRequest, AddUsageApiKeyWithSignatureRequest, ConvertToChainSecuredAccountRequest,
+    CreateWalletWithSignatureRequest, DeleteActionRequest, NewAccountRequest,
+    RemoveActionFromGroupRequest, RemoveGroupRequest, RemovePkpFromGroupRequest,
+    RemoveUsageApiKeyRequest, UpdateActionMetadataRequest, UpdateGroupRequest,
+    UpdateUsageApiKeyMetadataRequest, UpdateUsageApiKeyRequest,
 };
 use crate::core::v1::models::response::{
-    AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse, ApiKeyItem,
-    ChainConfigKeysResponse, CreateWalletResponse, CreateWalletWithSignatureResponse,
-    ListMetadataItem, NewAccountResponse, NodeChainConfigResponse, WalletItem,
+    AccountOpResponse, AddGroupResponse, AddUsageApiKeyResponse,
+    AddUsageApiKeyWithSignatureResponse, ApiKeyItem, ChainConfigKeysResponse, CreateWalletResponse,
+    CreateWalletWithSignatureResponse, ListMetadataItem, NewAccountResponse,
+    NodeChainConfigResponse, WalletItem,
 };
 use crate::stripe::StripeState;
 use rocket::State;
@@ -347,6 +349,16 @@ pub(super) async fn remove_pkp_from_group(
             .await,
         )
         .into(),
+    }
+}
+
+#[openapi(tag = "Account Management")]
+#[post("/add_usage_api_key_with_signature", format = "json", data = "<req>")]
+pub(super) async fn add_usage_api_key_with_signature(
+    req: Json<AddUsageApiKeyWithSignatureRequest>,
+) -> OpenApiResponse<AddUsageApiKeyWithSignatureResponse, ErrMessage> {
+    OpenApiResponse {
+        response: ApiResult(account_management::add_usage_api_key_with_signature(req).await).into(),
     }
 }
 

--- a/lit-api-server/src/core/v1/endpoints/mod.rs
+++ b/lit-api-server/src/core/v1/endpoints/mod.rs
@@ -31,6 +31,7 @@ pub fn routes_with_spec() -> (Vec<Route>, OpenApi) {
         add_pkp_to_group,
         remove_pkp_from_group,
         add_usage_api_key,
+        add_usage_api_key_with_signature,
         update_usage_api_key,
         remove_usage_api_key,
         update_group,

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -208,6 +208,23 @@ pub struct CreateWalletWithSignatureRequest {
     pub signature: String,
 }
 
+/// ChainSecured usage-key minting. Mirrors `CreateWalletWithSignatureRequest`:
+/// the user proves wallet ownership with an EIP-191 personal_sign signature,
+/// the server mints a usage-key wallet via DStack MPC and returns the secret
+/// (as the usage API key) plus address + derivation path. The client follows
+/// up with on-chain `registerWalletDerivation` and `setUsageApiKey` signed by
+/// their admin wallet — only the admin wallet of a ChainSecured account can
+/// call `setUsageApiKey` (see AppStorage.accountExistsAndIsMutable).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AddUsageApiKeyWithSignatureRequest {
+    /// EIP-191 plaintext message that was signed. Same format as
+    /// `create_wallet_with_signature`: `Address: 0x…`, `Chain ID: <u64>`,
+    /// `Issued At: <unix-seconds>` (case-sensitive prefixes).
+    pub message: String,
+    /// 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign).
+    pub signature: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EncryptRequest {
     pub api_key: String,

--- a/lit-api-server/src/core/v1/models/response.rs
+++ b/lit-api-server/src/core/v1/models/response.rs
@@ -54,6 +54,21 @@ pub struct AddUsageApiKeyResponse {
     pub usage_api_key: String,
 }
 
+/// Returned by `/add_usage_api_key_with_signature`. The client must follow up
+/// with on-chain `registerWalletDerivation(adminHash, wallet_address, derivation_path, name, description)`
+/// and `setUsageApiKey(adminHash, keccak256(usage_api_key), …)` — both signed
+/// by the admin wallet — to attach the usage key to the ChainSecured account.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AddUsageApiKeyWithSignatureResponse {
+    /// Base64-encoded 32-byte secret. Send as `X-Api-Key` / `Authorization: Bearer …` for usage requests; pass `keccak256(this)` to `setUsageApiKey`.
+    pub usage_api_key: String,
+    /// 0x-prefixed lowercase hex EVM address of the minted PKP wallet.
+    pub wallet_address: String,
+    /// 0x-prefixed lowercase hex (uint256). Pass through verbatim to
+    /// `registerWalletDerivation`'s `derivationPath` arg.
+    pub derivation_path: String,
+}
+
 /// Response for account config operations (add_pkp_to_group, remove_pkp_from_group, add_usage_api_key, remove_usage_api_key).
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AccountOpResponse {


### PR DESCRIPTION
## Summary

Adds `POST /core/v1/add_usage_api_key_with_signature`, the ChainSecured counterpart to `/add_usage_api_key`. Mirrors `create_wallet_with_signature` (CPL-281): the user proves wallet ownership with an EIP-191 `personal_sign` over a SIWE-style message; the server mints a usage-key wallet via DStack and returns the secret (base64) plus wallet address + derivation path. The client follows up on-chain with `registerWalletDerivation` and `setUsageApiKey` signed by their admin wallet — only the admin wallet of a ChainSecured account can call `setUsageApiKey` (see `AppStorage.accountExistsAndIsMutable`).

**Endpoint contract:**
- Body: `{ message, signature }` — same SIWE-lite shape (`Address:` / `Chain ID:` / `Issued At:`, ±300 s skew) as `create_wallet_with_signature`
- Response: `{ usage_api_key, wallet_address, derivation_path }`
- No `BilledManagementApiKey` guard — ChainSecured users have no master API key; the wallet signature IS the auth (matches sibling pattern)

**Helper hardening (applied across both ChainSecured endpoints):**
- Extracted `verify_chainsecured_siwe` from inline `create_wallet_with_signature` so both endpoints share the same SIWE verification path
- Renamed `parse_create_wallet_siwe` → `parse_chainsecured_siwe` (and the parsed struct) to reflect dual usage
- Reordered cheap rejects (length cap, parse, chain ID, timestamp window) BEFORE the expensive ECDSA recovery so attacker traffic with stale or wrong-network messages is dropped without doing crypto
- Hard-capped message length at 4 KiB (`MAX_SIWE_MESSAGE_LEN`)
- Reject duplicate `Address:` / `Chain ID:` / `Issued At:` lines (last-wins parsing previously could disagree with what the wallet UI showed the user)
- Updated `SIWE_TIMESTAMP_SKEW_SECONDS` doc comment to describe both consumers and clarify the threat model: returned secret bytes are equivalent to a fresh keypair until the admin attaches them on-chain

**k6 client:** regenerated via `cargo run --bin openapi_spec | npx @grafana/openapi-to-k6 …`. New `addUsageApiKeyWithSignature` method + types appear in `k6/litApiServer.ts`.

**Docs:** `docs/management/api_direct.mdx` updated to document the new endpoint alongside `create_wallet_with_signature` and `convert_to_chain_secured_account` (matches the pattern set by CPL-279).

## Test Coverage

No unit tests added for the SIWE primitives in this PR. Existing precedent (CPL-281's `create_wallet_with_signature`, `parse_create_wallet_siwe`, `recover_eip191_signer`) has 0% direct unit coverage; this PR maintains that stance rather than introducing a new pattern.

AI-assessed coverage on new branches: 0% (5 new code paths: length cap reject, 3 duplicate-line rejects, happy-path mint). Test stubs available for future hardening — see follow-up notes below. Coverage gap accepted in `/review`.

`cargo test --all-features` runs 209 existing tests, 0 failures (pre-existing baseline unchanged by this PR).

## Pre-Landing Review

Ran `/review` with full specialist coverage: testing + maintainability + security + api-contract specialists, Codex adversarial challenge, Claude adversarial subagent. **0 critical findings · 6 informational, all addressed.**

**Auto-fixed:** Stale doc comment above `SIWE_TIMESTAMP_SKEW_SECONDS`.

**User-approved fixes applied (3 — all on the shared helper):**
- Helper rename to drop endpoint-specific naming
- DoS reorder (cheap checks before ECDSA)
- Message hardening (length cap + duplicate-line rejection)

**Skipped → flagged as follow-up tickets (see below):**
- EIP-712 / domain separation between ChainSecured endpoints (architectural; covers all current and future SIWE-gated endpoints)
- Nonce store / per-IP rate limiting on unauthenticated DStack-minting endpoints (architectural)

PR Quality Score: 8.5/10 logged.

## Adversarial Review

Codex flagged some items as `[P1]` (public unbilled key-minting oracle, non-idempotency on connection drop, two-step commit externalized). De-rated to follow-up severity because the threat model is no worse than the existing `create_wallet_with_signature`: returned bytes are unattached on-chain and equivalent to a fresh `LocalWallet::random()` until the admin wallet calls `setUsageApiKey`. The "extra unregistered PKP — compute cost only" model continues to hold; the doc comment now says so accurately.

## TODOS

No items in `TODOS.md` map to this PR's scope.

## Follow-up tickets to file

- **CPL-NEW-1: ChainSecured SIWE → EIP-712 + domain separation.** Three-line plain-English message has no per-endpoint or domain binding; signature for endpoint A can be replayed against endpoint B within ±5 min. Bounded blast radius today (returned bytes are unattached on-chain) but should be hardened. Covers all current and future SIWE-gated endpoints.
- **CPL-NEW-2: Rate limit + nonce store for ChainSecured unauthenticated endpoints.** Both `create_wallet_with_signature` and `add_usage_api_key_with_signature` are unauthenticated and trigger DStack PKP minting per call. No per-IP / per-signer throttle.

Lower-priority follow-ups: precompute `usage_api_key_hash` in response (saves clients a base64-decode + keccak); inline `#[cfg(test)]` for `parse_chainsecured_siwe` + `recover_eip191_signer` round-trip (test stubs ready).

## CI gates verified locally

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` (209 passed, 0 failed)
- [x] Regenerated `k6/litApiServer.ts` matches the freshly-emitted OpenAPI spec byte-for-byte (k6-client-check will pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)