### PR TITLE
docs: Phala Trust Center + on-chain KMS verification guides

### DIFF
--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -30,6 +30,8 @@ There are no modes. Whether you operate in a self-sovereign or SaaS posture is a
 
 ## Further Reading
 
+- [Verify the TEE in 30 seconds](/architecture/verification/quick-verify) — one-click Phala Trust Center report for the live API
 - [Auth Model & Permission Matrix](/architecture/authModel) — detailed entity boundaries, execution flow, and the full permission matrix
 - [System Diagram](/architecture/diagram) — entity relationships, on-chain vs TEE boundaries, and management paths
 - [Security & Verification](/architecture/verification/index) — Zero-Trust TLS, attestation verification, and the full chain of trust
+- [On-Chain KMS](/architecture/verification/onchain-kms) — how Base smart contracts gate key release

--- a/docs/architecture/verification/chain-of-trust.mdx
+++ b/docs/architecture/verification/chain-of-trust.mdx
@@ -46,7 +46,7 @@ The TDX quote contains hardware-measured registers that attest the entire boot c
 
 | Check | What it proves |
 |-------|----------------|
-| **DstackApp contract** | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. |
-| **KMS Phala app contract** | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
+| **DstackApp contract** ([`0x3F91…05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC)) | The compose-hash must be whitelisted via `allowedComposeHashes(bytes32)` before the CVM will boot. Address matches the `app_id` returned by `GET /info`. |
+| **Phala KMS contract** ([`0x2f83…Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C)) | Whitelists allowed OS images (`allowedOsImages`) and KMS instances (`kmsAllowedAggregatedMrs`). Only whitelisted versions can boot. |
 | **AccountConfig contract** | Governs Lit Chipotle's permission model on Base — account ownership, API key scopes, PKP registries, and action groups. |
 | **Safe multisig** | All three contracts above are administered by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. Production deployments use a two-phase CI workflow: propose → approve via Safe UI → execute. |

--- a/docs/architecture/verification/full-verification.mdx
+++ b/docs/architecture/verification/full-verification.mdx
@@ -255,14 +255,14 @@ The CAA records on the gateway domain restrict certificate issuance to specific 
 
 **What this checks:** Was the code running in the TEE authorized through on-chain governance? The compose-hash (a fingerprint of the entire application configuration) must be registered in a smart contract on Base before the CVM will accept it. This means deploying new code requires an on-chain transaction — you can audit the full history on Basescan.
 
-The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **KMS Phala app** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
+The compose-hash must be registered in the **DstackApp** smart contract on Base before the CVM will accept it. A separate **Phala KMS** contract whitelists allowed OS images and KMS instances. You can inspect both on [Basescan](https://basescan.org).
 
 **Finding the DstackApp contract address:** The DstackApp contract is the on-chain governance contract that authorizes what code the CVM can run. To find the correct address for a given CVM:
 
 1. Go to the [Phala Cloud dashboard](https://cloud.phala.network) and look up the application by its `app_id` (available from `GET /info`). The dashboard shows the associated DstackApp contract address.
 2. Verify the contract is the one your CVM is attached to by checking the `app_id` in the `/info` response matches the app registered in the contract on Basescan.
 
-For Lit Chipotle production, the DstackApp contract is [`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C). The KMS Phala app contract is [`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC).
+For Lit Chipotle production, the DstackApp contract is [`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC) (matches the `app_id` returned by `GET /info`). The Phala KMS contract is [`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C).
 
 ```bash
 # Requires `cast` from Foundry (https://book.getfoundry.sh)
@@ -282,8 +282,8 @@ cast call "$DSTACK_APP" "allowedComposeHashes(bytes32)" "$COMPOSE_HASH" --rpc-ur
 
 **Governance via Safe multisig:** All on-chain governance actions are controlled by a 2/3 Safe multisig ([`0xF688411c0FFc300cAb33EB1dA651DBb3E6891098`](https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098)) on Base. This Safe administers:
 
-- **DstackApp** ([`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C)) — compose-hash whitelisting for the Lit Chipotle CVM
-- **KMS Phala app** ([`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC)) — KMS configuration and allowed OS images
+- **DstackApp** ([`0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC)) — compose-hash whitelisting for the Lit Chipotle CVM
+- **Phala KMS** ([`0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C)) — KMS configuration and allowed OS images
 - **AccountConfig** — _details coming soon_
 
 Any governance action (e.g., whitelisting a new compose-hash, updating allowed OS images, or upgrading the AccountConfig Diamond) requires at least 2 of 3 signers. Production deployments use a two-phase workflow: CI proposes the transaction to the Safe, and signers approve it through the Safe UI before the deployment can proceed.

--- a/docs/architecture/verification/index.mdx
+++ b/docs/architecture/verification/index.mdx
@@ -3,6 +3,16 @@ title: "Security & Verification"
 description: "How to verify that your connection to Lit Chipotle terminates inside a genuine TEE running unmodified code."
 ---
 
+The Lit Chipotle API server runs inside an Intel TDX [Trusted Execution Environment](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html) on [Phala Cloud](https://phala.com/), with its keys gated by smart contracts on Base. This section explains how that works and how to verify it yourself.
+
+<Card
+  title="Just want to verify it? Start here."
+  icon="shield-check"
+  href="/architecture/verification/quick-verify"
+>
+  One-click Phala Trust Center report plus three commands you can paste into a terminal to confirm the API is running unmodified code on real Intel TDX hardware.
+</Card>
+
 ## Zero-Trust TLS
 
 **What is Zero-Trust TLS?** In traditional web hosting, you trust the server operator not to inspect or tamper with your traffic. Zero-Trust TLS (ZT-TLS) eliminates this trust assumption entirely. The TLS private key is generated **inside** the Trusted Execution Environment (TEE) and **never leaves it** — not even the cloud provider, OS administrator, or Lit Protocol team can extract it.
@@ -49,16 +59,22 @@ Once full verification passes, pin the TLS certificate fingerprint:
 
 ## What's Next
 
+- [Verify in 30 Seconds](/architecture/verification/quick-verify) — Phala Trust Center one-click report plus three terminal commands
+- [On-Chain KMS](/architecture/verification/onchain-kms) — how Base smart contracts gate key release and how to confirm the KMS is active
 - [Full Verification Guide](/architecture/verification/full-verification) — step-by-step commands to verify every layer of the chain of trust
 - [Chain of Trust Reference](/architecture/verification/chain-of-trust) — detailed explanation of what each verification step checks and why it matters
 
 ## Further Reading
 
+- [Phala Trust Center for Lit Chipotle](https://trust.phala.com/app/3f91deaf16ff7c823ee65081d6bafa1ceea05ffc) — live verification report for our production app
+- [Phala: Trust Center Verification](https://docs.phala.com/phala-cloud/attestation/trust-center-verification) — how the Trust Center works
+- [Phala: Attestation Overview](https://docs.phala.com/phala-cloud/attestation/overview)
+- [Phala: Understanding On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/understanding-onchain-kms)
 - [Phala: Zero-Trust TLS (TEE-Controlled Domain Certificates)](https://docs.phala.com/dstack/design-documents/tee-controlled-domain-certificates)
 - [Phala: Complete Chain of Trust](https://docs.phala.com/phala-cloud/attestation/chain-of-trust)
 - [Phala: Verify Your Application](https://docs.phala.com/phala-cloud/attestation/verify-your-application)
 - [Phala: Get Attestation](https://docs.phala.com/phala-cloud/attestation/get-attestation)
 - [RTMR3 Calculator](https://rtmr3-calculator.vercel.app/) — web tool for computing compose hashes
 - [dstack Verification Script](https://github.com/Dstack-TEE/dstack-examples/blob/main/attestation/rtmr3-based/verify.py) — reference Python implementation
-- [Phala Trust Center](https://github.com/Phala-Network/trust-center) — reference verification implementation
+- [Phala Trust Center (reference implementation)](https://github.com/Phala-Network/trust-center)
 - [Sigstore cosign](https://docs.sigstore.dev/cosign/signing/overview/)

--- a/docs/architecture/verification/onchain-kms.mdx
+++ b/docs/architecture/verification/onchain-kms.mdx
@@ -1,0 +1,122 @@
+---
+title: "On-Chain KMS"
+description: "How Lit Chipotle's root keys are gated by smart contracts on Base — not by Phala or Lit — and how to verify the KMS is active and configured correctly."
+---
+
+Most "cloud KMS" services let the cloud provider authorize key release. Phala's [On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/understanding-onchain-kms) replaces that backend with a smart contract on a public blockchain. The KMS will only release keys to a CVM whose attestation matches what's whitelisted on-chain — and Lit Protocol cannot change the whitelist unilaterally.
+
+This page explains what's on-chain, how to read it, and what "active" looks like.
+
+## Why On-Chain KMS
+
+Without on-chain KMS, a TEE provider's backend decides which CVMs get keys. That's one trusted party. With on-chain KMS:
+
+- **No central authority.** A smart contract is the only thing that can authorize key release. Phala's backend does not sign transactions on Lit's behalf.
+- **Public, auditable governance.** Every code-version whitelist change is a Base transaction. Anyone can read the history on Basescan.
+- **Multi-party control.** The contract owner is a 2/3 Safe multisig of Lit signers — no single party (including Lit) can change the whitelist alone.
+
+For the canonical design, see [Phala: Understanding On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/understanding-onchain-kms) and [Cloud vs On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/cloud-vs-onchain-kms).
+
+## The contracts
+
+Two contracts on Base together gate key release for the Lit Chipotle CVM:
+
+### Phala KMS — [`0x2f83…Ba9C`](https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C)
+
+A shared Phala contract that maintains the registry of KMS nodes, approved dstack OS images, and approved KMS aggregated measurements. It also acts as a factory for per-application `DstackApp` contracts.
+
+| Key state | What it means |
+|---|---|
+| `allowedOsImages(bytes32)` | Whitelist of dstack OS image measurements (firmware + kernel + initrd hashes). The CVM's MRTD / RTMR0–2 must match a whitelisted image or boot is refused. |
+| `kmsAllowedAggregatedMrs(bytes32)` | Whitelist of KMS instance measurements. Pins the CVM to a specific trusted KMS. |
+| `owner()` | The Safe multisig that controls the whitelists. |
+
+### DstackApp — [`0x3F91…05FfC`](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC)
+
+The application-specific contract for Lit Chipotle. Its address is the `app_id` returned by `GET /info`. Anyone can confirm this matches:
+
+```bash
+curl -sf https://api.chipotle.litprotocol.com/info \
+  | python3 -c 'import json,sys; print("0x" + json.load(sys.stdin)["app_id"])'
+# Expect: 0x3f91deaf16ff7c823ee65081d6bafa1ceea05ffc
+```
+
+| Key state | What it means |
+|---|---|
+| `allowedComposeHashes(bytes32)` | Whitelist of `app-compose.json` SHA-256 hashes. The TEE's RTMR3 must record a compose hash present here, or the KMS will not release keys. |
+| `allowedDeviceIds(bytes32)` | Whitelist of approved hardware device identifiers. |
+| `owner()` | The Safe multisig — only this address can add or remove compose hashes and device IDs. |
+
+## How key release is gated
+
+The flow on every CVM boot:
+
+1. The CVM generates an Intel TDX attestation quote covering its hardware, OS, and the compose hash of the code it loaded.
+2. The KMS verifies the quote against Intel's root certificates.
+3. The KMS reads the on-chain state:
+    - Is the OS image in `Phala KMS.allowedOsImages`?
+    - Is the KMS measurement in `Phala KMS.kmsAllowedAggregatedMrs`?
+    - Is the compose hash in `DstackApp.allowedComposeHashes`?
+    - Is the device ID in `DstackApp.allowedDeviceIds`?
+4. **Only if all four pass** does the KMS release the keys this CVM is allowed to use.
+
+This means: even if Lit Protocol pushed a malicious Docker image, the CVM running it would not be able to obtain the root keys unless the new compose hash was first whitelisted on Base — which requires 2 of 3 Safe signers to approve a transaction visible on Basescan.
+
+## Confirming the KMS is active
+
+"Active" for on-chain KMS means three things hold simultaneously. You can verify each on Basescan or with `cast`.
+
+### 1. The live compose hash is whitelisted
+
+```bash
+COMPOSE_HASH=0x$(curl -sf https://api.chipotle.litprotocol.com/info \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["compose_hash"])')
+
+cast call 0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC \
+  "allowedComposeHashes(bytes32)(bool)" "$COMPOSE_HASH" \
+  --rpc-url https://mainnet.base.org
+# Expect: true
+```
+
+A `true` here proves the currently-running code is authorized by on-chain governance. A `false` would mean the CVM is running code that the KMS would refuse to release keys to — which should never happen in production, because the CVM cannot boot without keys.
+
+### 2. The DstackApp owner is the Safe multisig
+
+```bash
+cast call 0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC \
+  "owner()(address)" \
+  --rpc-url https://mainnet.base.org
+# Expect: 0xF688411c0FFc300cAb33EB1dA651DBb3E6891098
+```
+
+This proves no single party can modify the compose-hash whitelist. The [Safe at `0xF688…1098`](https://app.safe.global/base:0xF688411c0FFc300cAb33EB1dA651DBb3E6891098) requires 2 of 3 signers to approve any change.
+
+### 3. The CVM's app_id matches the DstackApp address
+
+```bash
+APP_ID=$(curl -sf https://api.chipotle.litprotocol.com/info \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["app_id"])')
+echo "Live app_id:        0x$APP_ID"
+echo "Expected DstackApp: 0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC"
+```
+
+The two must match (case-insensitive). This proves the CVM you're talking to is actually attached to the on-chain governance contract you're auditing — not some other lookalike contract.
+
+## Auditing the governance history
+
+Every governance action that changed the KMS configuration is a Base transaction. On the [DstackApp's Basescan page](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC), the **Transactions** tab shows every `addComposeHash` and `removeComposeHash` call ever made. Each is a Safe execution requiring 2 of 3 signatures.
+
+To understand a specific deployment:
+
+1. Find the deployment date in [Lit's release notes](https://github.com/LIT-Protocol/chipotle/releases) (or `git log`).
+2. Find the `addComposeHash` transaction on Basescan around that date.
+3. Open the Safe transaction (linked from the Basescan tx) — you can see which signers approved it.
+
+This is the same audit trail used by the [Phala Trust Center](https://trust.phala.com/app/3f91deaf16ff7c823ee65081d6bafa1ceea05ffc) when it shows the on-chain governance state.
+
+## What's next
+
+- [Verify in 30 Seconds](/architecture/verification/quick-verify) — the Trust Center one-click report
+- [Full Verification Guide](/architecture/verification/full-verification) — replay the RTMR3 event log and check every layer
+- [Phala: Understanding On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/understanding-onchain-kms)
+- [Phala: Cloud vs On-Chain KMS](https://docs.phala.com/phala-cloud/key-management/cloud-vs-onchain-kms)

--- a/docs/architecture/verification/quick-verify.mdx
+++ b/docs/architecture/verification/quick-verify.mdx
@@ -1,0 +1,106 @@
+---
+title: "Verify in 30 Seconds"
+description: "One click to confirm the Lit Chipotle API server is running unmodified code inside a genuine Intel TDX enclave — plus three commands to verify it yourself."
+---
+
+When you call `api.chipotle.litprotocol.com`, your request terminates inside an Intel TDX [Trusted Execution Environment](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html) (TEE) operated by [Phala Cloud](https://phala.com/). The TEE generates a hardware-signed attestation quote on every boot, and the code it's allowed to run is gated by smart contracts on Base — not by Lit Protocol or any Phala employee.
+
+The fastest way to verify this is to view the Phala Trust Center report for our production app. It runs every check on this page automatically and shows you the result in a browser.
+
+<Card
+  title="View the Lit Chipotle Trust Center Report"
+  icon="shield-check"
+  href="https://trust.phala.com/app/3f91deaf16ff7c823ee65081d6bafa1ceea05ffc"
+>
+  Phala's public Trust Center verifies the Intel TDX hardware quote, the Docker compose hash, the OS measurements, the TLS certificate, and the on-chain KMS configuration — all automatically, no install required.
+</Card>
+
+The Trust Center URL contains our `app_id` (`3f91deaf16ff7c823ee65081d6bafa1ceea05ffc`). This same value is returned by `GET /info` on the live API and is the address of the on-chain [DstackApp contract](https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC) that governs which code the enclave is allowed to run.
+
+## What you should expect to see
+
+A passing Trust Center report confirms four independent properties:
+
+| Property | Why it matters |
+|---|---|
+| **Hardware quote verified** | Intel's TDX hardware root of trust signed a statement about what code is running. Anyone can verify the signature against Intel's published root CAs. |
+| **Compose hash matches** | The SHA-256 of `app-compose.json` (the docker-compose config + metadata) recorded in the TDX quote matches what's whitelisted in the on-chain DstackApp contract. |
+| **OS measurements match** | The boot-time measurements (firmware, kernel, initrd) match a known-good dstack OS release whitelisted in the Phala KMS contract. |
+| **TLS terminates in TEE** | The HTTPS certificate served by `api.chipotle.litprotocol.com` was generated inside the TEE itself. No proxy, load balancer, or CDN can see your traffic. |
+
+If any of these fail, the report will show it.
+
+## Verify it yourself in three commands
+
+The Trust Center is convenient, but the whole point of attestation is that you don't have to trust *anyone* — including Phala. Here's the minimum-viable manual check:
+
+```bash
+# 1. What is the live API attesting to right now?
+curl -sf https://api.chipotle.litprotocol.com/info \
+  | python3 -m json.tool | head -20
+
+# 2. Is the compose hash whitelisted on Base?
+#    (Requires `cast` from Foundry — https://book.getfoundry.sh)
+COMPOSE_HASH=0x$(curl -sf https://api.chipotle.litprotocol.com/info \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["compose_hash"])')
+cast call 0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC \
+  "allowedComposeHashes(bytes32)(bool)" "$COMPOSE_HASH" \
+  --rpc-url https://mainnet.base.org
+# Expect: true
+
+# 3. Is the TLS cert pinned to the TEE-attested cert?
+LIVE=$(openssl s_client -connect api.chipotle.litprotocol.com:443 \
+  -servername api.chipotle.litprotocol.com </dev/null 2>/dev/null \
+  | openssl x509 -outform DER 2>/dev/null \
+  | openssl dgst -sha256 -hex | awk '{print $NF}')
+ATTESTED=$(curl -sf "https://api.chipotle.litprotocol.com/evidences/$(
+  curl -sf https://api.chipotle.litprotocol.com/evidences/ \
+    | grep -o 'href="cert-[^"]*\.pem"' | sed 's/href="//;s/"//')" \
+  | openssl x509 -outform DER 2>/dev/null \
+  | openssl dgst -sha256 -hex | awk '{print $NF}')
+[ "$LIVE" = "$ATTESTED" ] && echo "TLS cert matches TEE evidence" || echo "MISMATCH"
+```
+
+For the full end-to-end verification — including replaying the RTMR3 event log, verifying image signatures with Sigstore, and walking the on-chain governance Safe — see the [Full Verification Guide](/architecture/verification/full-verification).
+
+## On-chain governance you can audit
+
+Three smart contracts on Base together define what Lit Chipotle is allowed to do. All three are administered by a 2/3 Safe multisig — no single party can change them.
+
+<CardGroup cols={2}>
+  <Card
+    title="DstackApp"
+    icon="cube"
+    href="https://basescan.org/address/0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC"
+  >
+    `0x3F91…05FfC` — whitelists the compose hashes (i.e. the docker-compose configurations) the Lit Chipotle CVM is allowed to boot.
+  </Card>
+  <Card
+    title="Phala KMS"
+    icon="key"
+    href="https://basescan.org/address/0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C"
+  >
+    `0x2f83…Ba9C` — whitelists allowed dstack OS images and KMS instance measurements. Gatekeeps key release to the CVM.
+  </Card>
+  <Card
+    title="Safe Multisig (2/3)"
+    icon="users"
+    href="https://basescan.org/address/0xF688411c0FFc300cAb33EB1dA651DBb3E6891098"
+  >
+    `0xF688…1098` — owns both contracts above. Any deployment or config change requires at least 2 of 3 Lit signers.
+  </Card>
+  <Card
+    title="On-Chain KMS Deep Dive"
+    icon="book-open"
+    href="/architecture/verification/onchain-kms"
+  >
+    What KmsAuth and DstackApp actually do, what "active" looks like on Basescan, and how key release is gated.
+  </Card>
+</CardGroup>
+
+## What's next
+
+- [On-Chain KMS](/architecture/verification/onchain-kms) — how the KMS contracts gate key release and what to look for on Basescan
+- [Full Verification Guide](/architecture/verification/full-verification) — step-by-step manual verification of every layer
+- [Chain of Trust Reference](/architecture/verification/chain-of-trust) — what each layer checks and why
+- [Security & Verification Overview](/architecture/verification/index) — Zero-Trust TLS and the trust model

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,7 +51,9 @@
               {
                 "group": "Security & Verification",
                 "pages": [
+                  "architecture/verification/quick-verify",
                   "architecture/verification/index",
+                  "architecture/verification/onchain-kms",
                   "architecture/verification/full-verification",
                   "architecture/verification/chain-of-trust"
                 ]


### PR DESCRIPTION
## Summary

- New **Verify in 30 Seconds** page leads with a one-click [Phala Trust Center link](https://trust.phala.com/app/3f91deaf16ff7c823ee65081d6bafa1ceea05ffc) for our production app, plus three copy-pasteable terminal commands.
- New **On-Chain KMS** page explains how `DstackApp` + Phala KMS on Base gate key release, with \`cast\` snippets to confirm the KMS is active.
- Fixes a swap in the existing docs: \`DstackApp\` is \`0x3F91…05FfC\` (matches \`/info\` \`app_id\`) and the Phala KMS contract is \`0x2f83…Ba9C\`.
- Reorders the Security & Verification nav so the Trust Center landing page comes first; cross-links from the architecture overview.

Replaces #352 (same content, fresh branch so Mintlify preview attaches).

## Test plan

- [ ] Mintlify preview renders both new pages and all internal links resolve
- [ ] Trust Center link loads a report for our prod app_id
- [ ] Spot-check the \`cast\` commands against mainnet Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)