### PR TITLE
docs: add GitHub repo link to docs footer

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,7 +89,8 @@
   "footer": {
     "socials": {
       "x": "https://twitter.com/litprotocol",
-      "discord": "https://litgateway.com/discord"
+      "discord": "https://litgateway.com/discord",
+      "github": "https://github.com/LIT-Protocol/chipotle"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `github` entry to `footer.socials` in `docs/docs.json` so the Mintlify docs site links back to the LIT-Protocol/chipotle repo alongside the existing X and Discord links.

## Test plan
- [ ] Confirm the GitHub icon renders in the docs footer after deploy.