### PR TITLE
feat(CPL-288): show single login card via auth-mode toggle

### DIFF
--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -113,10 +113,11 @@ Radii:
 
 - Single card visible at a time. The "Authentication mode" pill toggle above
   the "I would like to" tabs picks API mode vs ChainSecured mode; only the
-  matching card is rendered (CSS gates `.login-card-api` and
-  `.login-card-chainsecured` on `body.login-mode-chainsecured`). The choice
-  persists via `setMode()`/sessionStorage so it survives a tab refresh and
-  matches the dashboard's post-login mode.
+  matching card is shown (CSS gates `.login-card-api` and
+  `.login-card-chainsecured` on `body.login-mode-chainsecured` via
+  `display: none`; both cards stay in the DOM). The choice persists via
+  `setMode()`/sessionStorage so it survives a tab refresh and matches the
+  dashboard's post-login mode.
 - API mode card carries the `RECOMMENDED` badge (filled primary) — primary path.
 - ChainSecured card carries the `WALLET REQUIRED` badge (muted, neutral fill)
   to set expectation.

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -111,15 +111,18 @@ Radii:
 
 ### Login mode cards
 
-- Side-by-side on desktop, stacked on mobile.
+- Single card visible at a time. The "Authentication mode" pill toggle above
+  the "I would like to" tabs picks API mode vs ChainSecured mode; only the
+  matching card is rendered (CSS gates `.login-card-api` and
+  `.login-card-chainsecured` on `body.login-mode-chainsecured`). The choice
+  persists via `setMode()`/sessionStorage so it survives a tab refresh and
+  matches the dashboard's post-login mode.
 - API mode card carries the `RECOMMENDED` badge (filled primary) — primary path.
 - ChainSecured card carries the `WALLET REQUIRED` badge (muted, neutral fill)
   to set expectation.
-- Neither card has a default highlight; both start with the same neutral
-  `--border` ring. Hover or focus-within either card → that card gets the
-  primary ring while the sibling stays neutral. The badges carry which is
-  recommended vs which requires a wallet, so the highlight follows intent
-  instead of pre-selecting one.
+- The visible card uses a neutral `--border` ring; hover or focus-within
+  promotes it to the primary ring. The badges carry which is recommended vs
+  which requires a wallet.
 - Each card's CTA (Log in / Create account / Connect wallet / Connect wallet
   & create) shares the same shape (full-width, btn-block padding) but its
   color follows the card's selected state: neutral outlined at rest, primary

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -614,6 +614,30 @@ export function initLogin() {
 
   ensureWalletWatch();
 
+  // CPL-288 — Auth mode toggle (API vs ChainSecured). Drives which login card
+  // is visible via `body.login-mode-chainsecured` (CSS in styles.css). Persists
+  // through setMode() so the same sessionStorage-backed mode the dashboard uses
+  // post-login is also primed before login.
+  const authModeApi = document.getElementById('login-auth-mode-api');
+  const authModeChainSecured = document.getElementById('login-auth-mode-chainsecured');
+  function applyLoginAuthMode(mode) {
+    const isSovereign = mode === 'sovereign';
+    setMode(isSovereign ? 'sovereign' : 'api');
+    document.body.classList.toggle('login-mode-chainsecured', isSovereign);
+    if (authModeApi) {
+      authModeApi.classList.toggle('is-active', !isSovereign);
+      authModeApi.setAttribute('aria-pressed', !isSovereign ? 'true' : 'false');
+    }
+    if (authModeChainSecured) {
+      authModeChainSecured.classList.toggle('is-active', isSovereign);
+      authModeChainSecured.setAttribute('aria-pressed', isSovereign ? 'true' : 'false');
+    }
+    hideStatus('login-status');
+  }
+  authModeApi?.addEventListener('click', () => applyLoginAuthMode('api'));
+  authModeChainSecured?.addEventListener('click', () => applyLoginAuthMode('sovereign'));
+  applyLoginAuthMode(getMode());
+
   const tabExisting = document.getElementById('login-tab-existing');
   const tabNew = document.getElementById('login-tab-new');
   const panelExisting = document.getElementById('login-panel-existing');

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -617,25 +617,37 @@ export function initLogin() {
   // CPL-288 — Auth mode toggle (API vs ChainSecured). Drives which login card
   // is visible via `body.login-mode-chainsecured` (CSS in styles.css). Persists
   // through setMode() so the same sessionStorage-backed mode the dashboard uses
-  // post-login is also primed before login.
+  // post-login is also primed before login. Implements the WAI-ARIA radiogroup
+  // pattern: roving tabindex (only the checked radio is tabbable) + arrow-key
+  // navigation that selects-on-move.
   const authModeApi = document.getElementById('login-auth-mode-api');
   const authModeChainSecured = document.getElementById('login-auth-mode-chainsecured');
-  function applyLoginAuthMode(mode) {
+  function applyLoginAuthMode(mode, focusActive = false) {
     const isSovereign = mode === 'sovereign';
     setMode(isSovereign ? 'sovereign' : 'api');
     document.body.classList.toggle('login-mode-chainsecured', isSovereign);
     if (authModeApi) {
       authModeApi.classList.toggle('is-active', !isSovereign);
-      authModeApi.setAttribute('aria-pressed', !isSovereign ? 'true' : 'false');
+      authModeApi.setAttribute('aria-checked', !isSovereign ? 'true' : 'false');
+      authModeApi.setAttribute('tabindex', !isSovereign ? '0' : '-1');
     }
     if (authModeChainSecured) {
       authModeChainSecured.classList.toggle('is-active', isSovereign);
-      authModeChainSecured.setAttribute('aria-pressed', isSovereign ? 'true' : 'false');
+      authModeChainSecured.setAttribute('aria-checked', isSovereign ? 'true' : 'false');
+      authModeChainSecured.setAttribute('tabindex', isSovereign ? '0' : '-1');
     }
+    if (focusActive) (isSovereign ? authModeChainSecured : authModeApi)?.focus();
     hideStatus('login-status');
   }
   authModeApi?.addEventListener('click', () => applyLoginAuthMode('api'));
   authModeChainSecured?.addEventListener('click', () => applyLoginAuthMode('sovereign'));
+  function onAuthModeKey(e) {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
+    e.preventDefault();
+    applyLoginAuthMode(getMode() === 'sovereign' ? 'api' : 'sovereign', true);
+  }
+  authModeApi?.addEventListener('keydown', onAuthModeKey);
+  authModeChainSecured?.addEventListener('keydown', onAuthModeKey);
   applyLoginAuthMode(getMode());
 
   const tabExisting = document.getElementById('login-tab-existing');

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -21,12 +21,12 @@
         <div id="login-status" class="status info" style="display: none;"></div>
         <div class="login-mode">
           <span class="login-mode-label" id="login-auth-mode-label">Authentication mode:</span>
-          <div class="login-tabs" role="group" aria-labelledby="login-auth-mode-label">
-            <button type="button" class="login-tab is-active" id="login-auth-mode-api" aria-pressed="true" data-auth-mode="api">
+          <div class="login-tabs" role="radiogroup" aria-labelledby="login-auth-mode-label">
+            <button type="button" class="login-tab is-active" role="radio" id="login-auth-mode-api" aria-checked="true" data-auth-mode="api">
               <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
               <span>API mode</span>
             </button>
-            <button type="button" class="login-tab" id="login-auth-mode-chainsecured" aria-pressed="false" data-auth-mode="sovereign">
+            <button type="button" class="login-tab" role="radio" id="login-auth-mode-chainsecured" aria-checked="false" data-auth-mode="sovereign">
               <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
               <span>ChainSecured mode</span>
             </button>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -20,6 +20,19 @@
         <p class="login-subtitle">Sign in to manage your account, or create a new one to get started.</p>
         <div id="login-status" class="status info" style="display: none;"></div>
         <div class="login-mode">
+          <span class="login-mode-label" id="login-auth-mode-label">Authentication mode:</span>
+          <div class="login-tabs" role="group" aria-labelledby="login-auth-mode-label">
+            <button type="button" class="login-tab is-active" id="login-auth-mode-api" aria-pressed="true" data-auth-mode="api">
+              <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>API mode</span>
+            </button>
+            <button type="button" class="login-tab" id="login-auth-mode-chainsecured" aria-pressed="false" data-auth-mode="sovereign">
+              <svg class="login-tab-check" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>ChainSecured mode</span>
+            </button>
+          </div>
+        </div>
+        <div class="login-mode">
           <span class="login-mode-label" id="login-mode-label">I would like to:</span>
           <div class="login-tabs" role="tablist" aria-labelledby="login-mode-label">
             <button type="button" class="login-tab is-active" role="tab" id="login-tab-existing" aria-selected="true" aria-controls="login-panel-existing" data-tab="existing">
@@ -34,7 +47,7 @@
         </div>
         <div id="login-panel-existing" class="login-tab-panel is-active" role="tabpanel" aria-labelledby="login-tab-existing">
           <div class="login-cards">
-            <div class="login-card login-card-recommended">
+            <div class="login-card login-card-recommended login-card-api">
               <span class="login-card-recommended-badge">Recommended</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></div>
               <h3 class="login-card-title">API mode</h3>
@@ -46,7 +59,7 @@
               </div>
               <button type="button" id="btn-login" class="btn btn-primary btn-block">Log in</button>
             </div>
-            <div class="login-card">
+            <div class="login-card login-card-chainsecured">
               <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
               <h3 class="login-card-title">ChainSecured mode <button type="button" class="login-card-help" aria-label="What is ChainSecured? Your wallet is the key. Writes are signed on-chain — no API key shared." data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</button></h3>
@@ -58,7 +71,7 @@
         </div>
         <div id="login-panel-new" class="login-tab-panel" role="tabpanel" aria-labelledby="login-tab-new" hidden>
           <div class="login-cards">
-            <div class="login-card login-card-recommended">
+            <div class="login-card login-card-recommended login-card-api">
               <span class="login-card-recommended-badge">Recommended</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-3 3"/><path d="m18 5 3 3"/></svg></div>
               <h3 class="login-card-title">API mode</h3>
@@ -78,7 +91,7 @@
               </div>
               <button type="button" id="btn-create-account" class="btn btn-primary btn-block">Create account</button>
             </div>
-            <div class="login-card">
+            <div class="login-card login-card-chainsecured">
               <span class="login-card-required-badge">Wallet required</span>
               <div class="login-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></div>
               <h3 class="login-card-title">ChainSecured mode <button type="button" class="login-card-help" aria-label="What is ChainSecured? Your wallet is the key. Writes are signed on-chain — no API key shared." data-tooltip="Your wallet is the key. Writes are signed on-chain — no API key shared.">?</button></h3>

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -113,8 +113,10 @@ select:focus-visible {
 
 .login-cards {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 1.5rem;
+  max-width: 460px;
+  margin: 0 auto;
 }
 
 .login-cards > .login-card {
@@ -128,10 +130,12 @@ select:focus-visible {
   flex-direction: column;
 }
 
-@media (max-width: 640px) {
-  .login-cards {
-    grid-template-columns: 1fr;
-  }
+/* CPL-288 — Single-card login: the auth-mode toggle (API mode / ChainSecured)
+   shows exactly one card at a time. body class set in initLogin() via
+   getMode(); 'api' is the default. */
+body:not(.login-mode-chainsecured) .login-card-chainsecured,
+body.login-mode-chainsecured .login-card-api {
+  display: none;
 }
 
 .login-title {


### PR DESCRIPTION
## Summary

[CPL-288](https://linear.app/litprotocol/issue/CPL-288/uiux-chainsecured-vs-api) — Replace the side-by-side API/ChainSecured cards on the dashboard login screen with a pill toggle that swaps between them.

**Changes**
- `lit-static/dapps/dashboard/index.html` — added the "Authentication mode" toggle row above the existing "I would like to" tabs; tagged each of the four cards with `login-card-api` or `login-card-chainsecured`.
- `lit-static/dapps/dashboard/styles.css` — `.login-cards` is now a single-column grid (`max-width: 460px`, centered). Two CSS rules hide the non-matching card based on `body.login-mode-chainsecured`.
- `lit-static/dapps/dashboard/auth.js` — in `initLogin()`, wired the toggle: clicks call `setMode('api'|'sovereign')`, toggle the body class, and update `is-active` / `aria-pressed`. On load, syncs from `getMode()` so the choice survives a tab refresh and matches the dashboard's post-login mode.
- `lit-static/dapps/dashboard/DESIGN.md` — updated the "Login mode cards" section to describe the single-card behavior.

The existing per-button `setMode()` calls in the click handlers (`btn-login`, `btn-login-wallet`, `btn-create-account`, `btn-create-chainsecured`) are unchanged and act as a defensive sync — the toggle has already set the mode, so they're effectively no-ops on the happy path.

## Pre-Landing Review

Clean. 0 critical, 1 informational (FOUC on hard-refresh for users with a stored ChainSecured preference) intentionally skipped — matches the existing `is-chainsecured` / `has-api-key` body-class pattern, which doesn't preflight either. One paint frame at most, only affects users who previously selected ChainSecured.

Verified the non-obvious paths:
- `convertToChainSecured` (`auth.js:880`) calls `location.reload()` after `setMode('sovereign')`, so on next paint `initLogin()` re-syncs the body class.
- `logOut()` doesn't reload but doesn't change mode either, so toggle/body-class state stays consistent with `getMode()`.
- `loginWithWallet` and `createChainSecuredAccount` revert mode to `prevMode` on failure. With the new toggle, `prevMode` is already `'sovereign'` (set by the toggle click), so the revert is a no-op — not a regression, the user's intent is now stickier.
- ChainSecured card is hidden by CSS unless toggle is active, so users cannot reach `btn-login-wallet` or `btn-create-chainsecured` while in API mode.

## Test plan

- [ ] On first load with no prior mode in sessionStorage, API toggle is active and only the API card shows in both Sign in and Create account tabs.
- [ ] Click ChainSecured toggle. Body gets `login-mode-chainsecured`, both tabs swap to the ChainSecured card.
- [ ] Click API toggle again — back to API card.
- [ ] Hard-refresh the page after selecting ChainSecured. Toggle returns in ChainSecured state and the right card is visible (briefly possible to see API card on first paint, expected).
- [ ] Sign in via API key → land on dashboard. Sign out → login screen shows API card again.
- [ ] Click ChainSecured toggle → connect wallet → land on dashboard. Sign out → login screen shows ChainSecured card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)