### PR TITLE
fix(CPL-314): hide "Convert to ChainSecured" menu outside API mode

### DIFF
--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -670,6 +670,12 @@ body.has-api-key .dashboard-wrap {
   font-family: inherit;
 }
 
+/* `.account-dropdown-item { display: block }` beats the UA `[hidden]` rule on
+   specificity, so the `hidden` attribute alone won't hide the button. */
+.account-dropdown-item[hidden] {
+  display: none;
+}
+
 .account-dropdown-item:hover {
   background: rgba(0, 0, 0, 0.05);
 }

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -670,8 +670,8 @@ body.has-api-key .dashboard-wrap {
   font-family: inherit;
 }
 
-/* `.account-dropdown-item { display: block }` beats the UA `[hidden]` rule on
-   specificity, so the `hidden` attribute alone won't hide the button. */
+/* `.account-dropdown-item { display: block }` overrides the UA `[hidden]`
+   mapping, so this rule restores `display: none` when `hidden` is present. */
 .account-dropdown-item[hidden] {
   display: none;
 }


### PR DESCRIPTION
## Summary

The "Convert to ChainSecured" item in the dashboard account dropdown was visible in ChainSecured mode even though `app.js:refreshConvertVisibility` sets `btn.hidden = true` whenever `getMode() !== 'api'`. The `hidden` attribute had no effect because `.account-dropdown-item { display: block }` (`styles.css:659`) is a class selector (specificity 0,1,0) and outranks the UA stylesheet's `[hidden] { display: none }` rule.

Fix: add `.account-dropdown-item[hidden] { display: none }` (specificity 0,2,0) so the existing JS visibility toggle actually hides the button. CSS-only — no JS or HTML changes.

[Linear: CPL-314](https://linear.app/litprotocol/issue/CPL-314/the-convert-to-chain-secured-menu-item-should-only-appear-in-api-mode)

## Test plan

- [ ] Sign in via API mode with an API key → open the account dropdown → "Convert to ChainSecured" is visible.
- [ ] Sign in via ChainSecured mode (wallet) → open the account dropdown → "Convert to ChainSecured" is hidden.
- [ ] Convert an API account to ChainSecured via the existing flow → after the post-conversion reload the button is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)