### PR TITLE
feat(CPL-325): raise default lit-action response cap to 1MB

### DIFF
--- a/lit-api-server/src/actions/client/mod.rs
+++ b/lit-api-server/src/actions/client/mod.rs
@@ -29,6 +29,8 @@ pub(crate) const DEFAULT_MAX_GET_KEYS_COUNT: u32 = 10; // 10 signature requests 
 pub(crate) const DEFAULT_MAX_RETRIES: u32 = 3;
 
 // Upper-bound constants (10x default) — chain config values beyond these are rejected.
+// Note: MAX_MAX_RESPONSE_LENGTH is intentionally omitted; the response cap is fixed at
+// DEFAULT_MAX_RESPONSE_LENGTH and chain config can only lower it.
 pub(crate) const MAX_TIMEOUT_MS: u64 = DEFAULT_TIMEOUT_MS * 10;
 pub(crate) const MAX_ASYNC_TIMEOUT_MS: u64 = DEFAULT_ASYNC_TIMEOUT_MS * 10;
 pub(crate) const MAX_CLIENT_TIMEOUT_MS_BUFFER: u64 = DEFAULT_CLIENT_TIMEOUT_MS_BUFFER * 10;

--- a/lit-api-server/src/actions/client/mod.rs
+++ b/lit-api-server/src/actions/client/mod.rs
@@ -24,7 +24,7 @@ pub(crate) const DEFAULT_MEMORY_LIMIT_MB: u32 = 64; // 64MB
 pub(crate) const DEFAULT_MAX_CODE_LENGTH: u64 = 16 * 1024 * 1024; // 16MB
 pub(crate) const DEFAULT_MAX_CONSOLE_LOG_LENGTH: u64 = 1024 * 100; // 100KB
 pub(crate) const DEFAULT_MAX_FETCH_COUNT: u32 = 50;
-pub(crate) const DEFAULT_MAX_RESPONSE_LENGTH: u64 = 1024 * 100; // 100KB
+pub(crate) const DEFAULT_MAX_RESPONSE_LENGTH: u64 = 1024 * 1024; // 1MB
 pub(crate) const DEFAULT_MAX_GET_KEYS_COUNT: u32 = 10; // 10 signature requests per action execution
 pub(crate) const DEFAULT_MAX_RETRIES: u32 = 3;
 
@@ -36,7 +36,6 @@ pub(crate) const MAX_MEMORY_LIMIT_MB: u32 = DEFAULT_MEMORY_LIMIT_MB * 10;
 pub(crate) const MAX_MAX_CODE_LENGTH: u64 = DEFAULT_MAX_CODE_LENGTH * 10;
 pub(crate) const MAX_MAX_CONSOLE_LOG_LENGTH: u64 = DEFAULT_MAX_CONSOLE_LOG_LENGTH * 10;
 pub(crate) const MAX_MAX_FETCH_COUNT: u32 = DEFAULT_MAX_FETCH_COUNT * 10;
-pub(crate) const MAX_MAX_RESPONSE_LENGTH: u64 = DEFAULT_MAX_RESPONSE_LENGTH * 10;
 pub(crate) const MAX_MAX_GET_KEYS_COUNT: u32 = DEFAULT_MAX_GET_KEYS_COUNT * 10;
 pub(crate) const MAX_MAX_RETRIES: u32 = DEFAULT_MAX_RETRIES * 10;
 

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -352,6 +352,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_config_value_max_response_length_capped_at_default() {
+        let mut snapshot = HashMap::new();
+        snapshot.insert(
+            ConfigKeys::LIT_ACTION_DEFAULT_MAX_RESPONSE_LENGTH.to_string(),
+            (DEFAULT_MAX_RESPONSE_LENGTH + 1).to_string(),
+        );
+        let result = parse_config_value::<u64>(
+            &snapshot,
+            &ConfigKeys::LIT_ACTION_DEFAULT_MAX_RESPONSE_LENGTH,
+            0,
+            DEFAULT_MAX_RESPONSE_LENGTH,
+        );
+        assert_eq!(result, None);
+    }
+
+    #[test]
     fn parse_config_value_exceeds_max() {
         let mut snapshot = HashMap::new();
         snapshot.insert(

--- a/lit-api-server/src/core/core_features.rs
+++ b/lit-api-server/src/core/core_features.rs
@@ -3,9 +3,9 @@ use crate::accounts::chain_config::{ChainConfig, ConfigKeys};
 use crate::actions::client::ClientBuilder;
 use crate::actions::client::models::DenoExecutionEnv;
 use crate::actions::client::{
-    MAX_ASYNC_TIMEOUT_MS, MAX_CLIENT_TIMEOUT_MS_BUFFER, MAX_MAX_CODE_LENGTH,
-    MAX_MAX_CONSOLE_LOG_LENGTH, MAX_MAX_FETCH_COUNT, MAX_MAX_GET_KEYS_COUNT,
-    MAX_MAX_RESPONSE_LENGTH, MAX_MAX_RETRIES, MAX_MEMORY_LIMIT_MB, MAX_TIMEOUT_MS,
+    DEFAULT_MAX_RESPONSE_LENGTH, MAX_ASYNC_TIMEOUT_MS, MAX_CLIENT_TIMEOUT_MS_BUFFER,
+    MAX_MAX_CODE_LENGTH, MAX_MAX_CONSOLE_LOG_LENGTH, MAX_MAX_FETCH_COUNT, MAX_MAX_GET_KEYS_COUNT,
+    MAX_MAX_RETRIES, MAX_MEMORY_LIMIT_MB, MAX_TIMEOUT_MS,
 };
 use crate::actions::grpc::GrpcClientPool;
 use crate::core::v1::helpers::api_status::ApiStatus;
@@ -283,7 +283,7 @@ async fn get_lit_action_client_builder(chain_config: Arc<ChainConfig>) -> Client
         &snapshot,
         &ConfigKeys::LIT_ACTION_DEFAULT_MAX_RESPONSE_LENGTH,
         0,
-        MAX_MAX_RESPONSE_LENGTH,
+        DEFAULT_MAX_RESPONSE_LENGTH,
     ) {
         builder.max_response_length(v);
     }


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_MAX_RESPONSE_LENGTH` from 100KB to 1MB so `LitActions.setResponse` accepts payloads up to 1MB by default.
- Remove the separate `MAX_MAX_RESPONSE_LENGTH` (previously `DEFAULT × 10`); chain config can now only lower the cap, never raise it above the 1MB default.

## Test plan
- [ ] `cargo check` on `lit-api-server` (passes locally)
- [ ] Exercise a lit-action returning ~1MB and confirm it succeeds; >1MB still errors with the existing "Response is too long" message