### PR TITLE
ci(next): point next deploys at prod6 cvm_yZQnD863

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -107,7 +107,11 @@ jobs:
             echo "node_config=NodeConfig.main.toml" >> "$GITHUB_OUTPUT"
             DOMAIN="api.dev.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
-            echo "phala_app_name=chipotle-next" >> "$GITHUB_OUTPUT"
+            # Targets the prod6 instance provisioned via `phala instances add`
+            # during the prod5→prod6 migration. Shares the same app_id
+            # (0x969a8c14...) and derived keys as the legacy chipotle-next
+            # instance on prod5.
+            echo "phala_app_name=chipotle-next-rep-z1nz6" >> "$GITHUB_OUTPUT"
             echo "instance_type=tdx.small" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-next" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.next.toml" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Switches the next-branch deploy target in deploy-staging.yml from the legacy chipotle-next name (prod5) to cvm_yZQnD863 (prod6). The prod6 instance shares the same app_id and KMS-derived keys as the prod5 one (provisioned via \`phala instances add\`), and Phala just enabled custom-domain SNI routing on the prod6 gateway, so test.chipotle.litprotocol.com now serves from prod6 with a valid LE cert.

## Test plan

- [ ] Confirm CI \`detect-changes\` and \`wait-for-api-available\` succeed against the custom domain (already verified via curl: TLS subject=test.chipotle.litprotocol.com, /version 200, /health 200).
- [ ] Merge a no-op next-branch change to trigger an end-to-end deploy and confirm \`phala deploy --cvm-id cvm_yZQnD863\` updates the prod6 instance cleanly.
- [ ] Once green, retire the prod5 chipotle-next CVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)