### PR TITLE
feat(CPL-313): preserve Stripe customer across ChainSecured conversion

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/AppStorage.sol
@@ -98,6 +98,7 @@ library AppStorage {
         uint256 pkpCount; // counter for creating unique pkp ids
         uint256 actionCount; // count of unique actions registered to this account
         uint256 groupCount; // counter for creating unique group ids
+        address billingWalletAddress; // wallet address that is used to bill the api key
     }
 
     /// @notice Root storage for AccountConfig. Stored at a fixed slot so all facets share the same state.

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
@@ -124,7 +124,10 @@ contract ViewsFacet {
     /// @notice Return the admin/owner wallet address for the account that owns the given API key.
     /// @dev Works with both master and usage API key hashes (resolves via allApiKeyHashesToMaster).
     ///      The admin wallet is set at account creation and is not necessarily the transaction creator.
-    /// @param apiKeyHash keccak256 of a master or usage API key (base64-encoded).
+    /// @param apiKeyHash Account identity hash. Accepts either keccak256 of a master or usage
+    ///        API key (base64-encoded) — the API-key flow — or keccak256(walletAddress) for
+    ///        ChainSecured callers, whose on-chain identity is derived from their wallet rather
+    ///        than a secret API key.
     /// @return The admin/owner wallet address stored on the resolved master account.
     function getAccountWalletAddress(
         uint256 apiKeyHash
@@ -136,7 +139,10 @@ contract ViewsFacet {
     /// @notice Return the billing wallet address for the account that owns the given API key.
     /// @dev Works with both master and usage API key hashes (resolves via allApiKeyHashesToMaster).
     ///      The billing wallet is set at account creation and is not necessarily the transaction creator.
-    /// @param apiKeyHash keccak256 of a master or usage API key (base64-encoded).
+    /// @param apiKeyHash Account identity hash. Accepts either keccak256 of a master or usage
+    ///        API key (base64-encoded) — the API-key flow — or keccak256(walletAddress) for
+    ///        ChainSecured callers, whose on-chain identity is derived from their wallet rather
+    ///        than a secret API key.
     /// @return The billing wallet address stored on the resolved master account.
     function getBillingWalletAddress(
         uint256 apiKeyHash

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/ViewsFacet.sol
@@ -133,6 +133,22 @@ contract ViewsFacet {
         return account.adminWalletAddress;
     }
 
+    /// @notice Return the billing wallet address for the account that owns the given API key.
+    /// @dev Works with both master and usage API key hashes (resolves via allApiKeyHashesToMaster).
+    ///      The billing wallet is set at account creation and is not necessarily the transaction creator.
+    /// @param apiKeyHash keccak256 of a master or usage API key (base64-encoded).
+    /// @return The billing wallet address stored on the resolved master account.
+    function getBillingWalletAddress(
+        uint256 apiKeyHash
+    ) public view returns (address) {
+        AppStorage.Account storage account = getReadOnlyAccount(apiKeyHash);
+        if (account.billingWalletAddress == address(0)) {
+            // older accounts may not have a billing wallet address
+            return account.adminWalletAddress;
+        }
+        return account.billingWalletAddress;
+    }
+
     function getWalletDerivation(
         uint256 apiKeyHash,
         address walletAddress

--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -81,7 +81,13 @@ contract WritesFacet {
         uint256 apiKeyHash = uint256(
             keccak256(abi.encodePacked(adminWalletAddress))
         );
-        newAccount(apiKeyHash, false, accountName, accountDescription, adminWalletAddress);
+        newAccount(
+            apiKeyHash,
+            false,
+            accountName,
+            accountDescription,
+            adminWalletAddress
+        );
     }
 
     function newAccount(
@@ -99,8 +105,7 @@ contract WritesFacet {
                 );
             }
             if (
-                apiKeyHash !=
-                uint256(keccak256(abi.encodePacked(msg.sender)))
+                apiKeyHash != uint256(keccak256(abi.encodePacked(msg.sender)))
             ) {
                 revert AppStorage.InvalidRequest(
                     "ChainSecured apiKeyHash must equal the keccak256 of the sender."
@@ -118,6 +123,7 @@ contract WritesFacet {
         AppStorage.Account storage account = s.accounts[apiKeyHash];
         account.managed = managed;
         account.adminWalletAddress = adminWalletAddress;
+        account.billingWalletAddress = adminWalletAddress;
         account.accountApiKey.metadata.id = apiKeyHash;
         account.accountApiKey.metadata.name = accountName;
         account.accountApiKey.metadata.description = accountDescription;
@@ -160,6 +166,9 @@ contract WritesFacet {
             );
         }
         account.managed = false;
+        if (account.billingWalletAddress == address(0)) {
+            account.billingWalletAddress = account.adminWalletAddress;
+        } // otherwise, keep the existing billing wallet address
         account.adminWalletAddress = newAdminWalletAddress;
         emit AccountConvertedToChainSecured(apiKeyHash, newAdminWalletAddress);
     }

--- a/lit-api-server/src/accounts/contracts/AccountConfig.json
+++ b/lit-api-server/src/accounts/contracts/AccountConfig.json
@@ -1354,6 +1354,25 @@
           "internalType": "uint256",
           "name": "apiKeyHash",
           "type": "uint256"
+        }
+      ],
+      "name": "getBillingWalletAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "apiKeyHash",
+          "type": "uint256"
         },
         {
           "internalType": "address",

--- a/lit-api-server/src/accounts/contracts/account_config_contract.rs
+++ b/lit-api-server/src/accounts/contracts/account_config_contract.rs
@@ -627,6 +627,28 @@ pub mod account_config {
                     },],
                 ),
                 (
+                    ::std::borrow::ToOwned::to_owned("getBillingWalletAddress"),
+                    ::std::vec![::ethers::core::abi::ethabi::Function {
+                        name: ::std::borrow::ToOwned::to_owned("getBillingWalletAddress",),
+                        inputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::borrow::ToOwned::to_owned("apiKeyHash"),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Uint(256usize,),
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("uint256"),
+                            ),
+                        },],
+                        outputs: ::std::vec![::ethers::core::abi::ethabi::Param {
+                            name: ::std::string::String::new(),
+                            kind: ::ethers::core::abi::ethabi::ParamType::Address,
+                            internal_type: ::core::option::Option::Some(
+                                ::std::borrow::ToOwned::to_owned("address"),
+                            ),
+                        },],
+                        constant: ::core::option::Option::None,
+                        state_mutability: ::ethers::core::abi::ethabi::StateMutability::View,
+                    },],
+                ),
+                (
                     ::std::borrow::ToOwned::to_owned("getPricing"),
                     ::std::vec![::ethers::core::abi::ethabi::Function {
                         name: ::std::borrow::ToOwned::to_owned("getPricing"),
@@ -3108,6 +3130,15 @@ pub mod account_config {
         ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
             self.0
                 .method_hash([80, 237, 91, 184], api_key_hash)
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `getBillingWalletAddress` (0x7249a9b6) function
+        pub fn get_billing_wallet_address(
+            &self,
+            api_key_hash: ::ethers::core::types::U256,
+        ) -> ::ethers::contract::builders::ContractCall<M, ::ethers::core::types::Address> {
+            self.0
+                .method_hash([114, 73, 169, 182], api_key_hash)
                 .expect("method not found (this should never happen)")
         }
         ///Calls the contract's `getPricing` (0xc12f1a42) function
@@ -5788,6 +5819,26 @@ pub mod account_config {
     pub struct GetAccountWalletAddressCall {
         pub api_key_hash: ::ethers::core::types::U256,
     }
+    ///Container type for all input parameters for the `getBillingWalletAddress` function with signature `getBillingWalletAddress(uint256)` and selector `0x7249a9b6`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthCall,
+        ::ethers::contract::EthDisplay,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    #[ethcall(
+        name = "getBillingWalletAddress",
+        abi = "getBillingWalletAddress(uint256)"
+    )]
+    pub struct GetBillingWalletAddressCall {
+        pub api_key_hash: ::ethers::core::types::U256,
+    }
     ///Container type for all input parameters for the `getPricing` function with signature `getPricing(uint256)` and selector `0xc12f1a42`
     #[derive(
         Clone,
@@ -6641,6 +6692,7 @@ pub mod account_config {
         CreditApiKey(CreditApiKeyCall),
         DebitApiKey(DebitApiKeyCall),
         GetAccountWalletAddress(GetAccountWalletAddressCall),
+        GetBillingWalletAddress(GetBillingWalletAddressCall),
         GetPricing(GetPricingCall),
         GetWalletDerivation(GetWalletDerivationCall),
         GroupIdsForAction(GroupIdsForActionCall),
@@ -6779,6 +6831,11 @@ pub mod account_config {
                 <GetAccountWalletAddressCall as ::ethers::core::abi::AbiDecode>::decode(data)
             {
                 return Ok(Self::GetAccountWalletAddress(decoded));
+            }
+            if let Ok(decoded) =
+                <GetBillingWalletAddressCall as ::ethers::core::abi::AbiDecode>::decode(data)
+            {
+                return Ok(Self::GetBillingWalletAddress(decoded));
             }
             if let Ok(decoded) = <GetPricingCall as ::ethers::core::abi::AbiDecode>::decode(data) {
                 return Ok(Self::GetPricing(decoded));
@@ -7010,6 +7067,9 @@ pub mod account_config {
                 Self::GetAccountWalletAddress(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
                 }
+                Self::GetBillingWalletAddress(element) => {
+                    ::ethers::core::abi::AbiEncode::encode(element)
+                }
                 Self::GetPricing(element) => ::ethers::core::abi::AbiEncode::encode(element),
                 Self::GetWalletDerivation(element) => {
                     ::ethers::core::abi::AbiEncode::encode(element)
@@ -7125,6 +7185,7 @@ pub mod account_config {
                 Self::CreditApiKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::DebitApiKey(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetAccountWalletAddress(element) => ::core::fmt::Display::fmt(element, f),
+                Self::GetBillingWalletAddress(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetPricing(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GetWalletDerivation(element) => ::core::fmt::Display::fmt(element, f),
                 Self::GroupIdsForAction(element) => ::core::fmt::Display::fmt(element, f),
@@ -7273,6 +7334,11 @@ pub mod account_config {
     impl ::core::convert::From<GetAccountWalletAddressCall> for AccountConfigCalls {
         fn from(value: GetAccountWalletAddressCall) -> Self {
             Self::GetAccountWalletAddress(value)
+        }
+    }
+    impl ::core::convert::From<GetBillingWalletAddressCall> for AccountConfigCalls {
+        fn from(value: GetBillingWalletAddressCall) -> Self {
+            Self::GetBillingWalletAddress(value)
         }
     }
     impl ::core::convert::From<GetPricingCall> for AccountConfigCalls {
@@ -7698,6 +7764,20 @@ pub mod account_config {
         Hash,
     )]
     pub struct GetAccountWalletAddressReturn(pub ::ethers::core::types::Address);
+    ///Container type for all return fields from the `getBillingWalletAddress` function with signature `getBillingWalletAddress(uint256)` and selector `0x7249a9b6`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        serde::Serialize,
+        serde::Deserialize,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct GetBillingWalletAddressReturn(pub ::ethers::core::types::Address);
     ///Container type for all return fields from the `getPricing` function with signature `getPricing(uint256)` and selector `0xc12f1a42`
     #[derive(
         Clone,

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -767,6 +767,31 @@ pub async fn get_account_wallet_address(key_or_hash: &str) -> Result<String> {
     Ok(format!("{:?}", wallet_address))
 }
 
+/// Resolve any account identity to the billing wallet address of its parent account.
+///
+/// Same input shape as [`get_account_wallet_address`]. Differs in that the
+/// returned wallet is the one used to identify the Stripe customer for billing,
+/// which is set at account creation and is preserved across conversion to
+/// ChainSecured — so converting a managed account does not strand its existing
+/// Stripe credits behind a new admin wallet (CPL-313). The contract's
+/// `getBillingWalletAddress` falls back to the admin wallet for legacy accounts
+/// that pre-date the billing-wallet field, keeping behaviour unchanged for them.
+#[instrument(
+    name = "accounts::get_billing_wallet_address",
+    level = "debug",
+    skip_all,
+    err
+)]
+pub async fn get_billing_wallet_address(key_or_hash: &str) -> Result<String> {
+    let contract = get_read_only_account_config_contract().await?;
+    let key_hash = usage_api_key_to_hash(key_or_hash);
+    let wallet_address = contract.get_billing_wallet_address(key_hash).call().await?;
+    if wallet_address == H160::zero() {
+        anyhow::bail!("account has no wallet address");
+    }
+    Ok(format!("{:?}", wallet_address))
+}
+
 pub async fn get_node_configuration_values() -> Result<Vec<KeyValueReturn>> {
     let contract = get_read_only_account_config_contract().await?;
     let values = contract.node_configuration_values().call().await?;

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -34,9 +34,10 @@ pub struct StripeState {
     /// Avoids duplicate customer creation caused by Stripe Search API indexing lag.
     /// Uses `time_to_idle` so frequently accessed entries stay warm.
     customer_cache: Cache<String, String>,
-    /// api_key → wallet_address cache.
-    /// Resolves both master and usage API keys to the account's creator wallet address
-    /// via the on-chain `allApiKeyHashesToMaster` mapping, avoiding a contract call per charge.
+    /// api_key → billing wallet address cache.
+    /// Resolves both master and usage API keys to the account's billing wallet address
+    /// (the wallet used to identify the Stripe customer) via the on-chain
+    /// `allApiKeyHashesToMaster` mapping, avoiding a contract call per charge.
     wallet_cache: Cache<String, String>,
     /// customer_id → credit balance cache (10-min TTL).
     /// Avoids a Stripe API call on every charge; stale reads may allow some
@@ -215,14 +216,17 @@ pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
     state.wallet_cache.invalidate(&cache_key(api_key)).await;
 }
 
-/// Resolve any account identity to its admin wallet address.
+/// Resolve any account identity to its billing wallet address.
 ///
 /// Accepts a raw API key (master or usage) or — for ChainSecured callers — a
 /// precomputed 0x-prefixed 32-byte hex hash (the wallet-derived
 /// `keccak256(walletAddress)`). Uses the on-chain `allApiKeyHashesToMaster`
 /// mapping so that usage API keys resolve to the same wallet (and therefore
-/// same Stripe customer) as their parent account key. Results are cached for
-/// 1 hour.
+/// same Stripe customer) as their parent account key. The billing wallet is
+/// set at account creation and preserved across conversion to ChainSecured,
+/// so charges keep hitting the same Stripe customer after the admin wallet
+/// rotates (CPL-313). Legacy accounts without a billing wallet fall back to
+/// the admin wallet on-chain. Results are cached for 1 hour.
 ///
 /// The cache is keyed by the keccak256 hash of the input (not the raw key)
 /// to avoid holding secret material in memory.
@@ -234,7 +238,7 @@ pub async fn resolve_wallet_address(api_key: &str, state: &StripeState) -> Resul
         .wallet_cache
         .try_get_with(key, async {
             tracing::debug!("stripe::resolve_wallet_address: cache miss, calling contract");
-            crate::accounts::get_account_wallet_address(api_key).await
+            crate::accounts::get_billing_wallet_address(api_key).await
         })
         .await
         .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{e}"));


### PR DESCRIPTION
## Summary

Fixes [CPL-313](https://linear.app/litprotocol/issue/CPL-313/fix-conversion-to-chain-secured-billing) — converting a managed account to ChainSecured was rotating the admin wallet and stranding existing Stripe credits behind a fresh customer record.

- **AccountConfig contract:** new `billingWalletAddress` field on `AppStorage.Account`, plus a `getBillingWalletAddress(uint256 apiKeyHash)` view. The billing wallet is set at account creation and **preserved** when `convertToChainSecured` rotates the admin wallet. Legacy accounts that pre-date the field fall back to the admin wallet on-chain so existing flows are unchanged.
- **lit-api-server:** new `accounts::get_billing_wallet_address` wrapper that mirrors `get_account_wallet_address` but calls the new view. The cached `stripe::resolve_wallet_address` helper now resolves through it, so every Stripe call site picks up the change with no per-endpoint edits:
  - `GET  /billing/balance`
  - `POST /billing/create_payment_intent`
  - `POST /billing/confirm_payment`
  - `BilledManagementApiKey` ($0.01-per-call charge)
  - `BilledLitActionApiKey` (credit-availability check)
- **Bindings:** regenerated `AccountConfig.json` and `account_config_contract.rs` from the new ABI.

The defensive `H160::zero()` bail keeps the same `"account has no wallet address"` string the existing `wallet_resolution_err` matcher in `core::v1::endpoints::billing` uses, so `AccountDoesNotExist` reverts continue to surface as `400 Invalid API key` rather than 500.

## Test plan

- [x] `cargo check -p lit-api-server` (incl. `--all-targets`) — clean
- [x] `cargo clippy -p lit-api-server --no-deps` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p lit-api-server --lib` — 225/225 pass (incl. all 23 `stripe::tests`, including `cache_key_accepts_precomputed_hash` which pins ChainSecured wallet-hash routing)
- [ ] Manual: spin up a managed account, top up via `/billing/create_payment_intent`, convert to ChainSecured via `convertToChainSecured`, confirm `/billing/balance` returns the **same** credits afterwards (rather than zero against a brand-new Stripe customer).
- [ ] Manual: verify a fresh ChainSecured-from-the-start account still resolves through the `billingWalletAddress = adminWalletAddress` path set in `WritesFacet.newAccount`.

No Rocket route handlers were added or changed, so `k6/litApiServer.ts` does not need regeneration.