### PR TITLE
feat(CPL-286): migrate ChainSecured signature envelope to EIP-712

### DIFF
--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -146,11 +146,12 @@ const apiKeyHash = ethers.solidityPackedKeccak256(
 const exists = await client.accountExistsByHash(apiKeyHash);
 ```
 
-PKP minting in ChainSecured mode uses a SIWE-style message that the server
-verifies before deriving key material via the TEE; the client then
-registers the derivation path on-chain in a second wallet-signed tx. Once
-the signer is connected and the address-derived `adminHashOverride` is set
-on the client (the dashboard does this automatically at login),
+PKP minting in ChainSecured mode uses an EIP-712 typed-data signature
+(`primaryType: "CreateWallet"`) that the server verifies before deriving
+key material via the TEE; the client then registers the derivation path
+on-chain in a second wallet-signed tx. Once the signer is connected and
+the address-derived `adminHashOverride` is set on the client (the
+dashboard does this automatically at login),
 `createWallet({ name, description })` does both steps for you — no
 account-level `apiKey` is required in ChainSecured mode.
 
@@ -226,20 +227,24 @@ the server's api\_payer signs the on-chain conversion on their behalf.
 3. **Connect the wallet** that will become the new admin (EOA, Safe, or
    any contract account on Base). The dashboard prompts a chain switch if
    your wallet isn't on the chain reported by `GET /get_node_chain_config`.
-4. **Sign the SIWE-style ownership-transfer message.** The dashboard
-   composes:
+4. **Sign the EIP-712 ownership-transfer typed data.** The dashboard
+   composes a typed-data envelope with `primaryType: "ConvertAccount"` —
+   wallet UIs surface it as a labelled struct (`address`, `issuedAt`)
+   under the `Lit ChainSecured` domain rather than a free-form message:
+   ```json
+   {
+     "primaryType": "ConvertAccount",
+     "domain":  { "name": "Lit ChainSecured", "version": "1", "chainId": "<chain id>" },
+     "message": { "address":  "<new admin address>", "issuedAt": "<unix seconds>" }
+   }
    ```
-   <host> wants you to take admin ownership of this account.
-
-   Address: <new admin address>
-   Chain ID: <chain id>
-   Issued At: <unix seconds>
-   ```
-   Your wallet produces an EIP-191 `personal_sign` signature.
+   Your wallet produces an EIP-712 signature (`eth_signTypedData_v4`).
 5. The dashboard `POST`s `/core/v1/convert_to_chain_secured_account` with
-   `{ new_admin_wallet_address, message, signature }` and your existing
-   API key in the header. The server verifies the address matches the
-   recovered signer, the chain ID matches the node, and the `Issued At`
+   `{ new_admin_wallet_address, typed_data, signature }` and your existing
+   API key in the header. The server verifies the typed-data digest
+   recovers to the new admin address, the `chainId` matches the node,
+   the `primaryType` matches `ConvertAccount` (preventing cross-flow
+   replay against the secret-emitting endpoints), and the `issuedAt`
    timestamp is within ±300 seconds, then has the api\_payer submit the
    on-chain conversion.
 6. On success, the dashboard switches mode to `sovereign`, clears the
@@ -259,7 +264,7 @@ const client = createClient('https://api.chipotle.litprotocol.com');
 const provider = new ethers.BrowserProvider(window.ethereum);
 const signer = await provider.getSigner();
 
-// Look up the chain id the server expects so the SIWE message matches.
+// Look up the chain id the server expects so the EIP-712 domain matches.
 const cfg = await client.getNodeChainConfig();
 
 const res = await client.convertToChainSecuredAccount({

--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -224,21 +224,39 @@ the server's api\_payer signs the on-chain conversion on their behalf.
    key.
 2. Open the account dropdown and click **Convert to ChainSecured**.
    Confirm the irreversible-action prompt.
-3. **Connect the wallet** that will become the new admin (EOA, Safe, or
-   any contract account on Base). The dashboard prompts a chain switch if
-   your wallet isn't on the chain reported by `GET /get_node_chain_config`.
+3. **Connect the wallet** that will become the new admin. **EOA only —
+   the server verifies the EIP-712 signature via plain ECDSA `recover()`
+   and does not yet validate ERC-1271 contract-account signatures**, so
+   Safes and other contract wallets are not supported in this flow today.
+   The dashboard prompts a chain switch if your wallet isn't on the chain
+   reported by `GET /get_node_chain_config`.
 4. **Sign the EIP-712 ownership-transfer typed data.** The dashboard
    composes a typed-data envelope with `primaryType: "ConvertAccount"` —
    wallet UIs surface it as a labelled struct (`address`, `issuedAt`)
-   under the `Lit ChainSecured` domain rather than a free-form message:
+   under the `Lit ChainSecured` domain rather than a free-form message.
+   The full canonical envelope is:
    ```json
    {
+     "types": {
+       "EIP712Domain": [
+         { "name": "name",    "type": "string"  },
+         { "name": "version", "type": "string"  },
+         { "name": "chainId", "type": "uint256" }
+       ],
+       "ConvertAccount": [
+         { "name": "address",  "type": "address" },
+         { "name": "issuedAt", "type": "uint256" }
+       ]
+     },
      "primaryType": "ConvertAccount",
      "domain":  { "name": "Lit ChainSecured", "version": "1", "chainId": "<chain id>" },
      "message": { "address":  "<new admin address>", "issuedAt": "<unix seconds>" }
    }
    ```
-   Your wallet produces an EIP-712 signature (`eth_signTypedData_v4`).
+   `types` is part of the EIP-712 type hash and the server schema
+   validator rejects payloads where it differs by even one field —
+   field declaration order matters. Your wallet produces an EIP-712
+   signature (`eth_signTypedData_v4`).
 5. The dashboard `POST`s `/core/v1/convert_to_chain_secured_account` with
    `{ new_admin_wallet_address, typed_data, signature }` and your existing
    API key in the header. The server verifies the typed-data digest

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -284,28 +284,56 @@ Execute a lit-action by sending JavaScript code and optional params. Use a usage
 
 Three HTTP endpoints back the ChainSecured (sovereign) flow. They sit alongside the on-chain writes — see [API mode vs ChainSecured mode](/management/account_modes) for the full SDK-side workflow and when to choose each mode.
 
-All three (and the billing-auth header described above) share the same SIWE-lite envelope. The `message` must contain four case-sensitive lines, each appearing exactly once: `Address: 0x…`, `Chain ID: <u64>`, `Issued At: <unix-seconds>`, and a `Purpose: <tag>` line that pins the signature to a specific flow. The purpose tag prevents cross-flow replay — a signature minted for one endpoint is rejected by every other endpoint. Other lines (domain, statement) are ignored. Messages longer than 4 KiB are rejected.
+All three (and the billing-auth header described above) share the same EIP-712 typed-data envelope. The wallet UI displays a labelled struct — `address` and `issuedAt` fields under a stable `(name: "Lit ChainSecured", version: "1", chainId)` domain — so users can see exactly what they're signing. The `primaryType` pins the signature to a specific flow and is part of the EIP-712 type hash, so a signature minted for one endpoint is rejected by every other endpoint at the digest level. Typed-data payloads longer than 4 KiB (serialised JSON) are rejected.
 
-| Endpoint | `Purpose:` value |
+| Endpoint | `primaryType` |
 |----------|------------------|
-| `/create_wallet_with_signature` | `lit-create-wallet-v1` |
-| `/convert_to_chain_secured_account` | `lit-convert-account-v1` |
-| `/add_usage_api_key_with_signature` | `lit-add-usage-api-key-v1` |
-| `X-Wallet-Auth` billing header | `lit-billing-auth-v1` |
+| `/create_wallet_with_signature` | `CreateWallet` |
+| `/convert_to_chain_secured_account` | `ConvertAccount` |
+| `/add_usage_api_key_with_signature` | `AddUsageApiKey` |
+| `X-Wallet-Auth` billing header | `BillingAuth` |
 
-The server enforces a ±5-minute window on `Issued At` as the only replay protection — no nonce store. Worst-case replay on the unauthenticated mint endpoints just produces an extra unattached PKP (compute cost only — see each endpoint below for specifics).
+The canonical typed-data shape (must match exactly — field declaration order is part of the EIP-712 type hash):
+
+```json
+{
+  "types": {
+    "EIP712Domain": [
+      { "name": "name",    "type": "string"  },
+      { "name": "version", "type": "string"  },
+      { "name": "chainId", "type": "uint256" }
+    ],
+    "<primaryType>": [
+      { "name": "address",  "type": "address" },
+      { "name": "issuedAt", "type": "uint256" }
+    ]
+  },
+  "primaryType": "<primaryType>",
+  "domain": {
+    "name": "Lit ChainSecured",
+    "version": "1",
+    "chainId": "8453"
+  },
+  "message": {
+    "address":  "0x…",
+    "issuedAt": "<unix-seconds>"
+  }
+}
+```
+
+The server enforces a ±5-minute window on `issuedAt` as the only replay protection — no nonce store. Worst-case replay on the unauthenticated mint endpoints just produces an extra unattached PKP (compute cost only — see each endpoint below for specifics).
 
 #### `POST /create_wallet_with_signature`
 
 Mints a PKP via DStack MPC after verifying a wallet-ownership signature. Used by `createWallet` in ChainSecured mode; the response is then passed to the on-chain `registerWalletDerivation` call (signed by the same wallet) to register the PKP to the account.
 
-No API key required. `Purpose:` line must be `lit-create-wallet-v1`.
+No API key required. `primaryType` must be `CreateWallet`.
 
 **Request body:**
 
 ```json
 {
-  "message": "<EIP-191 plaintext>",
+  "typed_data": { /* canonical EIP-712 typed data with primaryType: "CreateWallet" */ },
   "signature": "0x<65-byte hex>"
 }
 ```
@@ -324,21 +352,39 @@ Pass `derivation_path` verbatim into `registerWalletDerivation(adminHash, wallet
 ```bash
 curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/create_wallet_with_signature" \
   -H "Content-Type: application/json" \
-  -d '{"message":"chipotle.dev wants you to create a new wallet for ChainSecured account.\n\nAddress: 0xabc...\nChain ID: 8453\nIssued At: 1745798400\nPurpose: lit-create-wallet-v1","signature":"0x..."}'
+  -d '{
+    "typed_data": {
+      "types": {
+        "EIP712Domain": [
+          {"name":"name","type":"string"},
+          {"name":"version","type":"string"},
+          {"name":"chainId","type":"uint256"}
+        ],
+        "CreateWallet": [
+          {"name":"address","type":"address"},
+          {"name":"issuedAt","type":"uint256"}
+        ]
+      },
+      "primaryType": "CreateWallet",
+      "domain": {"name":"Lit ChainSecured","version":"1","chainId":"8453"},
+      "message": {"address":"0xabc...","issuedAt":"1745798400"}
+    },
+    "signature": "0x..."
+  }'
 ```
 
 #### `POST /convert_to_chain_secured_account`
 
 Flips a managed (API-mode) account to ChainSecured (unmanaged) in a single on-chain transaction. The account's `apiKeyHash` is preserved — groups, PKPs, action metadata, and usage API keys (everything keyed by `apiKeyHash` on-chain) stay attached. Only the admin wallet and the `managed` flag change on-chain. **Billing should be re-verified after conversion:** Stripe credits are associated with the Stripe customer resolved from the current admin wallet address, so a credit balance is not guaranteed to carry over automatically when the admin wallet changes. There is no reverse path.
 
-Requires the existing master API key (sent via `X-Api-Key` or `Authorization: Bearer`, per the auth header conventions above). The server's api\_payer signs the on-chain conversion after verifying the EIP-191 signature; the new admin must sign a SIWE-style message with `Purpose: lit-convert-account-v1`.
+Requires the existing master API key (sent via `X-Api-Key` or `Authorization: Bearer`, per the auth header conventions above). The server's api\_payer signs the on-chain conversion after verifying the wallet signature; the new admin must sign EIP-712 typed data with `primaryType: "ConvertAccount"`.
 
 **Request body:**
 
 ```json
 {
   "new_admin_wallet_address": "0x...",
-  "message": "<EIP-191 plaintext>",
+  "typed_data": { /* primaryType: "ConvertAccount" */ },
   "signature": "0x..."
 }
 ```
@@ -347,7 +393,26 @@ Requires the existing master API key (sent via `X-Api-Key` or `Authorization: Be
 curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/convert_to_chain_secured_account" \
   -H "Content-Type: application/json" \
   -H "X-Api-Key: KEY" \
-  -d '{"new_admin_wallet_address":"0xabc...","message":"chipotle.dev wants you to take admin ownership of this account.\n\nAddress: 0xabc...\nChain ID: 8453\nIssued At: 1745798400\nPurpose: lit-convert-account-v1","signature":"0x..."}'
+  -d '{
+    "new_admin_wallet_address":"0xabc...",
+    "typed_data": {
+      "types": {
+        "EIP712Domain": [
+          {"name":"name","type":"string"},
+          {"name":"version","type":"string"},
+          {"name":"chainId","type":"uint256"}
+        ],
+        "ConvertAccount": [
+          {"name":"address","type":"address"},
+          {"name":"issuedAt","type":"uint256"}
+        ]
+      },
+      "primaryType": "ConvertAccount",
+      "domain": {"name":"Lit ChainSecured","version":"1","chainId":"8453"},
+      "message": {"address":"0xabc...","issuedAt":"1745798400"}
+    },
+    "signature":"0x..."
+  }'
 ```
 
 See [API mode vs ChainSecured mode → Converting an API account to ChainSecured](/management/account_modes#converting-an-api-account-to-chainsecured) for the dashboard flow, the SDK wrapper (`client.convertToChainSecuredAccount`), and the post-conversion verification checklist.
@@ -356,13 +421,13 @@ See [API mode vs ChainSecured mode → Converting an API account to ChainSecured
 
 The ChainSecured counterpart to `/add_usage_api_key`. Mirrors `create_wallet_with_signature`: the server mints a usage-key wallet via DStack MPC after verifying a wallet-ownership signature, then returns the secret (base64-encoded) plus the wallet address and derivation path. The client follows up on-chain — only the admin wallet of a ChainSecured account can call `setUsageApiKey`, so the server cannot complete the attach for you.
 
-No API key required. `Purpose:` line must be `lit-add-usage-api-key-v1`. Worst-case replay just returns a fresh secret for an unattached wallet — equivalent to a freshly generated keypair until the admin wallet calls the on-chain follow-ups, so compute cost only.
+No API key required. `primaryType` must be `AddUsageApiKey`. Worst-case replay just returns a fresh secret for an unattached wallet — equivalent to a freshly generated keypair until the admin wallet calls the on-chain follow-ups, so compute cost only.
 
 **Request body:**
 
 ```json
 {
-  "message": "<EIP-191 plaintext>",
+  "typed_data": { /* primaryType: "AddUsageApiKey" */ },
   "signature": "0x<65-byte hex>"
 }
 ```
@@ -387,7 +452,25 @@ Until both land, the secret in `usage_api_key` is just a freshly minted keypair 
 ```bash
 curl -s -X POST "https://api.chipotle.litprotocol.com/core/v1/add_usage_api_key_with_signature" \
   -H "Content-Type: application/json" \
-  -d '{"message":"chipotle.dev wants you to mint a usage API key for ChainSecured account.\n\nAddress: 0xabc...\nChain ID: 8453\nIssued At: 1745798400\nPurpose: lit-add-usage-api-key-v1","signature":"0x..."}'
+  -d '{
+    "typed_data": {
+      "types": {
+        "EIP712Domain": [
+          {"name":"name","type":"string"},
+          {"name":"version","type":"string"},
+          {"name":"chainId","type":"uint256"}
+        ],
+        "AddUsageApiKey": [
+          {"name":"address","type":"address"},
+          {"name":"issuedAt","type":"uint256"}
+        ]
+      },
+      "primaryType": "AddUsageApiKey",
+      "domain": {"name":"Lit ChainSecured","version":"1","chainId":"8453"},
+      "message": {"address":"0xabc...","issuedAt":"1745798400"}
+    },
+    "signature":"0x..."
+  }'
 ```
 
 ---

--- a/k6/litApiServer.ts
+++ b/k6/litApiServer.ts
@@ -58,11 +58,11 @@ export interface AccountOpResponse {
  * Body for `convert_to_chain_secured_account`. The caller is authenticated by their existing API key (header). The supplied wallet becomes the on-chain admin and the account flips from managed to ChainSecured. The conversion is irreversible.
  */
 export interface ConvertToChainSecuredAccountRequest {
-  /** Hex-encoded EVM address (with or without 0x prefix). Must be the wallet the user controls; verified by an EIP-191 personal_sign signature. */
+  /** Hex-encoded EVM address (with or without 0x prefix). Must be the wallet the user controls; verified by an EIP-712 typed-data signature. */
   new_admin_wallet_address: string;
-  /** SIWE-style message that was signed by `new_admin_wallet_address`. Must include `Address:`, `Chain ID:`, and `Issued At:` lines (same format as `create_wallet_with_signature`). */
-  message: string;
-  /** EIP-191 signature of `message` produced by `new_admin_wallet_address`. */
+  /** EIP-712 typed-data object the wallet signed. Must use `primaryType: "ConvertAccount"` and the canonical schema (see `core::eip712`). */
+  typed_data: unknown;
+  /** 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of `typed_data`. */
   signature: string;
 }
 
@@ -80,14 +80,14 @@ export interface CreateWalletWithSignatureResponse {
 }
 
 /**
- * ChainSecured wallet creation. The client builds a SIWE-style message and signs it with their wallet; the server verifies the signature, mints a PKP via DStack MPC, and returns the new wallet address + derivation path so the client can register it on-chain via `registerWalletDerivation`.
+ * ChainSecured wallet creation. The client signs EIP-712 typed data with their wallet; the server verifies the signature, mints a PKP via DStack MPC, and returns the new wallet address + derivation path so the client can register it on-chain via `registerWalletDerivation`.
 
-V1 does not maintain a server-side nonce store. The server enforces a ±5-minute window on the message's `Issued At` timestamp, which is the only replay protection. Worst-case replay just mints an extra PKP (compute cost only — registration still requires a separate wallet signature on-chain).
+The server does not maintain a nonce store. Replay protection is a ±5-minute window on the `issuedAt` field plus the per-flow primaryType binding — worst-case replay still just mints an extra unregistered PKP (compute cost only; registration requires a separate wallet signature on-chain).
  */
 export interface CreateWalletWithSignatureRequest {
-  /** EIP-191 plaintext message that was signed. Must contain `Address: 0x…`, `Chain ID: <u64>`, and `Issued At: <unix-seconds>` lines (case-sensitive prefixes). */
-  message: string;
-  /** 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign). */
+  /** EIP-712 typed-data object the wallet signed. Must use `primaryType: "CreateWallet"` and the canonical schema (see `core::eip712`). */
+  typed_data: unknown;
+  /** 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of `typed_data`. */
   signature: string;
 }
 
@@ -225,12 +225,12 @@ export interface AddUsageApiKeyWithSignatureResponse {
 }
 
 /**
- * ChainSecured usage-key minting. Mirrors `CreateWalletWithSignatureRequest`: the user proves wallet ownership with an EIP-191 personal_sign signature, the server mints a usage-key wallet via DStack MPC and returns the secret (as the usage API key) plus address + derivation path. The client follows up with on-chain `registerWalletDerivation` and `setUsageApiKey` signed by their admin wallet — only the admin wallet of a ChainSecured account can call `setUsageApiKey` (see AppStorage.accountExistsAndIsMutable).
+ * ChainSecured usage-key minting. Mirrors `CreateWalletWithSignatureRequest`: the user proves wallet ownership with an EIP-712 typed-data signature, the server mints a usage-key wallet via DStack MPC and returns the secret (as the usage API key) plus address + derivation path. The client follows up with on-chain `registerWalletDerivation` and `setUsageApiKey` signed by their admin wallet — only the admin wallet of a ChainSecured account can call `setUsageApiKey` (see AppStorage.accountExistsAndIsMutable).
  */
 export interface AddUsageApiKeyWithSignatureRequest {
-  /** EIP-191 plaintext message that was signed. Same format as `create_wallet_with_signature`: `Address: 0x…`, `Chain ID: <u64>`, `Issued At: <unix-seconds>` (case-sensitive prefixes). */
-  message: string;
-  /** 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign). */
+  /** EIP-712 typed-data object the wallet signed. Must use `primaryType: "AddUsageApiKey"` and the canonical schema (see `core::eip712`). */
+  typed_data: unknown;
+  /** 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of `typed_data`. */
   signature: string;
 }
 
@@ -714,7 +714,7 @@ export type BillingStripeConfigDefault = StripeConfigResponse | ErrMessage;
 
 export type BillingBalanceHeaders = {
   /**
-   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{typed_data, signature})>` where `typed_data` is EIP-712 with `primaryType: "BillingAuth"`. The signature proves wallet possession; the typed data must include the connected wallet address and an issuedAt timestamp within ±5 minutes.
    */
   "X-Api-Key"?: string;
 };
@@ -723,7 +723,7 @@ export type BillingBalanceDefault = BillingBalanceResponse | ErrMessage;
 
 export type BillingCreatePaymentIntentHeaders = {
   /**
-   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{typed_data, signature})>` where `typed_data` is EIP-712 with `primaryType: "BillingAuth"`. The signature proves wallet possession; the typed data must include the connected wallet address and an issuedAt timestamp within ±5 minutes.
    */
   "X-Api-Key"?: string;
 };
@@ -734,7 +734,7 @@ export type BillingCreatePaymentIntentDefault =
 
 export type BillingConfirmPaymentHeaders = {
   /**
-   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{message, signature})>` where the message is a SIWE-lite EIP-191 payload with a `Purpose: lit-billing-auth-v1` line. The signature proves wallet possession; the signed message must include Address, Chain ID, and Issued At within ±5 minutes.
+   * API-mode auth: account or usage API key (alternatively `Authorization: Bearer <key>`). OR — for ChainSecured callers — omit X-Api-Key entirely and send `X-Wallet-Auth: <base64(JSON{typed_data, signature})>` where `typed_data` is EIP-712 with `primaryType: "BillingAuth"`. The signature proves wallet possession; the typed data must include the connected wallet address and an issuedAt timestamp within ±5 minutes.
    */
   "X-Api-Key"?: string;
 };

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -27,7 +27,6 @@ use crate::utils::parse_with_hash::{
 };
 use crate::{accounts, dstack};
 use elliptic_curve::group::GroupEncoding;
-use ethers::core::types::Signature as EthSignature;
 use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{H160, U256};
 use ipfs_hasher::IpfsHasher;
@@ -190,247 +189,14 @@ pub async fn create_wallet(
     })
 }
 
-/// V1 SIWE-lite. Shared by `create_wallet_with_signature` and
-/// `add_usage_api_key_with_signature` — both authenticate PKP minting
-/// with a wallet signature because ChainSecured users have no api key.
-/// The server only mints — the client follows up on-chain with
-/// `registerWalletDerivation` (and, for usage keys, `setUsageApiKey`)
-/// signed by the admin wallet (which may differ from the SIWE signer).
-///
-/// Replay: ±5-minute timestamp window, no nonce store. Worst case on
-/// either endpoint is an extra unregistered PKP — the bytes the server
-/// returns are unattached on-chain until the admin wallet calls the
-/// follow-up txns, so they are equivalent to a freshly generated keypair
-/// until then. Compute cost only.
-const SIWE_TIMESTAMP_SKEW_SECONDS: i64 = 300;
-
-/// Hard cap on the SIWE-lite message size to prevent unauthenticated callers
-/// from forcing the server to allocate / hash large strings before any cheap
-/// reject. 4 KiB is far above any legitimate four-line message.
-const MAX_SIWE_MESSAGE_LEN: usize = 4096;
-
-/// Parsed shape of a SIWE-lite message. Each flow that uses these signatures
-/// pins a specific `purpose` value to prevent cross-flow replay (CPL-285).
-struct ParsedCreateWalletSiwe {
-    address: H160,
-    chain_id: u64,
-    issued_at: i64,
-    purpose: String,
-}
-
-/// Stable purpose tags for each SIWE flow. The signature parser requires a
-/// `Purpose:` line that exactly matches one of these and individual callers
-/// verify the parsed purpose matches their flow — a billing-auth signature
-/// can't be replayed against `/create_wallet_with_signature` and vice versa
-/// (CPL-285 cross-flow replay).
-pub(crate) const SIWE_PURPOSE_BILLING_AUTH: &str = "lit-billing-auth-v1";
-pub(crate) const SIWE_PURPOSE_CREATE_WALLET: &str = "lit-create-wallet-v1";
-pub(crate) const SIWE_PURPOSE_CONVERT_ACCOUNT: &str = "lit-convert-account-v1";
-pub(crate) const SIWE_PURPOSE_ADD_USAGE_API_KEY: &str = "lit-add-usage-api-key-v1";
-
-/// Parses a SIWE-lite message. Required lines (case-sensitive), each must
-/// appear exactly once:
-///   `Address: 0x…`
-///   `Chain ID: <u64>`
-///   `Issued At: <unix-seconds>`
-///   `Purpose: <purpose-tag>`
-/// Other lines are ignored so callers can include domain/statement framing.
-/// Duplicate required lines are rejected (last-wins parsing would let a
-/// crafted message show one value to the wallet UI and another to the server).
-fn parse_create_wallet_siwe(message: &str) -> Result<ParsedCreateWalletSiwe, ApiStatus> {
-    let mut address: Option<H160> = None;
-    let mut chain_id: Option<u64> = None;
-    let mut issued_at: Option<i64> = None;
-    let mut purpose: Option<String> = None;
-    for line in message.lines() {
-        if let Some(v) = line.strip_prefix("Address:") {
-            if address.is_some() {
-                return Err(ApiStatus::bad_request(
-                    anyhow::anyhow!("Duplicate Address line"),
-                    "Duplicate Address line",
-                ));
-            }
-            let trimmed = v.trim();
-            let bytes = hex_to_bytes(trimmed.trim_start_matches("0x")).map_err(|_| {
-                ApiStatus::bad_request(
-                    anyhow::anyhow!("Address line not valid hex"),
-                    "Address line not valid hex",
-                )
-            })?;
-            if bytes.len() != 20 {
-                return Err(ApiStatus::bad_request(
-                    anyhow::anyhow!("Address must be 20 bytes"),
-                    "Address must be 20 bytes",
-                ));
-            }
-            address = Some(H160::from_slice(&bytes));
-        } else if let Some(v) = line.strip_prefix("Chain ID:") {
-            if chain_id.is_some() {
-                return Err(ApiStatus::bad_request(
-                    anyhow::anyhow!("Duplicate Chain ID line"),
-                    "Duplicate Chain ID line",
-                ));
-            }
-            chain_id = Some(v.trim().parse::<u64>().map_err(|_| {
-                ApiStatus::bad_request(
-                    anyhow::anyhow!("Chain ID line not a u64"),
-                    "Chain ID line not a u64",
-                )
-            })?);
-        } else if let Some(v) = line.strip_prefix("Issued At:") {
-            if issued_at.is_some() {
-                return Err(ApiStatus::bad_request(
-                    anyhow::anyhow!("Duplicate Issued At line"),
-                    "Duplicate Issued At line",
-                ));
-            }
-            issued_at = Some(v.trim().parse::<i64>().map_err(|_| {
-                ApiStatus::bad_request(
-                    anyhow::anyhow!("Issued At line not a unix timestamp"),
-                    "Issued At line not a unix timestamp",
-                )
-            })?);
-        } else if let Some(v) = line.strip_prefix("Purpose:") {
-            if purpose.is_some() {
-                return Err(ApiStatus::bad_request(
-                    anyhow::anyhow!("Duplicate Purpose line"),
-                    "Duplicate Purpose line",
-                ));
-            }
-            purpose = Some(v.trim().to_string());
-        }
-    }
-    Ok(ParsedCreateWalletSiwe {
-        address: address.ok_or_else(|| {
-            ApiStatus::bad_request(
-                anyhow::anyhow!("Missing Address line"),
-                "Missing Address line",
-            )
-        })?,
-        chain_id: chain_id.ok_or_else(|| {
-            ApiStatus::bad_request(
-                anyhow::anyhow!("Missing Chain ID line"),
-                "Missing Chain ID line",
-            )
-        })?,
-        issued_at: issued_at.ok_or_else(|| {
-            ApiStatus::bad_request(
-                anyhow::anyhow!("Missing Issued At line"),
-                "Missing Issued At line",
-            )
-        })?,
-        purpose: purpose.ok_or_else(|| {
-            ApiStatus::bad_request(
-                anyhow::anyhow!("Missing Purpose line"),
-                "Missing Purpose line",
-            )
-        })?,
-    })
-}
-
-/// Recovers the EIP-191 personal-sign signer for `message`.
-fn recover_eip191_signer(message: &str, signature_hex: &str) -> Result<H160, ApiStatus> {
-    let sig: EthSignature =
-        signature_hex
-            .trim()
-            .parse()
-            .map_err(|e: ethers::core::types::SignatureError| {
-                ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid signature hex")
-            })?;
-    sig.recover(message.as_bytes().to_vec())
-        .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))
-}
-
-/// Verify a SIWE-lite message + EIP-191 signature for a specific flow and
-/// return the verified wallet address. Centralises the parse → purpose →
-/// chain-id → timestamp → recover pipeline so every ChainSecured flow
-/// (`create_wallet_with_signature`, `convert_to_chain_secured_account`,
-/// `add_usage_api_key_with_signature`, billing-auth guard) reuses the same
-/// security envelope.
-///
-/// `expected_purpose` MUST be one of the `SIWE_PURPOSE_*` constants. Each
-/// flow pins its own value so a signature minted for one flow cannot be
-/// replayed against another (CPL-285).
-///
-/// Cheap rejects (length cap, parse, purpose, chain ID, timestamp window)
-/// run before the expensive ECDSA recovery so attacker traffic with stale,
-/// wrong-purpose, or wrong-chain messages is dropped without doing crypto.
-pub(crate) fn verify_siwe_signature(
-    message: &str,
-    signature: &str,
-    expected_purpose: &str,
-) -> Result<H160, ApiStatus> {
-    if message.len() > MAX_SIWE_MESSAGE_LEN {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!("Message exceeds {}-byte cap", MAX_SIWE_MESSAGE_LEN),
-            "Message too large",
-        ));
-    }
-    let parsed = parse_create_wallet_siwe(message)?;
-    if parsed.purpose != expected_purpose {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!(
-                "Purpose mismatch: message says {:?}, this endpoint expects {:?}",
-                parsed.purpose,
-                expected_purpose
-            ),
-            "Purpose mismatch — signature was minted for a different flow",
-        ));
-    }
-    let node_config = GLOBAL_NODE_CONFIG
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))
-        .map_err(|e| ApiStatus::internal_server_error(e, "GLOBAL_NODE_CONFIG missing"))?;
-    let expected_chain_id = node_config.chain.info().chain_id;
-    if parsed.chain_id != expected_chain_id {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!(
-                "Chain ID mismatch: message says {}, server is on {}",
-                parsed.chain_id,
-                expected_chain_id
-            ),
-            "Chain ID mismatch",
-        ));
-    }
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|e| {
-            ApiStatus::internal_server_error(
-                anyhow::anyhow!(e),
-                "System clock is before the Unix epoch",
-            )
-        })?
-        .as_secs() as i64;
-    // i128 subtraction: two i64s can never overflow into i128, and i128::abs
-    // is safe for any value produced by an i64 subtraction. Without this, a
-    // crafted `Issued At: i64::MIN` would wrap `(now - issued_at).abs()` back
-    // to a small/negative value and bypass the skew check in release builds.
-    let delta = (now as i128) - (parsed.issued_at as i128);
-    if delta.abs() > SIWE_TIMESTAMP_SKEW_SECONDS as i128 {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!(
-                "Issued At {} is outside the ±{}s window from now ({})",
-                parsed.issued_at,
-                SIWE_TIMESTAMP_SKEW_SECONDS,
-                now
-            ),
-            "Signed message timestamp is too old or too far in the future",
-        ));
-    }
-    let signer = recover_eip191_signer(message, signature)?;
-    if signer != parsed.address {
-        return Err(ApiStatus::bad_request(
-            anyhow::anyhow!("Signature does not match claimed address"),
-            "Signature does not match claimed address",
-        ));
-    }
-    Ok(parsed.address)
-}
-
 pub async fn create_wallet_with_signature(
     req: Json<CreateWalletWithSignatureRequest>,
 ) -> Result<CreateWalletWithSignatureResponse, ApiStatus> {
-    let signer = verify_siwe_signature(&req.message, &req.signature, SIWE_PURPOSE_CREATE_WALLET)?;
+    let signer = crate::core::eip712::verify_eip712_signature(
+        &req.typed_data,
+        &req.signature,
+        crate::core::eip712::PRIMARY_TYPE_CREATE_WALLET,
+    )?;
     tracing::info!(
         "create_wallet_with_signature: minting PKP for ChainSecured signer {:?}",
         signer
@@ -443,15 +209,18 @@ pub async fn create_wallet_with_signature(
 }
 
 /// ChainSecured usage API key: server only mints the wallet (PKP) gated by an
-/// EIP-191 wallet signature; the client follows up with on-chain
-/// `registerWalletDerivation` and `setUsageApiKey` signed by their admin
-/// wallet (api_payer cannot call setUsageApiKey for ChainSecured accounts —
-/// see AppStorage.accountExistsAndIsMutable).
+/// EIP-712 wallet signature (`primaryType: "AddUsageApiKey"`); the client
+/// follows up with on-chain `registerWalletDerivation` and `setUsageApiKey`
+/// signed by their admin wallet (api_payer cannot call setUsageApiKey for
+/// ChainSecured accounts — see AppStorage.accountExistsAndIsMutable).
 pub async fn add_usage_api_key_with_signature(
     req: Json<AddUsageApiKeyWithSignatureRequest>,
 ) -> Result<AddUsageApiKeyWithSignatureResponse, ApiStatus> {
-    let signer =
-        verify_siwe_signature(&req.message, &req.signature, SIWE_PURPOSE_ADD_USAGE_API_KEY)?;
+    let signer = crate::core::eip712::verify_eip712_signature(
+        &req.typed_data,
+        &req.signature,
+        crate::core::eip712::PRIMARY_TYPE_ADD_USAGE_API_KEY,
+    )?;
     tracing::info!(
         "add_usage_api_key_with_signature: minting usage-key PKP for ChainSecured signer {:?}",
         signer
@@ -467,9 +236,9 @@ pub async fn add_usage_api_key_with_signature(
 
 /// Convert a managed (API-mode) account into a ChainSecured (sovereign) account by
 /// reassigning its admin wallet to a user-controlled address. The user proves
-/// ownership of `new_admin_wallet_address` with a SIWE-style EIP-191 signature
-/// (same format as `create_wallet_with_signature`). The api_payer signs the
-/// on-chain `convertToChainSecuredAccount` call.
+/// ownership of `new_admin_wallet_address` with an EIP-712 typed-data signature
+/// (`primaryType: "ConvertAccount"`). The api_payer signs the on-chain
+/// `convertToChainSecuredAccount` call.
 ///
 /// Irreversible: the contract reverts if the account is already ChainSecured.
 pub async fn convert_to_chain_secured_account(
@@ -498,7 +267,11 @@ pub async fn convert_to_chain_secured_account(
         ));
     }
 
-    let signer = verify_siwe_signature(&req.message, &req.signature, SIWE_PURPOSE_CONVERT_ACCOUNT)?;
+    let signer = crate::core::eip712::verify_eip712_signature(
+        &req.typed_data,
+        &req.signature,
+        crate::core::eip712::PRIMARY_TYPE_CONVERT_ACCOUNT,
+    )?;
     if signer != claimed_address {
         return Err(ApiStatus::bad_request(
             anyhow::anyhow!("Signature does not match new_admin_wallet_address"),

--- a/lit-api-server/src/core/eip712.rs
+++ b/lit-api-server/src/core/eip712.rs
@@ -1,0 +1,783 @@
+//! EIP-712 typed-data verification for ChainSecured signatures (CPL-286).
+//!
+//! Wallet UIs render the signed payload as a typed struct with `primaryType`
+//! clearly labeled. Cross-flow replay is rejected at the type-hash level:
+//! a signature minted against `CreateWallet` cannot recover when the server
+//! hashes the same bytes against, say, `BillingAuth` or `AddUsageApiKey` —
+//! the type hash commits to the struct name, so different `primaryType`
+//! values produce different EIP-712 digests even with identical field
+//! values.
+//!
+//! Server-authoritative model: the client posts the full EIP-712 typed data
+//! the wallet signed. The server validates the domain, the schema for the
+//! claimed `primaryType`, and the timestamp window before doing any
+//! crypto — then recovers the signer from the digest and confirms it
+//! matches the `address` field inside the typed data.
+//!
+//! The wallet UI determines the digest. If the client builds different
+//! bytes than the server expects, the digest differs and recovery fails —
+//! no out-of-band type-hash check needed beyond pinning the schema.
+
+use ethers::core::types::transaction::eip712::{EIP712Domain, Eip712, Eip712DomainType, TypedData};
+use ethers::core::types::{Address, RecoveryMessage, Signature as EthSignature, U256};
+
+use crate::config::GLOBAL_NODE_CONFIG;
+use crate::core::v1::helpers::api_status::ApiStatus;
+
+/// ±5-minute window on `issuedAt`; the only replay protection (no nonce
+/// store). Worst-case replay on the unauthenticated mint endpoints just
+/// produces an extra unattached PKP — the bytes returned are equivalent to
+/// a freshly generated keypair until the admin wallet calls the on-chain
+/// follow-ups, so compute cost only.
+pub(crate) const TIMESTAMP_SKEW_SECONDS: i64 = 300;
+
+/// Hard cap on the JSON-serialised typed-data payload to bound the work an
+/// unauthenticated caller can force the server to do before any cheap
+/// reject. 4 KiB is far above any legitimate payload — the canonical shape
+/// is well under 1 KiB.
+pub(crate) const MAX_TYPED_DATA_LEN: usize = 4096;
+
+/// Stable EIP-712 domain `name` for all ChainSecured signatures. Wallet UIs
+/// surface this; do not change without a coordinated client release.
+pub(crate) const EIP712_DOMAIN_NAME: &str = "Lit ChainSecured";
+
+/// Domain `version`. Bump only when the typed-data schema changes in a way
+/// that requires re-signing — wallets refuse to interpret a v2 signature
+/// against a v1 domain (and vice versa).
+pub(crate) const EIP712_DOMAIN_VERSION: &str = "1";
+
+/// Canonical primary types per ChainSecured flow. Each endpoint pins one
+/// of these and rejects signatures whose `primaryType` doesn't match — the
+/// type hash commits to the struct name, so a signature minted for one
+/// flow cannot recover when the server hashes the same bytes against a
+/// different `primaryType`.
+pub(crate) const PRIMARY_TYPE_CREATE_WALLET: &str = "CreateWallet";
+pub(crate) const PRIMARY_TYPE_CONVERT_ACCOUNT: &str = "ConvertAccount";
+pub(crate) const PRIMARY_TYPE_ADD_USAGE_API_KEY: &str = "AddUsageApiKey";
+pub(crate) const PRIMARY_TYPE_BILLING_AUTH: &str = "BillingAuth";
+
+/// The four flows share an identical message struct: `(address, issuedAt)`.
+/// Field declaration order is part of the EIP-712 type hash — clients must
+/// declare the fields in this order, and any reordering is rejected by
+/// `validate_type_schema`.
+fn payload_field_schema() -> [Eip712DomainType; 2] {
+    [
+        Eip712DomainType {
+            name: "address".to_string(),
+            r#type: "address".to_string(),
+        },
+        Eip712DomainType {
+            name: "issuedAt".to_string(),
+            r#type: "uint256".to_string(),
+        },
+    ]
+}
+
+/// Canonical `EIP712Domain` field declaration. We use the (name, version,
+/// chainId) subset — no `verifyingContract` (this server is not an
+/// on-chain contract) and no `salt`. Clients must declare these in the
+/// same order; any other shape is rejected.
+fn domain_field_schema() -> [Eip712DomainType; 3] {
+    [
+        Eip712DomainType {
+            name: "name".to_string(),
+            r#type: "string".to_string(),
+        },
+        Eip712DomainType {
+            name: "version".to_string(),
+            r#type: "string".to_string(),
+        },
+        Eip712DomainType {
+            name: "chainId".to_string(),
+            r#type: "uint256".to_string(),
+        },
+    ]
+}
+
+fn is_known_primary_type(s: &str) -> bool {
+    matches!(
+        s,
+        PRIMARY_TYPE_CREATE_WALLET
+            | PRIMARY_TYPE_CONVERT_ACCOUNT
+            | PRIMARY_TYPE_ADD_USAGE_API_KEY
+            | PRIMARY_TYPE_BILLING_AUTH
+    )
+}
+
+/// Build the canonical typed data the server expects for a given flow.
+/// Used by tests to round-trip a wallet signature; not part of the request
+/// path (the request path validates the client-supplied typed data instead
+/// of rebuilding it, so the wallet's view and the server's view are bit-
+/// identical when verification succeeds).
+#[cfg(test)]
+pub(crate) fn build_canonical_typed_data(
+    primary_type: &str,
+    address: Address,
+    issued_at: i64,
+    chain_id: u64,
+) -> TypedData {
+    use std::collections::BTreeMap;
+
+    let mut types: BTreeMap<String, Vec<Eip712DomainType>> = BTreeMap::new();
+    types.insert("EIP712Domain".to_string(), domain_field_schema().to_vec());
+    types.insert(primary_type.to_string(), payload_field_schema().to_vec());
+
+    let mut message: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    message.insert(
+        "address".to_string(),
+        serde_json::Value::String(format!("0x{:x}", address)),
+    );
+    message.insert(
+        "issuedAt".to_string(),
+        serde_json::Value::String(issued_at.to_string()),
+    );
+
+    TypedData {
+        domain: EIP712Domain {
+            name: Some(EIP712_DOMAIN_NAME.to_string()),
+            version: Some(EIP712_DOMAIN_VERSION.to_string()),
+            chain_id: Some(U256::from(chain_id)),
+            verifying_contract: None,
+            salt: None,
+        },
+        types,
+        primary_type: primary_type.to_string(),
+        message,
+    }
+}
+
+/// Verify an EIP-712 typed-data + signature pair for a specific ChainSecured
+/// flow. Returns the recovered wallet address on success.
+///
+/// Cheap rejects (length cap, JSON parse, schema match, domain match,
+/// primary-type match, timestamp window) run before the expensive ECDSA
+/// recovery so junk traffic with stale, wrong-purpose, or wrong-chain
+/// payloads is dropped without doing crypto.
+pub(crate) fn verify_eip712_signature(
+    typed_data_json: &serde_json::Value,
+    signature_hex: &str,
+    expected_primary_type: &str,
+) -> Result<Address, ApiStatus> {
+    // Length cap before parsing — bound the work an unauthenticated caller
+    // can force the server to do before we hit anything expensive.
+    let serialized = serde_json::to_string(typed_data_json)
+        .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "typed_data not serializable"))?;
+    if serialized.len() > MAX_TYPED_DATA_LEN {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("typed_data exceeds {}-byte cap", MAX_TYPED_DATA_LEN),
+            "typed_data too large",
+        ));
+    }
+
+    let typed_data: TypedData = serde_json::from_value(typed_data_json.clone()).map_err(|e| {
+        ApiStatus::bad_request(
+            anyhow::anyhow!(e),
+            "typed_data is not a valid EIP-712 typed-data object",
+        )
+    })?;
+
+    if typed_data.primary_type != expected_primary_type {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "primaryType mismatch: typed_data says {:?}, this endpoint expects {:?}",
+                typed_data.primary_type,
+                expected_primary_type
+            ),
+            "primaryType mismatch — signature was minted for a different flow",
+        ));
+    }
+    if !is_known_primary_type(&typed_data.primary_type) {
+        // Defence in depth — `expected_primary_type` is always one of our
+        // constants, but pin the wider invariant explicitly so adding a new
+        // primary type forces us to update `is_known_primary_type` too.
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Unknown primaryType {:?}", typed_data.primary_type),
+            "Unknown primaryType",
+        ));
+    }
+
+    validate_domain(&typed_data.domain)?;
+    validate_type_schema(&typed_data)?;
+    let address = extract_address(&typed_data)?;
+    let issued_at = extract_issued_at(&typed_data)?;
+    validate_timestamp(issued_at)?;
+
+    let digest = typed_data.encode_eip712().map_err(|e| {
+        ApiStatus::internal_server_error(
+            anyhow::anyhow!("encode_eip712 failed: {}", e),
+            "encode_eip712 failed",
+        )
+    })?;
+    let sig: EthSignature =
+        signature_hex
+            .trim()
+            .parse()
+            .map_err(|e: ethers::core::types::SignatureError| {
+                ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid signature hex")
+            })?;
+    let recovered = sig
+        .recover(RecoveryMessage::Hash(digest.into()))
+        .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Signature recovery failed"))?;
+
+    if recovered != address {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Signature does not match claimed address"),
+            "Signature does not match claimed address",
+        ));
+    }
+    Ok(address)
+}
+
+fn validate_domain(domain: &EIP712Domain) -> Result<(), ApiStatus> {
+    if domain.name.as_deref() != Some(EIP712_DOMAIN_NAME) {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Domain name mismatch: typed_data says {:?}, expected {:?}",
+                domain.name,
+                EIP712_DOMAIN_NAME
+            ),
+            "Domain name mismatch",
+        ));
+    }
+    if domain.version.as_deref() != Some(EIP712_DOMAIN_VERSION) {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Domain version mismatch: typed_data says {:?}, expected {:?}",
+                domain.version,
+                EIP712_DOMAIN_VERSION
+            ),
+            "Domain version mismatch",
+        ));
+    }
+    let node_config = GLOBAL_NODE_CONFIG
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("Node configuration not found"))
+        .map_err(|e| ApiStatus::internal_server_error(e, "GLOBAL_NODE_CONFIG missing"))?;
+    let expected_chain_id = U256::from(node_config.chain.info().chain_id);
+    if domain.chain_id != Some(expected_chain_id) {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Chain ID mismatch: typed_data says {:?}, server is on {}",
+                domain.chain_id,
+                expected_chain_id
+            ),
+            "Chain ID mismatch",
+        ));
+    }
+    // Reject extra domain fields. A phishing site could otherwise include
+    // a verifyingContract or salt the user doesn't notice and bind the same
+    // bytes to a different domain than the wallet displays. We strictly
+    // pin the domain to (name, version, chainId).
+    if domain.verifying_contract.is_some() || domain.salt.is_some() {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!("Unexpected domain fields"),
+            "Domain must contain only name, version, chainId",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_type_schema(typed_data: &TypedData) -> Result<(), ApiStatus> {
+    let expected_payload = payload_field_schema();
+    let primary_decl = typed_data
+        .types
+        .get(&typed_data.primary_type)
+        .ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("Missing types[{}]", typed_data.primary_type),
+                "Missing primaryType in types",
+            )
+        })?;
+    if primary_decl.as_slice() != expected_payload.as_slice() {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "primaryType field schema mismatch — expected {:?}",
+                expected_payload
+            ),
+            "primaryType field schema mismatch",
+        ));
+    }
+
+    let expected_domain = domain_field_schema();
+    let domain_decl = typed_data.types.get("EIP712Domain").ok_or_else(|| {
+        ApiStatus::bad_request(
+            anyhow::anyhow!("Missing types[EIP712Domain]"),
+            "Missing EIP712Domain in types",
+        )
+    })?;
+    if domain_decl.as_slice() != expected_domain.as_slice() {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "EIP712Domain field schema mismatch — expected {:?}",
+                expected_domain
+            ),
+            "EIP712Domain field schema mismatch",
+        ));
+    }
+
+    // Reject any extra type definitions the client tried to smuggle in.
+    // We don't use them, but a wallet might display them (depending on
+    // implementation) and the user could be misled into thinking they
+    // signed something different.
+    if typed_data.types.len() != 2 {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Unexpected type definitions — expected only EIP712Domain and {}",
+                typed_data.primary_type
+            ),
+            "Unexpected type definitions",
+        ));
+    }
+
+    // Strict check on `message` content. The EIP-712 type hash only commits
+    // to the fields declared in `types[primaryType]`, so extras in `message`
+    // don't change the digest — but a phishing dApp could still embed
+    // decoy fields (e.g. `intent: "Subscribe to weekly briefing"`) that
+    // some wallet UIs render alongside the canonical fields, fooling the
+    // user into signing what looks like a different action. Pin the
+    // message to exactly the canonical (address, issuedAt) pair.
+    if typed_data.message.len() != 2
+        || !typed_data.message.contains_key("address")
+        || !typed_data.message.contains_key("issuedAt")
+    {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "message must contain exactly `address` and `issuedAt`, got {:?}",
+                typed_data.message.keys().collect::<Vec<_>>()
+            ),
+            "message contains unexpected fields",
+        ));
+    }
+    Ok(())
+}
+
+fn extract_address(typed_data: &TypedData) -> Result<Address, ApiStatus> {
+    let address_val = typed_data.message.get("address").ok_or_else(|| {
+        ApiStatus::bad_request(
+            anyhow::anyhow!("Missing message.address"),
+            "Missing message.address",
+        )
+    })?;
+    let address: Address = serde_json::from_value(address_val.clone())
+        .map_err(|e| ApiStatus::bad_request(anyhow::anyhow!(e), "Invalid message.address"))?;
+    Ok(address)
+}
+
+fn extract_issued_at(typed_data: &TypedData) -> Result<i64, ApiStatus> {
+    let issued_val = typed_data.message.get("issuedAt").ok_or_else(|| {
+        ApiStatus::bad_request(
+            anyhow::anyhow!("Missing message.issuedAt"),
+            "Missing message.issuedAt",
+        )
+    })?;
+    // ethers JS serializes uint256 as a string for typed data, but a small
+    // integer fits in JSON numbers — accept both shapes so the client can
+    // pick whichever is most natural for its stack.
+    match issued_val {
+        serde_json::Value::String(s) => s.parse::<i64>().map_err(|e| {
+            ApiStatus::bad_request(anyhow::anyhow!(e), "issuedAt not a unix timestamp")
+        }),
+        serde_json::Value::Number(n) => n.as_i64().ok_or_else(|| {
+            ApiStatus::bad_request(
+                anyhow::anyhow!("issuedAt not a unix timestamp"),
+                "issuedAt not a unix timestamp",
+            )
+        }),
+        _ => Err(ApiStatus::bad_request(
+            anyhow::anyhow!("issuedAt must be a number or numeric string"),
+            "issuedAt must be a number or numeric string",
+        )),
+    }
+}
+
+fn validate_timestamp(issued_at: i64) -> Result<(), ApiStatus> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| {
+            ApiStatus::internal_server_error(
+                anyhow::anyhow!(e),
+                "System clock is before the Unix epoch",
+            )
+        })?
+        .as_secs() as i64;
+    // i128 subtraction: two i64s can never overflow into i128, and i128::abs
+    // is safe for any value produced by an i64 subtraction. Without this, a
+    // crafted issuedAt of i64::MIN would wrap `(now - issued_at).abs()` back
+    // to a small/negative value and bypass the skew check in release builds.
+    let delta = (now as i128) - (issued_at as i128);
+    if delta.abs() > TIMESTAMP_SKEW_SECONDS as i128 {
+        return Err(ApiStatus::bad_request(
+            anyhow::anyhow!(
+                "Issued At {} is outside the ±{}s window from now ({})",
+                issued_at,
+                TIMESTAMP_SKEW_SECONDS,
+                now
+            ),
+            "Signed message timestamp is too old or too far in the future",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::core::types::H256;
+    use ethers::signers::{LocalWallet, Signer};
+
+    /// `GLOBAL_NODE_CONFIG` is a `OnceLock` populated at server startup. Tests
+    /// share it — only the first `get_or_init` wins, so every test below sees
+    /// the same chain. We pin to `Anvil` (chain_id 175188) since that's the
+    /// fixture chain used elsewhere in the test suite and matches what a CI
+    /// run sees.
+    fn ensure_test_chain_id() -> u64 {
+        let nc = crate::config::GLOBAL_NODE_CONFIG.get_or_init(|| crate::config::NodeConfig {
+            chain: crate::utils::chain_info::Chain::Anvil,
+            contract_address: "0x0000000000000000000000000000000000000000".to_string(),
+        });
+        nc.chain.info().chain_id
+    }
+
+    fn now_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    /// Builds canonical typed data, signs it with `wallet`, returns
+    /// `(typed_data_json, signature_hex)` so tests can hand them to the
+    /// verifier in the same shape an HTTP request would.
+    fn sign_canonical(
+        wallet: &LocalWallet,
+        primary_type: &str,
+        issued_at: i64,
+        chain_id: u64,
+    ) -> (serde_json::Value, String) {
+        let typed_data =
+            build_canonical_typed_data(primary_type, wallet.address(), issued_at, chain_id);
+        let digest = typed_data.encode_eip712().unwrap();
+        let sig = wallet.sign_hash(H256::from(digest)).unwrap();
+        let json = serde_json::to_value(&typed_data).unwrap();
+        (json, format!("0x{}", sig))
+    }
+
+    #[test]
+    fn happy_path_create_wallet() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        let recovered = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET).unwrap();
+        assert_eq!(recovered, wallet.address());
+    }
+
+    #[test]
+    fn happy_path_all_primary_types() {
+        let chain_id = ensure_test_chain_id();
+        for primary in [
+            PRIMARY_TYPE_CREATE_WALLET,
+            PRIMARY_TYPE_CONVERT_ACCOUNT,
+            PRIMARY_TYPE_ADD_USAGE_API_KEY,
+            PRIMARY_TYPE_BILLING_AUTH,
+        ] {
+            let wallet = LocalWallet::new(&mut rand::thread_rng());
+            let (typed, sig) = sign_canonical(&wallet, primary, now_secs(), chain_id);
+            let recovered = verify_eip712_signature(&typed, &sig, primary)
+                .unwrap_or_else(|e| panic!("expected {primary} to verify, got: {e:?}"));
+            assert_eq!(recovered, wallet.address(), "{primary} address mismatch");
+        }
+    }
+
+    /// The core CPL-286 promise: a signature minted for one flow must not
+    /// recover when the server hashes the typed data against a different
+    /// primaryType. This is rejected at the schema layer (we check
+    /// `expected_primary_type` before recovery), but the deeper guarantee
+    /// is that even if the schema check were bypassed, the digest would
+    /// differ. Both layers are exercised here.
+    #[test]
+    fn cross_flow_replay_rejected_at_primary_type_check() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        // User signs a CreateWallet typed payload.
+        let (typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        // Attacker forwards it to the AddUsageApiKey endpoint as-is.
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_ADD_USAGE_API_KEY)
+            .expect_err("must reject — primaryType mismatch");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("primaryType") || msg.contains("primary_type"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    /// Even if the attacker rewrites the `primaryType` field after the fact
+    /// (so it matches the target endpoint), the signature will not recover
+    /// because the EIP-712 digest commits to the type hash.
+    #[test]
+    fn cross_flow_replay_rejected_at_recovery_when_primary_type_rewritten() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        // User signs CreateWallet.
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        // Attacker rewrites primaryType + types map to look like AddUsageApiKey.
+        typed["primaryType"] = serde_json::json!(PRIMARY_TYPE_ADD_USAGE_API_KEY);
+        let payload_fields = serde_json::json!([
+            { "name": "address", "type": "address" },
+            { "name": "issuedAt", "type": "uint256" },
+        ]);
+        typed["types"]
+            .as_object_mut()
+            .unwrap()
+            .remove(PRIMARY_TYPE_CREATE_WALLET);
+        typed["types"]
+            .as_object_mut()
+            .unwrap()
+            .insert(PRIMARY_TYPE_ADD_USAGE_API_KEY.to_string(), payload_fields);
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_ADD_USAGE_API_KEY)
+            .expect_err("must reject — digest doesn't match the rewritten type hash");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Signature does not match") || msg.contains("Signature recovery failed"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    #[test]
+    fn rejects_chain_id_mismatch() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (typed, sig) = sign_canonical(
+            &wallet,
+            PRIMARY_TYPE_CREATE_WALLET,
+            now_secs(),
+            chain_id.wrapping_add(1),
+        );
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — wrong chainId");
+        assert!(format!("{err}").contains("Chain ID"));
+    }
+
+    #[test]
+    fn rejects_domain_name_mismatch() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        typed["domain"]["name"] = serde_json::json!("Not Lit ChainSecured");
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — wrong domain name");
+        assert!(format!("{err}").contains("Domain name"));
+    }
+
+    #[test]
+    fn rejects_domain_version_mismatch() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        typed["domain"]["version"] = serde_json::json!("99");
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — wrong domain version");
+        assert!(format!("{err}").contains("Domain version"));
+    }
+
+    #[test]
+    fn rejects_extra_domain_field_verifying_contract() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        typed["domain"]["verifyingContract"] =
+            serde_json::json!("0x1111111111111111111111111111111111111111");
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — verifyingContract is not allowed");
+        assert!(format!("{err}").contains("Domain"));
+    }
+
+    #[test]
+    fn rejects_schema_field_reorder() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        // Swap field order on the primary type — produces a different type hash.
+        typed["types"][PRIMARY_TYPE_CREATE_WALLET] = serde_json::json!([
+            { "name": "issuedAt", "type": "uint256" },
+            { "name": "address", "type": "address" },
+        ]);
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — schema fields reordered");
+        assert!(format!("{err}").contains("schema"));
+    }
+
+    #[test]
+    fn rejects_extra_type_definitions() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        // Smuggle in an extra type the wallet UI might display alongside.
+        typed["types"]["TotallyLegit"] = serde_json::json!([
+            { "name": "spookyField", "type": "string" },
+        ]);
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — types must contain exactly EIP712Domain + primaryType");
+        assert!(format!("{err}").contains("Unexpected type definitions"));
+    }
+
+    #[test]
+    fn rejects_timestamp_too_old() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let stale = now_secs() - TIMESTAMP_SKEW_SECONDS - 1;
+        let (typed, sig) = sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, stale, chain_id);
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — issued_at outside skew window");
+        assert!(format!("{err}").contains("timestamp"));
+    }
+
+    #[test]
+    fn rejects_timestamp_too_far_future() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let future = now_secs() + TIMESTAMP_SKEW_SECONDS + 1;
+        let (typed, sig) = sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, future, chain_id);
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — issued_at too far in future");
+        assert!(format!("{err}").contains("timestamp"));
+    }
+
+    /// `i64::MIN` would wrap on naive `(now - issued_at).abs()` in release
+    /// builds, which would let an attacker bypass the skew check. We can't
+    /// actually sign such typed data (uint256 can't hold negatives — the
+    /// wallet would refuse), but a malicious client can hand-craft the JSON
+    /// after the fact. This pins the i128 widening fix in `validate_timestamp`.
+    #[test]
+    fn rejects_i64_min_issued_at() {
+        let chain_id = ensure_test_chain_id();
+        let typed = serde_json::json!({
+            "types": {
+                "EIP712Domain": [
+                    { "name": "name", "type": "string" },
+                    { "name": "version", "type": "string" },
+                    { "name": "chainId", "type": "uint256" },
+                ],
+                "CreateWallet": [
+                    { "name": "address", "type": "address" },
+                    { "name": "issuedAt", "type": "uint256" },
+                ],
+            },
+            "primaryType": "CreateWallet",
+            "domain": {
+                "name": "Lit ChainSecured",
+                "version": "1",
+                "chainId": chain_id.to_string(),
+            },
+            "message": {
+                "address": "0x0000000000000000000000000000000000000000",
+                "issuedAt": i64::MIN.to_string(),
+            }
+        });
+        let err = verify_eip712_signature(&typed, "0x00", PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — issued_at saturates to i64::MIN");
+        assert!(format!("{err}").contains("timestamp"));
+    }
+
+    #[test]
+    fn rejects_address_signer_mismatch() {
+        let chain_id = ensure_test_chain_id();
+        let signer = LocalWallet::new(&mut rand::thread_rng());
+        let other = LocalWallet::new(&mut rand::thread_rng());
+        // typed data claims `other.address()` but is signed by `signer`.
+        let typed_data = build_canonical_typed_data(
+            PRIMARY_TYPE_CREATE_WALLET,
+            other.address(),
+            now_secs(),
+            chain_id,
+        );
+        let digest = typed_data.encode_eip712().unwrap();
+        let sig = signer.sign_hash(H256::from(digest)).unwrap();
+        let json = serde_json::to_value(&typed_data).unwrap();
+        let err = verify_eip712_signature(&json, &format!("0x{}", sig), PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — recovered signer ≠ claimed address");
+        assert!(format!("{err}").contains("Signature does not match"));
+    }
+
+    #[test]
+    fn rejects_bad_signature_hex() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (typed, _) = sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        let err = verify_eip712_signature(&typed, "0xnothex", PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — bad signature hex");
+        assert!(format!("{err}").contains("signature") || format!("{err}").contains("Signature"));
+    }
+
+    #[test]
+    fn rejects_malformed_typed_data_json() {
+        let _ = ensure_test_chain_id();
+        let bogus = serde_json::json!({ "not": "a typed data object" });
+        let err = verify_eip712_signature(&bogus, "0x00", PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — JSON does not deserialize as TypedData");
+        assert!(format!("{err}").to_lowercase().contains("typed_data"));
+    }
+
+    #[test]
+    fn rejects_oversized_typed_data() {
+        let _ = ensure_test_chain_id();
+        // Pad the domain.name with a giant string to blow past the cap. The
+        // domain validator runs after the size check, so this hits the size
+        // cap first (a strict-message-schema test below covers extras inside
+        // `message` separately, which now gets rejected by validate_type_schema
+        // before the size cap can be reached on a small payload).
+        let mut typed = serde_json::json!({
+            "types": {
+                "EIP712Domain": [
+                    { "name": "name", "type": "string" },
+                    { "name": "version", "type": "string" },
+                    { "name": "chainId", "type": "uint256" },
+                ],
+                "CreateWallet": [
+                    { "name": "address", "type": "address" },
+                    { "name": "issuedAt", "type": "uint256" },
+                ],
+            },
+            "primaryType": "CreateWallet",
+            "domain": {
+                "name": "Lit ChainSecured",
+                "version": "1",
+                "chainId": "175188",
+            },
+            "message": {
+                "address": "0x0000000000000000000000000000000000000000",
+                "issuedAt": "0",
+            }
+        });
+        typed["domain"]["name"] = serde_json::Value::String("x".repeat(MAX_TYPED_DATA_LEN + 1));
+        let err = verify_eip712_signature(&typed, "0x00", PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — typed_data exceeds size cap");
+        assert!(format!("{err}").contains("too large"));
+    }
+
+    /// CPL-286 hardening (Codex adversarial review): reject typed-data
+    /// `message` blobs that contain fields beyond the canonical
+    /// `(address, issuedAt)` pair. Extras don't change the EIP-712 digest
+    /// (they aren't in the type hash), but a phishing dApp could embed a
+    /// decoy field like `intent: "Subscribe to weekly briefing"` that some
+    /// wallet UIs render alongside the canonical fields, tricking the user
+    /// into signing what looks like a different action.
+    #[test]
+    fn rejects_extra_message_fields() {
+        let chain_id = ensure_test_chain_id();
+        let wallet = LocalWallet::new(&mut rand::thread_rng());
+        let (mut typed, sig) =
+            sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, now_secs(), chain_id);
+        typed["message"]["decoy"] = serde_json::json!("Authorize $10 subscription");
+        let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
+            .expect_err("must reject — message must contain only address + issuedAt");
+        assert!(format!("{err}").contains("unexpected fields"));
+    }
+}

--- a/lit-api-server/src/core/mod.rs
+++ b/lit-api-server/src/core/mod.rs
@@ -2,6 +2,7 @@ use crate::utils::{parse_with_hash::pkp_id_to_h160, u256_to_derviation_path};
 
 pub mod account_management;
 pub mod core_features;
+pub mod eip712;
 pub mod v1;
 
 pub async fn pkp_id_to_derviation_path(api_key: &str, pkp_id: &str) -> Result<String, String> {

--- a/lit-api-server/src/core/v1/guards/billing_auth.rs
+++ b/lit-api-server/src/core/v1/guards/billing_auth.rs
@@ -1,4 +1,4 @@
-//! Request guard for billing endpoints (CPL-285).
+//! Request guard for billing endpoints (CPL-285, CPL-286).
 //!
 //! Accepts either form of authentication:
 //!
@@ -7,12 +7,17 @@
 //!    downstream `stripe::resolve_wallet_address` keccak256-hashes to derive
 //!    the on-chain account.
 //!
-//! 2. **Wallet-signed** (ChainSecured): a SIWE-lite EIP-191 signed message in
-//!    a single header `X-Wallet-Auth: <base64(JSON{message, signature})>`.
-//!    The guard verifies the signature using the same security envelope as
-//!    `create_wallet_with_signature` (chain-id match, ±5-minute timestamp
-//!    skew). On success the wallet-derived `keccak256(walletAddress)` hex hash
-//!    is the identity passed to `resolve_wallet_address`.
+//! 2. **Wallet-signed** (ChainSecured): EIP-712 typed-data signature in a
+//!    single header `X-Wallet-Auth: <base64(JSON{typed_data, signature})>`
+//!    with `primaryType: "BillingAuth"` and the canonical schema (see
+//!    `core::eip712`). Wallet UIs render the typed struct so the user can
+//!    see they're signing a billing-auth payload, not a generic message
+//!    a phishing dApp could replay against the secret-emitting
+//!    `add_usage_api_key_with_signature` endpoint. Same security envelope
+//!    as `create_wallet_with_signature` (chain-id match, ±5-minute
+//!    timestamp skew). On success the wallet-derived
+//!    `keccak256(walletAddress)` hex hash is the identity passed to
+//!    `resolve_wallet_address`.
 //!
 //! This prevents the original CPL-285 weakness where the public wallet hash
 //! alone was a bearer credential — anyone who knew the wallet address could
@@ -28,7 +33,7 @@ use rocket_okapi::okapi::openapi3::{Object, Parameter, ParameterValue};
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 use serde::Deserialize;
 
-use crate::core::account_management::{SIWE_PURPOSE_BILLING_AUTH, verify_siwe_signature};
+use crate::core::eip712::{PRIMARY_TYPE_BILLING_AUTH, verify_eip712_signature};
 use crate::utils::parse_with_hash::is_precomputed_hash_shape;
 
 /// Identity proven by an inbound billing request.
@@ -61,9 +66,11 @@ impl BillingAuth {
     }
 }
 
+/// Inner JSON of `X-Wallet-Auth`: an EIP-712 typed-data payload signed by
+/// the wallet, with `primaryType: "BillingAuth"`.
 #[derive(Deserialize)]
 struct WalletAuthPayload {
-    message: String,
+    typed_data: serde_json::Value,
     signature: String,
 }
 
@@ -83,10 +90,10 @@ impl<'r> FromRequest<'r> for BillingAuth {
             if !bytes.is_empty()
                 && let Ok(payload) = serde_json::from_slice::<WalletAuthPayload>(&bytes)
             {
-                match verify_siwe_signature(
-                    &payload.message,
+                match verify_eip712_signature(
+                    &payload.typed_data,
                     &payload.signature,
-                    SIWE_PURPOSE_BILLING_AUTH,
+                    PRIMARY_TYPE_BILLING_AUTH,
                 ) {
                     Ok(wallet) => {
                         let wallet_hex = format!("0x{:x}", wallet);
@@ -112,7 +119,8 @@ impl<'r> FromRequest<'r> for BillingAuth {
         // string shaped like a precomputed account hash here — those must
         // come through the verified WalletSigned path only. Otherwise an
         // attacker could send `X-Api-Key: 0x{keccak256(walletAddress)}` and
-        // bypass SIWE entirely (CPL-285 hardening).
+        // bypass the wallet-signed EIP-712 path entirely (CPL-285, CPL-286
+        // hardening).
         let auth = request.headers().get_one("Authorization");
         if let Some(v) = auth {
             let v = v.trim();
@@ -171,11 +179,12 @@ impl<'r> OpenApiFromRequest<'r> for BillingAuth {
                 "API-mode auth: account or usage API key (alternatively \
                  `Authorization: Bearer <key>`). OR — for ChainSecured \
                  callers — omit X-Api-Key entirely and send \
-                 `X-Wallet-Auth: <base64(JSON{message, signature})>` where \
-                 the message is a SIWE-lite EIP-191 payload with a \
-                 `Purpose: lit-billing-auth-v1` line. The signature proves \
-                 wallet possession; the signed message must include \
-                 Address, Chain ID, and Issued At within ±5 minutes."
+                 `X-Wallet-Auth: <base64(JSON{typed_data, signature})>` \
+                 where `typed_data` is EIP-712 with \
+                 `primaryType: \"BillingAuth\"`. The signature proves \
+                 wallet possession; the typed data must include the \
+                 connected wallet address and an issuedAt timestamp \
+                 within ±5 minutes."
                     .to_owned(),
             ),
             required: false,
@@ -218,9 +227,10 @@ mod tests {
     }
 
     /// CPL-285: a public wallet hash sent in `X-Api-Key` would have bypassed
-    /// SIWE entirely after `usage_api_key_to_hash` started accepting the
-    /// precomputed-hash form. The shape check is what blocks it. This test
-    /// pins that decision so a future refactor can't silently undo it.
+    /// the wallet-signed path entirely after `usage_api_key_to_hash` started
+    /// accepting the precomputed-hash form. The shape check is what blocks
+    /// it. This test pins that decision so a future refactor can't silently
+    /// undo it.
     #[test]
     fn precomputed_hash_strings_are_recognized() {
         // A 0x-prefixed 66-char keccak hash must be detectable. The actual

--- a/lit-api-server/src/core/v1/models/request.rs
+++ b/lit-api-server/src/core/v1/models/request.rs
@@ -16,13 +16,14 @@ pub struct NewAccountRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ConvertToChainSecuredAccountRequest {
     /// Hex-encoded EVM address (with or without 0x prefix). Must be the wallet
-    /// the user controls; verified by an EIP-191 personal_sign signature.
+    /// the user controls; verified by an EIP-712 typed-data signature.
     pub new_admin_wallet_address: String,
-    /// SIWE-style message that was signed by `new_admin_wallet_address`. Must
-    /// include `Address:`, `Chain ID:`, and `Issued At:` lines (same format as
-    /// `create_wallet_with_signature`).
-    pub message: String,
-    /// EIP-191 signature of `message` produced by `new_admin_wallet_address`.
+    /// EIP-712 typed-data object the wallet signed. Must use
+    /// `primaryType: "ConvertAccount"` and the canonical schema (see
+    /// `core::eip712`).
+    pub typed_data: serde_json::Value,
+    /// 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of
+    /// `typed_data`.
     pub signature: String,
 }
 
@@ -188,40 +189,43 @@ pub struct ConfirmPaymentRequest {
     pub payment_intent_id: String,
 }
 
-/// ChainSecured wallet creation. The client builds a SIWE-style message
-/// and signs it with their wallet; the server verifies the signature, mints
-/// a PKP via DStack MPC, and returns the new wallet address + derivation
-/// path so the client can register it on-chain via `registerWalletDerivation`.
+/// ChainSecured wallet creation. The client signs EIP-712 typed data with
+/// their wallet; the server verifies the signature, mints a PKP via DStack
+/// MPC, and returns the new wallet address + derivation path so the client
+/// can register it on-chain via `registerWalletDerivation`.
 ///
-/// V1 does not maintain a server-side nonce store. The server enforces a
-/// ±5-minute window on the message's `Issued At` timestamp, which is the
-/// only replay protection. Worst-case replay just mints an extra PKP
-/// (compute cost only — registration still requires a separate wallet
-/// signature on-chain).
+/// The server does not maintain a nonce store. Replay protection is a
+/// ±5-minute window on the `issuedAt` field plus the per-flow primaryType
+/// binding — worst-case replay still just mints an extra unregistered PKP
+/// (compute cost only; registration requires a separate wallet signature
+/// on-chain).
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CreateWalletWithSignatureRequest {
-    /// EIP-191 plaintext message that was signed. Must contain
-    /// `Address: 0x…`, `Chain ID: <u64>`, and `Issued At: <unix-seconds>`
-    /// lines (case-sensitive prefixes).
-    pub message: String,
-    /// 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign).
+    /// EIP-712 typed-data object the wallet signed. Must use
+    /// `primaryType: "CreateWallet"` and the canonical schema (see
+    /// `core::eip712`).
+    pub typed_data: serde_json::Value,
+    /// 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of
+    /// `typed_data`.
     pub signature: String,
 }
 
 /// ChainSecured usage-key minting. Mirrors `CreateWalletWithSignatureRequest`:
-/// the user proves wallet ownership with an EIP-191 personal_sign signature,
-/// the server mints a usage-key wallet via DStack MPC and returns the secret
-/// (as the usage API key) plus address + derivation path. The client follows
-/// up with on-chain `registerWalletDerivation` and `setUsageApiKey` signed by
-/// their admin wallet — only the admin wallet of a ChainSecured account can
-/// call `setUsageApiKey` (see AppStorage.accountExistsAndIsMutable).
+/// the user proves wallet ownership with an EIP-712 typed-data signature,
+/// the server mints a usage-key wallet via DStack MPC and returns the
+/// secret (as the usage API key) plus address + derivation path. The
+/// client follows up with on-chain `registerWalletDerivation` and
+/// `setUsageApiKey` signed by their admin wallet — only the admin wallet
+/// of a ChainSecured account can call `setUsageApiKey` (see
+/// AppStorage.accountExistsAndIsMutable).
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AddUsageApiKeyWithSignatureRequest {
-    /// EIP-191 plaintext message that was signed. Same format as
-    /// `create_wallet_with_signature`: `Address: 0x…`, `Chain ID: <u64>`,
-    /// `Issued At: <unix-seconds>` (case-sensitive prefixes).
-    pub message: String,
-    /// 0x-prefixed hex signature (65 bytes — r||s||v, EIP-191 personal-sign).
+    /// EIP-712 typed-data object the wallet signed. Must use
+    /// `primaryType: "AddUsageApiKey"` and the canonical schema (see
+    /// `core::eip712`).
+    pub typed_data: serde_json::Value,
+    /// 65-byte 0x-prefixed signature (r||s||v) over the EIP-712 digest of
+    /// `typed_data`.
     pub signature: String,
 }
 

--- a/lit-static/core_sdk.js
+++ b/lit-static/core_sdk.js
@@ -324,6 +324,74 @@ export function rpcUrlForChainId(chainId) {
   return KNOWN_RPC_URLS[Number(chainId)] ?? null;
 }
 
+// --- ChainSecured EIP-712 envelope (CPL-286) ---
+//
+// All four ChainSecured signing flows share a single typed-data shape:
+// `{ address, issuedAt }` under a `(name, version, chainId)` domain. The
+// `primaryType` distinguishes the flow and is what the wallet UI labels
+// for the user — replacing the SIWE-lite plaintext envelope where a
+// phishing dApp could hide the `Purpose:` line in a long string.
+//
+// Server-side schema lives in `lit-api-server/src/core/eip712.rs`. Field
+// names, types, and ORDER must match exactly: the EIP-712 type hash is
+// derived from declared order, so any reordering produces a different
+// digest and the server's `validate_type_schema` rejects it.
+const CHAINSECURED_DOMAIN_NAME = 'Lit ChainSecured';
+const CHAINSECURED_DOMAIN_VERSION = '1';
+
+export const PRIMARY_TYPE_CREATE_WALLET = 'CreateWallet';
+export const PRIMARY_TYPE_CONVERT_ACCOUNT = 'ConvertAccount';
+export const PRIMARY_TYPE_ADD_USAGE_API_KEY = 'AddUsageApiKey';
+export const PRIMARY_TYPE_BILLING_AUTH = 'BillingAuth';
+
+/**
+ * Build the canonical EIP-712 typed data the server expects for a
+ * ChainSecured flow. Returns the full TypedData JSON (with EIP712Domain in
+ * `types`) ready to POST to the server. The same object is used to derive
+ * the wallet `signTypedData` arguments — keeping a single source of truth
+ * means the bytes the user sees in the wallet popup are bit-identical to
+ * what the server hashes.
+ */
+export function buildChainSecuredTypedData({ primaryType, address, chainId, issuedAt }) {
+  return {
+    types: {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+      ],
+      [primaryType]: [
+        { name: 'address', type: 'address' },
+        { name: 'issuedAt', type: 'uint256' },
+      ],
+    },
+    primaryType,
+    domain: {
+      name: CHAINSECURED_DOMAIN_NAME,
+      version: CHAINSECURED_DOMAIN_VERSION,
+      chainId: String(chainId),
+    },
+    message: {
+      address,
+      issuedAt: String(issuedAt),
+    },
+  };
+}
+
+/**
+ * Sign canonical typed data with `signer` (any ethers v6 Signer). ethers
+ * strips `EIP712Domain` from the `types` arg automatically, so we pass the
+ * payload-only types and let it handle the rest.
+ *
+ * @returns {Promise<{typed_data: object, signature: string}>}
+ */
+export async function signChainSecuredTypedData(signer, typedData) {
+  const { primaryType, domain, message } = typedData;
+  const payloadTypes = { [primaryType]: typedData.types[primaryType] };
+  const signature = await signer.signTypedData(domain, payloadTypes, message);
+  return { typed_data: typedData, signature };
+}
+
 const ETHERS_CDN_URL = 'https://cdn.jsdelivr.net/npm/ethers@6.13.0/dist/ethers.min.js';
 
 let _ethersPromise = null;
@@ -618,8 +686,9 @@ export class LitNodeSimpleApiClient {
    * POST /core/v1/convert_to_chain_secured_account
    * Hand the account's admin role over to a user-controlled wallet and flip
    * `managed` from true to false. The user proves wallet ownership with an
-   * EIP-191 personal_sign (same SIWE-lite shape as create_wallet_with_signature).
-   * The api_payer signs the on-chain `convertToChainSecuredAccount` call.
+   * EIP-712 typed-data signature (`primaryType: "ConvertAccount"`, same
+   * canonical envelope as create_wallet_with_signature). The api_payer
+   * signs the on-chain `convertToChainSecuredAccount` call.
    *
    * API mode only. Irreversible: the contract reverts if the account is
    * already ChainSecured.
@@ -642,17 +711,24 @@ export class LitNodeSimpleApiClient {
       throw new Error('convertToChainSecuredAccount: chainId is unknown — call getNodeChainConfig first');
     }
     const issuedAt = Math.floor(Date.now() / 1000);
-    const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';
-    // Purpose pins this signature to the convert-account flow only — prevents
-    // cross-flow replay against /create_wallet_with_signature or /billing/* (CPL-285).
-    const message = `${host} wants you to take admin ownership of this account.\n\nAddress: ${newAdminAddress}\nChain ID: ${targetChainId}\nIssued At: ${issuedAt}\nPurpose: lit-convert-account-v1`;
-    const signature = await signer.signMessage(message);
+    // EIP-712 typed data — the wallet UI surfaces `primaryType: ConvertAccount`
+    // and the (address, issuedAt) fields by name, so a phishing dApp can't
+    // disguise the request as a generic message and replay it against the
+    // secret-emitting endpoints (CPL-286). primaryType is part of the type
+    // hash, so the server rejects cross-flow replay at the digest level.
+    const typedData = buildChainSecuredTypedData({
+      primaryType: PRIMARY_TYPE_CONVERT_ACCOUNT,
+      address: newAdminAddress,
+      chainId: targetChainId,
+      issuedAt,
+    });
+    const { typed_data, signature } = await signChainSecuredTypedData(signer, typedData);
     const res = await fetch(`${this.baseUrl}/convert_to_chain_secured_account`, {
       method: 'POST',
       headers: headersWithApiKey(apiKey, { 'Content-Type': 'application/json' }),
       body: JSON.stringify({
         new_admin_wallet_address: newAdminAddress,
-        message,
+        typed_data,
         signature,
       }),
     });
@@ -756,8 +832,9 @@ export class LitNodeSimpleApiClient {
    * the PKP on-chain (api_payer pays gas, account is billed $0.01).
    *
    * ChainSecured mode: two wallet popups.
-   *   1. Sign a SIWE-style message proving wallet ownership; server verifies
-   *      and mints the PKP via DStack MPC (no on-chain write).
+   *   1. Sign EIP-712 typed data (`primaryType: CreateWallet`) proving wallet
+   *      ownership; server verifies and mints the PKP via DStack MPC (no
+   *      on-chain write).
    *   2. Wallet calls `registerWalletDerivation(adminHash, pkpAddress,
    *      derivationPath, name, description)` to register the PKP on-chain.
    *
@@ -781,24 +858,30 @@ export class LitNodeSimpleApiClient {
         throw new Error('createWallet (sovereign): wallet signer not connected');
       }
       // _verifyAbiIntegrity populates this.chainId from the RPC if it wasn't
-      // passed at construction. Run it before composing the SIWE message so
-      // the server sees a real "Chain ID:" line instead of "null" — the
-      // registerWalletDerivation step does the same verify, so this is free.
+      // passed at construction. Run it before building the EIP-712 typed
+      // data so domain.chainId is a real number — the registerWalletDerivation
+      // step does the same verify, so this is free.
       await this._verifyAbiIntegrity();
       if (this.chainId == null) {
         throw new Error('createWallet (sovereign): chainId could not be resolved from RPC');
       }
       const signerAddress = await this.signer.getAddress();
       const issuedAt = Math.floor(Date.now() / 1000);
-      const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit';
-      // Purpose pins this signature to the create-wallet flow only — prevents
-      // cross-flow replay against /convert_to_chain_secured_account or /billing/* (CPL-285).
-      const message = `${host} wants you to create a new wallet for ChainSecured account.\n\nAddress: ${signerAddress}\nChain ID: ${this.chainId}\nIssued At: ${issuedAt}\nPurpose: lit-create-wallet-v1`;
-      const signature = await this.signer.signMessage(message);
+      // EIP-712 typed data — wallet UI surfaces `primaryType: CreateWallet`
+      // and labelled fields. primaryType is part of the type hash, so a
+      // signature minted here cannot be replayed against the secret-emitting
+      // /add_usage_api_key_with_signature endpoint (CPL-286).
+      const typedData = buildChainSecuredTypedData({
+        primaryType: PRIMARY_TYPE_CREATE_WALLET,
+        address: signerAddress,
+        chainId: this.chainId,
+        issuedAt,
+      });
+      const { typed_data, signature } = await signChainSecuredTypedData(this.signer, typedData);
       const res = await fetch(`${this.baseUrl}/create_wallet_with_signature`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message, signature }),
+        body: JSON.stringify({ typed_data, signature }),
       });
       const minted = await parseResponse(res, 'create_wallet_with_signature');
       const { wallet_address, derivation_path } = minted;
@@ -1575,7 +1658,7 @@ export class LitNodeSimpleApiClient {
    * Returns the current credit balance for the authenticated user.
    * @param {string} apiKey - Raw API key. Ignored when `options.walletAuthHeader` is set.
    * @param {{walletAuthHeader?: string, signal?: AbortSignal}} [options]
-   *   walletAuthHeader: base64(JSON{message, signature}) for SIWE-style ChainSecured auth (CPL-285).
+   *   walletAuthHeader: base64(JSON{typed_data, signature}) for EIP-712 ChainSecured auth (CPL-285, CPL-286).
    *   signal: AbortController signal to cancel the request mid-flight.
    * @returns {Promise<{balance_cents: number, balance_display: string}>}
    */
@@ -1626,9 +1709,9 @@ export class LitNodeSimpleApiClient {
 
 /**
  * Build headers for billing endpoints. ChainSecured callers send an
- * X-Wallet-Auth header (base64(JSON{message, signature})); API-mode callers
- * send X-Api-Key. The server's BillingAuth guard prefers the wallet header
- * when both are present (CPL-285).
+ * X-Wallet-Auth header (base64(JSON{typed_data, signature})); API-mode
+ * callers send X-Api-Key. The server's BillingAuth guard prefers the
+ * wallet header when both are present (CPL-285, CPL-286).
  */
 function billingHeaders(apiKey, walletAuthHeader, extra = {}) {
   if (walletAuthHeader) {

--- a/lit-static/dapps/dashboard/DESIGN.md
+++ b/lit-static/dapps/dashboard/DESIGN.md
@@ -154,12 +154,13 @@ Lit Actions by pasting a usage API key they minted from the contract.
 Billing (balance, Add Funds, no-funds warning, billing banners) is **not**
 mode-conditional. Stripe credit funds action runs in both modes. ChainSecured
 only changes how admin writes are authorized (wallet vs API key), not how
-runs are paid for. ChainSecured users authenticate billing requests via a
-SIWE-style EIP-191 signed message (cached ~4 minutes per session) sent in
-the `X-Wallet-Auth` header — the dashboard's `getWalletAuthHeader()` builds
-the message and `BillingAuth` verifies it server-side. The signature pins
-the `Purpose: lit-billing-auth-v1` line to prevent cross-flow replay
-against `/create_wallet_with_signature` or `/convert_to_chain_secured_account`.
+runs are paid for. ChainSecured users authenticate billing requests via an
+EIP-712 typed-data signature (`primaryType: "BillingAuth"`, cached ~4
+minutes per session) sent in the `X-Wallet-Auth` header — the dashboard's
+`getWalletAuthHeader()` builds the typed data and `BillingAuth` verifies it
+server-side. The `primaryType` is part of the EIP-712 type hash, so a
+signature minted here cannot be replayed against the secret-emitting
+`/add_usage_api_key_with_signature` endpoint or any other ChainSecured flow.
 
 Validation guards must use `isAuthenticated()`, not `!apiKey` — ChainSecured
 users authenticate via wallet and have no account-level api key.

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -1,10 +1,13 @@
 /**
  * Billing — Stripe integration, payment flow.
  *
- * ChainSecured callers (CPL-285) authenticate to /billing/* with a SIWE-lite
- * EIP-191 signed message proving they hold the wallet's private key. The
- * signed payload is cached for ~4 minutes (server allows ±5min skew, we leave
- * a buffer) so the user only sees one wallet popup per billing session.
+ * ChainSecured callers (CPL-285, CPL-286) authenticate to /billing/* with an
+ * EIP-712 typed-data signature proving they hold the wallet's private key.
+ * The wallet UI surfaces `primaryType: BillingAuth` and labelled fields so a
+ * phishing dApp can't disguise the request as a generic message and replay
+ * it against the secret-emitting endpoints. The signed payload is cached
+ * for ~4 minutes (server allows ±5min skew, we leave a buffer) so the user
+ * only sees one wallet popup per billing session.
  *
  * All in-flight billing requests are tied to a module AbortController and a
  * captured-credential snapshot — `clearBillingSession()` is called on logout
@@ -14,6 +17,11 @@
  * the prior account.
  */
 
+import {
+  PRIMARY_TYPE_BILLING_AUTH,
+  buildChainSecuredTypedData,
+  signChainSecuredTypedData,
+} from '../../core_sdk.js';
 import {
   getApiKey,
   getChainSecuredHash,
@@ -36,12 +44,12 @@ const BILLING_RETRY_MS = 30000;
 // session change via clearBillingSession().
 let _abortController = null;
 
-// Cached SIWE auth payload. Re-used across billing requests within the
+// Cached wallet-auth payload. Re-used across billing requests within the
 // timestamp window. { headerValue, expiresAtMs, walletAddress }
 let _walletAuthCache = null;
 
 /**
- * True when we have a valid (unexpired, current-wallet) SIWE auth header.
+ * True when we have a valid (unexpired, current-wallet) wallet-auth header.
  * Used to decide whether to load the balance silently vs. wait for the user
  * to click Add Funds — we never want to auto-trigger a wallet popup just to
  * render the topbar balance (CPL-285 review feedback).
@@ -53,8 +61,9 @@ function hasValidWalletAuthCache() {
   return _walletAuthCache.expiresAtMs > Date.now() + 10_000;
 }
 
-// Server's SIWE_TIMESTAMP_SKEW_SECONDS is 300; we cache for 4 min to leave a
-// 1-min safety buffer against clock skew + in-flight latency.
+// Server's TIMESTAMP_SKEW_SECONDS is 300 (lit-api-server/src/core/eip712.rs);
+// we cache for 4 min to leave a 1-min safety buffer against clock skew +
+// in-flight latency.
 const WALLET_AUTH_TTL_MS = 4 * 60 * 1000;
 
 /**
@@ -73,7 +82,7 @@ function ensureAbortController() {
 }
 
 /**
- * Abort any in-flight billing requests and clear the cached SIWE auth
+ * Abort any in-flight billing requests and clear the cached wallet-auth
  * payload. Called on logout, mode switch, and wallet change so a mid-flight
  * fetch can't credit the prior account.
  */
@@ -128,30 +137,10 @@ export function resetBillingAvailability() {
 }
 
 /**
- * Build the SIWE-lite message body the server's `parse_create_wallet_siwe`
- * expects. Required lines (case-sensitive): `Address:`, `Chain ID:`,
- * `Issued At:`, `Purpose:`. The `Purpose` line pins this signature to the
- * billing-auth flow only — prevents cross-flow replay against
- * /create_wallet_with_signature or /convert_to_chain_secured_account (CPL-285).
- */
-function buildSiweMessage(wallet, chainId, issuedAt) {
-  const host = (typeof location !== 'undefined' && location.host) ? location.host : 'lit-dashboard';
-  return [
-    `${host} wants you to sign in to billing.`,
-    '',
-    'This signature lets the dashboard authenticate billing requests on your',
-    "behalf for ~5 minutes. It is not a transaction and won't be broadcast.",
-    '',
-    `Address: ${wallet}`,
-    `Chain ID: ${chainId}`,
-    `Issued At: ${issuedAt}`,
-    'Purpose: lit-billing-auth-v1',
-  ].join('\n');
-}
-
-/**
- * Get a cached SIWE auth header, or prompt the wallet to sign a fresh one.
- * Returns base64(JSON{message, signature}) for the X-Wallet-Auth header.
+ * Get a cached wallet-auth header, or prompt the wallet to sign a fresh one.
+ * Returns base64(JSON{typed_data, signature}) for the X-Wallet-Auth header.
+ * Server validates `primaryType: "BillingAuth"` against the canonical schema
+ * in `lit-api-server/src/core/eip712.rs` (CPL-286).
  */
 async function getWalletAuthHeader() {
   const wallet = getChainSecuredWallet();
@@ -169,13 +158,18 @@ async function getWalletAuthHeader() {
     ? Number(client.chainId)
     : Number((await client.getNodeChainConfig()).chain_id);
   const issuedAt = Math.floor(Date.now() / 1000);
-  const message = buildSiweMessage(wallet, chainIdNum, issuedAt);
+  const typedData = buildChainSecuredTypedData({
+    primaryType: PRIMARY_TYPE_BILLING_AUTH,
+    address: wallet,
+    chainId: chainIdNum,
+    issuedAt,
+  });
 
   const { connectEoa } = await import('../../wallet_connect.js');
   const { signer } = await connectEoa();
-  const signature = await signer.signMessage(message);
+  const { typed_data, signature } = await signChainSecuredTypedData(signer, typedData);
 
-  const headerValue = btoa(JSON.stringify({ message, signature }));
+  const headerValue = btoa(JSON.stringify({ typed_data, signature }));
   _walletAuthCache = {
     headerValue,
     expiresAtMs: Date.now() + WALLET_AUTH_TTL_MS,
@@ -187,7 +181,7 @@ async function getWalletAuthHeader() {
 /**
  * Resolve the SDK options for the current mode: { walletAuthHeader?, signal }.
  * In API mode we just attach the abort signal; in sovereign mode we also
- * obtain the SIWE header (prompting the wallet on cache miss).
+ * obtain the EIP-712 wallet-auth header (prompting the wallet on cache miss).
  */
 async function billingRequestOptions(signal) {
   const opts = { signal };
@@ -221,9 +215,10 @@ export function refreshBillingUI() {
       if (billingBanner) billingBanner.style.display = 'none';
       // In sovereign mode never auto-trigger a wallet popup just to render
       // the topbar balance. Only load the balance when we already hold a
-      // valid SIWE cache (e.g. immediately after the user funded). Otherwise
-      // the user explicitly opts in by clicking Add Funds — `openAddFundsModal`
-      // primes the auth and refreshes the balance after a successful payment.
+      // valid wallet-auth cache (e.g. immediately after the user funded).
+      // Otherwise the user explicitly opts in by clicking Add Funds —
+      // `openAddFundsModal` primes the auth and refreshes the balance after
+      // a successful payment.
       if (getMode() === 'sovereign') {
         if (hasValidWalletAuthCache()) {
           loadBillingBalance();
@@ -310,10 +305,10 @@ async function openAddFundsModal() {
     }
   }
 
-  // Sovereign mode: prime the SIWE cache now (one wallet popup) so the
-  // user's later Pay click — and the balance refresh that follows — flows
-  // without a second prompt. If they cancel the signature, surface that in
-  // the modal status and leave the modal open so they can retry.
+  // Sovereign mode: prime the wallet-auth cache now (one EIP-712 typed-data
+  // popup) so the user's later Pay click — and the balance refresh that
+  // follows — flows without a second prompt. If they cancel the signature,
+  // surface that in the modal status and leave the modal open so they can retry.
   if (getMode() === 'sovereign' && !hasValidWalletAuthCache()) {
     if (statusEl) {
       statusEl.textContent = 'Approve the wallet signature to enable billing for this session…';
@@ -324,7 +319,7 @@ async function openAddFundsModal() {
       await getWalletAuthHeader();
       if (statusEl) statusEl.style.display = 'none';
     } catch (e) {
-      logError('siwe-prime', e);
+      logError('wallet-auth-prime', e);
       if (statusEl) {
         statusEl.textContent = 'Wallet signature required to fund a ChainSecured account: ' + formatError(e);
         statusEl.className = 'status error';
@@ -419,7 +414,7 @@ export function initBilling() {
 
         // Separate try for confirmPayment — card is already charged at this point
         try {
-          // Re-fetch options in case the cached SIWE expired during Stripe.js round-trip.
+          // Re-fetch options in case the cached wallet-auth header expired during the Stripe.js round-trip.
           const opts2 = await billingRequestOptions(ctrl.signal);
           if (billingAuthKey() !== apiKey || ctrl.signal.aborted) return;
           await client.confirmPayment(apiKey, intent.payment_intent_id, opts2);


### PR DESCRIPTION
## Summary

Wallet UIs now render the ChainSecured signed payload as a labelled struct (`primaryType`, `address`, `issuedAt`) under a stable `(name: "Lit ChainSecured", version: "1", chainId)` domain instead of SIWE-lite plaintext. Each of the four flows pins its own `primaryType`, and the EIP-712 type hash commits to the struct name — so a signature minted for `CreateWallet` cannot recover when the server hashes the same bytes against `BillingAuth` or, critically, the secret-emitting `AddUsageApiKey`. This closes the phishing vector where a compromised dApp could prompt the user to sign a generic-looking message and replay it against an endpoint the user never intended to authorize.

The legacy SIWE-lite path is **removed entirely** (per-user direction — no deprecation window).

| Endpoint / header | `primaryType` |
|--|--|
| `/create_wallet_with_signature` | `CreateWallet` |
| `/convert_to_chain_secured_account` | `ConvertAccount` |
| `/add_usage_api_key_with_signature` | `AddUsageApiKey` |
| `X-Wallet-Auth` (billing) | `BillingAuth` |

**Server**: new `lit-api-server/src/core/eip712.rs` with strict validation (domain match, exact type schema match, exact message-field schema match, ±5min timestamp, 4 KiB length cap, ECDSA recovery via `RecoveryMessage::Hash`). 18 inline tests. Three handlers + the `BillingAuth` guard call `verify_eip712_signature` directly. Legacy `verify_siwe_signature` / `parse_create_wallet_siwe` / `recover_eip191_signer` / `SIWE_PURPOSE_*` deleted.

**Client**: `core_sdk.js` exports `buildChainSecuredTypedData` and `signChainSecuredTypedData`. `createWallet`, `convertToChainSecuredAccount`, and dashboard `getWalletAuthHeader` use `signer.signTypedData()` (ethers v6).

**Breaking change for external consumers**: request shapes for the three `*_with_signature` endpoints changed from `{message, signature}` → `{typed_data, signature}` (typed_data required). The `X-Wallet-Auth` inner JSON changed similarly.

## Test Coverage

```
lit-api-server/src/core/eip712.rs (NEW, 18 tests):
  ├── happy_path_create_wallet
  ├── happy_path_all_primary_types          (× 4 primary types)
  ├── cross_flow_replay_rejected_at_primary_type_check
  ├── cross_flow_replay_rejected_at_recovery_when_primary_type_rewritten
  ├── rejects_chain_id_mismatch
  ├── rejects_domain_name_mismatch / rejects_domain_version_mismatch
  ├── rejects_extra_domain_field_verifying_contract
  ├── rejects_schema_field_reorder
  ├── rejects_extra_type_definitions
  ├── rejects_extra_message_fields           (NEW — phishing decoy hardening)
  ├── rejects_timestamp_too_old / rejects_timestamp_too_far_future / rejects_i64_min_issued_at
  ├── rejects_address_signer_mismatch
  ├── rejects_bad_signature_hex
  ├── rejects_malformed_typed_data_json
  └── rejects_oversized_typed_data
```

Tests: 224 → 225 (+18 in eip712, –17 dispatcher tests deleted along with the legacy path).

## Pre-Landing Review

22 findings — 13 auto-fixed (all stale `SIWE` references in comments / docs / log tags after the legacy path was deleted; one critical doc rewrite where `account_modes.mdx` would otherwise have 400'd anyone following the published guide), 1 hardening applied from Codex adversarial review (strict `message`-field schema check rejects extra fields that some wallet UIs would render as decoys), 8 informational findings deferred as out-of-scope follow-ups.

CI gates verified locally with rustc 1.91:
- `cargo test --lib` — 225 passing
- `cargo clippy --tests -- -D warnings` — clean
- `cargo fmt --check` — clean
- k6 client regenerated against current OpenAPI spec

## Adversarial Review (Codex + Claude subagent)

Codex flagged 5 substantive issues. Two genuine new hardenings were applied; three are **pre-existing limitations** (same surface under the legacy SIWE-lite envelope) flagged as follow-ups for separate tickets:

**Applied in this PR:**
- Strict `message`-field schema check (rejects decoy fields a phishing dApp could embed for wallet-UI rendering)

**Deferred (not regressions, file as separate tickets):**
1. Wallet-signed billing identity collision for **converted** accounts (CPL-285 derived identity as `keccak(wallet)` but converted accounts preserve their old `apiKeyHash` on-chain — collision pre-existed CPL-286)
2. ERC-1271 / Safe contract-wallet support — both legacy `personal_sign` recovery and the new EIP-712 path use plain ECDSA `recover()`. The `account_modes.mdx` claim that Safe works was already inaccurate
3. Same-flow cross-account replay — in the worst case, an attacker holding a captured `ConvertAccount` signature plus a 2nd API key for a different account can convert that account too within the ±300s window. Same risk under legacy SIWE-lite. Hardening is to bind the `apiKeyHash` into the signed payload
4. 4 KiB length cap fires after Rocket's JSON parse — Rocket has its own outer 1 MiB body limit; same surface as before

## Plan Completion

CPL-286 Linear ticket items:
- ✅ Migrate SIWE-lite envelope to EIP-712 typed data
- ✅ Domain `(name: "Lit ChainSecured", chainId)`, no `verifyingContract`
- ✅ Typed struct per flow with `primaryType` baked into the type hash
- ✅ Server validates `primaryType` matches the endpoint at the digest level
- 🔁 Backwards compatibility / deprecation window — **CHANGED** per user direction ("no deprecation window required") to complete legacy removal in this PR

## Test plan

- [x] `cargo test --lib` (lit-api-server) — 225 passing
- [x] `cargo clippy --tests -- -D warnings` — clean (rustc 1.91)
- [x] `cargo fmt --check` — clean
- [x] `npx @grafana/openapi-to-k6` regenerated `k6/litApiServer.ts`
- [ ] Manual: dashboard `Connect wallet → Create wallet` triggers an EIP-712 popup with labelled fields
- [ ] Manual: dashboard `Add Funds` flow signs `BillingAuth` typed data once and reuses for ~4 minutes
- [ ] Manual: `Convert to ChainSecured` flow signs `ConvertAccount` typed data and the api_payer relays the on-chain conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)