### PR TITLE
feat(CPL-320): force wallet connect before ChainSecured conversion confirm

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -835,8 +835,10 @@ async function createChainSecuredAccount(btn) {
 /**
  * Account-dropdown handler. Converts the currently signed-in API account into a
  * ChainSecured account by reassigning its admin wallet. Flow:
- *   1. Confirm (irreversible).
- *   2. Connect wallet (sign-in EOA, enforce chain match).
+ *   1. Connect wallet (sign-in EOA, enforce chain match) — forced *before* the
+ *      confirmation modal so the user can't commit to the irreversible action
+ *      without a working signer in hand (CPL-320).
+ *   2. Confirm (irreversible).
  *   3. POST /core/v1/convert_to_chain_secured_account (api_payer signs the
  *      on-chain `convertToChainSecuredAccount` call).
  *   4. Switch dashboard mode to sovereign and reload.
@@ -850,25 +852,24 @@ export async function convertToChainSecured() {
     showStatus('login-status', 'Convert is only available while signed in with an API key.', 'error');
     return;
   }
-  const ok = await confirmDelete(
-    "Convert this account to ChainSecured?\n\nYour connected wallet becomes the on-chain admin and your API key's write authority is removed permanently. This cannot be undone.\n\nYou will be asked to sign a message with your wallet to prove ownership, and will be signed in as the wallet after conversion.",
-    { title: 'Confirm ownership change', confirmLabel: 'Convert' },
-  );
-  if (!ok) return;
 
-  showActionProgress('Convert to ChainSecured', 'Connect a wallet to take over admin ownership.');
+  let signer;
+  let expectedChainId;
+  let client;
   try {
-    const client = await getClient();
+    showActionProgress('Convert to ChainSecured', 'Connect a wallet to take over admin ownership.');
+    client = await getClient();
     // API-mode clients don't bootstrap chain config; fetch it now so we can
     // enforce a wallet-chain match before signing AND pass `chainId` to the
     // SDK (which would otherwise throw "chainId is unknown").
     const cfg = await client.getNodeChainConfig();
-    const expectedChainId = cfg && cfg.chain_id != null ? Number(cfg.chain_id) : null;
+    expectedChainId = cfg && cfg.chain_id != null ? Number(cfg.chain_id) : null;
     if (expectedChainId == null) {
       throw new Error('Server did not report a chain id; cannot convert.');
     }
     const { connectEoa, switchChain } = await import('../../wallet_connect.js');
-    let { signer, chainId } = await connectEoa();
+    let chainId;
+    ({ signer, chainId } = await connectEoa());
     if (chainId !== expectedChainId) {
       try {
         await switchChain(expectedChainId);
@@ -879,15 +880,30 @@ export async function convertToChainSecured() {
       }
       ({ signer } = await connectEoa());
     }
-    // The SDK call is one opaque await: wallet sign → server signs+broadcasts
-    // the on-chain tx → server awaits inclusion → returns. By the time it
-    // resolves the conversion is already on-chain, so the progress text
-    // covers both phases (sign + submit) before the await rather than
-    // claiming a phase that has already happened after.
-    showActionProgress(
-      'Convert to ChainSecured',
-      'Sign in your wallet, then we submit the conversion on-chain (this may take ~10–30 seconds)…',
-    );
+  } catch (e) {
+    closeActionProgress();
+    logError('convert-to-chainsecured', e);
+    showStatus('login-status', 'Convert canceled: ' + formatError(e), 'error');
+    return;
+  }
+  closeActionProgress();
+
+  const ok = await confirmDelete(
+    "Convert this account to ChainSecured?\n\nYour connected wallet becomes the on-chain admin and your API key's write authority is removed permanently. This cannot be undone.\n\nYou will be asked to sign a message with your wallet to prove ownership, and will be signed in as the wallet after conversion.",
+    { title: 'Confirm ownership change', confirmLabel: 'Convert' },
+  );
+  if (!ok) return;
+
+  // The SDK call is one opaque await: wallet sign → server signs+broadcasts
+  // the on-chain tx → server awaits inclusion → returns. By the time it
+  // resolves the conversion is already on-chain, so the progress text
+  // covers both phases (sign + submit) before the await rather than
+  // claiming a phase that has already happened after.
+  showActionProgress(
+    'Convert to ChainSecured',
+    'Sign in your wallet, then we submit the conversion on-chain (this may take ~10–30 seconds)…',
+  );
+  try {
     const res = await client.convertToChainSecuredAccount({ apiKey, signer, chainId: expectedChainId });
     showActionProgress('Convert to ChainSecured', 'Conversion confirmed. Switching to ChainSecured mode…');
     setMode('sovereign');


### PR DESCRIPTION
## Summary

CPL-320 — the "Convert to ChainSecured" flow used to show the destructive confirm modal first and only prompt for a wallet *after* the user clicked Convert. If the user had no wallet, rejected the prompt, or was on the wrong chain, they had already committed mentally to the irreversible action before the wallet check happened.

This PR reorders `convertToChainSecured()` so the wallet connection (and chain match) is forced **before** the confirm modal opens. Wallet/chain failures abort with "Convert canceled" without ever entering the destructive code path.

## Flow change

Before: Confirm → Connect wallet → Switch chain → SDK call
After:  Connect wallet → Switch chain → Confirm → SDK call

If the user has no `window.ethereum`, rejects the connect prompt, or refuses the chain switch, we surface a `Convert canceled: <reason>` status and return early — the confirm dialog never opens.

## Files

- `lit-static/dapps/dashboard/auth.js` — split the function into a pre-confirm wallet-acquisition block and a post-confirm submission block. The action-progress modal carries the existing "Connect a wallet to take over admin ownership" copy during the wallet step, and the post-confirm step reuses the already-fetched `client`, `signer`, and `expectedChainId` rather than re-acquiring them.

## Notes

- No copy changes to the confirmation modal itself; CPL-316 wording is preserved verbatim.
- No server, contract, or k6 changes. Pure JS reordering inside the dashboard dApp.
- `node --check` passes. No automated browser/UI test in this dashboard area, so no automated coverage added.

## Test plan

- [ ] Sign in with an API key, click "Convert to ChainSecured" with **no wallet installed** — expect "Convert canceled: No browser wallet found…" status, no confirm dialog.
- [ ] Click "Convert to ChainSecured" and **reject** the wallet's connect prompt — expect "Convert canceled: …" status, no confirm dialog.
- [ ] Click "Convert to ChainSecured" with the wallet on the **wrong chain** and reject the switch — expect "Convert canceled: Your wallet is on chain X but this dashboard expects chain Y…", no confirm dialog.
- [ ] Click "Convert to ChainSecured" with a healthy wallet on the correct chain — expect confirm modal to appear after the wallet popup, then the existing happy-path conversion proceeds.
- [ ] Cancel the confirm modal after the wallet is connected — expect a clean return to the dashboard with no further status, no on-chain side effect.

Linear: https://linear.app/litprotocol/issue/CPL-320/force-a-wallet-connection-prompt-when-the-chain-secured

🤖 Generated with [Claude Code](https://claude.com/claude-code)