### PR TITLE
ci(prod): point prod deploy at chipotle-prod-rep-r68r6 on prod2

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -216,8 +216,8 @@ jobs:
             }' > "$PROVISION_FILE"
           echo "Request payload size: $(wc -c < "$PROVISION_FILE") bytes"
 
-          echo "Calling POST /cvms/chipotle-prod/compose_file/provision ..."
-          OUTPUT=$(phala api /cvms/chipotle-prod/compose_file/provision \
+          echo "Calling POST /cvms/chipotle-prod-rep-r68r6/compose_file/provision ..."
+          OUTPUT=$(phala api /cvms/chipotle-prod-rep-r68r6/compose_file/provision \
             -X POST \
             --input "$PROVISION_FILE" \
             2>&1) || {
@@ -247,7 +247,7 @@ jobs:
 
           # Extract the AppAuth (dstack_app) address from the CVM's KMS info.
           # This is the per-app contract that controls compose-hash whitelisting.
-          CVM_INFO=$(phala api /cvms/chipotle-prod --json 2>&1) || true
+          CVM_INFO=$(phala api /cvms/chipotle-prod-rep-r68r6 --json 2>&1) || true
           echo "CVM info (kms): $(echo "$CVM_INFO" | jq '.kms_info // .detail' 2>/dev/null)"
           APP_AUTH=$(echo "$CVM_INFO" | jq -r '.kms_info.dstack_app_address // empty')
           if [ -z "$APP_AUTH" ]; then
@@ -268,7 +268,7 @@ jobs:
           # using the @phala/cloud SDK so the Safe proposal uses the correct
           # value that the KMS will check via allowedComposeHashes.
           echo "Fetching full app_compose from Phala API..."
-          FULL_COMPOSE=$(phala api /cvms/chipotle-prod/compose_file --json 2>&1) || {
+          FULL_COMPOSE=$(phala api /cvms/chipotle-prod-rep-r68r6/compose_file --json 2>&1) || {
             echo "::error::Failed to fetch compose file: $FULL_COMPOSE"
             exit 1
           }
@@ -436,7 +436,7 @@ jobs:
           jq -n \
             --arg compose_hash "${{ needs.prepare-deploy.outputs.compose_hash }}" \
             --arg safe_tx_hash "${{ needs.propose-compose-hash.outputs.safe_tx_hash }}" \
-            --arg phala_app_name "chipotle-prod" \
+            --arg phala_app_name "chipotle-prod-rep-r68r6" \
             --arg base_url "https://api.chipotle.litprotocol.com" \
             --arg api_root_url "https://api.chipotle.litprotocol.com/core/v1" \
             --arg safe_address "${{ vars.SAFE_ADDRESS_CHIPOTLE_PROD }}" \

--- a/.github/workflows/manual_phala-envs-update-prod.yml
+++ b/.github/workflows/manual_phala-envs-update-prod.yml
@@ -1,0 +1,104 @@
+# Push sealed environment variables to a specific Phala CVM and start it (PROD).
+#
+# Prod-flavored sibling of manual_phala-envs-update.yml. Used during CVM
+# migrations (e.g. prod6 → prod2) to bootstrap a freshly-provisioned chipotle-prod
+# replica with the same live env vars CI would normally push during the
+# tag-triggered deploy-prod-* flow.
+#
+# Differences from the next/staging variant:
+#   - Stripe LIVE keys (STRIPE_SECRET_KEY / STRIPE_PUBLISHABLE_KEY), not sandbox
+#   - Defaults: CERTBOT_DOMAIN=api.chipotle.litprotocol.com, GCP_PROJECT_ID=chipotle-prod
+#
+# Env block mirrors deploy-prod-1-propose.yml:341-372 (encryptEnvVars step).
+#
+# Required secrets:
+#   PHALA_CLOUD_API_KEY            - Phala Cloud API key
+#   PHALA_DSTACKAPP_PRIVATE_KEY    - DstackApp owner key (unused for prod Safe-owned app,
+#                                     kept for parity with `phala envs update` CLI args)
+#   BASE_CHAIN_RPC                 - Base mainnet RPC URL
+#   GCP_SERVICE_ACCOUNT_JSON       - GCP service account key
+#   STRIPE_SECRET_KEY              - Stripe LIVE secret key
+#   STRIPE_PUBLISHABLE_KEY         - Stripe LIVE publishable key
+#   CERTBOT_AWS_ACCESS_KEY_ID      - Route 53 IAM access key
+#   CERTBOT_AWS_SECRET_ACCESS_KEY  - Route 53 IAM secret key
+#   CERTBOT_AWS_ROLE_ARN           - IAM role ARN for STS assumption
+#
+# Required vars:
+#   CERTBOT_AWS_REGION             - AWS region for STS endpoint
+
+name: Phala Envs Update + Start (Prod, manual)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      cvm_id:
+        description: "Target CVM (UUID, app_id, instance_id, or name) — e.g. cvm_qwrMBqKl"
+        required: true
+        type: string
+      certbot_domain:
+        description: "CERTBOT_DOMAIN for dstack-ingress. Leave blank to skip ingress cert acquisition."
+        required: false
+        type: string
+        default: "api.chipotle.litprotocol.com"
+      gcp_project_id:
+        description: "GCP_PROJECT_ID for otel-collector"
+        required: false
+        type: string
+        default: "chipotle-prod"
+      start:
+        description: "Start the CVM after pushing envs"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  envs-update:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Phala CLI
+        run: npm install -g phala
+
+      - name: Push sealed envs to CVM
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+          PRIVATE_KEY: ${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}
+          ETH_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
+          BASE_CHAIN_RPC: ${{ secrets.BASE_CHAIN_RPC }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+          CERTBOT_AWS_ACCESS_KEY_ID: ${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}
+          CERTBOT_AWS_SECRET_ACCESS_KEY: ${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}
+          CERTBOT_AWS_ROLE_ARN: ${{ secrets.CERTBOT_AWS_ROLE_ARN }}
+        run: |
+          phala envs update "${{ inputs.cvm_id }}" \
+            -e "STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY" \
+            -e "STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY" \
+            -e "GCP_SERVICE_ACCOUNT_JSON=$GCP_SERVICE_ACCOUNT_JSON" \
+            -e "GCP_PROJECT_ID=${{ inputs.gcp_project_id }}" \
+            -e "BASE_CHAIN_RPC=$BASE_CHAIN_RPC" \
+            -e "CERTBOT_DOMAIN=${{ inputs.certbot_domain }}" \
+            -e "CERTBOT_AWS_ACCESS_KEY_ID=$CERTBOT_AWS_ACCESS_KEY_ID" \
+            -e "CERTBOT_AWS_SECRET_ACCESS_KEY=$CERTBOT_AWS_SECRET_ACCESS_KEY" \
+            -e "CERTBOT_AWS_ROLE_ARN=$CERTBOT_AWS_ROLE_ARN" \
+            -e "CERTBOT_AWS_REGION=${{ vars.CERTBOT_AWS_REGION }}"
+
+      - name: Start CVM
+        if: inputs.start
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+        run: |
+          phala cvms start "${{ inputs.cvm_id }}"
+
+      - name: Show CVM status
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+        run: |
+          phala cvms get "${{ inputs.cvm_id }}"


### PR DESCRIPTION
## Summary
- Swaps the four CVM-name references in \`deploy-prod-1-propose.yml\` from \`chipotle-prod\` (on prod6) to \`chipotle-prod-rep-r68r6\` (the new replica on prod2 provisioned during the migration).
- Pulls \`manual_phala-envs-update-prod.yml\` into \`main\` (merged into \`next\` via #343 / #344 during the migration).

## Migration context (already complete, durable on-chain)
- New CVM \`chipotle-prod-rep-r68r6\` (\`cvm_qwrMBqKl\`) is running on prod2.
- Device \`0x6bb63f8c...d2e0\` allowlisted on the AppAuth contract \`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC\` via Safe-multisig tx \`0xe1b96bf2d095797e18abecd37eac3862be086f9c4cdf2e0752d2a78fad74e652\`.
- Same \`app_id\` (\`3f91deaf...\`), same compose hash (\`cc43e72a...\`), same Safe, same AppAuth as the prod6 CVM. Only the CVM instance moves.
- Verified \`/version\` returns \`commit_version: v1.1.1\` and \`/health\` returns \`lit_actions_reachable: true, billing_keys_present: true\` via the direct prod2 gateway URL.

## What this PR does NOT change
- \`GCP_PROJECT_ID=chipotle-prod\` on lines 172 and 366 — that's the GCP project name, not the CVM name. Stays as-is.
- No code changes to \`lit-api-server\`, \`lit-actions\`, or any image — same compose hash already on-chain.

## After merge
- prod6 CVM (\`cvm_YKRXzoja\`, name \`chipotle-prod\`) keeps serving until stopped.
- Next \`v*\` tag deploy will land on prod2 via the new CVM name.
- Once a prod deploy has succeeded against prod2 post-merge, stop prod6 with \`phala cvms stop cvm_YKRXzoja\`. DNS settles within ~12h once prod6's ingress drops the CNAME.

## Test plan
- [ ] Self-review the diff.
- [ ] Merge.
- [ ] On next prod deploy (\`v1.1.2\` or whatever ships next), confirm Phase 1 provisions against \`chipotle-prod-rep-r68r6\` and the deploy-context's \`phala_app_name\` reflects the new name.
- [ ] After Phase 2 succeeds, stop the prod6 instance \`cvm_YKRXzoja\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)