### PR TITLE
feat(CPL-317): block ChainSecured conversion if wallet already owns an account

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/WritesFacet.sol
@@ -155,7 +155,13 @@ contract WritesFacet {
                 "newAdminWalletAddress must be non-zero"
             );
         }
+        uint256 newApiKeyHash = uint256(
+            keccak256(abi.encodePacked(newAdminWalletAddress))
+        );
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
+        if (s.allApiKeyHashesToMaster[newApiKeyHash] != 0) {
+            revert AppStorage.AccountAlreadyExists(newApiKeyHash);
+        }
         if (s.allApiKeyHashesToMaster[apiKeyHash] != apiKeyHash) {
             revert AppStorage.AccountDoesNotExist(apiKeyHash);
         }
@@ -165,6 +171,7 @@ contract WritesFacet {
                 "Account is already ChainSecured."
             );
         }
+        s.allApiKeyHashesToMaster[newApiKeyHash] = apiKeyHash; // effectively map the new admin wallet to the existing account, without removing the old one.
         account.managed = false;
         if (account.billingWalletAddress == address(0)) {
             account.billingWalletAddress = account.adminWalletAddress;


### PR DESCRIPTION
## Summary

Adds a guard in `convertToChainSecuredAccount` (WritesFacet) that prevents an api_payer from reassigning a managed account to a new admin wallet whose `keccak256(address)` is already registered in `allApiKeyHashesToMaster` — either as another account's master or as a usage key for any account.

When the guard passes, the new wallet's hash is mapped to the existing master account hash, so the newly assigned wallet can log in and resolve to the converted account's groups, actions, PKPs, usage keys, and Stripe customer (preserved by CPL-313). The original API-key hash is left intact, keeping existing usage-key resolutions working.

Validation now runs before any state mutation.

## Test Coverage

No Foundry/Hardhat tests added in this PR — deferred to a follow-up. Suggested cases for the follow-up:

- happy path: managed account → new wallet's hash resolves to the same master; old hash still resolves; `account.managed == false`; `adminWalletAddress` updated; `billingWalletAddress` preserved
- revert: `newAdminWalletAddress == address(0)`
- revert: account already ChainSecured
- revert: account does not exist
- revert: `newApiKeyHash` collides with another account's master
- revert: `newApiKeyHash` collides with a usage key on any account
- revert: caller is not api_payer/owner

## Pre-Landing Review

Manually reviewed in two passes:

1. First pass caught a Solidity compile error (`s` referenced before declaration) and a checks-effects ordering issue. Both addressed.
2. Second pass verified login/access semantics against `AppStorage.accountExistsAndIsMutable` (AppStorage.sol:138-153): the new wallet resolves to the master via `allApiKeyHashesToMaster`, and `account.adminWalletAddress == sender` after the flip, so the new wallet has full access.

Contract compiles (`npx hardhat compile`).

## ABI / deployment notes

- No new function, event, or error added — `ACCOUNT_CONFIG_ABI_VERSION` does not need to be bumped and the JS ABI subset does not need to be regenerated (per the CPL-280 header note in `account_config_full_abi.js`).
- Facet bytecode changes, but proxy runtime bytecode pins are not affected (facet upgrades route through `diamondCut`).

## Test plan

- [ ] Deploy facet via `diamondCut` to a test network
- [ ] Convert a managed account to ChainSecured with a fresh wallet → confirm new wallet can sign in to the dashboard and see the account's groups/PKPs/usage keys
- [ ] Try to convert with a wallet that already owns a ChainSecured account → expect `AccountAlreadyExists` revert
- [ ] Try to convert with a wallet whose hash collides with an existing usage key → expect `AccountAlreadyExists` revert
- [ ] Try to re-run conversion on an already-ChainSecured account → expect `InvalidRequest("Account is already ChainSecured.")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)