### PR TITLE
ci(next): point next deploys at prod2 chipotle-next-rep-sa6xj

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -107,11 +107,11 @@ jobs:
             echo "node_config=NodeConfig.main.toml" >> "$GITHUB_OUTPUT"
             DOMAIN="api.dev.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
-            # Targets the prod6 instance provisioned via `phala instances add`
-            # during the prod5→prod6 migration. Shares the same app_id
-            # (0x969a8c14...) and derived keys as the legacy chipotle-next
-            # instance on prod5.
-            echo "phala_app_name=chipotle-next-rep-z1nz6" >> "$GITHUB_OUTPUT"
+            # Targets the prod2 instance provisioned via `phala instances add`
+            # during the prod6→prod2 migration. Shares the same app_id
+            # (0x969a8c14...) and derived keys as previous chipotle-next
+            # instances.
+            echo "phala_app_name=chipotle-next-rep-sa6xj" >> "$GITHUB_OUTPUT"
             echo "instance_type=tdx.small" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-next" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.next.toml" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

prod6 was flagged unhealthy by Phala. Moved next to prod2 using the same \`phala instances add\` migration playbook, with the new replica \`chipotle-next-rep-sa6xj\` sharing the same app_id (0x969a8c14...) and derived keys as the prior instances. CVM is up, /health green, on-chain device allowlisted, envs pushed and decrypted. Stop prod6 after this deploy lands cleanly to end any DNS contention.

## Test plan

- [ ] CI deploy to chipotle-next-rep-sa6xj succeeds.
- [ ] \`test.chipotle.litprotocol.com/core/v1/version\` reflects the deployed SHA.
- [ ] Stop prod6 cvm_yZQnD863; confirm DNS settles on _.dstack-base-prod2.phala.network within ~12h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)