### PR TITLE
fix(CPL-297): redact plaintext api keys in add_usage_api_key log

### DIFF
--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -331,15 +331,15 @@ pub async fn add_usage_api_key(
 ) -> Result<bool> {
     let (contract, signer_address, client) =
         get_signable_account_config_contract(signer_pool.clone()).await?;
+    let account_api_key_hash = api_key_hash(api_key);
+    let usage_api_key_hash = api_key_hash(usage_api_key);
     tracing::info!(
-        "Adding usage API key to account: {}, usage_api_key: {}, expiration: {}, balance: {}",
-        api_key,
-        usage_api_key,
+        "Adding usage API key to account: account_api_key_hash={:#x}, usage_api_key_hash={:#x}, expiration: {}, balance: {}",
+        account_api_key_hash,
+        usage_api_key_hash,
         expiration,
         balance
     );
-    let account_api_key_hash = api_key_hash(api_key);
-    let usage_api_key_hash = api_key_hash(usage_api_key);
 
     let function_call = contract.setUsageApiKey(
         account_api_key_hash,


### PR DESCRIPTION
## Summary
- `accounts::add_usage_api_key` was logging the plaintext master `api_key` and `usage_api_key` at `info`. With `RUST_LOG=trace` shipped to production (via `docker-compose.phala.yml`), these propagated to the OTLP backend — anyone with read access could harvest working API keys.
- Log the keccak256 `U256` hashes (`account_api_key_hash`, `usage_api_key_hash`) instead. The hashes were already being computed on the next two lines; the log is moved below the hash computations.
- Linear: [CPL-297](https://linear.app/litprotocol/issue/CPL-297/high-add-usage-api-key-logs-plaintext-master-usage-api-keys)

## Scope
This PR addresses fix item 1 only from the ticket. Deferred (separate decisions):
- Item 2: CI lint to flag `tracing::*!.*api_key` patterns
- Item 3: lowering default `RUST_LOG` from `trace` to `info` and removing the `trace` override in `docker-compose.phala.yml`
- Items 4–5: operational (key rotation during leak window, customer notification)

## Test plan
- [x] `cargo check -p lit-api-server` passes
- [ ] CI green
- [ ] Manual: invoke `add_usage_api_key` and confirm logs show `account_api_key_hash=0x…` / `usage_api_key_hash=0x…` (no plaintext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)