### PR TITLE
ci: add manual prod envs-update workflow (for prod6→prod2 migration)

### DIFF
--- a/.github/workflows/manual_phala-envs-update-prod.yml
+++ b/.github/workflows/manual_phala-envs-update-prod.yml
@@ -1,0 +1,104 @@
+# Push sealed environment variables to a specific Phala CVM and start it (PROD).
+#
+# Prod-flavored sibling of manual_phala-envs-update.yml. Used during CVM
+# migrations (e.g. prod6 → prod2) to bootstrap a freshly-provisioned chipotle-prod
+# replica with the same live env vars CI would normally push during the
+# tag-triggered deploy-prod-* flow.
+#
+# Differences from the next/staging variant:
+#   - Stripe LIVE keys (STRIPE_SECRET_KEY / STRIPE_PUBLISHABLE_KEY), not sandbox
+#   - Defaults: CERTBOT_DOMAIN=api.chipotle.litprotocol.com, GCP_PROJECT_ID=chipotle-prod
+#
+# Env block mirrors deploy-prod-1-propose.yml:341-372 (encryptEnvVars step).
+#
+# Required secrets:
+#   PHALA_CLOUD_API_KEY            - Phala Cloud API key
+#   PHALA_DSTACKAPP_PRIVATE_KEY    - DstackApp owner key (unused for prod Safe-owned app,
+#                                     kept for parity with `phala envs update` CLI args)
+#   BASE_CHAIN_RPC                 - Base mainnet RPC URL
+#   GCP_SERVICE_ACCOUNT_JSON       - GCP service account key
+#   STRIPE_SECRET_KEY              - Stripe LIVE secret key
+#   STRIPE_PUBLISHABLE_KEY         - Stripe LIVE publishable key
+#   CERTBOT_AWS_ACCESS_KEY_ID      - Route 53 IAM access key
+#   CERTBOT_AWS_SECRET_ACCESS_KEY  - Route 53 IAM secret key
+#   CERTBOT_AWS_ROLE_ARN           - IAM role ARN for STS assumption
+#
+# Required vars:
+#   CERTBOT_AWS_REGION             - AWS region for STS endpoint
+
+name: Phala Envs Update + Start (Prod, manual)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      cvm_id:
+        description: "Target CVM (UUID, app_id, instance_id, or name) — e.g. cvm_qwrMBqKl"
+        required: true
+        type: string
+      certbot_domain:
+        description: "CERTBOT_DOMAIN for dstack-ingress. Leave blank to skip ingress cert acquisition."
+        required: false
+        type: string
+        default: "api.chipotle.litprotocol.com"
+      gcp_project_id:
+        description: "GCP_PROJECT_ID for otel-collector"
+        required: false
+        type: string
+        default: "chipotle-prod"
+      start:
+        description: "Start the CVM after pushing envs"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  envs-update:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Phala CLI
+        run: npm install -g phala
+
+      - name: Push sealed envs to CVM
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+          PRIVATE_KEY: ${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}
+          ETH_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
+          BASE_CHAIN_RPC: ${{ secrets.BASE_CHAIN_RPC }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+          CERTBOT_AWS_ACCESS_KEY_ID: ${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}
+          CERTBOT_AWS_SECRET_ACCESS_KEY: ${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}
+          CERTBOT_AWS_ROLE_ARN: ${{ secrets.CERTBOT_AWS_ROLE_ARN }}
+        run: |
+          phala envs update "${{ inputs.cvm_id }}" \
+            -e "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" \
+            -e "STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY" \
+            -e "GCP_SERVICE_ACCOUNT_JSON=$GCP_SERVICE_ACCOUNT_JSON" \
+            -e "GCP_PROJECT_ID=${{ inputs.gcp_project_id }}" \
+            -e "BASE_CHAIN_RPC=$BASE_CHAIN_RPC" \
+            -e "CERTBOT_DOMAIN=${{ inputs.certbot_domain }}" \
+            -e "CERTBOT_AWS_ACCESS_KEY_ID=$CERTBOT_AWS_ACCESS_KEY_ID" \
+            -e "CERTBOT_AWS_SECRET_ACCESS_KEY=$CERTBOT_AWS_SECRET_ACCESS_KEY" \
+            -e "CERTBOT_AWS_ROLE_ARN=$CERTBOT_AWS_ROLE_ARN" \
+            -e "CERTBOT_AWS_REGION=${{ vars.CERTBOT_AWS_REGION }}"
+
+      - name: Start CVM
+        if: inputs.start
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+        run: |
+          phala cvms start "${{ inputs.cvm_id }}"
+
+      - name: Show CVM status
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+        run: |
+          phala cvms get "${{ inputs.cvm_id }}"


### PR DESCRIPTION
## Summary
- Adds \`manual_phala-envs-update-prod.yml\`, a prod-flavored sibling of \`manual_phala-envs-update.yml\`.
- Mirrors the env block from \`deploy-prod-1-propose.yml\`: live Stripe keys, \`GCP_PROJECT_ID=chipotle-prod\`, \`CERTBOT_DOMAIN=api.chipotle.litprotocol.com\`.
- Used to bootstrap the freshly-provisioned \`chipotle-prod-rep-r68r6\` CVM on prod2 with the live envs that the tag-triggered prod deploy would normally push.

## Why merge to \`next\` and not \`main\`
Pushing to \`main\` triggers \`deploy-staging.yml\` (deploys chipotle-dev) and \`deploy-static.yml\`. We want to land just the CI-helper here, run it once, then ship the deploy-target swap (\`chipotle-prod\` → \`chipotle-prod-rep-r68r6\` in deploy-prod-*.yml) as a separate PR into main. Same pattern as the \`next\` migration (PR #325 → \`next\`).

## Test plan
- [ ] Merge into \`next\`.
- [ ] \`gh workflow run "Phala Envs Update + Start (Prod, manual)" --ref next -f cvm_id=cvm_qwrMBqKl\`
- [ ] Verify https://api.chipotle.litprotocol.com/health returns \`lit_actions_reachable: true\` and \`billing_keys_present: true\` after CVM starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)