### PR TITLE
fix(ci): inject prod API base URL into auth.js, not stale app.js

### DIFF
--- a/.github/workflows/deploy-prod-3-static.yml
+++ b/.github/workflows/deploy-prod-3-static.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: "20"
 
       - name: Inject API URL
-        run: sed -i "s|__LIT_API_BASE_URL__|https://api.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/app.js
+        run: sed -i "s|__LIT_API_BASE_URL__|https://api.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

Fix the prod static-deploy workflow so the dashboard ships with the production API URL instead of the literal placeholder.

The `__LIT_API_BASE_URL__` placeholder lives in `lit-static/dapps/dashboard/auth.js:260` (it moved there when `app.js` was split into ES modules). The prod workflow's sed step still targeted `lit-static/dapps/dashboard/app.js`, so the substitution was a no-op and prod shipped the un-substituted placeholder. The dev/next workflow (`deploy-static.yml`) was already updated to `auth.js`; only the prod workflow was missed.

## Symptom in production

`POST https://dashboard.chipotle.litprotocol.com/dapps/dashboard/__LIT_API_BASE_URL__/core/v1/new_account` → `405 Method Not Allowed`

The dashboard's `getBaseUrl()` returned the literal string `__LIT_API_BASE_URL__`, so `fetch(\`${baseUrl}/core/v1/new_account\`)` resolved as a relative path under the dashboard origin and hit Cloudflare Pages' static handler with a POST.

## After this fix

- `Deploy Prod 3: Static Site` will substitute `__LIT_API_BASE_URL__` → `https://api.chipotle.litprotocol.com` in the deployed `auth.js`.
- New-account POSTs will hit the actual API server again.

## Follow-up after merge

1. Re-run the `Deploy Prod 3: Static Site` workflow (`workflow_dispatch`) with the current version tag so the dashboard is republished with the substitution applied.
2. Verify in the deployed bundle that `getBaseUrl()` returns `https://api.chipotle.litprotocol.com`, and that creating a new account from the dashboard succeeds.

## Test plan

- [ ] Re-run `Deploy Prod 3: Static Site` workflow after merge
- [ ] Confirm deployed `auth.js` no longer contains the literal `__LIT_API_BASE_URL__`
- [ ] Create a new account from `https://dashboard.chipotle.litprotocol.com` and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)