### PR TITLE
fix(CPL-300): drop root in lit-api-server and lit-actions containers

### DIFF
--- a/Dockerfile.lit-actions
+++ b/Dockerfile.lit-actions
@@ -25,9 +25,14 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
+# Drop privileges so a JS sandbox escape cannot reach root in the CVM.
+RUN useradd -u 10001 -m lit
+
 WORKDIR /app
 
 COPY --from=builder /build/lit-actions/target/release/lit_actions /usr/local/bin/
 COPY lit-actions/integrity.lock /app/integrity.lock
+
+USER lit
 
 CMD ["lit_actions", "--socket", "/tmp/lit_actions.sock", "--integrity-lock", "/app/integrity.lock"]

--- a/Dockerfile.lit-api-server
+++ b/Dockerfile.lit-api-server
@@ -21,6 +21,9 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
+# Drop privileges so an RCE cannot weaponise /var/run/dstack.sock as a KMS oracle.
+RUN useradd -u 10001 -m lit
+
 WORKDIR /app
 
 COPY --from=builder /build/lit-api-server/target/release/lit-api-server /usr/local/bin/
@@ -30,5 +33,7 @@ COPY --from=builder /build/lit-api-server/log_levels.toml /app/
 # NodeConfig.toml required at startup (main branch uses NodeConfig.main.toml; default: next)
 ARG NODE_CONFIG=NodeConfig.next.toml
 COPY --from=builder /build/lit-api-server/${NODE_CONFIG} /app/NodeConfig.toml
+
+USER lit
 
 CMD ["lit-api-server"]


### PR DESCRIPTION
## Summary

Closes the defense-in-depth gap from [CPL-300](https://linear.app/litprotocol/issue/CPL-300/high-dockerfilelit-api-server-and-dockerfilelit-actions-have-no-user) (audit finding from `.context/CSO-CPL-281-report.md`#11). Both Dockerfiles previously had no `USER` directive, so the containers ran as root inside the Phala CVM. Any RCE in `lit-api-server` (sandbox escape, panic-handler exploit, etc.) would have inherited root with full access to `/var/run/dstack.sock` — turning the dstack KMS into a signing/attestation oracle for arbitrary `report_data`.

Both Dockerfiles now drop to a non-root `lit` user (uid 10001, matching the existing convention in `Dockerfile.otel-collector:9`):

- `Dockerfile.lit-api-server`: `useradd -u 10001 -m lit` + `USER lit` before `CMD`
- `Dockerfile.lit-actions`: same pattern

## Why this works without compose changes

- **`/tmp/lit_actions.sock`** — `lit-actions/grpc/unix.rs:66` already chmods the bound socket to `0o777`, so the `lit-api-server` side connects regardless of UID. The shared `lit-socket` named volume initialises from the image's `/tmp` (mode 1777), so non-root binds.
- **`/var/run/dstack.sock`** — bind-mounted from the host; the same compose's `dstack-ingress` service already accesses this socket without privileged mode, confirming non-root works.

## Verification

- `docker buildx build --check` — **passes both Dockerfiles, no warnings.**
- Live container check: `useradd -u 10001 -m lit` succeeds in `debian:bookworm-slim`, `/tmp` is mode 1777 (drwxrwxrwt), the `lit` user can create files there. So `lit-actions` can bind `/tmp/lit_actions.sock`.

## Out of scope

The unrelated root-level `Dockerfile` (development convenience build) is also missing a `USER` directive but is not deployed to Phala. Tracked separately if the audit decides to widen scope.

## Test plan

- [ ] `Phala Simulator Validation` CI passes (validates dstack socket access end-to-end).
- [ ] After merge: trigger Phala deploy on `next` and confirm `lit-api-server` and `lit_actions` start, `id` shows `uid=10001(lit)`, and `/attestation` endpoint still returns a valid quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)