### PR TITLE
feat(CPL-323): raise jsParams limit, enforce combined 16 MB code + jsParams budget

### DIFF
--- a/docs/lit-actions/limits.mdx
+++ b/docs/lit-actions/limits.mdx
@@ -13,11 +13,10 @@ The following limits apply to all Lit Action executions on Chipotle. They are de
 
 | Limit | Default |
 |---|---|
-| Maximum action code size (inline) | 16 MB |
+| Maximum combined `code` + `js_params` payload | 16 MB |
 | Maximum IPFS action size | N/A |
-| Maximum `js_params` payload | 64 KB |
 
-Action code submitted inline via the API or Dashboard must not exceed 16 MB. Downloading actions via IPFS is not currently supported. If your action requires large static data, consider fetching it at runtime via `fetch` rather than bundling it into the action itself.
+Action code and `js_params` share a single 16 MB budget — `code` and `js_params` may each be as large as you like as long as the sum of their sizes (code bytes + JSON-serialized `js_params` bytes) does not exceed 16 MB. Downloading actions via IPFS is not currently supported. If your action requires large static data, consider fetching it at runtime via `fetch` rather than bundling it into the action itself.
 
 ---
 

--- a/lit-api-server/Rocket.toml
+++ b/lit-api-server/Rocket.toml
@@ -5,5 +5,5 @@ logging = { level = "info" }
 
 [default.limits]
 form = "10 MiB"
-json = "10 MiB"
+json = "20 MiB"
 file = "10 MiB"

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -167,10 +167,17 @@ impl Client {
         // auth_context: &models::AuthContext,
         call_depth: u32,
     ) -> Result<ExecutionState> {
-        if code.len() > self.max_code_length as usize {
+        let js_params_bytes = globals
+            .as_ref()
+            .and_then(|v| serde_json::to_vec(v).ok())
+            .unwrap_or_default();
+        let combined_len = code.len() + js_params_bytes.len();
+        if combined_len > self.max_code_length as usize {
             bail!(
-                "Code payload is too large ({} bytes). Max length is {} bytes.",
+                "Combined code + js_params payload is too large ({} bytes: {} code + {} js_params). Max combined size is {} bytes.",
+                combined_len,
                 code.len(),
+                js_params_bytes.len(),
                 self.max_code_length,
             );
         }
@@ -210,7 +217,11 @@ impl Client {
             .send_async(
                 ExecutionRequest {
                     code: code.to_string(),
-                    js_params: globals.and_then(|v| serde_json::to_vec(&v).ok()),
+                    js_params: if globals.is_some() {
+                        Some(js_params_bytes)
+                    } else {
+                        None
+                    },
                     auth_context: serde_json::to_vec(&[0; 0]).ok(),
                     http_headers: self.http_headers.clone(),
                     timeout: Some(self.timeout_ms),

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -169,15 +169,17 @@ impl Client {
     ) -> Result<ExecutionState> {
         let js_params_bytes = globals
             .as_ref()
-            .and_then(|v| serde_json::to_vec(v).ok())
-            .unwrap_or_default();
-        let combined_len = code.len() + js_params_bytes.len();
+            .map(serde_json::to_vec)
+            .transpose()
+            .context("failed to serialize js_params")?;
+        let js_params_len = js_params_bytes.as_ref().map_or(0, Vec::len);
+        let combined_len = code.len() + js_params_len;
         if combined_len > self.max_code_length as usize {
             bail!(
                 "Combined code + js_params payload is too large ({} bytes: {} code + {} js_params). Max combined size is {} bytes.",
                 combined_len,
                 code.len(),
-                js_params_bytes.len(),
+                js_params_len,
                 self.max_code_length,
             );
         }
@@ -217,11 +219,7 @@ impl Client {
             .send_async(
                 ExecutionRequest {
                     code: code.to_string(),
-                    js_params: if globals.is_some() {
-                        Some(js_params_bytes)
-                    } else {
-                        None
-                    },
+                    js_params: js_params_bytes,
                     auth_context: serde_json::to_vec(&[0; 0]).ok(),
                     http_headers: self.http_headers.clone(),
                     timeout: Some(self.timeout_ms),

--- a/lit-api-server/src/actions/tests.rs
+++ b/lit-api-server/src/actions/tests.rs
@@ -537,7 +537,7 @@ async fn max_code_length(server: TestServer) {
 
     assert_eq!(
         res.unwrap_err().to_string().lines().next().unwrap(),
-        "unexpected error: Code payload is too large (14 bytes). Max length is 10 bytes."
+        "unexpected error: Combined code + js_params payload is too large (14 bytes: 14 code + 0 js_params). Max combined size is 10 bytes."
     );
 }
 

--- a/lit-static/SKILL.md
+++ b/lit-static/SKILL.md
@@ -200,8 +200,7 @@ Use `[0]` as wildcard for "all groups" in any group array.
 
 | Limit | Value |
 |-------|-------|
-| Max code size (inline) | 16 MB |
-| Max `js_params` payload | 64 KB |
+| Max combined `code` + `js_params` payload | 16 MB |
 | Max execution time | 15 minutes |
 | Max memory | 64 MB |
 | Max HTTP fetches per action | 50 |


### PR DESCRIPTION
## Summary

Replaces the 64 KB documented (but unenforced) `js_params` cap with a single 16 MB combined budget for `code + js_params` against `max_code_length`. The 16 MB budget is enforced server-side in `execute_js_inner` by serializing `js_params` once and summing its length with `code.len()` before dispatching to the lit-actions runtime. Rocket's JSON body limit is raised from 10 MiB to 20 MiB so a full 16 MB combined payload fits after JSON-encoding overhead. Docs (`docs/lit-actions/limits.mdx`, `lit-static/SKILL.md`) updated to describe the shared budget; the (currently disabled) `max_code_length` test assertion updated to match the new error string.

## Test plan

- [ ] `cargo check --tests` clean (verified locally)
- [ ] `cargo fmt --check` clean (verified locally)
- [ ] Submit a request where `code + js_params` is just under 16 MB and confirm it executes
- [ ] Submit a request where `code + js_params` exceeds 16 MB and confirm the new combined-size error fires
- [ ] Confirm a ~15 MB JSON body is no longer rejected by Rocket at the body-limit layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)