### PR TITLE
feat(CPL-285): allow Stripe billing in ChainSecured mode with SIWE auth

### DIFF
--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -688,7 +688,7 @@ export type BillingStripeConfigDefault = StripeConfigResponse | ErrMessage;
 
 export type BillingBalanceHeaders = {
   /**
-   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
    */
   "X-Api-Key": string;
 };
@@ -697,7 +697,7 @@ export type BillingBalanceDefault = BillingBalanceResponse | ErrMessage;
 
 export type BillingCreatePaymentIntentHeaders = {
   /**
-   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
    */
   "X-Api-Key": string;
 };
@@ -708,7 +708,7 @@ export type BillingCreatePaymentIntentDefault =
 
 export type BillingConfirmPaymentHeaders = {
   /**
-   * Account or usage API key. Alternatively use Authorization: Bearer <key>.
+   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
    */
   "X-Api-Key": string;
 };

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -688,18 +688,18 @@ export type BillingStripeConfigDefault = StripeConfigResponse | ErrMessage;
 
 export type BillingBalanceHeaders = {
   /**
-   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
    */
-  "X-Api-Key": string;
+  "X-Api-Key"?: string;
 };
 
 export type BillingBalanceDefault = BillingBalanceResponse | ErrMessage;
 
 export type BillingCreatePaymentIntentHeaders = {
   /**
-   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
    */
-  "X-Api-Key": string;
+  "X-Api-Key"?: string;
 };
 
 export type BillingCreatePaymentIntentDefault =
@@ -708,9 +708,9 @@ export type BillingCreatePaymentIntentDefault =
 
 export type BillingConfirmPaymentHeaders = {
   /**
-   * Account or usage API key (legacy), OR send X-Wallet-Auth: base64(JSON{message, signature}) for SIWE-style ChainSecured authentication.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
    */
-  "X-Api-Key": string;
+  "X-Api-Key"?: string;
 };
 
 export type BillingConfirmPaymentDefault = AccountOpResponse | ErrMessage;
@@ -2096,7 +2096,7 @@ export class LitApiServerClient {
    * GET /billing/balance — returns the current credit balance for the authenticated user.
    */
   billingBalance(
-    headers: BillingBalanceHeaders,
+    headers?: BillingBalanceHeaders,
     requestParameters?: Params,
   ): {
     response: Response;
@@ -2140,7 +2140,7 @@ export class LitApiServerClient {
    */
   billingCreatePaymentIntent(
     createPaymentIntentRequest: CreatePaymentIntentRequest,
-    headers: BillingCreatePaymentIntentHeaders,
+    headers?: BillingCreatePaymentIntentHeaders,
     requestParameters?: Params,
   ): {
     response: Response;
@@ -2190,7 +2190,7 @@ export class LitApiServerClient {
    */
   billingConfirmPayment(
     confirmPaymentRequest: ConfirmPaymentRequest,
-    headers: BillingConfirmPaymentHeaders,
+    headers?: BillingConfirmPaymentHeaders,
     requestParameters?: Params,
   ): {
     response: Response;

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -743,19 +743,23 @@ pub async fn can_execute_action_and_use_wallet(
     Ok(result)
 }
 
-/// Resolve any API key (master or usage) to the creator wallet address of its parent account.
+/// Resolve any account identity to the admin wallet address of its parent account.
 ///
-/// This is the authoritative wallet address for billing: both master and usage keys resolve
-/// to the same account wallet, ensuring charges hit the correct Stripe customer.
+/// `key_or_hash` accepts either a raw API key (master or usage, hashed via
+/// keccak256 to derive the on-chain account hash) or a precomputed 0x-prefixed
+/// 32-byte hex hash. The hash form is used by ChainSecured callers, whose
+/// on-chain identity is `keccak256(walletAddress)` — there is no raw key to
+/// send. Both master and usage keys resolve to the same account wallet,
+/// ensuring charges hit the correct Stripe customer.
 #[instrument(
     name = "accounts::get_account_wallet_address",
     level = "debug",
     skip_all,
     err
 )]
-pub async fn get_account_wallet_address(api_key: &str) -> Result<String> {
+pub async fn get_account_wallet_address(key_or_hash: &str) -> Result<String> {
     let contract = get_read_only_account_config_contract().await?;
-    let key_hash = api_key_hash(api_key);
+    let key_hash = usage_api_key_to_hash(key_or_hash);
     let wallet_address = contract.get_account_wallet_address(key_hash).call().await?;
     if wallet_address == H160::zero() {
         anyhow::bail!("account has no wallet address");

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -21,7 +21,7 @@ use crate::stripe::StripeState;
 use crate::utils::generate_unique_derivation_path;
 use crate::utils::parse_with_hash::{
     hashed_cid_to_u256, hex_array_to_h160_array, hex_array_to_u256_array, ipfs_cid_to_u256,
-    string_group_id_to_u256,
+    is_precomputed_hash_shape, string_group_id_to_u256,
 };
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
@@ -52,6 +52,30 @@ fn map_contract_error(e: anyhow::Error, context: &str) -> ApiStatus {
     } else {
         ApiStatus::internal_server_error(e, context)
     }
+}
+
+/// Encode a 32-byte secret into the base64 form used for raw API keys, and
+/// reject anything shaped like a precomputed account hash (CPL-285).
+///
+/// Standard base64 of 32 bytes is 44 chars, so the 66-char hash shape is
+/// arithmetically unreachable today. The check is defense-in-depth against a
+/// future format change (e.g. switching to 0x-prefixed hex) that would create a
+/// confused-deputy collision with `usage_api_key_to_hash`. `debug_assert!`
+/// fires in dev/test, the runtime branch returns 500 in release.
+fn encode_api_key_from_secret(secret: &[u8; 32]) -> Result<String, ApiStatus> {
+    let encoded = base64_light::base64_encode_bytes(secret);
+    debug_assert!(
+        !is_precomputed_hash_shape(&encoded),
+        "API key generator produced a value shaped like a precomputed account hash; \
+         this would collide with usage_api_key_to_hash and route to the wrong on-chain account"
+    );
+    if is_precomputed_hash_shape(&encoded) {
+        return Err(ApiStatus::internal_server_error(
+            anyhow::anyhow!("generated api_key matched precomputed-hash shape"),
+            "Internal key generation invariant violated",
+        ));
+    }
+    Ok(encoded)
 }
 
 // Create a new wallet and return the public key, wallet address, and secret.
@@ -85,7 +109,7 @@ pub async fn new_account(
     let email = new_account_request.email.clone().unwrap_or_default();
 
     let (_public_key, wallet_address, secret, derivation_path) = create_new_wallet().await?;
-    let api_key = base64_light::base64_encode_bytes(&secret);
+    let api_key = encode_api_key_from_secret(&secret)?;
 
     if let Err(e) = accounts::new_account(
         signer_pool.clone(),
@@ -173,22 +197,35 @@ pub async fn create_wallet(
 /// extra unregistered PKP (compute cost only).
 const SIWE_TIMESTAMP_SKEW_SECONDS: i64 = 300;
 
-/// Parsed shape of a `create_wallet_with_signature` SIWE message.
+/// Parsed shape of a SIWE-lite message. Each flow that uses these signatures
+/// pins a specific `purpose` value to prevent cross-flow replay (CPL-285).
 struct ParsedCreateWalletSiwe {
     address: H160,
     chain_id: u64,
     issued_at: i64,
+    purpose: String,
 }
 
-/// Parses a `create_wallet_with_signature` message. Required lines (case-sensitive):
+/// Stable purpose tags for each SIWE flow. The signature parser requires a
+/// `Purpose:` line that exactly matches one of these and individual callers
+/// verify the parsed purpose matches their flow — a billing-auth signature
+/// can't be replayed against `/create_wallet_with_signature` and vice versa
+/// (CPL-285 cross-flow replay).
+pub(crate) const SIWE_PURPOSE_BILLING_AUTH: &str = "lit-billing-auth-v1";
+pub(crate) const SIWE_PURPOSE_CREATE_WALLET: &str = "lit-create-wallet-v1";
+pub(crate) const SIWE_PURPOSE_CONVERT_ACCOUNT: &str = "lit-convert-account-v1";
+
+/// Parses a SIWE-lite message. Required lines (case-sensitive):
 ///   `Address: 0x…`
 ///   `Chain ID: <u64>`
 ///   `Issued At: <unix-seconds>`
+///   `Purpose: <purpose-tag>`
 /// Other lines are ignored so callers can include domain/statement framing.
 fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, ApiStatus> {
     let mut address: Option<H160> = None;
     let mut chain_id: Option<u64> = None;
     let mut issued_at: Option<i64> = None;
+    let mut purpose: Option<String> = None;
     for line in message.lines() {
         if let Some(v) = line.strip_prefix("Address:") {
             let trimmed = v.trim();
@@ -219,6 +256,8 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
                     "Issued At line not a unix timestamp",
                 )
             })?);
+        } else if let Some(v) = line.strip_prefix("Purpose:") {
+            purpose = Some(v.trim().to_string());
         }
     }
     Ok(ParsedCreateWalletSiwe {
@@ -240,6 +279,12 @@ fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, Api
                 "Missing Issued At line",
             )
         })?,
+        purpose: purpose.ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("Missing Purpose line"),
+                "Missing Purpose line",
+            )
+        })?,
     })
 }
 
@@ -256,10 +301,90 @@ fn recover_eip191_signer(message: &str, signature_hex: &str) -> Result<H160, Api
         .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))
 }
 
+/// Verify a SIWE-lite message + EIP-191 signature for a specific flow and
+/// return the verified wallet address. Centralises the parse → recover →
+/// purpose → chain-id → timestamp pipeline so the billing-auth guard reuses
+/// the same security envelope as `create_wallet_with_signature` /
+/// `convert_to_chain_secured_account`.
+///
+/// `expected_purpose` MUST be one of the `SIWE_PURPOSE_*` constants. Each
+/// flow pins its own value so a signature minted for one flow cannot be
+/// replayed against another (CPL-285).
+pub(crate) fn verify_siwe_signature(
+    message: &str,
+    signature: &str,
+    expected_purpose: &str,
+) -> Result<H160, ApiStatus> {
+    let parsed = parse_create_wallet_siwe(message)?;
+    if parsed.purpose != expected_purpose {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Purpose mismatch: message says {:?}, this endpoint expects {:?}",
+                parsed.purpose,
+                expected_purpose
+            ),
+            "Purpose mismatch — signature was minted for a different flow",
+        ));
+    }
+    let signer = recover_eip191_signer(message, signature)?;
+    if signer != parsed.address {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Signature does not match claimed address"),
+            "Signature does not match claimed address",
+        ));
+    }
+    let node_config = GLOBAL_NODE_CONFIG
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))
+        .map_err(|e| ApiStatus::internal_server_error(e, "GLOBAL_NODE_CONFIG missing"))?;
+    let expected_chain_id = node_config.chain.info().chain_id;
+    if parsed.chain_id != expected_chain_id {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Chain ID mismatch: message says {}, server is on {}",
+                parsed.chain_id,
+                expected_chain_id
+            ),
+            "Chain ID mismatch",
+        ));
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| {
+            ApiStatus::internal_server_error(
+                anyhow::anyhow!(e),
+                "System clock is before the Unix epoch",
+            )
+        })?
+        .as_secs() as i64;
+    if (now - parsed.issued_at).abs() > SIWE_TIMESTAMP_SKEW_SECONDS {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Issued At {} is outside the ±{}s window from now ({})",
+                parsed.issued_at,
+                SIWE_TIMESTAMP_SKEW_SECONDS,
+                now
+            ),
+            "Signed message timestamp is too old or too far in the future",
+        ));
+    }
+    Ok(parsed.address)
+}
+
 pub async fn create_wallet_with_signature(
     req: Json<CreateWalletWithSignatureRequest>,
 ) -> Result<CreateWalletWithSignatureResponse, ApiStatus> {
     let parsed = parse_create_wallet_siwe(&req.message)?;
+    if parsed.purpose != SIWE_PURPOSE_CREATE_WALLET {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Purpose mismatch: message says {:?}, this endpoint expects {:?}",
+                parsed.purpose,
+                SIWE_PURPOSE_CREATE_WALLET
+            ),
+            "Purpose mismatch — signature was minted for a different flow",
+        ));
+    }
     let signer = recover_eip191_signer(&req.message, &req.signature)?;
     if signer != parsed.address {
         return Err(ApiStatus::bad_request(
@@ -350,6 +475,16 @@ pub async fn convert_to_chain_secured_account(
     }
 
     let parsed = parse_create_wallet_siwe(&req.message)?;
+    if parsed.purpose != SIWE_PURPOSE_CONVERT_ACCOUNT {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Purpose mismatch: message says {:?}, this endpoint expects {:?}",
+                parsed.purpose,
+                SIWE_PURPOSE_CONVERT_ACCOUNT
+            ),
+            "Purpose mismatch — signature was minted for a different flow",
+        ));
+    }
     if parsed.address != claimed_address {
         return Err(ApiStatus::bad_request(
             anyhow::anyhow!("Signed Address does not match new_admin_wallet_address"),
@@ -557,7 +692,7 @@ pub async fn add_usage_api_key(
     )
     .await?;
 
-    let usage_api_key = base64_light::base64_encode_bytes(&secret);
+    let usage_api_key = encode_api_key_from_secret(&secret)?;
 
     accounts::add_usage_api_key(
         signer_pool,
@@ -955,4 +1090,40 @@ pub async fn get_admin_api_payer() -> Result<String, ApiStatus> {
     })?;
     let wallet_address = local_wallet.address();
     Ok(bytes_to_0x_hex(wallet_address.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Base64 of 32 bytes is always 44 chars, so it can never collide with the
+    /// 66-char `0x[hex]{64}` precomputed-hash shape (CPL-285). This test pins
+    /// that property so a future change to the encoding is forced to confront it.
+    #[test]
+    fn encode_api_key_from_secret_never_matches_hash_shape() {
+        // Sample a few representative byte patterns: zeros, all-ones, a hash-like
+        // pattern, and a typical random secret.
+        for secret in &[
+            [0u8; 32],
+            [0xffu8; 32],
+            // hex digits 0-9 a-f then repeated
+            [
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab,
+                0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67,
+                0x89, 0xab, 0xcd, 0xef,
+            ],
+            [
+                0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+                0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x12, 0x34, 0x56, 0x78,
+                0x9a, 0xbc, 0xde, 0xf0,
+            ],
+        ] {
+            let encoded = encode_api_key_from_secret(secret).expect("happy path must succeed");
+            assert_eq!(encoded.len(), 44, "base64 of 32 bytes is always 44 chars");
+            assert!(
+                !crate::utils::parse_with_hash::is_precomputed_hash_shape(&encoded),
+                "encoded API key {encoded:?} unexpectedly matched precomputed-hash shape",
+            );
+        }
+    }
 }

--- a/lit-api-server/src/core/v1/endpoints/billing.rs
+++ b/lit-api-server/src/core/v1/endpoints/billing.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::core::v1::guards::apikey::ApiKey;
+use crate::core::v1::guards::billing_auth::BillingAuth;
 use crate::core::v1::helpers::api_status::{ApiResult, ApiStatus, ErrMessage};
 use crate::core::v1::helpers::open_api_response::OpenApiResponse;
 use crate::core::v1::models::request::{ConfirmPaymentRequest, CreatePaymentIntentRequest};
@@ -63,10 +63,10 @@ pub(super) async fn billing_stripe_config(
 #[openapi(tag = "Billing")]
 #[get("/billing/balance")]
 pub(super) async fn billing_balance(
-    api_key: ApiKey,
+    auth: BillingAuth,
     stripe_state: &State<Option<Arc<StripeState>>>,
 ) -> OpenApiResponse<BillingBalanceResponse, ErrMessage> {
-    let result = billing_balance_impl(api_key.0.as_str(), stripe_state.inner()).await;
+    let result = billing_balance_impl(auth.identity_string(), stripe_state.inner()).await;
     OpenApiResponse {
         response: ApiResult(result).into(),
     }
@@ -103,12 +103,12 @@ async fn billing_balance_impl(
 #[openapi(tag = "Billing")]
 #[post("/billing/create_payment_intent", format = "json", data = "<req>")]
 pub(super) async fn billing_create_payment_intent(
-    api_key: ApiKey,
+    auth: BillingAuth,
     stripe_state: &State<Option<Arc<StripeState>>>,
     req: Json<CreatePaymentIntentRequest>,
 ) -> OpenApiResponse<CreatePaymentIntentResponse, ErrMessage> {
     let result =
-        billing_create_payment_intent_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
+        billing_create_payment_intent_impl(auth.identity_string(), stripe_state.inner(), req).await;
     OpenApiResponse {
         response: ApiResult(result).into(),
     }
@@ -137,11 +137,12 @@ async fn billing_create_payment_intent_impl(
 #[openapi(tag = "Billing")]
 #[post("/billing/confirm_payment", format = "json", data = "<req>")]
 pub(super) async fn billing_confirm_payment(
-    api_key: ApiKey,
+    auth: BillingAuth,
     stripe_state: &State<Option<Arc<StripeState>>>,
     req: Json<ConfirmPaymentRequest>,
 ) -> OpenApiResponse<AccountOpResponse, ErrMessage> {
-    let result = billing_confirm_payment_impl(api_key.0.as_str(), stripe_state.inner(), req).await;
+    let result =
+        billing_confirm_payment_impl(auth.identity_string(), stripe_state.inner(), req).await;
     OpenApiResponse {
         response: ApiResult(result).into(),
     }

--- a/lit-api-server/src/core/v1/guards/billing_auth.rs
+++ b/lit-api-server/src/core/v1/guards/billing_auth.rs
@@ -1,0 +1,189 @@
+//! Request guard for billing endpoints (CPL-285).
+//!
+//! Accepts either form of authentication:
+//!
+//! 1. **API key** (legacy): the existing `Authorization: Bearer <key>` /
+//!    `X-Api-Key: <key>` extraction. Identity = the raw key string, which the
+//!    downstream `stripe::resolve_wallet_address` keccak256-hashes to derive
+//!    the on-chain account.
+//!
+//! 2. **Wallet-signed** (ChainSecured): a SIWE-lite EIP-191 signed message in
+//!    a single header:
+//!      `X-Wallet-Auth: <base64(JSON{message, signature})>`
+//!    The guard verifies the signature using the same security envelope as
+//!    `create_wallet_with_signature` (chain-id match, ±5-minute timestamp
+//!    skew). On success the wallet-derived `keccak256(walletAddress)` hex hash
+//!    is the identity passed to `resolve_wallet_address`.
+//!
+//! This prevents the original CPL-285 weakness where the public wallet hash
+//! alone was a bearer credential — anyone who knew the wallet address could
+//! query balance and spawn PaymentIntents. The signature proves possession of
+//! the wallet's private key.
+
+use ethers::utils::keccak256;
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+use rocket_okapi::Result as RocketOkapiResult;
+use rocket_okapi::r#gen::OpenApiGenerator;
+use rocket_okapi::okapi::openapi3::{Object, Parameter, ParameterValue};
+use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
+use serde::Deserialize;
+
+use crate::core::account_management::{SIWE_PURPOSE_BILLING_AUTH, verify_siwe_signature};
+
+/// Identity proven by an inbound billing request.
+#[derive(Clone, Debug)]
+pub enum BillingAuth {
+    /// Raw API key (master or usage). Hashed by `resolve_wallet_address`.
+    ApiKey(String),
+    /// Successfully verified wallet signature. Carries the wallet-derived
+    /// `keccak256(walletAddress)` hex hash for direct use as the identity
+    /// string passed to `resolve_wallet_address` (no further hashing needed).
+    WalletSigned {
+        wallet_address_hex: String,
+        api_key_hash_hex: String,
+    },
+}
+
+impl BillingAuth {
+    /// String to pass to `stripe::resolve_wallet_address`. For API-key flows
+    /// this is the raw key (gets hashed downstream). For wallet-signed flows
+    /// this is the precomputed `0x{keccak256_hex(walletAddress)}` — the
+    /// `usage_api_key_to_hash` helper detects the precomputed-hash shape and
+    /// uses it directly.
+    pub fn identity_string(&self) -> &str {
+        match self {
+            BillingAuth::ApiKey(k) => k.as_str(),
+            BillingAuth::WalletSigned {
+                api_key_hash_hex, ..
+            } => api_key_hash_hex.as_str(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WalletAuthPayload {
+    message: String,
+    signature: String,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BillingAuth {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<BillingAuth, Self::Error> {
+        // Wallet-signed path takes precedence ONLY when the header parses
+        // cleanly. A malformed X-Wallet-Auth (bad base64, bad JSON) falls
+        // through to the API-key path so a junk-header proxy or stale
+        // localStorage entry doesn't lock out an otherwise-valid API key.
+        // A well-formed but signature-invalid payload IS a 401 — the caller
+        // explicitly claimed wallet identity and we reject it.
+        if let Some(encoded) = request.headers().get_one("X-Wallet-Auth") {
+            let bytes = base64_light::base64_decode(encoded.trim());
+            if !bytes.is_empty()
+                && let Ok(payload) = serde_json::from_slice::<WalletAuthPayload>(&bytes)
+            {
+                match verify_siwe_signature(
+                    &payload.message,
+                    &payload.signature,
+                    SIWE_PURPOSE_BILLING_AUTH,
+                ) {
+                    Ok(wallet) => {
+                        let wallet_hex = format!("0x{:x}", wallet);
+                        let hash = keccak256(wallet.as_bytes());
+                        let api_key_hash_hex = format!("0x{}", hex::encode(hash));
+                        return Outcome::Success(BillingAuth::WalletSigned {
+                            wallet_address_hex: wallet_hex,
+                            api_key_hash_hex,
+                        });
+                    }
+                    Err(_) => return Outcome::Error((Status::Unauthorized, ())),
+                }
+            }
+            // Bad base64 or bad JSON — fall through to the API-key path. We
+            // log a warning so misbehaving clients are visible but don't
+            // block legitimate API-key callers.
+            tracing::warn!(
+                "X-Wallet-Auth header present but unparseable; falling through to API key"
+            );
+        }
+
+        // Legacy API-key path — same logic as `apikey::ApiKey`.
+        let auth = request.headers().get_one("Authorization");
+        if let Some(v) = auth {
+            let v = v.trim();
+            let mut parts = v.split_whitespace();
+            if let (Some(scheme), Some(key_part)) = (parts.next(), parts.next())
+                && scheme.eq_ignore_ascii_case("bearer")
+            {
+                let key = key_part.trim();
+                if !key.is_empty() {
+                    return Outcome::Success(BillingAuth::ApiKey(key.to_string()));
+                }
+            }
+        }
+        if let Some(key) = request.headers().get_one("X-Api-Key") {
+            let key = key.trim();
+            if !key.is_empty() {
+                return Outcome::Success(BillingAuth::ApiKey(key.to_string()));
+            }
+        }
+        Outcome::Error((Status::Unauthorized, ()))
+    }
+}
+
+impl<'r> OpenApiFromRequest<'r> for BillingAuth {
+    fn from_request_input(
+        generator: &mut OpenApiGenerator,
+        _name: String,
+        required: bool,
+    ) -> RocketOkapiResult<RequestHeaderInput> {
+        let schema = generator.json_schema::<String>();
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            name: "X-Api-Key".to_owned(),
+            location: "header".to_owned(),
+            description: Some(
+                "Account or usage API key (legacy), OR send X-Wallet-Auth: \
+                 base64(JSON{message, signature}) for SIWE-style ChainSecured \
+                 authentication."
+                    .to_owned(),
+            ),
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Object::default(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_string_returns_raw_key_for_apikey_variant() {
+        let auth = BillingAuth::ApiKey("my-raw-key".to_string());
+        assert_eq!(auth.identity_string(), "my-raw-key");
+    }
+
+    #[test]
+    fn identity_string_returns_hash_for_walletsigned_variant() {
+        let auth = BillingAuth::WalletSigned {
+            wallet_address_hex: "0x1111111111111111111111111111111111111111".to_string(),
+            api_key_hash_hex: "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+                .to_string(),
+        };
+        assert_eq!(
+            auth.identity_string(),
+            "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        );
+    }
+}

--- a/lit-api-server/src/core/v1/guards/billing_auth.rs
+++ b/lit-api-server/src/core/v1/guards/billing_auth.rs
@@ -8,8 +8,7 @@
 //!    the on-chain account.
 //!
 //! 2. **Wallet-signed** (ChainSecured): a SIWE-lite EIP-191 signed message in
-//!    a single header:
-//!      `X-Wallet-Auth: <base64(JSON{message, signature})>`
+//!    a single header `X-Wallet-Auth: <base64(JSON{message, signature})>`.
 //!    The guard verifies the signature using the same security envelope as
 //!    `create_wallet_with_signature` (chain-id match, ±5-minute timestamp
 //!    skew). On success the wallet-derived `keccak256(walletAddress)` hex hash

--- a/lit-api-server/src/core/v1/guards/billing_auth.rs
+++ b/lit-api-server/src/core/v1/guards/billing_auth.rs
@@ -29,6 +29,7 @@ use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 use serde::Deserialize;
 
 use crate::core::account_management::{SIWE_PURPOSE_BILLING_AUTH, verify_siwe_signature};
+use crate::utils::parse_with_hash::is_precomputed_hash_shape;
 
 /// Identity proven by an inbound billing request.
 #[derive(Clone, Debug)]
@@ -107,7 +108,11 @@ impl<'r> FromRequest<'r> for BillingAuth {
             );
         }
 
-        // Legacy API-key path — same logic as `apikey::ApiKey`.
+        // Legacy API-key path — same logic as `apikey::ApiKey`. Reject any
+        // string shaped like a precomputed account hash here — those must
+        // come through the verified WalletSigned path only. Otherwise an
+        // attacker could send `X-Api-Key: 0x{keccak256(walletAddress)}` and
+        // bypass SIWE entirely (CPL-285 hardening).
         let auth = request.headers().get_one("Authorization");
         if let Some(v) = auth {
             let v = v.trim();
@@ -117,6 +122,13 @@ impl<'r> FromRequest<'r> for BillingAuth {
             {
                 let key = key_part.trim();
                 if !key.is_empty() {
+                    if is_precomputed_hash_shape(key) {
+                        tracing::warn!(
+                            "rejecting Authorization Bearer that looks like a precomputed account hash; \
+                             ChainSecured callers must use X-Wallet-Auth"
+                        );
+                        return Outcome::Error((Status::Unauthorized, ()));
+                    }
                     return Outcome::Success(BillingAuth::ApiKey(key.to_string()));
                 }
             }
@@ -124,6 +136,13 @@ impl<'r> FromRequest<'r> for BillingAuth {
         if let Some(key) = request.headers().get_one("X-Api-Key") {
             let key = key.trim();
             if !key.is_empty() {
+                if is_precomputed_hash_shape(key) {
+                    tracing::warn!(
+                        "rejecting X-Api-Key that looks like a precomputed account hash; \
+                         ChainSecured callers must use X-Wallet-Auth"
+                    );
+                    return Outcome::Error((Status::Unauthorized, ()));
+                }
                 return Outcome::Success(BillingAuth::ApiKey(key.to_string()));
             }
         }
@@ -135,19 +154,31 @@ impl<'r> OpenApiFromRequest<'r> for BillingAuth {
     fn from_request_input(
         generator: &mut OpenApiGenerator,
         _name: String,
-        required: bool,
+        _required: bool,
     ) -> RocketOkapiResult<RequestHeaderInput> {
+        // BillingAuth accepts EITHER X-Api-Key OR X-Wallet-Auth — neither is
+        // strictly required on its own. rocket_okapi 0.9 only supports
+        // emitting one Parameter per guard, so we mark X-Api-Key as
+        // optional and document the X-Wallet-Auth alternative in the
+        // description. This prevents codegen (k6/openapi-to-k6) from
+        // declaring `X-Api-Key: string` as a required field on
+        // ChainSecured callers who never send it (CPL-285 review feedback).
         let schema = generator.json_schema::<String>();
         Ok(RequestHeaderInput::Parameter(Parameter {
             name: "X-Api-Key".to_owned(),
             location: "header".to_owned(),
             description: Some(
-                "Account or usage API key (legacy), OR send X-Wallet-Auth: \
-                 base64(JSON{message, signature}) for SIWE-style ChainSecured \
-                 authentication."
+                "API-mode auth: account or usage API key (alternatively \
+                 `Authorization: Bearer <key>`). OR — for ChainSecured \
+                 callers — omit X-Api-Key entirely and send \
+                 `X-Wallet-Auth: <base64(JSON{message, signature})>` where \
+                 the message is a SIWE-lite EIP-191 payload with a \
+                 `Purpose: lit-billing-auth-v1` line. The signature proves \
+                 wallet possession; the signed message must include \
+                 Address, Chain ID, and Issued At within ±5 minutes."
                     .to_owned(),
             ),
-            required,
+            required: false,
             deprecated: false,
             allow_empty_value: false,
             value: ParameterValue::Schema {
@@ -184,5 +215,21 @@ mod tests {
             auth.identity_string(),
             "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         );
+    }
+
+    /// CPL-285: a public wallet hash sent in `X-Api-Key` would have bypassed
+    /// SIWE entirely after `usage_api_key_to_hash` started accepting the
+    /// precomputed-hash form. The shape check is what blocks it. This test
+    /// pins that decision so a future refactor can't silently undo it.
+    #[test]
+    fn precomputed_hash_strings_are_recognized() {
+        // A 0x-prefixed 66-char keccak hash must be detectable. The actual
+        // rejection happens in FromRequest::from_request, but the building
+        // block is is_precomputed_hash_shape — verify it discriminates.
+        let wallet_hash = "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        assert!(is_precomputed_hash_shape(wallet_hash));
+        // A real base64 API key (44 chars, base64 alphabet) does not match.
+        let api_key = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5";
+        assert!(!is_precomputed_hash_shape(api_key));
     }
 }

--- a/lit-api-server/src/core/v1/guards/mod.rs
+++ b/lit-api-server/src/core/v1/guards/mod.rs
@@ -1,3 +1,4 @@
 pub mod apikey;
 pub mod billing;
+pub mod billing_auth;
 pub mod cpu_overload;

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -195,13 +195,17 @@ async fn stripe_post_with_idempotency(
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-/// Compute a non-sensitive cache key from a raw API key string.
+/// Compute a non-sensitive cache key from an account identity string.
 ///
-/// Uses the same keccak256 hash that the contract uses, so no secret material
-/// is held in the cache's key set.  Avoids leaking raw API keys via memory
-/// dumps, debug tooling, or telemetry.
-fn cache_key(api_key: &str) -> String {
-    crate::utils::parse_with_hash::api_key_hash(api_key).to_string()
+/// Accepts either a raw API key (hashed via keccak256) or a precomputed
+/// 0x-prefixed 32-byte hex hash (used by ChainSecured callers, whose on-chain
+/// identity is `keccak256(walletAddress)`). Both forms collapse to the same
+/// U256 cache key, so a raw key and its hash share a cache entry.
+///
+/// Using the hash means no secret material is held in the cache's key set —
+/// avoids leaking raw API keys via memory dumps, debug tooling, or telemetry.
+fn cache_key(key_or_hash: &str) -> String {
+    crate::utils::parse_with_hash::usage_api_key_to_hash(key_or_hash).to_string()
 }
 
 /// Remove an API key from the wallet address cache.
@@ -211,13 +215,16 @@ pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
     state.wallet_cache.invalidate(&cache_key(api_key)).await;
 }
 
-/// Resolve any API key (master or usage) to the account's creator wallet address.
+/// Resolve any account identity to its admin wallet address.
 ///
-/// Uses the on-chain `allApiKeyHashesToMaster` mapping so that usage API keys
-/// resolve to the same wallet (and therefore same Stripe customer) as their
-/// parent account key.  Results are cached for 1 hour.
+/// Accepts a raw API key (master or usage) or — for ChainSecured callers — a
+/// precomputed 0x-prefixed 32-byte hex hash (the wallet-derived
+/// `keccak256(walletAddress)`). Uses the on-chain `allApiKeyHashesToMaster`
+/// mapping so that usage API keys resolve to the same wallet (and therefore
+/// same Stripe customer) as their parent account key. Results are cached for
+/// 1 hour.
 ///
-/// The cache is keyed by the keccak256 hash of the API key (not the raw key)
+/// The cache is keyed by the keccak256 hash of the input (not the raw key)
 /// to avoid holding secret material in memory.
 #[instrument(name = "stripe::resolve_wallet_address", skip_all, err)]
 pub async fn resolve_wallet_address(api_key: &str, state: &StripeState) -> Result<String> {
@@ -1007,6 +1014,17 @@ mod tests {
     #[test]
     fn cache_key_different_inputs() {
         assert_ne!(cache_key("key-a"), cache_key("key-b"));
+    }
+
+    #[test]
+    fn cache_key_accepts_precomputed_hash() {
+        // ChainSecured callers send the wallet-derived hash directly. A raw key
+        // and its keccak256 hex form must collapse to the same cache key — and
+        // therefore resolve to the same on-chain account / Stripe customer.
+        use crate::utils::parse_with_hash::api_key_hash;
+        let raw = "test-api-key";
+        let hash_hex = format!("0x{:064x}", api_key_hash(raw));
+        assert_eq!(cache_key(raw), cache_key(&hash_hex));
     }
     // ── Balance cache merge logic ────────────────────────────────────────────
 

--- a/lit-api-server/src/utils/parse_with_hash.rs
+++ b/lit-api-server/src/utils/parse_with_hash.rs
@@ -9,15 +9,32 @@ pub fn api_key_hash(api_key_base_64: &str) -> U256 {
     U256::from_big_endian(&keccak256(api_key_base_64.as_bytes()))
 }
 
+/// True when `s` is shaped like a precomputed 32-byte keccak256 hash:
+/// lowercase 0x-prefixed, exactly 66 chars, body all hex. (`hex_to_bytes`
+/// does not accept the uppercase `0X` prefix, so we don't either — the prior
+/// `|| starts_with("0X")` clause was dead code.)
+///
+/// `usage_api_key_to_hash` interprets these strings as already-hashed identities
+/// instead of raw API keys (CPL-285). Any raw API key that happened to match
+/// this shape would silently route to the wrong on-chain account, so issuance
+/// rejects keys of this shape — see `core::account_management::new_account`.
+pub fn is_precomputed_hash_shape(s: &str) -> bool {
+    let trimmed = s.trim();
+    if !(trimmed.starts_with("0x") && trimmed.len() == 66) {
+        return false;
+    }
+    matches!(hex_to_bytes(trimmed), Ok(bytes) if bytes.len() == 32)
+}
+
 /// Hash a usage API key string, OR pass through a pre-computed keccak256 hash.
-/// If `s` is a 0x-prefixed 66-character hex string (32 bytes), it is treated as
-/// an already-computed hash and parsed directly. Otherwise it is keccak256-hashed.
+/// If `s` is a lowercase 0x-prefixed 66-character hex string (32 bytes), it is
+/// treated as an already-computed hash and parsed directly. Otherwise it is
+/// keccak256-hashed. `s.trim()` removes surrounding whitespace.
 pub fn usage_api_key_to_hash(s: &str) -> U256 {
     let trimmed = s.trim();
-    if ((trimmed.starts_with("0x") || trimmed.starts_with("0X")) && trimmed.len() == 66)
-        && let Ok(bytes) = hex_to_bytes(trimmed)
-        && bytes.len() == 32
-    {
+    if is_precomputed_hash_shape(trimmed) {
+        // `is_precomputed_hash_shape` already validated 32-byte hex.
+        let bytes = hex_to_bytes(trimmed).expect("validated above");
         return U256::from_big_endian(&bytes);
     }
     api_key_hash(trimmed)
@@ -198,6 +215,63 @@ mod tests {
         // A short 0x string is not a precomputed hash; it should be keccak256-hashed.
         let result = usage_api_key_to_hash("0xabcd");
         assert_eq!(result, api_key_hash("0xabcd"));
+    }
+
+    // ── is_precomputed_hash_shape (CPL-285) ─────────────────────────────
+    #[test]
+    fn is_precomputed_hash_shape_accepts_canonical_hash() {
+        assert!(is_precomputed_hash_shape(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        ));
+        assert!(is_precomputed_hash_shape(
+            "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        ));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_uppercase_prefix() {
+        // `hex_to_bytes` doesn't accept `0X`, so neither do we.
+        assert!(!is_precomputed_hash_shape(
+            "0X0000000000000000000000000000000000000000000000000000000000000001"
+        ));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_short_strings() {
+        assert!(!is_precomputed_hash_shape("0xabcd"));
+        assert!(!is_precomputed_hash_shape("0x"));
+        assert!(!is_precomputed_hash_shape(""));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_long_strings() {
+        // 67 chars — one too many.
+        assert!(!is_precomputed_hash_shape(
+            "0x00000000000000000000000000000000000000000000000000000000000000010"
+        ));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_no_prefix() {
+        // 64 hex chars without 0x — would have to be exactly 66 with prefix.
+        assert!(!is_precomputed_hash_shape(
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        ));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_non_hex_body() {
+        // 66 chars, 0x prefix, but body has a non-hex char.
+        assert!(!is_precomputed_hash_shape(
+            "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+        ));
+    }
+
+    #[test]
+    fn is_precomputed_hash_shape_rejects_typical_base64_api_key() {
+        // Base64 of 32 random bytes is 44 chars — never matches.
+        let synthetic_api_key = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5";
+        assert!(!is_precomputed_hash_shape(synthetic_api_key));
     }
 
     // ── parse_u256 (via string_to_hashed_u256 / hashed_cid_to_u256) ────

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -294,7 +294,11 @@ async function parseResponse(res, context) {
     const message = bodyMessage
       ? `${context}: ${bodyMessage}`
       : `${context}: ${res.status} ${res.statusText}`;
-    throw new Error(message);
+    const err = new Error(message);
+    // Surface the HTTP status so callers can react to auth failures (401/400)
+    // distinctly from network/5xx without parsing the message string.
+    err.status = res.status;
+    throw err;
   }
   try {
     return text ? JSON.parse(text) : null;
@@ -639,7 +643,9 @@ export class LitNodeSimpleApiClient {
     }
     const issuedAt = Math.floor(Date.now() / 1000);
     const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';
-    const message = `${host} wants you to take admin ownership of this account.\n\nAddress: ${newAdminAddress}\nChain ID: ${targetChainId}\nIssued At: ${issuedAt}`;
+    // Purpose pins this signature to the convert-account flow only — prevents
+    // cross-flow replay against /create_wallet_with_signature or /billing/* (CPL-285).
+    const message = `${host} wants you to take admin ownership of this account.\n\nAddress: ${newAdminAddress}\nChain ID: ${targetChainId}\nIssued At: ${issuedAt}\nPurpose: lit-convert-account-v1`;
     const signature = await signer.signMessage(message);
     const res = await fetch(`${this.baseUrl}/convert_to_chain_secured_account`, {
       method: 'POST',
@@ -785,7 +791,9 @@ export class LitNodeSimpleApiClient {
       const signerAddress = await this.signer.getAddress();
       const issuedAt = Math.floor(Date.now() / 1000);
       const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';
-      const message = `${host} wants you to create a new wallet for ChainSecured account.\n\nAddress: ${signerAddress}\nChain ID: ${this.chainId}\nIssued At: ${issuedAt}`;
+      // Purpose pins this signature to the create-wallet flow only — prevents
+      // cross-flow replay against /convert_to_chain_secured_account or /billing/* (CPL-285).
+      const message = `${host} wants you to create a new wallet for ChainSecured account.\n\nAddress: ${signerAddress}\nChain ID: ${this.chainId}\nIssued At: ${issuedAt}\nPurpose: lit-create-wallet-v1`;
       const signature = await this.signer.signMessage(message);
       const res = await fetch(`${this.baseUrl}/create_wallet_with_signature`, {
         method: 'POST',
@@ -1564,13 +1572,17 @@ export class LitNodeSimpleApiClient {
 
   /**
    * GET /core/v1/billing/balance
-   * Returns the current credit balance for the authenticated API key.
-   * @param {string} apiKey
+   * Returns the current credit balance for the authenticated user.
+   * @param {string} apiKey - Raw API key. Ignored when `options.walletAuthHeader` is set.
+   * @param {{walletAuthHeader?: string, signal?: AbortSignal}} [options]
+   *   walletAuthHeader: base64(JSON{message, signature}) for SIWE-style ChainSecured auth (CPL-285).
+   *   signal: AbortController signal to cancel the request mid-flight.
    * @returns {Promise<{balance_cents: number, balance_display: string}>}
    */
-  async getBillingBalance(apiKey) {
+  async getBillingBalance(apiKey, options = {}) {
     const res = await fetch(`${this.baseUrl}/billing/balance`, {
-      headers: headersWithApiKey(apiKey),
+      headers: billingHeaders(apiKey, options.walletAuthHeader),
+      signal: options.signal,
     });
     return parseResponse(res, 'billing/balance');
   }
@@ -1578,15 +1590,17 @@ export class LitNodeSimpleApiClient {
   /**
    * POST /core/v1/billing/create_payment_intent
    * Creates a Stripe PaymentIntent; returns client_secret and payment_intent_id.
-   * @param {string} apiKey
+   * @param {string} apiKey - Ignored when `options.walletAuthHeader` is set.
    * @param {number} amountCents - Amount in US cents (minimum 500)
+   * @param {{walletAuthHeader?: string, signal?: AbortSignal}} [options]
    * @returns {Promise<{client_secret: string, payment_intent_id: string}>}
    */
-  async createPaymentIntent(apiKey, amountCents) {
+  async createPaymentIntent(apiKey, amountCents, options = {}) {
     const res = await fetch(`${this.baseUrl}/billing/create_payment_intent`, {
       method: 'POST',
-      headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+      headers: billingHeaders(apiKey, options.walletAuthHeader, { 'Content-Type': 'application/json' }),
       body: JSON.stringify({ amount_cents: amountCents }),
+      signal: options.signal,
     });
     return parseResponse(res, 'billing/create_payment_intent');
   }
@@ -1594,18 +1608,33 @@ export class LitNodeSimpleApiClient {
   /**
    * POST /core/v1/billing/confirm_payment
    * Verifies a succeeded PaymentIntent and credits the account.
-   * @param {string} apiKey
+   * @param {string} apiKey - Ignored when `options.walletAuthHeader` is set.
    * @param {string} paymentIntentId
+   * @param {{walletAuthHeader?: string, signal?: AbortSignal}} [options]
    * @returns {Promise<void>}
    */
-  async confirmPayment(apiKey, paymentIntentId) {
+  async confirmPayment(apiKey, paymentIntentId, options = {}) {
     const res = await fetch(`${this.baseUrl}/billing/confirm_payment`, {
       method: 'POST',
-      headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
+      headers: billingHeaders(apiKey, options.walletAuthHeader, { 'Content-Type': 'application/json' }),
       body: JSON.stringify({ payment_intent_id: paymentIntentId }),
+      signal: options.signal,
     });
     return parseResponse(res, 'billing/confirm_payment');
   }
+}
+
+/**
+ * Build headers for billing endpoints. ChainSecured callers send an
+ * X-Wallet-Auth header (base64(JSON{message, signature})); API-mode callers
+ * send X-Api-Key. The server's BillingAuth guard prefers the wallet header
+ * when both are present (CPL-285).
+ */
+function billingHeaders(apiKey, walletAuthHeader, extra = {}) {
+  if (walletAuthHeader) {
+    return { 'X-Wallet-Auth': walletAuthHeader, ...extra };
+  }
+  return { 'X-Api-Key': apiKey, ...extra };
 }
 
 /**

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -154,7 +154,12 @@ Lit Actions by pasting a usage API key they minted from the contract.
 Billing (balance, Add Funds, no-funds warning, billing banners) is **not**
 mode-conditional. Stripe credit funds action runs in both modes. ChainSecured
 only changes how admin writes are authorized (wallet vs API key), not how
-runs are paid for.
+runs are paid for. ChainSecured users authenticate billing requests via a
+SIWE-style EIP-191 signed message (cached ~4 minutes per session) sent in
+the `X-Wallet-Auth` header — the dashboard's `getWalletAuthHeader()` builds
+the message and `BillingAuth` verifies it server-side. The signature pins
+the `Purpose: lit-billing-auth-v1` line to prevent cross-flow replay
+against `/create_wallet_with_signature` or `/convert_to_chain_secured_account`.
 
 Validation guards must use `isAuthenticated()`, not `!apiKey` — ChainSecured
 users authenticate via wallet and have no account-level api key.

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -56,7 +56,11 @@ export function getApiKey() {
 export function setApiKey(v) {
   if (v) sessionStorage.setItem(STORAGE_KEY_API, v);
   else sessionStorage.removeItem(STORAGE_KEY_API);
-  import('./billing.js').then((m) => m.resetBillingAvailability()).catch(() => {});
+  import('./billing.js').then((m) => {
+    m.resetBillingAvailability();
+    // Abort any in-flight billing requests under the prior identity (CPL-285).
+    if (typeof m.clearBillingSession === 'function') m.clearBillingSession();
+  }).catch(() => {});
   updateAuthUI();
 }
 
@@ -89,6 +93,10 @@ export async function setChainSecuredSession({ walletAddress, apiKeyHash }) {
 export function clearChainSecuredSession() {
   sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_WALLET);
   sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_HASH);
+  // Abort any in-flight billing requests under the prior wallet (CPL-285).
+  import('./billing.js').then((m) => {
+    if (typeof m.clearBillingSession === 'function') m.clearBillingSession();
+  }).catch(() => {});
   resetClient();
 }
 
@@ -113,6 +121,11 @@ export function logOut() {
   sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_WALLET);
   sessionStorage.removeItem(STORAGE_KEY_CHAINSECURED_HASH);
   clearOverrideState();
+  // Abort any in-flight billing requests under the prior identity (CPL-285).
+  import('./billing.js').then((m) => {
+    m.resetBillingAvailability();
+    if (typeof m.clearBillingSession === 'function') m.clearBillingSession();
+  }).catch(() => {});
   resetClient();
   updateAuthUI();
 }

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -1,8 +1,27 @@
 /**
  * Billing — Stripe integration, payment flow.
+ *
+ * ChainSecured callers (CPL-285) authenticate to /billing/* with a SIWE-lite
+ * EIP-191 signed message proving they hold the wallet's private key. The
+ * signed payload is cached for ~4 minutes (server allows ±5min skew, we leave
+ * a buffer) so the user only sees one wallet popup per billing session.
+ *
+ * All in-flight billing requests are tied to a module AbortController and a
+ * captured-credential snapshot — `clearBillingSession()` is called on logout
+ * or wallet switch and aborts pending fetches; every post-await branch
+ * re-checks `billingAuthKey() === captured` before mutating UI or calling
+ * Stripe.confirmCardPayment so a mid-flight session change can never credit
+ * the prior account.
  */
 
-import { getApiKey, getClient, hasUsageKeyOverride } from './auth.js';
+import {
+  getApiKey,
+  getChainSecuredHash,
+  getChainSecuredWallet,
+  getClient,
+  getMode,
+  hasUsageKeyOverride,
+} from './auth.js';
 import { formatError, logError } from './ui-utils.js';
 
 let _stripe = null;
@@ -12,6 +31,66 @@ let _billingAvailable = null;
 let _billingCheckedAt = 0;
 let _billingRetryTimer = null;
 const BILLING_RETRY_MS = 30000;
+
+// AbortController for in-flight billing fetches. Recreated lazily; aborted on
+// session change via clearBillingSession().
+let _abortController = null;
+
+// Cached SIWE auth payload. Re-used across billing requests within the
+// timestamp window. { headerValue, expiresAtMs, walletAddress }
+let _walletAuthCache = null;
+
+// Server's SIWE_TIMESTAMP_SKEW_SECONDS is 300; we cache for 4 min to leave a
+// 1-min safety buffer against clock skew + in-flight latency.
+const WALLET_AUTH_TTL_MS = 4 * 60 * 1000;
+
+/**
+ * Mode-branched (NOT a `||` fallback): a stale `STORAGE_KEY_API` left over
+ * from a previous API login must not be sent in sovereign mode (CPL-285).
+ */
+function billingAuthKey() {
+  return getMode() === 'sovereign' ? getChainSecuredHash() : getApiKey();
+}
+
+function ensureAbortController() {
+  if (!_abortController || _abortController.signal.aborted) {
+    _abortController = new AbortController();
+  }
+  return _abortController;
+}
+
+/**
+ * Abort any in-flight billing requests and clear the cached SIWE auth
+ * payload. Called on logout, mode switch, and wallet change so a mid-flight
+ * fetch can't credit the prior account.
+ */
+export function clearBillingSession() {
+  if (_abortController) {
+    _abortController.abort();
+    _abortController = null;
+  }
+  _walletAuthCache = null;
+}
+
+/**
+ * Evict the cached wallet-auth payload so the next billing request prompts a
+ * fresh signature. Only call from error handlers when the failure was an auth
+ * rejection — never on transient network/5xx, where evicting would force the
+ * user through a wallet popup on every retry (signature-prompt fatigue,
+ * phishing-overlay surface).
+ */
+function evictWalletAuthCache() {
+  _walletAuthCache = null;
+}
+
+/**
+ * True when an SDK error came from the server actually rejecting the
+ * credential — not a network blip, 5xx, or a Stripe.js failure. The SDK
+ * stamps `err.status` on Error objects from `parseResponse` (CPL-285).
+ */
+function isAuthError(e) {
+  return !!(e && (e.status === 401 || e.status === 400));
+}
 
 export async function checkBillingAvailable() {
   if (_billingAvailable === true) return true;
@@ -35,8 +114,78 @@ export function resetBillingAvailability() {
   if (_billingRetryTimer) { clearTimeout(_billingRetryTimer); _billingRetryTimer = null; }
 }
 
+/**
+ * Build the SIWE-lite message body the server's `parse_create_wallet_siwe`
+ * expects. Required lines (case-sensitive): `Address:`, `Chain ID:`,
+ * `Issued At:`, `Purpose:`. The `Purpose` line pins this signature to the
+ * billing-auth flow only — prevents cross-flow replay against
+ * /create_wallet_with_signature or /convert_to_chain_secured_account (CPL-285).
+ */
+function buildSiweMessage(wallet, chainId, issuedAt) {
+  const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit-dashboard';
+  return [
+    `${host} wants you to sign in to billing.`,
+    '',
+    'This signature lets the dashboard authenticate billing requests on your',
+    "behalf for ~5 minutes. It is not a transaction and won't be broadcast.",
+    '',
+    `Address: ${wallet}`,
+    `Chain ID: ${chainId}`,
+    `Issued At: ${issuedAt}`,
+    'Purpose: lit-billing-auth-v1',
+  ].join('\n');
+}
+
+/**
+ * Get a cached SIWE auth header, or prompt the wallet to sign a fresh one.
+ * Returns base64(JSON{message, signature}) for the X-Wallet-Auth header.
+ */
+async function getWalletAuthHeader() {
+  const wallet = getChainSecuredWallet();
+  if (!wallet) {
+    throw new Error('No connected ChainSecured wallet — sign in first.');
+  }
+  const cachedFor = _walletAuthCache && _walletAuthCache.walletAddress;
+  if (cachedFor && cachedFor.toLowerCase() === wallet.toLowerCase()
+      && _walletAuthCache.expiresAtMs > Date.now() + 10_000) {
+    return _walletAuthCache.headerValue;
+  }
+
+  const client = await getClient();
+  const chainIdNum = client.chainId != null
+    ? Number(client.chainId)
+    : Number((await client.getNodeChainConfig()).chain_id);
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const message = buildSiweMessage(wallet, chainIdNum, issuedAt);
+
+  const { connectEoa } = await import('../../wallet_connect.js');
+  const { signer } = await connectEoa();
+  const signature = await signer.signMessage(message);
+
+  const headerValue = btoa(JSON.stringify({ message, signature }));
+  _walletAuthCache = {
+    headerValue,
+    expiresAtMs: Date.now() + WALLET_AUTH_TTL_MS,
+    walletAddress: wallet,
+  };
+  return headerValue;
+}
+
+/**
+ * Resolve the SDK options for the current mode: { walletAuthHeader?, signal }.
+ * In API mode we just attach the abort signal; in sovereign mode we also
+ * obtain the SIWE header (prompting the wallet on cache miss).
+ */
+async function billingRequestOptions(signal) {
+  const opts = { signal };
+  if (getMode() === 'sovereign') {
+    opts.walletAuthHeader = await getWalletAuthHeader();
+  }
+  return opts;
+}
+
 export function refreshBillingUI() {
-  const capturedKey = getApiKey();
+  const capturedKey = billingAuthKey();
   const balanceEl = document.getElementById('billing-balance-display');
   const addFundsBtn = document.getElementById('btn-add-funds');
   const notRequiredEl = document.getElementById('billing-not-required');
@@ -51,13 +200,20 @@ export function refreshBillingUI() {
     return;
   }
   checkBillingAvailable().then((available) => {
-    if (getApiKey() !== capturedKey) return;
+    if (billingAuthKey() !== capturedKey) return;
     if (available) {
       if (balanceEl) balanceEl.style.display = '';
       if (addFundsBtn) addFundsBtn.style.display = '';
       if (notRequiredEl) notRequiredEl.style.display = 'none';
       if (billingBanner) billingBanner.style.display = 'none';
-      loadBillingBalance();
+      // Don't auto-trigger a wallet popup just to render the balance — the
+      // ChainSecured user signs once when they explicitly click Add Funds.
+      // Display "—" until they do.
+      if (getMode() === 'sovereign' && balanceEl && !balanceEl.textContent) {
+        balanceEl.textContent = '—';
+      } else {
+        loadBillingBalance();
+      }
     } else {
       if (balanceEl) balanceEl.style.display = 'none';
       if (addFundsBtn) addFundsBtn.style.display = 'none';
@@ -74,23 +230,32 @@ export function refreshBillingUI() {
 }
 
 async function loadBillingBalance() {
-  const apiKey = getApiKey();
+  const apiKey = billingAuthKey();
   if (!apiKey) return;
   const el = document.getElementById('billing-balance-display');
   if (!el) return;
   const noFundsWarning = document.getElementById('no-funds-warning');
+  const ctrl = ensureAbortController();
   try {
     const client = await getClient();
-    const data = await client.getBillingBalance(apiKey);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const opts = await billingRequestOptions(ctrl.signal);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+    const data = await client.getBillingBalance(apiKey, opts);
+    if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
     el.textContent = data.balance_display || '';
     if (noFundsWarning) {
       const hasNoFunds = typeof data.balance_cents === 'number' && data.balance_cents >= 0;
       noFundsWarning.style.display = hasNoFunds ? '' : 'none';
     }
   } catch (e) {
+    if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
+    if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
     logError('loadBillingBalance', e);
-    el.textContent = 'Balance unavailable';
-    if (noFundsWarning) noFundsWarning.style.display = 'none';
+    if (billingAuthKey() === apiKey) {
+      el.textContent = 'Balance unavailable';
+      if (noFundsWarning) noFundsWarning.style.display = 'none';
+    }
   }
 }
 
@@ -151,7 +316,7 @@ export function initBilling() {
 
   if (payBtn) {
     payBtn.addEventListener('click', async () => {
-      const apiKey = getApiKey();
+      const apiKey = billingAuthKey();
       if (!apiKey || !_stripe || !_stripeCard) return;
 
       const amountInput = document.getElementById('billing-amount');
@@ -171,10 +336,20 @@ export function initBilling() {
       payBtn.disabled = true;
       if (statusEl) { statusEl.style.display = 'none'; }
 
+      const ctrl = ensureAbortController();
       let intentId = null;
       try {
         const client = await getClient();
-        const intent = await client.createPaymentIntent(apiKey, amountCents);
+        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+        const opts = await billingRequestOptions(ctrl.signal);
+        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+        const intent = await client.createPaymentIntent(apiKey, amountCents, opts);
+        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) {
+          // Auth changed after intent was created — log but don't proceed.
+          // The PaymentIntent will simply expire unconfirmed.
+          logError('payment', new Error('session changed mid-flight, dropping intent'), { intentId: intent.payment_intent_id });
+          return;
+        }
         intentId = intent.payment_intent_id;
 
         const result = await _stripe.confirmCardPayment(intent.client_secret, {
@@ -185,9 +360,24 @@ export function initBilling() {
           throw new Error(result.error.message);
         }
 
+        if (billingAuthKey() !== apiKey || ctrl.signal.aborted) {
+          // Card was charged, but the session changed before we could call
+          // confirmPayment. The funds are reserved on the original wallet's
+          // Stripe customer; surface the intent ID for manual reconciliation.
+          if (statusEl) {
+            statusEl.textContent = 'Payment processed — session changed before crediting. Reference: ' + intent.payment_intent_id;
+            statusEl.className = 'status info';
+            statusEl.style.display = 'block';
+          }
+          return;
+        }
+
         // Separate try for confirmPayment — card is already charged at this point
         try {
-          await client.confirmPayment(apiKey, intent.payment_intent_id);
+          // Re-fetch options in case the cached SIWE expired during Stripe.js round-trip.
+          const opts2 = await billingRequestOptions(ctrl.signal);
+          if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
+          await client.confirmPayment(apiKey, intent.payment_intent_id, opts2);
         } catch (confirmErr) {
           logError('confirmPayment', confirmErr, { intentId });
           if (statusEl) {
@@ -203,8 +393,10 @@ export function initBilling() {
         closeBillingModal();
         await loadBillingBalance();
       } catch (e) {
+        if (e && (e.name === 'AbortError' || ctrl.signal.aborted)) return;
+        if (getMode() === 'sovereign' && isAuthError(e)) evictWalletAuthCache();
         logError('payment', e, { intentId });
-        if (statusEl) {
+        if (statusEl && billingAuthKey() === apiKey) {
           statusEl.textContent = 'Payment failed: ' + formatError(e);
           statusEl.className = 'status error';
           statusEl.style.display = 'block';
@@ -215,4 +407,3 @@ export function initBilling() {
     });
   }
 }
-

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -40,6 +40,19 @@ let _abortController = null;
 // timestamp window. { headerValue, expiresAtMs, walletAddress }
 let _walletAuthCache = null;
 
+/**
+ * True when we have a valid (unexpired, current-wallet) SIWE auth header.
+ * Used to decide whether to load the balance silently vs. wait for the user
+ * to click Add Funds — we never want to auto-trigger a wallet popup just to
+ * render the topbar balance (CPL-285 review feedback).
+ */
+function hasValidWalletAuthCache() {
+  if (!_walletAuthCache) return false;
+  const wallet = getChainSecuredWallet();
+  if (!wallet || _walletAuthCache.walletAddress.toLowerCase() !== wallet.toLowerCase()) return false;
+  return _walletAuthCache.expiresAtMs > Date.now() + 10_000;
+}
+
 // Server's SIWE_TIMESTAMP_SKEW_SECONDS is 300; we cache for 4 min to leave a
 // 1-min safety buffer against clock skew + in-flight latency.
 const WALLET_AUTH_TTL_MS = 4 * 60 * 1000;
@@ -206,11 +219,17 @@ export function refreshBillingUI() {
       if (addFundsBtn) addFundsBtn.style.display = '';
       if (notRequiredEl) notRequiredEl.style.display = 'none';
       if (billingBanner) billingBanner.style.display = 'none';
-      // Don't auto-trigger a wallet popup just to render the balance — the
-      // ChainSecured user signs once when they explicitly click Add Funds.
-      // Display "—" until they do.
-      if (getMode() === 'sovereign' && balanceEl && !balanceEl.textContent) {
-        balanceEl.textContent = '—';
+      // In sovereign mode never auto-trigger a wallet popup just to render
+      // the topbar balance. Only load the balance when we already hold a
+      // valid SIWE cache (e.g. immediately after the user funded). Otherwise
+      // the user explicitly opts in by clicking Add Funds — `openAddFundsModal`
+      // primes the auth and refreshes the balance after a successful payment.
+      if (getMode() === 'sovereign') {
+        if (hasValidWalletAuthCache()) {
+          loadBillingBalance();
+        } else if (balanceEl && !balanceEl.textContent) {
+          balanceEl.textContent = '—';
+        }
       } else {
         loadBillingBalance();
       }
@@ -289,6 +308,32 @@ async function openAddFundsModal() {
       }
       return;
     }
+  }
+
+  // Sovereign mode: prime the SIWE cache now (one wallet popup) so the
+  // user's later Pay click — and the balance refresh that follows — flows
+  // without a second prompt. If they cancel the signature, surface that in
+  // the modal status and leave the modal open so they can retry.
+  if (getMode() === 'sovereign' && !hasValidWalletAuthCache()) {
+    if (statusEl) {
+      statusEl.textContent = 'Approve the wallet signature to enable billing for this session…';
+      statusEl.className = 'status info';
+      statusEl.style.display = 'block';
+    }
+    try {
+      await getWalletAuthHeader();
+      if (statusEl) statusEl.style.display = 'none';
+    } catch (e) {
+      logError('siwe-prime', e);
+      if (statusEl) {
+        statusEl.textContent = 'Wallet signature required to fund a ChainSecured account: ' + formatError(e);
+        statusEl.className = 'status error';
+        statusEl.style.display = 'block';
+      }
+      return;
+    }
+    // Now that we have a valid cache, surface the actual balance.
+    loadBillingBalance();
   }
 
   if (payBtn) payBtn.disabled = false;


### PR DESCRIPTION
## Summary

Restores the **Add Funds** button for ChainSecured (sovereign-mode) accounts and closes the trust-boundary gap that the wallet-hash-as-bearer approach would otherwise leave open.

**Server**
- New `BillingAuth` request guard on `/billing/*` endpoints accepts either an API key (legacy) or a SIWE-style EIP-191 signed message via `X-Wallet-Auth: <base64(JSON{message, signature})>`. The signature proves the caller holds the wallet's private key.
- `accounts::get_account_wallet_address` and `stripe::cache_key` now flow through `usage_api_key_to_hash` so a 0x-prefixed 32-byte hex hash passes through unhashed. Both forms collapse to the same on-chain account / Stripe customer.
- New `SIWE_PURPOSE_*` tags pin each signature flow (`lit-billing-auth-v1`, `lit-create-wallet-v1`, `lit-convert-account-v1`). Cross-flow replay is now blocked: a billing signature can't be replayed against `/create_wallet_with_signature` and vice versa.
- API key issuance rejects values shaped like `0x[hex]{64}` so a future format change can't collide with the precomputed-hash detection.
- A malformed `X-Wallet-Auth` header now falls through to the API-key path (junk proxies, stale storage); only verified-but-rejected signatures return 401.

**Frontend**
- Mode-branched billing auth (no `||` fallback) so a stale `STORAGE_KEY_API` from a prior session can never override the wallet hash.
- SIWE prompt cached for ~4 minutes (server allows ±5min) so users sign once per billing session.
- AbortController on logout / wallet-switch aborts in-flight billing fetches.
- Post-await re-checks across `loadBillingBalance` and the pay flow.
- Cache eviction only on HTTP 401/400 — network/5xx don't trigger signature-prompt fatigue.

## Tests

206 unit tests passing (was 197 before this branch). New coverage:
- `is_precomputed_hash_shape` — 7 tests covering canonical hash, prefix variants, length, hex body, base64 collision space.
- `cache_key_accepts_precomputed_hash` — proves raw key + its keccak hex collapse to the same cache entry.
- `BillingAuth::identity_string` — both variants.
- `encode_api_key_from_secret_never_matches_hash_shape` — invariant test for the issuance guard.

## Pre-Landing Review

Two cross-model adversarial passes (Claude subagent + Codex) ran against this diff. Findings addressed:
- **CRITICAL** — anonymous wallet-hash-as-bearer credential → fixed by SIWE requirement on `BillingAuth`.
- **HIGH** — confused deputy (API key shaped like a hash) → fixed by `encode_api_key_from_secret` rejection at issuance.
- **HIGH** — cross-flow signature replay between billing-auth, create-wallet, convert-account → fixed by `Purpose:` line pinning per flow.
- **HIGH** — mixed-mode session (stale API key wins over wallet hash) → fixed by mode-branched `billingAuthKey()`.
- **MEDIUM** — malformed `X-Wallet-Auth` locks out API-key callers → fixed by graceful fall-through.
- **MEDIUM** — over-aggressive cache eviction → fixed by limiting eviction to HTTP 401/400.
- **MEDIUM** — mid-flight session race → fixed by AbortController + post-await re-checks.

## Coverage

~75% AI-assessed coverage. Documented gaps (user accepted):
- `verify_siwe_signature` end-to-end — covered transitively by the existing production `create_wallet_with_signature` and `convert_to_chain_secured_account` flows that share the same parser/recovery pipeline.
- Rocket endpoint integration tests — no existing test infrastructure in the repo for HTTP-level tests.
- Frontend SIWE flow — no JS test framework configured.

## Manual QA recommended before merge

The frontend SIWE flow has no automated test. Please verify in a browser:
1. ChainSecured user clicks **Add Funds** → wallet popup with SIWE message → sign → modal opens.
2. Same user clicks **Add Funds** again within ~4 minutes → no second wallet popup (cached signature).
3. After 5+ minutes → second wallet popup (cache expired or server rejected).
4. API-mode user adds funds → no wallet popup (regression check, X-Api-Key path).
5. API-mode → click **ChainSecured wallet login** without logging out → next billing call uses wallet hash, not stale API key.
6. Logout mid-payment → in-flight fetch aborts cleanly; payment_intent_id surfaced for reconciliation if Stripe charge succeeded.

## TODOS

No TODOS.md items completed in this PR.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 206 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `k6/litApiServer.ts` regenerated to match OpenAPI
- [ ] Browser dogfood of SIWE flow (see Manual QA above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)