### PR TITLE
fix(CPL-290): collapse double-credit race in confirm_payment_and_credit

### DIFF
--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -47,6 +47,11 @@ pub struct StripeState {
     /// for 60 seconds, so each customer triggers at most one Stripe GET per minute
     /// regardless of request rate.
     balance_refresh_in_flight: Cache<String, ()>,
+    /// Per-PaymentIntent mutexes that serialize concurrent
+    /// `confirm_payment_and_credit` calls for the same intent.  Idempotency keys
+    /// on the Stripe POSTs are the authoritative defence against double-credit;
+    /// this lock just short-circuits racers locally before they reach the network.
+    confirm_payment_locks: Cache<String, Arc<tokio::sync::Mutex<()>>>,
 }
 
 impl std::fmt::Debug for StripeState {
@@ -87,6 +92,10 @@ pub fn init() -> Option<Arc<StripeState>> {
         .max_capacity(10_000)
         .time_to_live(Duration::from_secs(60)) // cooldown: max 1 refresh per customer per minute
         .build();
+    let confirm_payment_locks = Cache::builder()
+        .max_capacity(10_000)
+        .time_to_idle(Duration::from_secs(120))
+        .build();
     tracing::info!("stripe: billing enabled");
     Some(Arc::new(StripeState {
         publishable_key,
@@ -96,6 +105,7 @@ pub fn init() -> Option<Arc<StripeState>> {
         wallet_cache,
         balance_cache,
         balance_refresh_in_flight,
+        confirm_payment_locks,
     }))
 }
 
@@ -558,17 +568,31 @@ pub async fn create_payment_intent(
 /// Verify a PaymentIntent succeeded and credit the customer's account.
 ///
 /// Replay protection:
-/// 1. Checks `metadata.credited == "true"` on the PaymentIntent — rejects if already applied.
-/// 2. Verifies the PaymentIntent's `customer` field matches the caller's Stripe customer —
+/// 1. A per-PaymentIntent local mutex serializes concurrent calls so the
+///    check-then-act below can't race with itself in this process.
+/// 2. Both Stripe POSTs use deterministic `Idempotency-Key`s derived from the
+///    PaymentIntent ID, so even if the local lock is bypassed (eviction,
+///    multi-process) Stripe's 24h idempotency window collapses duplicates
+///    server-side.
+/// 3. Checks `metadata.credited == "true"` on the PaymentIntent — rejects if already applied.
+/// 4. Verifies the PaymentIntent's `customer` field matches the caller's Stripe customer —
 ///    prevents one account from claiming another account's payment.
-/// 3. Marks the PaymentIntent as credited (`metadata[credited]=true`) **before** creating
+/// 5. Marks the PaymentIntent as credited (`metadata[credited]=true`) **before** creating
 ///    the balance transaction, so a crash or retry after this point is safe (the second call
-///    will be rejected by check 1).
+///    will be rejected by check 3).
 pub async fn confirm_payment_and_credit(
     payment_intent_id: &str,
     wallet_address: &str,
     state: &StripeState,
 ) -> Result<()> {
+    let lock = state
+        .confirm_payment_locks
+        .get_with(payment_intent_id.to_string(), async {
+            Arc::new(tokio::sync::Mutex::new(()))
+        })
+        .await;
+    let _guard = lock.lock().await;
+
     let resp = stripe_get(state, &format!("payment_intents/{payment_intent_id}"), &[]).await?;
 
     let pi_status = resp
@@ -614,15 +638,16 @@ pub async fn confirm_payment_and_credit(
 
     // Mark as credited before creating the balance transaction so that any subsequent
     // call with the same intent ID is rejected even if the process crashes after this point.
-    stripe_post(
+    stripe_post_with_idempotency(
         state,
         &format!("payment_intents/{payment_intent_id}"),
         &[("metadata[credited]", "true")],
+        &format!("credit-mark:{payment_intent_id}"),
     )
     .await?;
 
     let credit = (-amount).to_string(); // negative = credit to customer
-    stripe_post(
+    stripe_post_with_idempotency(
         state,
         &format!("customers/{customer_id}/balance_transactions"),
         &[
@@ -630,6 +655,7 @@ pub async fn confirm_payment_and_credit(
             ("currency", "usd"),
             ("description", &format!("Top-up via {payment_intent_id}")),
         ],
+        &format!("credit-tx:{payment_intent_id}"),
     )
     .await?;
 


### PR DESCRIPTION
## Summary

[CPL-290](https://linear.app/litprotocol/issue/CPL-290/crit-stripe-confirm-payment-and-credit-double-credit-race-concurrent) — `confirm_payment_and_credit` performed an unguarded check-then-act on `metadata.credited` and posted to `customers/{cid}/balance_transactions` with no `Idempotency-Key`. Concurrent POSTs to `/billing/confirm_payment` with the same `payment_intent_id` all observed `metadata.credited != "true"` and each created a distinct credit ledger entry, multiplying the credit by the racing concurrency. For a $100 PI at N=10 racers, an attacker netted $900 of free credit per fresh PI.

Two layers of defence, defense-in-depth:

1. **Per-PaymentIntent `tokio::sync::Mutex`** — stored in a moka cache (`Cache<String, Arc<Mutex<()>>>`, 120s `time_to_idle`) on `StripeState`, acquired at function entry. Concurrent racers serialize locally; the second to enter the critical section reads the freshly-set `metadata.credited == "true"` from the GET and bails with "already credited."
2. **Deterministic `Idempotency-Key`s** on both Stripe POSTs:
   - `credit-mark:{payment_intent_id}` for the PaymentIntent metadata update
   - `credit-tx:{payment_intent_id}` for the `customers/{cid}/balance_transactions` create

   Distinct keys per endpoint avoid Stripe's "same key, different request fingerprint" error. The 24h idempotency window collapses duplicates server-side even if the local mutex is bypassed (cache eviction, multi-process deploys, restart mid-request).

The `stripe_post_with_idempotency` helper already existed at `stripe.rs:176` (used by the per-charge ledger path) — this PR just wires `confirm_payment_and_credit`'s two POSTs through it.

## Pre-Landing Review

Self-review focused on the new locking + idempotency layer. No issues found.

- **Lock cache eviction:** TTL is 120s `time_to_idle`, well above the typical confirm-payment latency. Even on eviction, idempotency keys are the authoritative defence — Stripe collapses duplicates regardless of local lock state.
- **`get_with` vs `try_get_with`:** Used `get_with` for the lock cache (returns `Arc<Mutex>`, no fallible result to cache). The mutex is released as soon as the function exits via the `_guard` RAII binding.
- **Idempotency-key collision:** Distinct keys per endpoint (`credit-mark:` vs `credit-tx:`) — safe because Stripe scopes idempotency keys per (account, key) and stores the request fingerprint. Reusing one key across two different paths would error on the second call.
- **Replay-guard ordering:** Lock → GET → status/credited/customer checks → metadata mark → ledger entry. The metadata mark still happens before the credit creation, preserving the existing crash-safety property (a crash between mark and ledger creates a stuck PI but never a double-credit).
- **Stripe customer lookup inside the guard:** `get_customer_by_wallet` is called while holding the lock. The customer cache is in-process and bounded; under contention the second racer hits a cache hit. No deadlock risk (no nested same-key locks).

## Test Coverage

No new automated coverage. The existing test pattern in `stripe.rs` is unit tests for pure helpers (`parse_stripe_response`, `cents_to_display`, `cache_key`, `should_update_balance_cache`, `unix_to_utc_date`, `aggregate_report_rows`) — there is no HTTP mock infrastructure for `stripe_post`/`stripe_get`, so neither `confirm_payment_and_credit` nor `charge` have direct unit tests today. Adding one for this fix would require introducing a mock layer beyond the scope of a CRIT race-condition patch.

The fix is amenable to manual verification via the exploit POC in the Linear ticket against a test PaymentIntent — concurrent N×curl will now produce one ledger entry instead of N.

## Verification

- `cargo build` — clean
- `cargo test --lib` (lit-api-server) — 225 passed, 0 failed (23 stripe tests included)
- `cargo clippy --lib --no-deps` — clean, no warnings
- `cargo fmt --all -- --check` — clean

No rocket route changes; k6 client regen not required.

## TODOS

No TODOS.md items completed in this PR.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 225/225 passing
- [x] `cargo clippy --lib --no-deps` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: replay the exploit POC (`for i in 1..5; do curl -X POST .../billing/confirm_payment -d '{"payment_intent_id":"pi_xxx"}' & done; wait`) on a test PI and verify exactly one credit ledger entry is created in the Stripe dashboard (was N, should be 1).
- [ ] Manual: confirm legitimate first-time confirm still credits successfully and the `metadata.credited` flag flips to `"true"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)