### PR TITLE
test(CPL-322): add Forge tests for AccountConfig diamond contracts

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          # Pinned for reproducibility. Bump intentionally when upgrading.
+          version: v1.5.1
 
       - name: Build contracts
         working-directory: lit-api-server/blockchain/lit_node_express

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,49 @@
+name: Contract Tests
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  forge-test:
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: forge-test
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Reset workspace to HEAD
+        run: git checkout HEAD -- .
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install contract dependencies
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npm ci
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Build contracts
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: forge build --sizes
+
+      - name: Run forge tests
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: forge test -vv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lit-api-server/blockchain/lit_node_express/lib/forge-std"]
+	path = lit-api-server/blockchain/lit_node_express/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/lit-api-server/blockchain/lit_node_express/.gitignore
+++ b/lit-api-server/blockchain/lit_node_express/.gitignore
@@ -1,3 +1,6 @@
 /node_modules
 /artifacts
 /cache
+/cache_forge
+/out
+broadcast/

--- a/lit-api-server/blockchain/lit_node_express/foundry.toml
+++ b/lit-api-server/blockchain/lit_node_express/foundry.toml
@@ -1,0 +1,20 @@
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = ["lib", "node_modules"]
+cache_path = "cache_forge"
+solc_version = "0.8.28"
+optimizer = true
+optimizer_runs = 100
+via_ir = true
+fs_permissions = [{ access = "read", path = "./" }]
+
+# Match Hardhat's compilation surface so we don't drift.
+auto_detect_solc = false
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = false
+int_types = "long"

--- a/lit-api-server/blockchain/lit_node_express/remappings.txt
+++ b/lit-api-server/blockchain/lit_node_express/remappings.txt
@@ -1,0 +1,2 @@
+@openzeppelin/=node_modules/@openzeppelin/
+forge-std/=lib/forge-std/src/

--- a/lit-api-server/blockchain/lit_node_express/test/AccessControl.t.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/AccessControl.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {BaseTest} from "./helpers/BaseTest.sol";
+import {AppStorage} from "../contracts/AccountConfigFacets/AppStorage.sol";
+import {NotContractOwner} from "../libraries/LibDiamond.sol";
+
+/// @notice Verifies the gating predicates around APIConfigFacet and BillingFacet.
+///         The Writes/Views facets gate via account-level checks and are covered
+///         in Accounts.t.sol.
+contract AccessControlTest is BaseTest {
+    // -------- APIConfigFacet --------
+
+    function test_setApiPayers_strangerReverts() public {
+        address[] memory empty = new address[](0);
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrOwner.selector, stranger)
+        );
+        apiConfig.setApiPayers(empty);
+    }
+
+    function test_setApiPayers_regularApiPayerReverts() public {
+        // setApiPayers is gated to owner OR adminApiPayer only — even an existing
+        // api payer (apiPayer) is rejected, to prevent hostile takeover.
+        address[] memory empty = new address[](0);
+        vm.prank(apiPayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrOwner.selector, apiPayer)
+        );
+        apiConfig.setApiPayers(empty);
+    }
+
+    function test_setApiPayers_owner() public {
+        address[] memory next = new address[](1);
+        next[0] = user;
+        vm.prank(owner);
+        apiConfig.setApiPayers(next);
+        address[] memory got = views_.api_payers();
+        assertEq(got.length, 1);
+        assertEq(got[0], user);
+    }
+
+    function test_setApiPayers_adminApiPayer() public {
+        address[] memory next = new address[](1);
+        next[0] = user;
+        vm.prank(adminApiPayer);
+        apiConfig.setApiPayers(next);
+        assertEq(views_.api_payers()[0], user);
+    }
+
+    function test_setConfigOperator_strangerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyConfigOperatorOrOwner.selector, stranger)
+        );
+        apiConfig.setConfigOperator(user);
+    }
+
+    function test_setConfigOperator_owner() public {
+        vm.prank(owner);
+        apiConfig.setConfigOperator(user);
+        assertEq(views_.configOperator(), user);
+    }
+
+    function test_setConfigOperator_currentConfigOperator() public {
+        // Owner is the initial configOperator. Reassign to user, then user should be able to.
+        vm.prank(owner);
+        apiConfig.setConfigOperator(user);
+        vm.prank(user);
+        apiConfig.setConfigOperator(stranger);
+        assertEq(views_.configOperator(), stranger);
+    }
+
+    function test_setRequestedApiPayerCount_strangerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrOwner.selector, stranger)
+        );
+        apiConfig.setRequestedApiPayerCount(7);
+    }
+
+    function test_setRequestedApiPayerCount_apiPayerOk() public {
+        vm.prank(apiPayer);
+        apiConfig.setRequestedApiPayerCount(7);
+        assertEq(views_.requestedApiPayerCount(), 7);
+    }
+
+    function test_serverTrigger_onlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(NotContractOwner.selector, stranger, owner));
+        apiConfig.serverTrigger(123);
+
+        // Even an api payer cannot.
+        vm.prank(apiPayer);
+        vm.expectRevert(abi.encodeWithSelector(NotContractOwner.selector, apiPayer, owner));
+        apiConfig.serverTrigger(123);
+
+        vm.prank(owner);
+        apiConfig.serverTrigger(123); // ok
+    }
+
+    // -------- BillingFacet --------
+
+    function test_setPricing_strangerReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrPricingOperator.selector, stranger)
+        );
+        billing.setPricing(2, 99);
+    }
+
+    function test_setPricing_apiPayerOk() public {
+        vm.prank(apiPayer);
+        billing.setPricing(2, 99);
+        assertEq(billing.getPricing(2), 99);
+    }
+
+    function test_setPricing_pricingOperatorOk() public {
+        // pricingOperator defaults to the owner from the constructor.
+        vm.prank(owner);
+        billing.setPricing(2, 99);
+        assertEq(billing.getPricing(2), 99);
+    }
+
+    function test_setPricingOperator_onlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(NotContractOwner.selector, stranger, owner));
+        billing.setPricingOperator(user);
+
+        // Existing pricingOperator (= owner) can. After reassignment, the previous
+        // pricingOperator (now non-owner) loses the ability.
+        vm.prank(owner);
+        billing.setPricingOperator(user);
+        assertEq(views_.pricingOperator(), user);
+    }
+
+    function test_creditAndDebitApiKey_apiPayerFlow() public {
+        // Create a managed account so apiPayer has access.
+        uint256 hash = uint256(keccak256("billed"));
+        vm.prank(apiPayer);
+        writes.newAccount(hash, true, "managed", "billed", user);
+
+        vm.prank(apiPayer);
+        billing.creditApiKey(hash, 100);
+
+        vm.prank(apiPayer);
+        billing.debitApiKey(hash, 40);
+
+        // Can't debit more than the remaining balance.
+        vm.prank(apiPayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.InsufficientBalance.selector, hash, 1000)
+        );
+        billing.debitApiKey(hash, 1000);
+    }
+
+    function test_debitApiKey_strangerReverts() public {
+        vm.prank(apiPayer);
+        writes.newAccount(uint256(keccak256("k")), true, "x", "x", user);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrPricingOperator.selector, stranger)
+        );
+        billing.debitApiKey(uint256(keccak256("k")), 1);
+    }
+}

--- a/lit-api-server/blockchain/lit_node_express/test/Accounts.t.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/Accounts.t.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {BaseTest} from "./helpers/BaseTest.sol";
+import {AppStorage} from "../contracts/AccountConfigFacets/AppStorage.sol";
+import {ViewsFacet} from "../contracts/AccountConfigFacets/ViewsFacet.sol";
+
+contract AccountsTest is BaseTest {
+    function test_newChainSecuredAccount_writesPersistAndAreReadable() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+
+        uint256 hash = apiKeyHashOf(user);
+        assertEq(views_.getAccountWalletAddress(hash), user);
+        assertEq(views_.getBillingWalletAddress(hash), user);
+        assertEq(views_.accountCount(), 1);
+        assertEq(views_.indexToAccountHashAt(1), hash);
+    }
+
+    function test_newChainSecuredAccount_rejectsDuplicate() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+
+        uint256 hash = apiKeyHashOf(user);
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(AppStorage.AccountAlreadyExists.selector, hash));
+        writes.newChainSecuredAccount("alice2", "second");
+    }
+
+    function test_newAccount_apiPayerCanCreateManagedAccount() public {
+        uint256 hash = uint256(keccak256("api-key-1"));
+        vm.prank(apiPayer);
+        writes.newAccount(hash, true, "managed", "by api payer", user);
+
+        assertEq(views_.getAccountWalletAddress(hash), user);
+    }
+
+    function test_newAccount_strangerCannotCreateManagedAccount() public {
+        // Non-api-payer can only create unmanaged accounts whose apiKeyHash matches their wallet.
+        uint256 hash = uint256(keccak256("api-key-1"));
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AppStorage.InvalidRequest.selector,
+                "ChainSecured accounts must be unmanaged."
+            )
+        );
+        writes.newAccount(hash, true, "managed", "no go", stranger);
+    }
+
+    function test_newAccount_strangerHashMismatchReverts() public {
+        // Even unmanaged, the apiKeyHash for a non-api-payer caller must equal keccak(sender).
+        uint256 hash = uint256(keccak256("not-my-hash"));
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AppStorage.InvalidRequest.selector,
+                "ChainSecured apiKeyHash must equal the keccak256 of the sender."
+            )
+        );
+        writes.newAccount(hash, false, "x", "x", stranger);
+    }
+
+    function test_addGroup_thenListGroups() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+        uint256 hash = apiKeyHashOf(user);
+
+        uint256[] memory cidHashes = new uint256[](2);
+        cidHashes[0] = uint256(keccak256("cid-a"));
+        cidHashes[1] = uint256(keccak256("cid-b"));
+        address[] memory pkpIds = new address[](0);
+
+        vm.prank(user);
+        uint256 groupId = writes.addGroup(hash, "g1", "first group", cidHashes, pkpIds);
+        assertEq(groupId, 1);
+
+        AppStorage.Metadata[] memory groups = views_.listGroups(hash, 0, 10);
+        assertEq(groups.length, 1);
+        assertEq(groups[0].id, 1);
+        assertEq(groups[0].name, "g1");
+
+        ViewsFacet.GroupReturn memory group = views_.listGroupContents(hash, groupId);
+        assertEq(group.cidHash.length, 2);
+    }
+
+    function test_setUsageApiKey_thenListApiKeys() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+        uint256 hash = apiKeyHashOf(user);
+
+        uint256 usageHash = uint256(keccak256("usage-key-1"));
+        uint256[] memory empty = new uint256[](0);
+        vm.prank(user);
+        writes.setUsageApiKey(
+            hash,
+            usageHash,
+            block.timestamp + 7 days,
+            0,
+            "usage-1",
+            "limited usage key",
+            false,
+            false,
+            false,
+            empty,
+            empty,
+            empty,
+            empty
+        );
+
+        ViewsFacet.UsageApiKeyReturn[] memory keys = views_.listApiKeys(hash, 0, 10);
+        assertEq(keys.length, 1);
+        assertEq(keys[0].apiKeyHash, usageHash);
+        assertEq(keys[0].metadata.name, "usage-1");
+
+        // The usage key should resolve to the same master account.
+        assertEq(views_.getAccountWalletAddress(usageHash), user);
+    }
+
+    function test_addAction_thenListActions_thenRemove() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+        uint256 hash = apiKeyHashOf(user);
+
+        uint256 actionHash = uint256(keccak256("action-cid"));
+        vm.prank(user);
+        writes.addAction(hash, "act1", "first action", actionHash);
+
+        AppStorage.Metadata[] memory actions = views_.listActions(hash, 0, 10);
+        assertEq(actions.length, 1);
+        assertEq(actions[0].id, actionHash);
+        assertEq(actions[0].name, "act1");
+
+        vm.prank(user);
+        writes.removeAction(hash, actionHash);
+
+        actions = views_.listActions(hash, 0, 10);
+        assertEq(actions.length, 0);
+    }
+
+    function test_registerWalletDerivation_storesAndIsListable() public {
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+        uint256 hash = apiKeyHashOf(user);
+
+        address pkpAddr = address(0xBEEF);
+        vm.prank(user);
+        writes.registerWalletDerivation(hash, pkpAddr, 42, "pkp-1", "first pkp");
+
+        assertEq(views_.getWalletDerivation(hash, pkpAddr), 42);
+        AppStorage.PkpData[] memory pkps = views_.listPkps(hash, 0, 10);
+        assertEq(pkps.length, 1);
+        assertEq(pkps[0].pkpId, pkpAddr);
+
+        // Re-registering same pkp must revert.
+        vm.prank(user);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.InvalidRequest.selector, "PKP already registered")
+        );
+        writes.registerWalletDerivation(hash, pkpAddr, 43, "dup", "dup");
+    }
+
+    function test_listGroupContents_unknownAccountReverts() public {
+        uint256 hash = apiKeyHashOf(user);
+        vm.expectRevert(abi.encodeWithSelector(AppStorage.AccountDoesNotExist.selector, hash));
+        views_.getAccountWalletAddress(hash);
+    }
+
+    function test_convertToChainSecured_apiPayerOnly() public {
+        // First create a managed account via api payer.
+        uint256 hash = uint256(keccak256("managed-key"));
+        vm.prank(apiPayer);
+        writes.newAccount(hash, true, "managed", "via api payer", apiPayer);
+
+        // Stranger cannot convert.
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(AppStorage.OnlyApiPayerOrOwner.selector, stranger)
+        );
+        writes.convertToChainSecuredAccount(hash, user);
+
+        // Api payer can; afterward the new admin wallet hash also resolves.
+        vm.prank(apiPayer);
+        writes.convertToChainSecuredAccount(hash, user);
+        assertEq(views_.getAccountWalletAddress(hash), user);
+        assertEq(views_.getAccountWalletAddress(apiKeyHashOf(user)), user);
+    }
+
+    function test_convertToChainSecured_secondCallReverts() public {
+        // Already-unmanaged accounts can't be re-converted.
+        vm.prank(user);
+        writes.newChainSecuredAccount("alice", "primary");
+        uint256 hash = apiKeyHashOf(user);
+
+        vm.prank(apiPayer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AppStorage.InvalidRequest.selector,
+                "Account is already ChainSecured."
+            )
+        );
+        writes.convertToChainSecuredAccount(hash, stranger);
+    }
+}

--- a/lit-api-server/blockchain/lit_node_express/test/Accounts.t.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/Accounts.t.sol
@@ -160,7 +160,10 @@ contract AccountsTest is BaseTest {
         writes.registerWalletDerivation(hash, pkpAddr, 43, "dup", "dup");
     }
 
-    function test_listGroupContents_unknownAccountReverts() public {
+    function test_views_unknownAccountReverts() public {
+        // Any read that resolves through `getReadOnlyAccount` should revert for a
+        // hash that has never been written. Using `getAccountWalletAddress` as the
+        // probe — the same revert path covers every account-scoped view.
         uint256 hash = apiKeyHashOf(user);
         vm.expectRevert(abi.encodeWithSelector(AppStorage.AccountDoesNotExist.selector, hash));
         views_.getAccountWalletAddress(hash);

--- a/lit-api-server/blockchain/lit_node_express/test/Diamond.t.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/Diamond.t.sol
@@ -49,7 +49,8 @@ contract DiamondTest is BaseTest {
     }
 
     function test_fallback_unknownSelectorReverts() public {
-        // FunctionNotFound(bytes4) selector + arbitrary bytes4
+        // Send calldata starting with a selector the diamond has not cut in, so the
+        // fallback's lookup returns address(0) and reverts with FunctionNotFound.
         bytes4 unknown = bytes4(0xdeadbeef);
         (bool ok,) = d.diamond.call(abi.encodePacked(unknown));
         assertFalse(ok, "call to unknown selector should revert");

--- a/lit-api-server/blockchain/lit_node_express/test/Diamond.t.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/Diamond.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {BaseTest} from "./helpers/BaseTest.sol";
+import {DiamondDeploy} from "./helpers/DiamondDeploy.sol";
+import {ViewsFacet} from "../contracts/AccountConfigFacets/ViewsFacet.sol";
+import {WritesFacet} from "../contracts/AccountConfigFacets/WritesFacet.sol";
+import {APIConfigFacet} from "../contracts/AccountConfigFacets/APIConfigFacet.sol";
+import {BillingFacet} from "../contracts/AccountConfigFacets/BillingFacet.sol";
+import {DiamondCutFacet} from "../libraries/diamond/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../libraries/diamond/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../libraries/diamond/OwnershipFacet.sol";
+import {IDiamondLoupe} from "../interfaces/IDiamondLoupe.sol";
+import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
+import {IDiamond} from "../interfaces/IDiamond.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC173} from "../interfaces/IERC173.sol";
+import {NotContractOwner} from "../libraries/LibDiamond.sol";
+
+contract DiamondTest is BaseTest {
+    function test_owner_setAtConstruction() public view {
+        assertEq(ownership.owner(), owner);
+    }
+
+    function test_loupe_facetsListsAllSevenFacets() public view {
+        IDiamondLoupe.Facet[] memory facets = loupe.facets();
+        assertEq(facets.length, 7, "expected 7 facets");
+
+        // Every facet entry must reference a real, distinct address.
+        for (uint256 i = 0; i < facets.length; i++) {
+            assertTrue(facets[i].facetAddress != address(0));
+            assertGt(facets[i].functionSelectors.length, 0);
+        }
+    }
+
+    function test_loupe_facetAddressRoutesEachFacetSelector() public view {
+        // Spot-check one selector per facet routes to the right deployed facet.
+        assertEq(loupe.facetAddress(DiamondCutFacet.diamondCut.selector), d.diamondCut);
+        assertEq(loupe.facetAddress(DiamondLoupeFacet.facets.selector), d.diamondLoupe);
+        assertEq(loupe.facetAddress(OwnershipFacet.owner.selector), d.ownership);
+        assertEq(loupe.facetAddress(ViewsFacet.accountCount.selector), d.views);
+        assertEq(loupe.facetAddress(WritesFacet.newAccount.selector), d.writes);
+        assertEq(loupe.facetAddress(APIConfigFacet.setApiPayers.selector), d.apiConfig);
+        assertEq(loupe.facetAddress(BillingFacet.getPricing.selector), d.billing);
+    }
+
+    function test_loupe_unknownSelectorReturnsZero() public view {
+        assertEq(loupe.facetAddress(bytes4(0xdeadbeef)), address(0));
+    }
+
+    function test_fallback_unknownSelectorReverts() public {
+        // FunctionNotFound(bytes4) selector + arbitrary bytes4
+        bytes4 unknown = bytes4(0xdeadbeef);
+        (bool ok,) = d.diamond.call(abi.encodePacked(unknown));
+        assertFalse(ok, "call to unknown selector should revert");
+    }
+
+    function test_directEthTransferReverts() public {
+        vm.deal(stranger, 1 ether);
+        vm.prank(stranger);
+        (bool ok,) = d.diamond.call{value: 1}("");
+        assertFalse(ok, "direct ETH transfer should revert");
+    }
+
+    function test_supportsInterface_standardIds() public view {
+        assertTrue(loupe.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(loupe.supportsInterface(type(IDiamondCut).interfaceId));
+        assertTrue(loupe.supportsInterface(type(IDiamondLoupe).interfaceId));
+        assertTrue(loupe.supportsInterface(type(IERC173).interfaceId));
+        assertFalse(loupe.supportsInterface(bytes4(0xffffffff)));
+    }
+
+    function test_transferOwnership_onlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(NotContractOwner.selector, stranger, owner));
+        ownership.transferOwnership(stranger);
+    }
+
+    function test_transferOwnership_owner() public {
+        vm.prank(owner);
+        ownership.transferOwnership(user);
+        assertEq(ownership.owner(), user);
+    }
+
+    function test_diamondCut_onlyOwner() public {
+        IDiamond.FacetCut[] memory empty = new IDiamond.FacetCut[](0);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(NotContractOwner.selector, stranger, owner));
+        cut.diamondCut(empty, address(0), "");
+    }
+
+    function test_constructor_setsDefaults() public view {
+        // Constructor primes pricing[1]=1, requestedApiPayerCount=3, pricingOperator=owner,
+        // configOperator=owner.
+        assertEq(views_.pricingOperator(), owner);
+        assertEq(views_.configOperator(), owner);
+        assertEq(billing.getPricing(1), 1);
+        assertEq(views_.requestedApiPayerCount(), 3);
+    }
+}

--- a/lit-api-server/blockchain/lit_node_express/test/helpers/BaseTest.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/helpers/BaseTest.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {DiamondDeploy} from "./DiamondDeploy.sol";
+import {ViewsFacet} from "../../contracts/AccountConfigFacets/ViewsFacet.sol";
+import {WritesFacet} from "../../contracts/AccountConfigFacets/WritesFacet.sol";
+import {APIConfigFacet} from "../../contracts/AccountConfigFacets/APIConfigFacet.sol";
+import {BillingFacet} from "../../contracts/AccountConfigFacets/BillingFacet.sol";
+import {DiamondCutFacet} from "../../libraries/diamond/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../libraries/diamond/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../../libraries/diamond/OwnershipFacet.sol";
+
+/// @notice Base for AccountConfig diamond tests. Deploys the full diamond and
+///         exposes facet-typed views into the same address so individual tests
+///         stay readable.
+abstract contract BaseTest is Test {
+    address internal owner = makeAddr("owner");
+    address internal apiPayer = makeAddr("apiPayer");
+    address internal adminApiPayer = makeAddr("adminApiPayer");
+    address internal user = makeAddr("user");
+    address internal stranger = makeAddr("stranger");
+
+    DiamondDeploy.Deployed internal d;
+
+    // Facet-typed views into the diamond address.
+    ViewsFacet internal views_;
+    WritesFacet internal writes;
+    APIConfigFacet internal apiConfig;
+    BillingFacet internal billing;
+    DiamondCutFacet internal cut;
+    DiamondLoupeFacet internal loupe;
+    OwnershipFacet internal ownership;
+
+    function setUp() public virtual {
+        d = DiamondDeploy.deploy(owner);
+        views_ = ViewsFacet(d.diamond);
+        writes = WritesFacet(d.diamond);
+        apiConfig = APIConfigFacet(d.diamond);
+        billing = BillingFacet(d.diamond);
+        cut = DiamondCutFacet(d.diamond);
+        loupe = DiamondLoupeFacet(d.diamond);
+        ownership = OwnershipFacet(d.diamond);
+
+        // Wire the api_payer set + admin api payer the same way production does.
+        address[] memory payers = new address[](1);
+        payers[0] = apiPayer;
+        vm.prank(owner);
+        apiConfig.setApiPayers(payers);
+        vm.prank(owner);
+        apiConfig.setAdminApiPayerAccount(adminApiPayer);
+    }
+
+    function apiKeyHashOf(address wallet) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(wallet)));
+    }
+}

--- a/lit-api-server/blockchain/lit_node_express/test/helpers/DiamondDeploy.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/helpers/DiamondDeploy.sol
@@ -14,7 +14,13 @@ import {IDiamond} from "../../interfaces/IDiamond.sol";
 import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
 
 /// @notice Test-only helper that deploys an `AccountConfig` diamond with all
-///         production facets cut in. Mirrors the production Rust `contract_deployer`.
+///         production facets cut in.
+/// @dev    The production Rust `contract_deployer` derives selectors from the
+///         compiled facet ABI. To keep this helper self-contained (and avoid
+///         pulling in cheatcode-driven ABI parsing in every test run), the
+///         selector arrays below are maintained by hand. If you add or rename
+///         a public/external function on any facet, update the matching
+///         `*Selectors()` function or the new selector will not be cut in.
 library DiamondDeploy {
     struct Deployed {
         address payable diamond;

--- a/lit-api-server/blockchain/lit_node_express/test/helpers/DiamondDeploy.sol
+++ b/lit-api-server/blockchain/lit_node_express/test/helpers/DiamondDeploy.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.28;
+
+import {AccountConfig} from "../../contracts/AccountConfig.sol";
+import {ViewsFacet} from "../../contracts/AccountConfigFacets/ViewsFacet.sol";
+import {WritesFacet} from "../../contracts/AccountConfigFacets/WritesFacet.sol";
+import {APIConfigFacet} from "../../contracts/AccountConfigFacets/APIConfigFacet.sol";
+import {BillingFacet} from "../../contracts/AccountConfigFacets/BillingFacet.sol";
+import {DiamondInit} from "../../contracts/AccountConfigFacets/DiamondInit.sol";
+import {DiamondCutFacet} from "../../libraries/diamond/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../libraries/diamond/DiamondLoupeFacet.sol";
+import {OwnershipFacet} from "../../libraries/diamond/OwnershipFacet.sol";
+import {IDiamond} from "../../interfaces/IDiamond.sol";
+import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
+
+/// @notice Test-only helper that deploys an `AccountConfig` diamond with all
+///         production facets cut in. Mirrors the production Rust `contract_deployer`.
+library DiamondDeploy {
+    struct Deployed {
+        address payable diamond;
+        address diamondCut;
+        address diamondLoupe;
+        address ownership;
+        address views;
+        address writes;
+        address apiConfig;
+        address billing;
+        address diamondInit;
+    }
+
+    function deploy(address owner) internal returns (Deployed memory d) {
+        d.diamondCut = address(new DiamondCutFacet());
+        d.diamondLoupe = address(new DiamondLoupeFacet());
+        d.ownership = address(new OwnershipFacet());
+        d.views = address(new ViewsFacet());
+        d.writes = address(new WritesFacet());
+        d.apiConfig = address(new APIConfigFacet());
+        d.billing = address(new BillingFacet());
+        d.diamondInit = address(new DiamondInit());
+
+        IDiamond.FacetCut[] memory cut = new IDiamond.FacetCut[](7);
+        cut[0] = IDiamond.FacetCut({
+            facetAddress: d.diamondCut,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: diamondCutSelectors()
+        });
+        cut[1] = IDiamond.FacetCut({
+            facetAddress: d.diamondLoupe,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: diamondLoupeSelectors()
+        });
+        cut[2] = IDiamond.FacetCut({
+            facetAddress: d.ownership,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: ownershipSelectors()
+        });
+        cut[3] = IDiamond.FacetCut({
+            facetAddress: d.views,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: viewsSelectors()
+        });
+        cut[4] = IDiamond.FacetCut({
+            facetAddress: d.writes,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: writesSelectors()
+        });
+        cut[5] = IDiamond.FacetCut({
+            facetAddress: d.apiConfig,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: apiConfigSelectors()
+        });
+        cut[6] = IDiamond.FacetCut({
+            facetAddress: d.billing,
+            action: IDiamond.FacetCutAction.Add,
+            functionSelectors: billingSelectors()
+        });
+
+        bytes memory initCalldata = abi.encodeWithSelector(DiamondInit.init.selector);
+        AccountConfig diamond = new AccountConfig(owner, cut, d.diamondInit, initCalldata);
+        d.diamond = payable(address(diamond));
+    }
+
+    function diamondCutSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](1);
+        s[0] = DiamondCutFacet.diamondCut.selector;
+    }
+
+    function diamondLoupeSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](5);
+        s[0] = DiamondLoupeFacet.facets.selector;
+        s[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        s[2] = DiamondLoupeFacet.facetAddresses.selector;
+        s[3] = DiamondLoupeFacet.facetAddress.selector;
+        s[4] = DiamondLoupeFacet.supportsInterface.selector;
+    }
+
+    function ownershipSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](2);
+        s[0] = OwnershipFacet.transferOwnership.selector;
+        s[1] = OwnershipFacet.owner.selector;
+    }
+
+    function viewsSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](34);
+        s[0] = ViewsFacet.adminApiPayerAccount.selector;
+        s[1] = ViewsFacet.api_payers.selector;
+        s[2] = ViewsFacet.pricingOperator.selector;
+        s[3] = ViewsFacet.configOperator.selector;
+        s[4] = ViewsFacet.pkpCount.selector;
+        s[5] = ViewsFacet.accountCount.selector;
+        s[6] = ViewsFacet.indexToAccountHashAt.selector;
+        s[7] = ViewsFacet.allPkpIdsAt.selector;
+        s[8] = ViewsFacet.pricingAt.selector;
+        s[9] = ViewsFacet.apiPayerCount.selector;
+        s[10] = ViewsFacet.requestedApiPayerCount.selector;
+        s[11] = ViewsFacet.rebalanceAmount.selector;
+        s[12] = ViewsFacet.nodeConfigurationKeys.selector;
+        s[13] = ViewsFacet.nodeConfigurationValue.selector;
+        s[14] = ViewsFacet.nodeConfigurationValues.selector;
+        s[15] = ViewsFacet.accountExistsAndIsMutable.selector;
+        s[16] = ViewsFacet.getAccountWalletAddress.selector;
+        s[17] = ViewsFacet.getBillingWalletAddress.selector;
+        s[18] = ViewsFacet.getWalletDerivation.selector;
+        s[19] = ViewsFacet.listApiKeys.selector;
+        s[20] = ViewsFacet.listGroups.selector;
+        s[21] = ViewsFacet.listGroupContents.selector;
+        s[22] = ViewsFacet.listPkps.selector;
+        s[23] = ViewsFacet.listWalletsInGroup.selector;
+        s[24] = ViewsFacet.listActions.selector;
+        s[25] = ViewsFacet.listActionsInGroup.selector;
+        s[26] = ViewsFacet.canExecuteAction.selector;
+        s[27] = ViewsFacet.canUseWalletInAction.selector;
+        s[28] = ViewsFacet.apiKeyCanExecuteForAnyGroup.selector;
+        s[29] = ViewsFacet.groupIdsForAction.selector;
+        s[30] = ViewsFacet.groupIdsForActionAndWallet.selector;
+        s[31] = ViewsFacet.canExecuteActionFast.selector;
+        s[32] = ViewsFacet.canUseWalletInActionFast.selector;
+        s[33] = ViewsFacet.canExecuteActionAndUseWallet.selector;
+    }
+
+    function writesSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](19);
+        s[0] = WritesFacet.newChainSecuredAccount.selector;
+        s[1] = WritesFacet.newAccount.selector;
+        s[2] = WritesFacet.convertToChainSecuredAccount.selector;
+        s[3] = WritesFacet.setUsageApiKey.selector;
+        s[4] = WritesFacet.addGroup.selector;
+        s[5] = WritesFacet.updateGroup.selector;
+        s[6] = WritesFacet.updateGroupMetadata.selector;
+        s[7] = WritesFacet.removeGroup.selector;
+        s[8] = WritesFacet.addPkpToGroup.selector;
+        s[9] = WritesFacet.addAction.selector;
+        s[10] = WritesFacet.removeAction.selector;
+        s[11] = WritesFacet.addActionToGroup.selector;
+        s[12] = WritesFacet.updateActionMetadata.selector;
+        s[13] = WritesFacet.removeActionFromGroup.selector;
+        s[14] = WritesFacet.removePkpFromGroup.selector;
+        s[15] = WritesFacet.updateUsageApiKeyMetadata.selector;
+        s[16] = WritesFacet.removeUsageApiKey.selector;
+        s[17] = WritesFacet.registerWalletDerivation.selector;
+        s[18] = WritesFacet.setNodeConfiguration.selector;
+    }
+
+    function apiConfigSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](6);
+        s[0] = APIConfigFacet.setConfigOperator.selector;
+        s[1] = APIConfigFacet.setRequestedApiPayerCount.selector;
+        s[2] = APIConfigFacet.setAdminApiPayerAccount.selector;
+        s[3] = APIConfigFacet.setApiPayers.selector;
+        s[4] = APIConfigFacet.setRebalanceAmount.selector;
+        s[5] = APIConfigFacet.serverTrigger.selector;
+    }
+
+    function billingSelectors() internal pure returns (bytes4[] memory s) {
+        s = new bytes4[](5);
+        s[0] = BillingFacet.getPricing.selector;
+        s[1] = BillingFacet.debitApiKey.selector;
+        s[2] = BillingFacet.creditApiKey.selector;
+        s[3] = BillingFacet.setPricing.selector;
+        s[4] = BillingFacet.setPricingOperator.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- Set up Foundry side-by-side with the existing Hardhat tooling (foundry.toml, remappings, forge-std submodule). Hardhat config and deploy paths are untouched.
- Add 39 tests across three suites for the `AccountConfig` diamond and its 7 facets, plus a `DiamondDeploy` helper that mirrors the production Rust deployer.
- Add a `contract-tests.yml` CI workflow that runs `forge build` + `forge test` on push and PR.

## Test coverage
- **Diamond plumbing** (11): loupe routing for every facet, `supportsInterface` for IERC165 / IDiamondCut / IDiamondLoupe / IERC173, ownership transfer gating, `diamondCut` owner-only, fallback on unknown selector, direct-ETH revert, constructor-set defaults (pricing, operators, requestedApiPayerCount).
- **Writes / Views round-trips** (12): ChainSecured + managed account creation, duplicate / hash-mismatch reverts, group/usage-key/action/PKP CRUD, ChainSecured conversion (apiPayer-only, second-call revert).
- **Access control** (16): APIConfig and Billing gating across owner / api payer / admin api payer / config operator / pricing operator roles, plus rejection paths. Notably verifies `setApiPayers` rejects a regular api payer (only owner / admin api payer permitted, preventing hostile takeover).

Out of scope here (good follow-ups): per-usage-key permission flows (`canCreateGroup`, `canAddPkpToGroup`, …), Stripe-adjacent billing surface beyond credit/debit, and fuzz/invariant tests.

## Test plan
- [x] `forge build` clean
- [x] `forge test` — 39 / 39 passing locally
- [ ] CI workflow `contract-tests` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)