### PR TITLE
fix(CPL-316): clarify ChainSecured conversion modal copy

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -851,7 +851,8 @@ export async function convertToChainSecured() {
     return;
   }
   const ok = await confirmDelete(
-    "Convert this account to ChainSecured?\n\nYour connected wallet becomes the on-chain admin and your API key's write authority is removed permanently. This cannot be undone.\n\nYou will be signed in as the wallet after conversion.",
+    "Convert this account to ChainSecured?\n\nYour connected wallet becomes the on-chain admin and your API key's write authority is removed permanently. This cannot be undone.\n\nYou will be asked to sign a message with your wallet to prove ownership, and will be signed in as the wallet after conversion.",
+    { title: 'Confirm ownership change', confirmLabel: 'Convert' },
   );
   if (!ok) return;
 

--- a/lit-static/dapps/dashboard/ui-utils.js
+++ b/lit-static/dapps/dashboard/ui-utils.js
@@ -150,12 +150,16 @@ export function initModalClose() {
 
 let _confirmResolve = null;
 
-export function confirmDelete(message) {
+export function confirmDelete(message, opts) {
   return new Promise((resolve) => {
     _confirmResolve = resolve;
     const overlay = document.getElementById('confirm-overlay');
     const msgEl = document.getElementById('confirm-message');
+    const titleEl = overlay?.querySelector('.modal-title');
+    const confirmBtn = document.getElementById('confirm-delete-btn');
     if (msgEl) msgEl.textContent = message || 'Are you sure you want to delete this item?';
+    if (titleEl) titleEl.textContent = opts?.title || 'Confirm delete';
+    if (confirmBtn) confirmBtn.textContent = opts?.confirmLabel || 'Delete';
     if (overlay) {
       overlay.classList.add('is-open');
       overlay.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary

CPL-316 — the "Convert to ChainSecured" confirmation modal still read like a delete dialog and didn't mention that the wallet has to sign to prove ownership.

- Title: `Confirm delete` → `Confirm ownership change`
- Button: `Delete` → `Convert`
- Body adds: "You will be asked to sign a message with your wallet to prove ownership"

The shared `confirmDelete()` now takes an optional `{ title, confirmLabel }`. Defaults preserve the existing "Confirm delete" / "Delete" wording, so the actions/keys/groups callers are unchanged.

## Files

- `lit-static/dapps/dashboard/auth.js` — pass new title and button label when invoking the convert flow
- `lit-static/dapps/dashboard/ui-utils.js` — extend `confirmDelete(message, opts)` and reset title/button text on every call so state doesn't leak between invocations

## Notes

- Diff is 9 lines across 2 files. No backend, schema, or contract changes. No new test framework in this dashboard area, so no automated coverage added.
- The dialog body uses `textContent`; `\n\n` collapses in `.modal-body`. That's pre-existing behavior — happy to switch the body to `white-space: pre-line` in a follow-up if real paragraph breaks are wanted.

## Test plan

- [ ] Sign in with an API key, click "Convert to ChainSecured" in the account menu
- [ ] Verify modal title reads "Confirm ownership change", action button reads "Convert", and body mentions signing to prove ownership
- [ ] Cancel returns to the dashboard with no state change
- [ ] Open a delete confirm (e.g., delete a usage key) and verify it still says "Confirm delete" / "Delete"

Linear: https://linear.app/litprotocol/issue/CPL-316/convert-to-chain-secured-modal-update