### PR TITLE
fix(ci): encrypt prod envs client-side (workaround for buggy phala envs update pubkey lookup)

### DIFF
--- a/.github/workflows/manual_phala-envs-update-prod.yml
+++ b/.github/workflows/manual_phala-envs-update-prod.yml
@@ -8,13 +8,15 @@
 # Differences from the next/staging variant:
 #   - Stripe LIVE keys (STRIPE_SECRET_KEY / STRIPE_PUBLISHABLE_KEY), not sandbox
 #   - Defaults: CERTBOT_DOMAIN=api.chipotle.litprotocol.com, GCP_PROJECT_ID=chipotle-prod
+#   - Encrypts env vars client-side and pushes via `phala envs update --encrypted-env`.
+#     The CLI's internal pubkey lookup is broken for Safe-owned apps (it passes
+#     kms_type "base" instead of a real slug like "kms-base-prod2"); see the
+#     same workaround in deploy-prod-1-propose.yml:307-383.
 #
 # Env block mirrors deploy-prod-1-propose.yml:341-372 (encryptEnvVars step).
 #
 # Required secrets:
 #   PHALA_CLOUD_API_KEY            - Phala Cloud API key
-#   PHALA_DSTACKAPP_PRIVATE_KEY    - DstackApp owner key (unused for prod Safe-owned app,
-#                                     kept for parity with `phala envs update` CLI args)
 #   BASE_CHAIN_RPC                 - Base mainnet RPC URL
 #   GCP_SERVICE_ACCOUNT_JSON       - GCP service account key
 #   STRIPE_SECRET_KEY              - Stripe LIVE secret key
@@ -48,6 +50,11 @@ on:
         required: false
         type: string
         default: "chipotle-prod"
+      kms_slug:
+        description: "KMS slug to fetch the encryption pubkey from (e.g. kms-base-prod2)"
+        required: false
+        type: string
+        default: "kms-base-prod2"
       start:
         description: "Start the CVM after pushing envs"
         required: false
@@ -65,30 +72,91 @@ jobs:
       - name: Install Phala CLI
         run: npm install -g phala
 
-      - name: Push sealed envs to CVM
+      - name: Resolve CVM app_id
+        id: cvm
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
-          PRIVATE_KEY: ${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}
-          ETH_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
-          BASE_CHAIN_RPC: ${{ secrets.BASE_CHAIN_RPC }}
+        run: |
+          set -euo pipefail
+          APP_ID=$(phala cvms get "${{ inputs.cvm_id }}" --json | jq -r '.app_id')
+          if [ -z "$APP_ID" ] || [ "$APP_ID" = "null" ]; then
+            echo "::error::Could not resolve app_id for CVM ${{ inputs.cvm_id }}"
+            exit 1
+          fi
+          echo "Resolved app_id: $APP_ID"
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch CVM encryption public key
+        id: pubkey
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+          KMS_SLUG: ${{ inputs.kms_slug }}
+          APP_ID: ${{ steps.cvm.outputs.app_id }}
+        run: |
+          set -euo pipefail
+          # Workaround: `phala envs update` passes kms_type ("base") to the
+          # /kms/{kms}/pubkey/{app_id} API, but the API expects a KMS slug
+          # (e.g. "kms-base-prod2"). Fetch the pubkey directly via the correct
+          # slug, then encrypt client-side.
+          echo "Fetching encryption pubkey via /kms/$KMS_SLUG/pubkey/$APP_ID ..."
+          PUBKEY_RESPONSE=$(phala api "/kms/$KMS_SLUG/pubkey/$APP_ID" --json)
+          PUBKEY=$(echo "$PUBKEY_RESPONSE" | jq -r '.public_key')
+          if [ -z "$PUBKEY" ] || [ "$PUBKEY" = "null" ]; then
+            echo "::error::Failed to extract public_key from KMS response: $PUBKEY_RESPONSE"
+            exit 1
+          fi
+          echo "Got encryption pubkey: ${PUBKEY:0:16}..."
+          echo "encrypt_pubkey=$PUBKEY" >> "$GITHUB_OUTPUT"
+
+      - name: Encrypt environment variables for CVM
+        id: encrypt
+        env:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+          BASE_CHAIN_RPC: ${{ secrets.BASE_CHAIN_RPC }}
           CERTBOT_AWS_ACCESS_KEY_ID: ${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}
           CERTBOT_AWS_SECRET_ACCESS_KEY: ${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}
           CERTBOT_AWS_ROLE_ARN: ${{ secrets.CERTBOT_AWS_ROLE_ARN }}
+          CERTBOT_AWS_REGION: ${{ vars.CERTBOT_AWS_REGION }}
+          GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
+          CERTBOT_DOMAIN: ${{ inputs.certbot_domain }}
+          ENCRYPT_PUBKEY: ${{ steps.pubkey.outputs.encrypt_pubkey }}
         run: |
-          phala envs update "${{ inputs.cvm_id }}" \
-            -e "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" \
-            -e "STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY" \
-            -e "GCP_SERVICE_ACCOUNT_JSON=$GCP_SERVICE_ACCOUNT_JSON" \
-            -e "GCP_PROJECT_ID=${{ inputs.gcp_project_id }}" \
-            -e "BASE_CHAIN_RPC=$BASE_CHAIN_RPC" \
-            -e "CERTBOT_DOMAIN=${{ inputs.certbot_domain }}" \
-            -e "CERTBOT_AWS_ACCESS_KEY_ID=$CERTBOT_AWS_ACCESS_KEY_ID" \
-            -e "CERTBOT_AWS_SECRET_ACCESS_KEY=$CERTBOT_AWS_SECRET_ACCESS_KEY" \
-            -e "CERTBOT_AWS_ROLE_ARN=$CERTBOT_AWS_ROLE_ARN" \
-            -e "CERTBOT_AWS_REGION=${{ vars.CERTBOT_AWS_REGION }}"
+          set -euo pipefail
+          ENCRYPTED_ENV=$(node -e '
+            const path = require("path");
+            const prefix = require("child_process").execSync("npm prefix -g").toString().trim();
+            const { encryptEnvVars } = require(
+              require.resolve("@phala/cloud", { paths: [path.join(prefix, "lib/node_modules/phala")] })
+            );
+            const envs = [
+              { key: "STRIPE_SECRET_KEY", value: process.env.STRIPE_SECRET_KEY },
+              { key: "STRIPE_PUBLISHABLE_KEY", value: process.env.STRIPE_PUBLISHABLE_KEY },
+              { key: "GCP_SERVICE_ACCOUNT_JSON", value: process.env.GCP_SERVICE_ACCOUNT_JSON },
+              { key: "GCP_PROJECT_ID", value: process.env.GCP_PROJECT_ID },
+              { key: "BASE_CHAIN_RPC", value: process.env.BASE_CHAIN_RPC },
+              { key: "CERTBOT_DOMAIN", value: process.env.CERTBOT_DOMAIN },
+              { key: "CERTBOT_AWS_ACCESS_KEY_ID", value: process.env.CERTBOT_AWS_ACCESS_KEY_ID },
+              { key: "CERTBOT_AWS_SECRET_ACCESS_KEY", value: process.env.CERTBOT_AWS_SECRET_ACCESS_KEY },
+              { key: "CERTBOT_AWS_ROLE_ARN", value: process.env.CERTBOT_AWS_ROLE_ARN },
+              { key: "CERTBOT_AWS_REGION", value: process.env.CERTBOT_AWS_REGION },
+            ];
+            encryptEnvVars(envs, process.env.ENCRYPT_PUBKEY).then(hex => process.stdout.write(hex));
+          ')
+          if [ -z "$ENCRYPTED_ENV" ]; then
+            echo "::error::encryptEnvVars returned empty output"
+            exit 1
+          fi
+          echo "Encrypted env length: ${#ENCRYPTED_ENV} chars"
+          echo "encrypted_env=$ENCRYPTED_ENV" >> "$GITHUB_OUTPUT"
+
+      - name: Push sealed envs to CVM
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+          ENCRYPTED_ENV: ${{ steps.encrypt.outputs.encrypted_env }}
+        run: |
+          phala envs update "${{ inputs.cvm_id }}" --encrypted-env "$ENCRYPTED_ENV"
 
       - name: Start CVM
         if: inputs.start


### PR DESCRIPTION
## Summary
- `phala envs update` failed on `chipotle-prod-rep-r68r6` with `Failed to get app env encrypt pubkey`. Root cause: the CLI's internal pubkey lookup passes `kms_type` ("base") to `/kms/{kms}/pubkey/{app_id}` instead of a real KMS slug. Same bug noted in `deploy-prod-1-propose.yml:316-319`.
- Workaround mirrors the deploy-prod-1 path: fetch pubkey via the correct slug, encrypt with `@phala/cloud`'s `encryptEnvVars`, push via `phala envs update --encrypted-env`.
- Added `kms_slug` input (default `kms-base-prod2`) for future migrations.

## Why next worked but prod didn't
The next/staging workflow had `PRIVATE_KEY` + `ETH_RPC_URL` in the env, which triggered the CLI's `--private-key` code path. That path uses on-chain pubkey resolution and avoids the broken slug lookup. Prod is Safe-owned, so we can't supply a private key.

## Test plan
- [ ] Merge into `next`.
- [ ] Re-run `Phala Envs Update + Start (Prod, manual)` with `cvm_id=cvm_qwrMBqKl`.
- [ ] Confirm the "Fetch CVM encryption public key" step succeeds against `/kms/kms-base-prod2/pubkey/3f91deaf16ff7c823ee65081d6bafa1ceea05ffc` (already pre-flighted, returns a valid pubkey).
- [ ] CVM `chipotle-prod-rep-r68r6` starts, then `curl https://api.chipotle.litprotocol.com/health` returns `lit_actions_reachable: true`, `billing_keys_present: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)