### PR TITLE
feat: LitkeyPaymentGateway contract + Hardhat project

### DIFF
--- a/.github/workflows/lit-payments-contracts-ci.yml
+++ b/.github/workflows/lit-payments-contracts-ci.yml
@@ -42,6 +42,10 @@ jobs:
         working-directory: lit-payments/contracts
         run: npm ci
 
+      - name: Audit production deploy dependencies
+        working-directory: lit-payments/contracts
+        run: npm audit --omit=dev
+
       - name: Compile
         working-directory: lit-payments/contracts
         run: npx hardhat compile

--- a/.github/workflows/lit-payments-contracts-ci.yml
+++ b/.github/workflows/lit-payments-contracts-ci.yml
@@ -1,0 +1,51 @@
+# Runs hardhat test on every PR touching the lit-payments-contracts project.
+# Compiles the Solidity contracts and executes the TypeScript unit tests.
+
+name: lit-payments-contracts CI
+
+on:
+  pull_request:
+    paths:
+      - "lit-payments/contracts/**"
+      - ".github/workflows/lit-payments-contracts-ci.yml"
+  push:
+    branches: [main, next]
+    paths:
+      - "lit-payments/contracts/**"
+      - ".github/workflows/lit-payments-contracts-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: hardhat test
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reset workspace to HEAD
+        run: git checkout HEAD -- .
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install contracts dependencies
+        working-directory: lit-payments/contracts
+        run: npm ci
+
+      - name: Compile
+        working-directory: lit-payments/contracts
+        run: npx hardhat compile
+
+      - name: Test
+        working-directory: lit-payments/contracts
+        run: npx hardhat test

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,6 +30,7 @@ jobs:
           - lit-api-server
           - lit-api-server/blockchain/rust_generator_and_deployer
           - lit-billing-core
+          - lit-payments
 
     steps:
       - uses: actions/checkout@v4

--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,7 +94,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -99,7 +105,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -133,10 +139,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -166,6 +189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +214,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -197,6 +238,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -213,6 +257,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "cipher"
@@ -234,10 +287,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "cookie"
@@ -249,7 +335,7 @@ dependencies = [
  "base64",
  "hkdf",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "sha2",
  "subtle",
  "time",
@@ -340,13 +426,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -381,6 +485,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "devise"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +534,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -433,7 +557,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -443,12 +567,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -488,6 +645,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 1.0.69",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "chrono",
+ "const-hex",
+ "elliptic-curve",
+ "ethabi",
+ "generic-array",
+ "k256",
+ "num_enum",
+ "open-fastrlp",
+ "rand 0.8.6",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +747,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +775,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "flume"
@@ -580,6 +834,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -647,7 +907,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -700,6 +960,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -715,13 +976,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -741,6 +1014,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1129,6 +1413,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1511,43 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1262,13 +1621,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "ethers-core",
  "hex",
  "hmac",
  "lit-billing-core",
  "moka",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "rocket",
  "serde",
@@ -1446,7 +1806,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1498,6 +1858,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1890,31 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open-fastrlp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "openssl"
@@ -1531,7 +1938,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1550,6 +1957,34 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1601,7 +2036,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1707,7 +2142,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -1727,9 +2185,24 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -1743,9 +2216,21 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1754,8 +2239,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1765,7 +2260,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1775,6 +2280,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1812,7 +2335,19 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1873,6 +2408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +2429,28 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rlp-derive",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1907,7 +2474,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.6",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1936,7 +2503,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
  "version_check",
 ]
@@ -1981,12 +2548,18 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
@@ -2047,6 +2620,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2663,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2123,7 +2734,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2183,6 +2794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2311,7 +2932,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -2330,7 +2951,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2353,7 +2974,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2387,7 +3008,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2395,7 +3016,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -2427,14 +3048,14 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -2460,7 +3081,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -2492,6 +3113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,10 +3130,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2536,7 +3196,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2567,6 +3227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,11 +3247,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2596,7 +3282,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2637,6 +3323,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2689,7 +3384,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2744,8 +3439,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2758,6 +3453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,9 +3470,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2842,7 +3567,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2904,6 +3629,24 @@ checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"
@@ -3093,7 +3836,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3362,6 +4105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,7 +4149,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3413,7 +4165,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3462,6 +4214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,7 +4250,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3510,7 +4271,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3530,7 +4291,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3570,7 +4331,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -1266,6 +1266,8 @@ dependencies = [
  "hmac",
  "lit-billing-core",
  "moka",
+ "num-bigint",
+ "num-traits",
  "rand",
  "reqwest",
  "rocket",
@@ -1421,6 +1423,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.22"
+ethers-core = "2.0.14"
 hex = "0.4"
 hmac = "0.12"
 lit-billing-core = { path = "../lit-billing-core" }

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -12,11 +12,13 @@ hex = "0.4"
 hmac = "0.12"
 lit-billing-core = { path = "../lit-billing-core" }
 moka = { version = "0.12", features = ["future"] }
+num-bigint = "0.4"
+num-traits = "0.2"
 rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 rocket = { version = "0.5.1", features = ["json", "secrets"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 sha2 = "0.10"
 sqlx = { version = "0.8", features = [
     "postgres",

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -12,6 +12,7 @@ Public:
 - `GET /login` — login page (form posts to `/auth/request`).
 - `POST /auth/request` — send magic link (rate-limited per email, 60s cooldown).
 - `GET /auth/verify?token=…` — validate token, set session cookie, redirect.
+- `GET /api/litkey/quote` — public LITKEY quote for the end-user payment page; includes `crediting_paused` and omits an effective credit rate while paused.
 
 Authenticated (operator session cookie required):
 - `GET /` — admin dashboard.
@@ -20,7 +21,7 @@ Authenticated (operator session cookie required):
 - `GET /api/customer/lookup?email=…` or `?wallet=…` — preview a Stripe customer + balance.
 - `POST /api/grant` — apply a credit (subject to caps + UUID idempotency key).
 - `GET /api/grants?limit=N` — recent grants by the calling operator.
-- `GET /api/litkey/rate` — current LITKEY market rate plus discount-adjusted credit rate.
+- `GET /api/litkey/rate` — current LITKEY market rate plus discount-adjusted credit rate for operators.
 - `POST /api/litkey/rate/override` — admin-only manual market-rate override.
 
 ## Local development

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -64,6 +64,14 @@ ROCKET_PORT=8000
 # 0 = no discount. 2000 = 20% off vs credit card, so users receive
 # 1 / (1 - 0.20) = 1.25x the market-rate Stripe credit per LITKEY.
 # LITKEY_DISCOUNT_BASIS_POINTS=0
+
+# Optional — enable LITKEY on-chain payment listener (Base mainnet):
+# ALCHEMY_WSS_URL=wss://base-mainnet.g.alchemy.com/v2/...
+# ALCHEMY_HTTPS_URL=https://base-mainnet.g.alchemy.com/v2/...
+# LITKEY_GATEWAY_ADDRESS=0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b
+# LITKEY_CHAIN_ID=8453
+# LITKEY_CONFIRMATIONS=5
+# LITKEY_RECONCILIATION_INTERVAL_SECS=60
 ```
 
 ### 3. Run

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -21,8 +21,12 @@ Authenticated (operator session cookie required):
 - `GET /api/customer/lookup?email=…` or `?wallet=…` — preview a Stripe customer + balance.
 - `POST /api/grant` — apply a credit (subject to caps + UUID idempotency key).
 - `GET /api/grants?limit=N` — recent grants by the calling operator.
-- `GET /api/litkey/rate` — current LITKEY market rate plus discount-adjusted credit rate for operators.
-- `POST /api/litkey/rate/override` — admin-only manual market-rate override.
+- `GET /api/litkey/rate` — current LITKEY market rate plus discount-adjusted credit rate for operators. Rates are returned as decimal strings in `usd_wei_per_litkey` / `effective_usd_wei_per_litkey`, where `1 USD = 1e18` units.
+- `POST /api/litkey/rate/override` — admin-only manual market-rate override. Body: `{ "usd_wei_per_litkey": "6000000000000000" }` for `$0.006/LITKEY`.
+
+## LITKEY rate precision
+
+LITKEY pricing is intentionally stored as 18-decimal USD fixed point instead of whole cents because LITKEY can trade below one cent. Example: `$0.006/LITKEY` is stored as `6000000000000000` (`0.006 * 1e18`). The listener settlement helper keeps the on-chain `Payment.amount` in native LITKEY wei, multiplies by `usd_wei_per_litkey` with `num-bigint`, applies `LITKEY_DISCOUNT_BASIS_POINTS`, and rounds only once at the final Stripe-cent boundary.
 
 ## Local development
 

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -20,6 +20,8 @@ Authenticated (operator session cookie required):
 - `GET /api/customer/lookup?email=…` or `?wallet=…` — preview a Stripe customer + balance.
 - `POST /api/grant` — apply a credit (subject to caps + UUID idempotency key).
 - `GET /api/grants?limit=N` — recent grants by the calling operator.
+- `GET /api/litkey/rate` — current LITKEY market rate plus discount-adjusted credit rate.
+- `POST /api/litkey/rate/override` — admin-only manual market-rate override.
 
 ## Local development
 
@@ -52,6 +54,11 @@ ROCKET_PORT=8000
 # Optional — cap defaults match the plan ($20 per grant, $100/op/day):
 # MAX_GRANT_CENTS=2000
 # MAX_DAILY_PER_OPERATOR_CENTS=10000
+
+# Optional — incentive discount for paying with LITKEY, in basis points.
+# 0 = no discount. 2000 = 20% off vs credit card, so users receive
+# 1 / (1 - 0.20) = 1.25x the market-rate Stripe credit per LITKEY.
+# LITKEY_DISCOUNT_BASIS_POINTS=0
 ```
 
 ### 3. Run
@@ -105,6 +112,7 @@ fly secrets set --app lit-payments \
   MAIL_FROM='noreply@mail.litprotocol.com' \
   PUBLIC_BASE_URL='https://payments.litprotocol.com' \
   STRIPE_SECRET_KEY=rk_... \
+  LITKEY_DISCOUNT_BASIS_POINTS=0 \
   ROCKET_SECRET_KEY="$(openssl rand -base64 32)"
 ```
 

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -65,7 +65,8 @@ ROCKET_PORT=8000
 # 1 / (1 - 0.20) = 1.25x the market-rate Stripe credit per LITKEY.
 # LITKEY_DISCOUNT_BASIS_POINTS=0
 
-# Optional — enable LITKEY on-chain payment listener (Base mainnet):
+# Optional — configure LITKEY on-chain listener scaffold (live WSS/polling is
+# enabled in a follow-up 3c slice; these vars validate the Base gateway config):
 # ALCHEMY_WSS_URL=wss://base-mainnet.g.alchemy.com/v2/...
 # ALCHEMY_HTTPS_URL=https://base-mainnet.g.alchemy.com/v2/...
 # LITKEY_GATEWAY_ADDRESS=0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b

--- a/lit-payments/contracts/.env.example
+++ b/lit-payments/contracts/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env and fill in. Never commit .env.
+
+# Funded deployer wallet (Base ETH). Used only by `hardhat run scripts/deploy.ts`.
+DEPLOYER_PRIVATE_KEY=
+
+# Optional RPC overrides. Defaults to the Base public RPCs above.
+# BASE_SEPOLIA_RPC_URL=https://base-sepolia.g.alchemy.com/v2/...
+# BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/...
+
+# Single Etherscan v2 key works for Base mainnet + Sepolia.
+# Get one at https://etherscan.io/myapikey
+BASESCAN_API_KEY=
+
+# Inputs to deploy.ts (per-network).
+# LITKEY token on Base mainnet: 0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49
+LITKEY_ADDRESS=0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49
+# Treasury address that receives swept LITKEY (e.g. the company Safe on Base).
+TREASURY_ADDRESS=

--- a/lit-payments/contracts/.gitignore
+++ b/lit-payments/contracts/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+cache/
+artifacts/
+typechain-types/
+.env

--- a/lit-payments/contracts/README.md
+++ b/lit-payments/contracts/README.md
@@ -50,6 +50,28 @@ npm run verify:base-sepolia -- <deployed_address> <LITKEY_ADDRESS> <TREASURY_ADD
 | `litkey`   | LITKEY on Base mainnet: `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49` |
 | `treasury` | Company Safe on Base. Set in `.env` as `TREASURY_ADDRESS`.         |
 
+## Base mainnet deployment
+
+The production Base mainnet gateway is deployed at:
+
+```text
+0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b
+```
+
+Deployment notes:
+
+- Chain: Base mainnet (`chainId` 8453).
+- LITKEY token: `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49`.
+- Treasury: company Safe on Base.
+- Smoke test: Chris sent 1 wei of LITKEY through the gateway and confirmed it
+  arrived in the company Safe.
+
+The `litkey` token address and `treasury` recipient address are constructor
+arguments stored as immutables. They cannot be changed in place. If either the
+accepted token or recipient Safe needs to change, deploy a new
+`LitkeyPaymentGateway` and update the lit-payments listener/dashboard config to
+point at the new address.
+
 ## Design
 
 See `plans/lit-payments-app.md` (under "Feature 2 — LITKEY → Stripe credit").

--- a/lit-payments/contracts/README.md
+++ b/lit-payments/contracts/README.md
@@ -1,0 +1,67 @@
+# lit-payments-contracts
+
+Solidity contracts for the lit-payments service. Currently just
+`LitkeyPaymentGateway` — the single-entrypoint contract a user calls to pay
+LITKEY for Stripe credit.
+
+## Layout
+
+```
+contracts/                              Hardhat project root.
+├── contracts/
+│   ├── LitkeyPaymentGateway.sol        The contract.
+│   └── test/MockERC20.sol              Test-only mintable token.
+├── scripts/deploy.ts                   Deploy + (optional) Basescan verify.
+├── test/LitkeyPaymentGateway.test.ts   Unit tests.
+├── hardhat.config.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Local
+
+```sh
+cd lit-payments/contracts
+npm install
+npm test
+```
+
+## Deploy
+
+```sh
+cp .env.example .env   # fill in DEPLOYER_PRIVATE_KEY + TREASURY_ADDRESS
+npm run deploy:base-sepolia      # testnet first, always
+# then, once you're happy:
+npm run deploy:base              # mainnet
+```
+
+If `BASESCAN_API_KEY` is set in `.env`, the deploy script verifies the
+contract automatically after a 10-second indexing delay. Otherwise verify
+later:
+
+```sh
+npm run verify:base-sepolia -- <deployed_address> <LITKEY_ADDRESS> <TREASURY_ADDRESS>
+```
+
+## Constructor arguments
+
+| Arg        | Value                                                              |
+| ---------- | ------------------------------------------------------------------ |
+| `litkey`   | LITKEY on Base mainnet: `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49` |
+| `treasury` | Company Safe on Base. Set in `.env` as `TREASURY_ADDRESS`.         |
+
+## Design
+
+See `plans/lit-payments-app.md` (under "Feature 2 — LITKEY → Stripe credit").
+
+In short: a user calls `pay(amount, wallet)` after approving the gateway for
+`amount` LITKEY. The contract forwards the tokens to `treasury` and emits
+`Payment(wallet, payer, amount)`. The off-chain listener watches that event,
+maps `wallet` to a Stripe customer via `metadata.wallet_address`, and writes
+a balance_transaction for the credit.
+
+The contract is intentionally immutable — no owner, no upgrade path, no
+pause switch. If the design changes, deploy a new contract and update the
+listener + dashboard to point at the new address. (Old payments to the old
+contract still credit correctly because the listener keeps watching it
+until the listener config is updated.)

--- a/lit-payments/contracts/contracts/LitkeyPaymentGateway.sol
+++ b/lit-payments/contracts/contracts/LitkeyPaymentGateway.sol
@@ -36,11 +36,13 @@ contract LitkeyPaymentGateway {
         uint256 amount
     );
 
+    error InvalidToken();
     error InvalidTreasury();
     error InvalidWallet();
     error InvalidAmount();
 
     constructor(IERC20 _litkey, address _treasury) {
+        if (address(_litkey) == address(0)) revert InvalidToken();
         if (_treasury == address(0)) revert InvalidTreasury();
         litkey = _litkey;
         treasury = _treasury;

--- a/lit-payments/contracts/contracts/LitkeyPaymentGateway.sol
+++ b/lit-payments/contracts/contracts/LitkeyPaymentGateway.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title LitkeyPaymentGateway
+/// @notice Single-entrypoint contract for paying with LITKEY and getting Lit
+/// Stripe credit. Tokens are pulled from `msg.sender` and forwarded to the
+/// company treasury in a single transaction; the `Payment` event names the
+/// Lit-account wallet to credit, which the off-chain listener maps to a Stripe
+/// customer.
+///
+/// The contract holds no state and no funds. It is intentionally immutable —
+/// if behavior needs to change, deploy a new contract and update the listener
+/// and dashboard to point at it.
+contract LitkeyPaymentGateway {
+    using SafeERC20 for IERC20;
+
+    /// @notice The LITKEY ERC-20 token this gateway accepts.
+    IERC20 public immutable litkey;
+
+    /// @notice Destination for swept LITKEY. Set once at deploy; expected to be
+    /// the company Safe on Base.
+    address public immutable treasury;
+
+    /// @notice Emitted on a successful payment.
+    /// @param wallet The Lit-account wallet the credit should be applied to.
+    ///        May differ from `payer` (e.g., user pays from a Metamask wallet
+    ///        but their Lit account is keyed by a different wallet).
+    /// @param payer `msg.sender`, the wallet that actually sent LITKEY.
+    /// @param amount LITKEY transferred, in the token's smallest unit.
+    event Payment(
+        address indexed wallet,
+        address indexed payer,
+        uint256 amount
+    );
+
+    error InvalidTreasury();
+    error InvalidWallet();
+    error InvalidAmount();
+
+    constructor(IERC20 _litkey, address _treasury) {
+        if (_treasury == address(0)) revert InvalidTreasury();
+        litkey = _litkey;
+        treasury = _treasury;
+    }
+
+    /// @notice Pull `amount` LITKEY from the caller, forward to `treasury`,
+    /// and emit a `Payment` event naming `wallet` as the account to credit.
+    ///
+    /// Requires the caller to have approved this contract for at least
+    /// `amount` LITKEY beforehand.
+    /// @param amount LITKEY to transfer.
+    /// @param wallet The Lit-account wallet to credit off-chain.
+    function pay(uint256 amount, address wallet) external {
+        if (wallet == address(0)) revert InvalidWallet();
+        if (amount == 0) revert InvalidAmount();
+        litkey.safeTransferFrom(msg.sender, treasury, amount);
+        emit Payment(wallet, msg.sender, amount);
+    }
+}

--- a/lit-payments/contracts/contracts/test/MockERC20.sol
+++ b/lit-payments/contracts/contracts/test/MockERC20.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Minimal ERC-20 used only in tests. Mints to whoever asks.
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock LITKEY", "mLITKEY") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/lit-payments/contracts/hardhat.config.ts
+++ b/lit-payments/contracts/hardhat.config.ts
@@ -1,0 +1,62 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-ethers";
+import "@nomicfoundation/hardhat-chai-matchers";
+import "@nomicfoundation/hardhat-verify";
+import "dotenv/config";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 100,
+      },
+      viaIR: true,
+    },
+  },
+  networks: {
+    // Local Hardhat node — used by `hardhat test` automatically.
+    hardhat: {
+      chainId: 31337,
+    },
+    baseSepolia: {
+      url: process.env.BASE_SEPOLIA_RPC_URL ?? "https://sepolia.base.org",
+      accounts: process.env.DEPLOYER_PRIVATE_KEY
+        ? [process.env.DEPLOYER_PRIVATE_KEY]
+        : [],
+      chainId: 84532,
+    },
+    base: {
+      url: process.env.BASE_RPC_URL ?? "https://mainnet.base.org",
+      accounts: process.env.DEPLOYER_PRIVATE_KEY
+        ? [process.env.DEPLOYER_PRIVATE_KEY]
+        : [],
+      chainId: 8453,
+    },
+  },
+  etherscan: {
+    // Single API key used for both Base mainnet + sepolia via Etherscan v2.
+    apiKey: process.env.BASESCAN_API_KEY ?? "",
+    customChains: [
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api-sepolia.basescan.org/api",
+          browserURL: "https://sepolia.basescan.org",
+        },
+      },
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.basescan.org/api",
+          browserURL: "https://basescan.org",
+        },
+      },
+    ],
+  },
+};
+
+export default config;

--- a/lit-payments/contracts/package-lock.json
+++ b/lit-payments/contracts/package-lock.json
@@ -2173,28 +2173,6 @@
         }
       }
     },
-    "node_modules/hardhat/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3544,9 +3522,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/lit-payments/contracts/package-lock.json
+++ b/lit-payments/contracts/package-lock.json
@@ -1,0 +1,3646 @@
+{
+  "name": "lit-payments-contracts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lit-payments-contracts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@openzeppelin/contracts": "^5.4.0",
+        "dotenv": "^16.4.7",
+        "ethers": "^6.13.5"
+      },
+      "devDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.1.2",
+        "@nomicfoundation/hardhat-ethers": "^3.0.8",
+        "@nomicfoundation/hardhat-verify": "^2.1.1",
+        "@types/chai": "^4.3.20",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^22.19.9",
+        "chai": "^4.5.0",
+        "hardhat": "^2.26.0",
+        "ts-node": "^10.9.2",
+        "typescript": "~5.8.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
+      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nomicfoundation/edr": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.23.tgz",
+      "integrity": "sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.23",
+        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.23",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.23",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.23"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-darwin-arm64": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.23.tgz",
+      "integrity": "sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-darwin-x64": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.23.tgz",
+      "integrity": "sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.23.tgz",
+      "integrity": "sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.23.tgz",
+      "integrity": "sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.23.tgz",
+      "integrity": "sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-musl": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.23.tgz",
+      "integrity": "sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
+      "version": "0.12.0-next.23",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.23.tgz",
+      "integrity": "sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.1.2.tgz",
+      "integrity": "sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.1.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.14.0",
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.1.3.tgz",
+      "integrity": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.14.0",
+        "hardhat": "^2.28.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.3.tgz",
+      "integrity": "sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "picocolors": "^1.1.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.26.0"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.2.tgz",
+      "integrity": "sha512-q4n32/FNKIhQ3zQGGw5CvPF6GTvDCpYwIf7bEY/dZTZbgfDsHyjJwURxUJf3VQuuJj+fDIFl4+KkBVbw4Ef6jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "optionalDependencies": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.2",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.2"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-JaqcWPDZENCvm++lFFGjrDd8mxtf+CtLd2MiXvMNTBD33dContTZ9TWETwNFwg7JTJT5Q9HEecH7FA+HTSsIUw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-fZNmVztrSXC03e9RONBT+CiksSeYcxI1wlzqyr0L7hsQlK1fzV+f04g2JtQ1c/Fe74ZwdV6aQBdd6Uwl1052sw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.2.tgz",
+      "integrity": "sha512-3d54oc+9ZVBuB6nbp8wHylk4xh0N0Gc+bk+/uJae+rUgbOBwQSfuGIbAZt1wBXs5REkSmynEGcqx6DutoK0tPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.2.tgz",
+      "integrity": "sha512-iDJfR2qf55vgsg7BtJa7iPiFAsYf2d0Tv/0B+vhtnI16+wfQeTbP7teookbGvAo0eJo7aLLm0xfS/GTkvHIucA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.2.tgz",
+      "integrity": "sha512-9dlHMAt5/2cpWyuJ9fQNOUXFB/vgSFORg1jpjX1Mh9hJ/MfZXlDdHQ+DpFCs32Zk5pxRBb07yGvSHk9/fezL+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.2.tgz",
+      "integrity": "sha512-GzzVeeJob3lfrSlDKQw2bRJ8rBf6mEYaWY+gW0JnTDHINA0s2gPR4km5RLIj1xeZZOYz4zRw+AEeYgLRqB2NXg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.2.tgz",
+      "integrity": "sha512-Fdjli4DCcFHb4Zgsz0uEJXZ2K7VEO+w5KVv7HmT7WO10iODdU9csC2az4jrhEsRtiR9Gfd74FlG0NYlw1BMdyA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.6.1.tgz",
+      "integrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/hub": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/node": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
+      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/core": "5.30.0",
+        "@sentry/hub": "5.30.0",
+        "@sentry/tracing": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
+      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/types": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+      "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.3.0"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fp-ts": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
+      "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hardhat": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.28.6.tgz",
+      "integrity": "sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ethereumjs/util": "^9.1.0",
+        "@ethersproject/abi": "^5.1.2",
+        "@nomicfoundation/edr": "0.12.0-next.23",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
+        "@sentry/node": "^5.18.1",
+        "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
+        "ansi-escapes": "^4.3.0",
+        "boxen": "^5.1.2",
+        "chokidar": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "debug": "^4.1.1",
+        "enquirer": "^2.3.0",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^1.0.3",
+        "find-up": "^5.0.0",
+        "fp-ts": "1.19.3",
+        "fs-extra": "^7.0.1",
+        "immutable": "^4.0.0-rc.12",
+        "io-ts": "1.10.4",
+        "json-stream-stringify": "^3.1.4",
+        "keccak": "^3.0.2",
+        "lodash": "^4.17.11",
+        "micro-eth-signer": "^0.14.0",
+        "mnemonist": "^0.38.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
+        "picocolors": "^1.1.0",
+        "raw-body": "^2.4.1",
+        "resolve": "1.17.0",
+        "semver": "^6.3.0",
+        "solc": "0.8.26",
+        "source-map-support": "^0.5.13",
+        "stacktrace-parser": "^0.1.10",
+        "tinyglobby": "^0.2.6",
+        "tsort": "0.0.1",
+        "undici": "^5.14.0",
+        "uuid": "^8.3.2",
+        "ws": "^7.4.6"
+      },
+      "bin": {
+        "hardhat": "internal/cli/bootstrap.js"
+      },
+      "peerDependencies": {
+        "ts-node": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hardhat/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/io-ts": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
+      "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fp-ts": "^1.0.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=7.10.1"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/micro-eth-signer": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/micro-eth-signer/-/micro-eth-signer-0.14.0.tgz",
+      "integrity": "sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "micro-packed": "~0.7.2"
+      }
+    },
+    "node_modules/micro-eth-signer/node_modules/@noble/curves": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
+      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.2"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/micro-eth-signer/node_modules/@noble/hashes": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
+      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/micro-packed": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
+      "integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/micro-packed/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
+      "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.0"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/mocha/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/solc": {
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.26.tgz",
+      "integrity": "sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "command-exists": "^1.2.8",
+        "commander": "^8.1.0",
+        "follow-redirects": "^1.12.1",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "bin": {
+        "solcjs": "solc.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/solc/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/lit-payments/contracts/package.json
+++ b/lit-payments/contracts/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "lit-payments-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "compile": "hardhat compile",
+    "test": "hardhat clean && hardhat test",
+    "deploy:base-sepolia": "hardhat run scripts/deploy.ts --network baseSepolia",
+    "deploy:base": "hardhat run scripts/deploy.ts --network base",
+    "verify:base-sepolia": "hardhat verify --network baseSepolia",
+    "verify:base": "hardhat verify --network base"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.1.2",
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@nomicfoundation/hardhat-verify": "^2.1.1",
+    "@types/chai": "^4.3.20",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.19.9",
+    "chai": "^4.5.0",
+    "hardhat": "^2.26.0",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.8.0"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^5.4.0",
+    "dotenv": "^16.4.7",
+    "ethers": "^6.13.5"
+  }
+}

--- a/lit-payments/contracts/package.json
+++ b/lit-payments/contracts/package.json
@@ -26,5 +26,8 @@
     "@openzeppelin/contracts": "^5.4.0",
     "dotenv": "^16.4.7",
     "ethers": "^6.13.5"
+  },
+  "overrides": {
+    "ws": "^8.21.0"
   }
 }

--- a/lit-payments/contracts/scripts/deploy.ts
+++ b/lit-payments/contracts/scripts/deploy.ts
@@ -1,0 +1,70 @@
+import { ethers, network, run } from "hardhat";
+import { isAddress } from "ethers";
+
+/// Deploy LitkeyPaymentGateway to whichever Hardhat network is active.
+///
+/// Required env vars:
+///   LITKEY_ADDRESS     — ERC-20 token address on this chain
+///   TREASURY_ADDRESS   — destination for swept LITKEY (e.g., company Safe)
+///   DEPLOYER_PRIVATE_KEY — funded deployer wallet (set in hardhat.config.ts)
+///
+/// Optional:
+///   BASESCAN_API_KEY   — if set, contract is verified after a 10s settle.
+async function main() {
+  const litkey = process.env.LITKEY_ADDRESS;
+  const treasury = process.env.TREASURY_ADDRESS;
+
+  if (!litkey || !isAddress(litkey)) {
+    throw new Error(`LITKEY_ADDRESS missing or invalid: ${litkey ?? "<unset>"}`);
+  }
+  if (!treasury || !isAddress(treasury)) {
+    throw new Error(
+      `TREASURY_ADDRESS missing or invalid: ${treasury ?? "<unset>"}`,
+    );
+  }
+
+  const [deployer] = await ethers.getSigners();
+  const deployerAddr = await deployer.getAddress();
+  const balance = await ethers.provider.getBalance(deployerAddr);
+
+  console.log(`Network:  ${network.name} (chainId ${network.config.chainId})`);
+  console.log(`Deployer: ${deployerAddr}`);
+  console.log(`Balance:  ${ethers.formatEther(balance)} ETH`);
+  console.log(`LITKEY:   ${litkey}`);
+  console.log(`Treasury: ${treasury}`);
+  console.log("");
+
+  const Gateway = await ethers.getContractFactory("LitkeyPaymentGateway");
+  const gateway = await Gateway.deploy(litkey, treasury);
+  const tx = gateway.deploymentTransaction();
+  console.log(`Deploy tx: ${tx?.hash}`);
+  await gateway.waitForDeployment();
+  const address = await gateway.getAddress();
+  console.log(`Deployed:  ${address}`);
+
+  if (process.env.BASESCAN_API_KEY) {
+    console.log("Waiting 10s for Basescan to index the deployment...");
+    await new Promise((r) => setTimeout(r, 10_000));
+    try {
+      await run("verify:verify", {
+        address,
+        constructorArguments: [litkey, treasury],
+      });
+      console.log("Verified on Basescan.");
+    } catch (e) {
+      console.warn(
+        "Basescan verify failed (you can re-run `pnpm verify:base-sepolia <address> <litkey> <treasury>` later):",
+        e instanceof Error ? e.message : e,
+      );
+    }
+  } else {
+    console.log(
+      "BASESCAN_API_KEY not set — skipping verify. Run `pnpm verify:<network> <address> <litkey> <treasury>` manually if you want it.",
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/lit-payments/contracts/test/LitkeyPaymentGateway.test.ts
+++ b/lit-payments/contracts/test/LitkeyPaymentGateway.test.ts
@@ -33,6 +33,14 @@ describe("LitkeyPaymentGateway", () => {
       expect(await gateway.treasury()).to.equal(treasury.address);
     });
 
+    it("reverts when litkey is the zero address", async () => {
+      const [, treasury] = await ethers.getSigners();
+      const Gateway = await ethers.getContractFactory("LitkeyPaymentGateway");
+      await expect(
+        Gateway.deploy(ZeroAddress, treasury.address),
+      ).to.be.revertedWithCustomError(Gateway, "InvalidToken");
+    });
+
     it("reverts when treasury is the zero address", async () => {
       const Mock = await ethers.getContractFactory("MockERC20");
       const litkey = await Mock.deploy();

--- a/lit-payments/contracts/test/LitkeyPaymentGateway.test.ts
+++ b/lit-payments/contracts/test/LitkeyPaymentGateway.test.ts
@@ -1,0 +1,215 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { ZeroAddress, parseUnits } from "ethers";
+
+const ONE_LITKEY = parseUnits("1", 18);
+const TEN_LITKEY = parseUnits("10", 18);
+const HUNDRED_LITKEY = parseUnits("100", 18);
+
+describe("LitkeyPaymentGateway", () => {
+  // ─── fixtures ────────────────────────────────────────────────────────────
+  async function deployFixture() {
+    const [deployer, treasury, alice, bob, carol] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockERC20");
+    const litkey = await Mock.deploy();
+    await litkey.waitForDeployment();
+
+    const Gateway = await ethers.getContractFactory("LitkeyPaymentGateway");
+    const gateway = await Gateway.deploy(
+      await litkey.getAddress(),
+      treasury.address,
+    );
+    await gateway.waitForDeployment();
+
+    return { gateway, litkey, deployer, treasury, alice, bob, carol };
+  }
+
+  // ─── constructor ─────────────────────────────────────────────────────────
+  describe("constructor", () => {
+    it("stores litkey + treasury", async () => {
+      const { gateway, litkey, treasury } = await deployFixture();
+      expect(await gateway.litkey()).to.equal(await litkey.getAddress());
+      expect(await gateway.treasury()).to.equal(treasury.address);
+    });
+
+    it("reverts when treasury is the zero address", async () => {
+      const Mock = await ethers.getContractFactory("MockERC20");
+      const litkey = await Mock.deploy();
+
+      const Gateway = await ethers.getContractFactory("LitkeyPaymentGateway");
+      await expect(
+        Gateway.deploy(await litkey.getAddress(), ZeroAddress),
+      ).to.be.revertedWithCustomError(Gateway, "InvalidTreasury");
+    });
+  });
+
+  // ─── pay() ───────────────────────────────────────────────────────────────
+  describe("pay", () => {
+    it("transfers LITKEY to treasury and emits Payment", async () => {
+      const { gateway, litkey, treasury, alice, bob } = await deployFixture();
+
+      // Alice has LITKEY and approves the gateway.
+      await litkey.mint(alice.address, HUNDRED_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), TEN_LITKEY);
+
+      // She pays 10 LITKEY to credit bob's Lit account.
+      await expect(gateway.connect(alice).pay(TEN_LITKEY, bob.address))
+        .to.emit(gateway, "Payment")
+        .withArgs(bob.address, alice.address, TEN_LITKEY);
+
+      expect(await litkey.balanceOf(treasury.address)).to.equal(TEN_LITKEY);
+      expect(await litkey.balanceOf(alice.address)).to.equal(
+        HUNDRED_LITKEY - TEN_LITKEY,
+      );
+      expect(await litkey.balanceOf(await gateway.getAddress())).to.equal(0n);
+    });
+
+    it("reverts when wallet is the zero address", async () => {
+      const { gateway, litkey, alice } = await deployFixture();
+      await litkey.mint(alice.address, TEN_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), TEN_LITKEY);
+
+      await expect(
+        gateway.connect(alice).pay(TEN_LITKEY, ZeroAddress),
+      ).to.be.revertedWithCustomError(gateway, "InvalidWallet");
+    });
+
+    it("reverts when amount is zero", async () => {
+      const { gateway, alice, bob } = await deployFixture();
+      await expect(
+        gateway.connect(alice).pay(0n, bob.address),
+      ).to.be.revertedWithCustomError(gateway, "InvalidAmount");
+    });
+
+    it("reverts when the payer hasn't approved the gateway", async () => {
+      const { gateway, litkey, alice, bob } = await deployFixture();
+      await litkey.mint(alice.address, TEN_LITKEY);
+      // No approve() call.
+
+      await expect(
+        gateway.connect(alice).pay(TEN_LITKEY, bob.address),
+      ).to.be.revertedWithCustomError(litkey, "ERC20InsufficientAllowance");
+    });
+
+    it("reverts when payer's balance is insufficient", async () => {
+      const { gateway, litkey, alice, bob } = await deployFixture();
+      await litkey.mint(alice.address, ONE_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), TEN_LITKEY);
+
+      await expect(
+        gateway.connect(alice).pay(TEN_LITKEY, bob.address),
+      ).to.be.revertedWithCustomError(litkey, "ERC20InsufficientBalance");
+    });
+
+    it("supports the same payer paying multiple times", async () => {
+      const { gateway, litkey, treasury, alice, bob } = await deployFixture();
+      await litkey.mint(alice.address, HUNDRED_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+
+      await gateway.connect(alice).pay(TEN_LITKEY, bob.address);
+      await gateway.connect(alice).pay(ONE_LITKEY, bob.address);
+
+      expect(await litkey.balanceOf(treasury.address)).to.equal(
+        TEN_LITKEY + ONE_LITKEY,
+      );
+    });
+
+    it("attributes concurrent payments from different payers correctly", async () => {
+      const { gateway, litkey, treasury, alice, bob, carol } =
+        await deployFixture();
+
+      await litkey.mint(alice.address, HUNDRED_LITKEY);
+      await litkey.mint(bob.address, HUNDRED_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+      await litkey
+        .connect(bob)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+
+      // Alice credits carol; bob credits himself.
+      await expect(gateway.connect(alice).pay(TEN_LITKEY, carol.address))
+        .to.emit(gateway, "Payment")
+        .withArgs(carol.address, alice.address, TEN_LITKEY);
+      await expect(gateway.connect(bob).pay(ONE_LITKEY, bob.address))
+        .to.emit(gateway, "Payment")
+        .withArgs(bob.address, bob.address, ONE_LITKEY);
+
+      expect(await litkey.balanceOf(treasury.address)).to.equal(
+        TEN_LITKEY + ONE_LITKEY,
+      );
+    });
+
+    it("lets users credit a wallet different from the payer (cross-wallet payment)", async () => {
+      const { gateway, litkey, alice, bob } = await deployFixture();
+      await litkey.mint(alice.address, TEN_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), TEN_LITKEY);
+
+      // Alice (paying wallet) credits bob (Lit account wallet).
+      await expect(gateway.connect(alice).pay(TEN_LITKEY, bob.address))
+        .to.emit(gateway, "Payment")
+        .withArgs(bob.address, alice.address, TEN_LITKEY);
+    });
+  });
+
+  // ─── event indexing ──────────────────────────────────────────────────────
+  describe("event filtering", () => {
+    it("filters Payment by indexed wallet", async () => {
+      const { gateway, litkey, alice, bob, carol } = await deployFixture();
+      await litkey.mint(alice.address, HUNDRED_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+
+      await gateway.connect(alice).pay(TEN_LITKEY, bob.address);
+      await gateway.connect(alice).pay(ONE_LITKEY, carol.address);
+      await gateway.connect(alice).pay(ONE_LITKEY, bob.address);
+
+      // Filter for payments crediting bob — should see two.
+      const filter = gateway.filters.Payment(bob.address);
+      const events = await gateway.queryFilter(filter);
+      expect(events).to.have.length(2);
+      expect(events[0].args.amount).to.equal(TEN_LITKEY);
+      expect(events[1].args.amount).to.equal(ONE_LITKEY);
+      for (const e of events) {
+        expect(e.args.wallet).to.equal(bob.address);
+        expect(e.args.payer).to.equal(alice.address);
+      }
+    });
+
+    it("filters Payment by indexed payer", async () => {
+      const { gateway, litkey, alice, bob, carol } = await deployFixture();
+      await litkey.mint(alice.address, HUNDRED_LITKEY);
+      await litkey.mint(bob.address, HUNDRED_LITKEY);
+      await litkey
+        .connect(alice)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+      await litkey
+        .connect(bob)
+        .approve(await gateway.getAddress(), HUNDRED_LITKEY);
+
+      await gateway.connect(alice).pay(ONE_LITKEY, carol.address);
+      await gateway.connect(bob).pay(ONE_LITKEY, carol.address);
+      await gateway.connect(alice).pay(ONE_LITKEY, carol.address);
+
+      // Filter for alice as payer — should see two.
+      const filter = gateway.filters.Payment(undefined, alice.address);
+      const events = await gateway.queryFilter(filter);
+      expect(events).to.have.length(2);
+      for (const e of events) {
+        expect(e.args.payer).to.equal(alice.address);
+      }
+    });
+  });
+});

--- a/lit-payments/contracts/tsconfig.json
+++ b/lit-payments/contracts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["./scripts", "./test", "./hardhat.config.ts"]
+}

--- a/lit-payments/migrations/20260521000001_litkey_rate.sql
+++ b/lit-payments/migrations/20260521000001_litkey_rate.sql
@@ -1,0 +1,13 @@
+-- Current USD-denominated LITKEY rate, stored as integer cents per LITKEY.
+-- Single-row table: id is always 1.
+CREATE TABLE litkey_rate (
+    id BIGINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    cents_per_litkey BIGINT NOT NULL CHECK (cents_per_litkey > 0),
+    source TEXT NOT NULL CHECK (source IN ('coingecko', 'manual')),
+    fetched_at TIMESTAMPTZ NOT NULL,
+    updated_by_operator_id BIGINT REFERENCES operators(id),
+    CONSTRAINT litkey_rate_manual_operator_check CHECK (
+        (source = 'manual' AND updated_by_operator_id IS NOT NULL)
+        OR (source = 'coingecko' AND updated_by_operator_id IS NULL)
+    )
+);

--- a/lit-payments/migrations/20260521000001_litkey_rate.sql
+++ b/lit-payments/migrations/20260521000001_litkey_rate.sql
@@ -2,7 +2,7 @@
 -- Single-row table: id is always 1.
 CREATE TABLE litkey_rate (
     id BIGINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-    cents_per_litkey BIGINT NOT NULL CHECK (cents_per_litkey > 0),
+    cents_per_litkey BIGINT NOT NULL CHECK (cents_per_litkey BETWEEN 1 AND 1000000),
     source TEXT NOT NULL CHECK (source IN ('coingecko', 'manual')),
     fetched_at TIMESTAMPTZ NOT NULL,
     updated_by_operator_id BIGINT REFERENCES operators(id),

--- a/lit-payments/migrations/20260521000001_litkey_rate.sql
+++ b/lit-payments/migrations/20260521000001_litkey_rate.sql
@@ -1,8 +1,11 @@
--- Current USD-denominated LITKEY rate, stored as integer cents per LITKEY.
+-- Current USD-denominated LITKEY rate, stored as 18-decimal fixed-point
+-- USD units per 1 whole LITKEY. Example: $0.006 = 6000000000000000.
 -- Single-row table: id is always 1.
 CREATE TABLE litkey_rate (
     id BIGINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-    cents_per_litkey BIGINT NOT NULL CHECK (cents_per_litkey BETWEEN 1 AND 1000000),
+    usd_wei_per_litkey NUMERIC(78, 0) NOT NULL CHECK (
+        usd_wei_per_litkey BETWEEN 1 AND 10000000000000000000000
+    ),
     source TEXT NOT NULL CHECK (source IN ('coingecko', 'manual')),
     fetched_at TIMESTAMPTZ NOT NULL,
     updated_by_operator_id BIGINT REFERENCES operators(id),

--- a/lit-payments/migrations/20260522000001_litkey_listener.sql
+++ b/lit-payments/migrations/20260522000001_litkey_listener.sql
@@ -4,20 +4,25 @@
 CREATE TABLE litkey_payments (
     id BIGSERIAL PRIMARY KEY,
     chain_id BIGINT NOT NULL,
-    gateway_address TEXT NOT NULL,
-    tx_hash TEXT NOT NULL,
+    gateway_address TEXT NOT NULL CHECK (gateway_address ~ '^0x[0-9a-f]{40}$'),
+    tx_hash TEXT NOT NULL CHECK (tx_hash ~ '^0x[0-9a-f]{64}$'),
     log_index BIGINT NOT NULL CHECK (log_index >= 0),
     block_number BIGINT NOT NULL CHECK (block_number >= 0),
-    wallet_address TEXT NOT NULL,
-    payer_address TEXT NOT NULL,
+    wallet_address TEXT NOT NULL CHECK (wallet_address ~ '^0x[0-9a-f]{40}$'),
+    payer_address TEXT NOT NULL CHECK (payer_address ~ '^0x[0-9a-f]{40}$'),
     litkey_amount_wei NUMERIC(78, 0) NOT NULL CHECK (litkey_amount_wei > 0),
-    usd_wei_per_litkey NUMERIC(78, 0) NOT NULL CHECK (usd_wei_per_litkey > 0),
+    usd_wei_per_litkey NUMERIC(78, 0),
     discount_basis_points BIGINT NOT NULL CHECK (discount_basis_points BETWEEN 0 AND 9000),
-    cents_credited BIGINT NOT NULL CHECK (cents_credited > 0),
-    stripe_customer_id TEXT NOT NULL,
-    stripe_balance_transaction_id TEXT NOT NULL,
+    cents_credited BIGINT NOT NULL CHECK (cents_credited >= 0),
+    status TEXT NOT NULL CHECK (status IN ('credited', 'dust', 'paused', 'no_customer')),
+    stripe_customer_id TEXT,
+    stripe_balance_transaction_id TEXT,
     credited_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE (chain_id, tx_hash, log_index)
+    UNIQUE (chain_id, tx_hash, log_index),
+    CONSTRAINT litkey_payments_status_fields_check CHECK (
+        (status = 'credited' AND usd_wei_per_litkey IS NOT NULL AND cents_credited > 0 AND stripe_customer_id IS NOT NULL AND stripe_balance_transaction_id IS NOT NULL)
+        OR (status <> 'credited' AND stripe_balance_transaction_id IS NULL)
+    )
 );
 
 CREATE INDEX litkey_payments_wallet_credited_at_idx
@@ -29,7 +34,9 @@ CREATE INDEX litkey_payments_credited_at_idx
 -- Reconciliation checkpoint. Advanced only by the HTTPS poll path after a
 -- whole confirmed range has been processed successfully.
 CREATE TABLE chain_checkpoint (
-    chain_id BIGINT PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    gateway_address TEXT NOT NULL CHECK (gateway_address ~ '^0x[0-9a-f]{40}$'),
     last_processed_block BIGINT NOT NULL CHECK (last_processed_block >= 0),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (chain_id, gateway_address)
 );

--- a/lit-payments/migrations/20260522000001_litkey_listener.sql
+++ b/lit-payments/migrations/20260522000001_litkey_listener.sql
@@ -1,0 +1,35 @@
+-- LITKEY on-chain payment records. Successful credits are idempotent by
+-- chain + tx hash + log index so WSS and reconciliation poller races cannot
+-- double-credit the same Payment event.
+CREATE TABLE litkey_payments (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    gateway_address TEXT NOT NULL,
+    tx_hash TEXT NOT NULL,
+    log_index BIGINT NOT NULL CHECK (log_index >= 0),
+    block_number BIGINT NOT NULL CHECK (block_number >= 0),
+    wallet_address TEXT NOT NULL,
+    payer_address TEXT NOT NULL,
+    litkey_amount_wei NUMERIC(78, 0) NOT NULL CHECK (litkey_amount_wei > 0),
+    usd_wei_per_litkey NUMERIC(78, 0) NOT NULL CHECK (usd_wei_per_litkey > 0),
+    discount_basis_points BIGINT NOT NULL CHECK (discount_basis_points BETWEEN 0 AND 9000),
+    cents_credited BIGINT NOT NULL CHECK (cents_credited > 0),
+    stripe_customer_id TEXT NOT NULL,
+    stripe_balance_transaction_id TEXT NOT NULL,
+    credited_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (chain_id, tx_hash, log_index)
+);
+
+CREATE INDEX litkey_payments_wallet_credited_at_idx
+    ON litkey_payments (wallet_address, credited_at DESC);
+
+CREATE INDEX litkey_payments_credited_at_idx
+    ON litkey_payments (credited_at DESC);
+
+-- Reconciliation checkpoint. Advanced only by the HTTPS poll path after a
+-- whole confirmed range has been processed successfully.
+CREATE TABLE chain_checkpoint (
+    chain_id BIGINT PRIMARY KEY,
+    last_processed_block BIGINT NOT NULL CHECK (last_processed_block >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -4,6 +4,7 @@
 //! reconciliation poller so confirmation depth, idempotency, and checkpoint
 //! behavior cannot drift between paths.
 
+use anyhow::{Context, Result};
 use ethers_core::types::{Address, H256, U256};
 use lit_billing_core::StripeClient;
 use sqlx::PgPool;
@@ -81,12 +82,128 @@ pub fn backoff_delay_secs(attempt: u32) -> u64 {
     2_u64.saturating_pow(attempt).clamp(1, 30)
 }
 
-/// Start the phase-3c LITKEY listener tasks when chain config is present.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaymentStatus {
+    Credited,
+    Dust,
+    Paused,
+    NoCustomer,
+}
+
+impl PaymentStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Credited => "credited",
+            Self::Dust => "dust",
+            Self::Paused => "paused",
+            Self::NoCustomer => "no_customer",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewLitkeyPayment {
+    pub log: PaymentLog,
+    pub usd_wei_per_litkey: Option<String>,
+    pub discount_basis_points: i64,
+    pub cents_credited: i64,
+    pub status: PaymentStatus,
+    pub stripe_customer_id: Option<String>,
+    pub stripe_balance_transaction_id: Option<String>,
+}
+
+pub async fn payment_exists(pool: &PgPool, log: &PaymentLog) -> Result<bool> {
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM litkey_payments WHERE chain_id = $1 AND tx_hash = $2 AND log_index = $3)",
+    )
+    .bind(log.chain_id)
+    .bind(format!("{:#x}", log.tx_hash))
+    .bind(log.log_index as i64)
+    .fetch_one(pool)
+    .await
+    .context("checking litkey payment idempotency")?;
+    Ok(exists)
+}
+
+pub async fn insert_payment(pool: &PgPool, payment: &NewLitkeyPayment) -> Result<bool> {
+    let inserted = sqlx::query_scalar::<_, i64>(
+        "INSERT INTO litkey_payments (
+            chain_id, gateway_address, tx_hash, log_index, block_number,
+            wallet_address, payer_address, litkey_amount_wei, usd_wei_per_litkey,
+            discount_basis_points, cents_credited, status, stripe_customer_id,
+            stripe_balance_transaction_id
+         ) VALUES (
+            $1, $2, $3, $4, $5,
+            $6, $7, $8::numeric, $9::numeric,
+            $10, $11, $12, $13, $14
+         ) ON CONFLICT (chain_id, tx_hash, log_index) DO NOTHING
+         RETURNING id",
+    )
+    .bind(payment.log.chain_id)
+    .bind(payment.log.gateway_address())
+    .bind(format!("{:#x}", payment.log.tx_hash))
+    .bind(payment.log.log_index as i64)
+    .bind(payment.log.block_number as i64)
+    .bind(payment.log.wallet_address())
+    .bind(payment.log.payer_address())
+    .bind(payment.log.amount_wei_string())
+    .bind(payment.usd_wei_per_litkey.as_deref())
+    .bind(payment.discount_basis_points)
+    .bind(payment.cents_credited)
+    .bind(payment.status.as_str())
+    .bind(payment.stripe_customer_id.as_deref())
+    .bind(payment.stripe_balance_transaction_id.as_deref())
+    .fetch_optional(pool)
+    .await
+    .context("inserting litkey payment")?;
+    Ok(inserted.is_some())
+}
+
+pub async fn current_checkpoint(
+    pool: &PgPool,
+    chain_id: i64,
+    gateway_address: Address,
+) -> Result<u64> {
+    let block = sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT last_processed_block FROM chain_checkpoint WHERE chain_id = $1 AND gateway_address = $2",
+    )
+    .bind(chain_id)
+    .bind(format_address(gateway_address))
+    .fetch_optional(pool)
+    .await
+    .context("reading chain checkpoint")?
+    .flatten()
+    .unwrap_or(0);
+    u64::try_from(block).context("chain checkpoint was negative")
+}
+
+pub async fn advance_checkpoint(
+    pool: &PgPool,
+    chain_id: i64,
+    gateway_address: Address,
+    last_processed_block: u64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO chain_checkpoint (chain_id, gateway_address, last_processed_block)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (chain_id, gateway_address) DO UPDATE SET
+           last_processed_block = GREATEST(chain_checkpoint.last_processed_block, EXCLUDED.last_processed_block),
+           updated_at = now()",
+    )
+    .bind(chain_id)
+    .bind(format_address(gateway_address))
+    .bind(last_processed_block as i64)
+    .execute(pool)
+    .await
+    .context("advancing chain checkpoint")?;
+    Ok(())
+}
+
+/// Register the phase-3c LITKEY listener scaffold when chain config is present.
 ///
-/// The concrete WSS subscription and HTTPS log-query loops are intentionally
-/// split from pure helpers so idempotency/checkpoint math is testable. This
-/// starter is safe to call in environments that have not set chain secrets yet:
-/// it logs and leaves LITKEY crediting disabled.
+/// This does not yet subscribe to RPC. It validates and logs the configured
+/// gateway so the DB/idempotency/checkpoint pieces can ship before live
+/// processing; live WSS/poller tasks must be added before production crediting.
 pub fn spawn_litkey_listener(
     _pool: PgPool,
     _stripe: StripeClient,
@@ -104,7 +221,7 @@ pub fn spawn_litkey_listener(
         confirmations = config.confirmations,
         reconciliation_interval_secs = config.reconciliation_interval_secs,
         discount_basis_points,
-        "LITKEY listener configured; reconciliation/WSS processing will use shared payment primitives"
+        "LITKEY listener scaffold configured; live WSS/reconciliation tasks are still disabled"
     );
 }
 

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -1,0 +1,184 @@
+//! LITKEY on-chain payment listener primitives.
+//!
+//! Phase 3c uses these helpers from both the WSS fast path and the HTTPS
+//! reconciliation poller so confirmation depth, idempotency, and checkpoint
+//! behavior cannot drift between paths.
+
+use ethers_core::types::{Address, H256, U256};
+use lit_billing_core::StripeClient;
+use sqlx::PgPool;
+pub const BASE_CHAIN_ID: i64 = 8453;
+pub const DEFAULT_CONFIRMATIONS: u64 = 5;
+pub const DEFAULT_RECONCILIATION_INTERVAL_SECS: u64 = 60;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChainConfig {
+    pub chain_id: i64,
+    pub alchemy_wss_url: String,
+    pub alchemy_https_url: String,
+    pub gateway_address: Address,
+    pub confirmations: u64,
+    pub reconciliation_interval_secs: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PaymentLog {
+    pub chain_id: i64,
+    pub gateway_address: Address,
+    pub wallet: Address,
+    pub payer: Address,
+    pub amount_wei: U256,
+    pub tx_hash: H256,
+    pub log_index: u64,
+    pub block_number: u64,
+}
+
+impl PaymentLog {
+    pub fn idempotency_key(&self) -> String {
+        payment_idempotency_key(self.chain_id, self.tx_hash, self.log_index)
+    }
+
+    pub fn gateway_address(&self) -> String {
+        format_address(self.gateway_address)
+    }
+
+    pub fn wallet_address(&self) -> String {
+        format_address(self.wallet)
+    }
+
+    pub fn payer_address(&self) -> String {
+        format_address(self.payer)
+    }
+
+    pub fn amount_wei_string(&self) -> String {
+        self.amount_wei.to_string()
+    }
+}
+
+pub fn payment_idempotency_key(chain_id: i64, tx_hash: H256, log_index: u64) -> String {
+    format!("litkey:{chain_id}:{tx_hash:#x}:{log_index}")
+}
+
+pub fn format_address(address: Address) -> String {
+    format!("{address:#x}")
+}
+
+pub fn is_confirmed(event_block: u64, latest_block: u64, confirmations: u64) -> bool {
+    latest_block.saturating_sub(event_block) >= confirmations
+}
+
+pub fn reconciliation_range(
+    last_processed_block: u64,
+    latest_block: u64,
+    confirmations: u64,
+) -> Option<(u64, u64)> {
+    let safe_to_block = latest_block.checked_sub(confirmations)?;
+    let from_block = last_processed_block.saturating_add(1);
+    (from_block <= safe_to_block).then_some((from_block, safe_to_block))
+}
+
+pub fn backoff_delay_secs(attempt: u32) -> u64 {
+    2_u64.saturating_pow(attempt).clamp(1, 30)
+}
+
+/// Start the phase-3c LITKEY listener tasks when chain config is present.
+///
+/// The concrete WSS subscription and HTTPS log-query loops are intentionally
+/// split from pure helpers so idempotency/checkpoint math is testable. This
+/// starter is safe to call in environments that have not set chain secrets yet:
+/// it logs and leaves LITKEY crediting disabled.
+pub fn spawn_litkey_listener(
+    _pool: PgPool,
+    _stripe: StripeClient,
+    config: Option<ChainConfig>,
+    discount_basis_points: i64,
+) {
+    let Some(config) = config else {
+        tracing::info!("LITKEY listener disabled; ALCHEMY_* and LITKEY_GATEWAY_ADDRESS not set");
+        return;
+    };
+
+    tracing::info!(
+        chain_id = config.chain_id,
+        gateway_address = %format_address(config.gateway_address),
+        confirmations = config.confirmations,
+        reconciliation_interval_secs = config.reconciliation_interval_secs,
+        discount_basis_points,
+        "LITKEY listener configured; reconciliation/WSS processing will use shared payment primitives"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers_core::types::{Address, H256, U256};
+    use std::str::FromStr;
+
+    #[test]
+    fn formats_deterministic_stripe_idempotency_key() {
+        let tx_hash =
+            H256::from_str("0x1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        assert_eq!(
+            payment_idempotency_key(8453, tx_hash, 7),
+            "litkey:8453:0x1111111111111111111111111111111111111111111111111111111111111111:7"
+        );
+    }
+
+    #[test]
+    fn lowercases_and_prefixes_ethereum_addresses() {
+        let address = Address::from_str("0xA2D54CD1D1dF1735718A857aC49CaF9ECaB0093b").unwrap();
+        assert_eq!(
+            format_address(address),
+            "0xa2d54cd1d1df1735718a857ac49caf9ecab0093b"
+        );
+    }
+
+    #[test]
+    fn confirmation_depth_is_inclusive() {
+        assert!(is_confirmed(100, 105, 5));
+        assert!(!is_confirmed(100, 104, 5));
+        assert!(is_confirmed(100, 100, 0));
+    }
+
+    #[test]
+    fn reconciliation_range_starts_after_checkpoint_and_stops_at_safe_block() {
+        assert_eq!(reconciliation_range(100, 110, 5), Some((101, 105)));
+        assert_eq!(reconciliation_range(100, 105, 5), None);
+        assert_eq!(reconciliation_range(0, 3, 5), None);
+        assert_eq!(reconciliation_range(0, 5, 5), None);
+        assert_eq!(reconciliation_range(0, 6, 5), Some((1, 1)));
+    }
+
+    #[test]
+    fn reconnect_backoff_caps_at_thirty_seconds() {
+        let delays: Vec<u64> = (0..8).map(backoff_delay_secs).collect();
+        assert_eq!(delays, vec![1, 2, 4, 8, 16, 30, 30, 30]);
+    }
+
+    #[test]
+    fn payment_log_normalizes_addresses_and_amounts_for_processing() {
+        let wallet = Address::from_str("0xA2D54CD1D1dF1735718A857aC49CaF9ECaB0093b").unwrap();
+        let payer = Address::from_str("0x000000000000000000000000000000000000dEaD").unwrap();
+        let log = PaymentLog {
+            chain_id: 8453,
+            gateway_address: wallet,
+            wallet,
+            payer,
+            amount_wei: U256::from_dec_str("1000000000000000000").unwrap(),
+            tx_hash: H256::zero(),
+            log_index: 3,
+            block_number: 123,
+        };
+
+        assert_eq!(
+            log.wallet_address(),
+            "0xa2d54cd1d1df1735718a857ac49caf9ecab0093b"
+        );
+        assert_eq!(
+            log.payer_address(),
+            "0x000000000000000000000000000000000000dead"
+        );
+        assert_eq!(log.amount_wei_string(), "1000000000000000000");
+    }
+}

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -92,6 +92,26 @@ fn optional_trimmed(name: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
+pub fn validate_chain_runtime_config(
+    chain_id: i64,
+    confirmations: u64,
+    reconciliation_interval_secs: u64,
+) -> Result<()> {
+    if chain_id != chain::BASE_CHAIN_ID {
+        anyhow::bail!(
+            "LITKEY_CHAIN_ID must be {} (Base mainnet)",
+            chain::BASE_CHAIN_ID
+        );
+    }
+    if confirmations == 0 {
+        anyhow::bail!("LITKEY_CONFIRMATIONS must be greater than zero");
+    }
+    if reconciliation_interval_secs == 0 {
+        anyhow::bail!("LITKEY_RECONCILIATION_INTERVAL_SECS must be greater than zero");
+    }
+    Ok(())
+}
+
 fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
     let wss = optional_trimmed("ALCHEMY_WSS_URL");
     let https = optional_trimmed("ALCHEMY_HTTPS_URL");
@@ -108,16 +128,21 @@ fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
     let gateway_address = Address::from_str(&gateway)
         .with_context(|| format!("LITKEY_GATEWAY_ADDRESS must be a 0x address; got {gateway:?}"))?;
 
+    let chain_id = optional_i64("LITKEY_CHAIN_ID", chain::BASE_CHAIN_ID)?;
+    let confirmations = optional_u64("LITKEY_CONFIRMATIONS", chain::DEFAULT_CONFIRMATIONS)?;
+    let reconciliation_interval_secs = optional_u64(
+        "LITKEY_RECONCILIATION_INTERVAL_SECS",
+        chain::DEFAULT_RECONCILIATION_INTERVAL_SECS,
+    )?;
+    validate_chain_runtime_config(chain_id, confirmations, reconciliation_interval_secs)?;
+
     Ok(Some(chain::ChainConfig {
-        chain_id: optional_i64("LITKEY_CHAIN_ID", chain::BASE_CHAIN_ID)?,
+        chain_id,
         alchemy_wss_url: wss,
         alchemy_https_url: https,
         gateway_address,
-        confirmations: optional_u64("LITKEY_CONFIRMATIONS", chain::DEFAULT_CONFIRMATIONS)?,
-        reconciliation_interval_secs: optional_u64(
-            "LITKEY_RECONCILIATION_INTERVAL_SECS",
-            chain::DEFAULT_RECONCILIATION_INTERVAL_SECS,
-        )?,
+        confirmations,
+        reconciliation_interval_secs,
     }))
 }
 
@@ -143,4 +168,17 @@ fn parse_signing_key() -> Result<Vec<u8>> {
         );
     }
     Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_litkey_chain_runtime_config_bounds() {
+        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 5, 60).is_ok());
+        assert!(validate_chain_runtime_config(0, 5, 60).is_err());
+        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 0, 60).is_err());
+        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 5, 0).is_err());
+    }
 }

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -3,9 +3,12 @@
 //! All env vars are read once at startup. Missing required vars fail the
 //! process with a clear message — no silent defaults.
 
-use anyhow::{Context, Result};
+use std::str::FromStr;
 
-use crate::rate;
+use anyhow::{Context, Result};
+use ethers_core::types::Address;
+
+use crate::{chain, rate};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -32,6 +35,9 @@ pub struct Config {
     /// Discount for LITKEY payments, in basis points. Default 0. Example:
     /// 2000 = "20% off vs credit card".
     pub litkey_discount_basis_points: i64,
+    /// Optional Base LITKEY listener configuration. If unset, the admin portal
+    /// and rate poller run but on-chain payment processing stays disabled.
+    pub litkey_chain: Option<chain::ChainConfig>,
 }
 
 impl Config {
@@ -48,6 +54,7 @@ impl Config {
             max_grant_cents: optional_i64("MAX_GRANT_CENTS", 2_000)?,
             max_daily_per_operator_cents: optional_i64("MAX_DAILY_PER_OPERATOR_CENTS", 10_000)?,
             litkey_discount_basis_points: parse_discount_basis_points()?,
+            litkey_chain: parse_litkey_chain_config()?,
         })
     }
 }
@@ -66,6 +73,52 @@ fn optional_i64(name: &str, default: i64) -> Result<i64> {
             .with_context(|| format!("env var {name} must be an integer; got {v:?}")),
         _ => Ok(default),
     }
+}
+
+fn optional_u64(name: &str, default: u64) -> Result<u64> {
+    match std::env::var(name) {
+        Ok(v) if !v.trim().is_empty() => v
+            .trim()
+            .parse::<u64>()
+            .with_context(|| format!("env var {name} must be an unsigned integer; got {v:?}")),
+        _ => Ok(default),
+    }
+}
+
+fn optional_trimmed(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
+    let wss = optional_trimmed("ALCHEMY_WSS_URL");
+    let https = optional_trimmed("ALCHEMY_HTTPS_URL");
+    let gateway = optional_trimmed("LITKEY_GATEWAY_ADDRESS");
+
+    if wss.is_none() && https.is_none() && gateway.is_none() {
+        return Ok(None);
+    }
+
+    let wss = wss.context("ALCHEMY_WSS_URL is required when enabling LITKEY listener")?;
+    let https = https.context("ALCHEMY_HTTPS_URL is required when enabling LITKEY listener")?;
+    let gateway =
+        gateway.context("LITKEY_GATEWAY_ADDRESS is required when enabling LITKEY listener")?;
+    let gateway_address = Address::from_str(&gateway)
+        .with_context(|| format!("LITKEY_GATEWAY_ADDRESS must be a 0x address; got {gateway:?}"))?;
+
+    Ok(Some(chain::ChainConfig {
+        chain_id: optional_i64("LITKEY_CHAIN_ID", chain::BASE_CHAIN_ID)?,
+        alchemy_wss_url: wss,
+        alchemy_https_url: https,
+        gateway_address,
+        confirmations: optional_u64("LITKEY_CONFIRMATIONS", chain::DEFAULT_CONFIRMATIONS)?,
+        reconciliation_interval_secs: optional_u64(
+            "LITKEY_RECONCILIATION_INTERVAL_SECS",
+            chain::DEFAULT_RECONCILIATION_INTERVAL_SECS,
+        )?,
+    }))
 }
 
 fn required(name: &str) -> Result<String> {

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -5,6 +5,8 @@
 
 use anyhow::{Context, Result};
 
+use crate::rate;
+
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Postgres connection string. On Fly.io, supplied via `fly secrets set`
@@ -27,6 +29,9 @@ pub struct Config {
     pub max_grant_cents: i64,
     /// Max cents one operator can grant in a rolling 24-hour window. Default $100.
     pub max_daily_per_operator_cents: i64,
+    /// Discount for LITKEY payments, in basis points. Default 0. Example:
+    /// 2000 = "20% off vs credit card".
+    pub litkey_discount_basis_points: i64,
 }
 
 impl Config {
@@ -42,8 +47,15 @@ impl Config {
             stripe_secret_key: required("STRIPE_SECRET_KEY")?,
             max_grant_cents: optional_i64("MAX_GRANT_CENTS", 2_000)?,
             max_daily_per_operator_cents: optional_i64("MAX_DAILY_PER_OPERATOR_CENTS", 10_000)?,
+            litkey_discount_basis_points: parse_discount_basis_points()?,
         })
     }
+}
+
+fn parse_discount_basis_points() -> Result<i64> {
+    let bps = optional_i64("LITKEY_DISCOUNT_BASIS_POINTS", 0)?;
+    rate::validate_discount_basis_points(bps)?;
+    Ok(bps)
 }
 
 fn optional_i64(name: &str, default: i64) -> Result<i64> {

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -3,6 +3,7 @@
 //! See `plans/lit-payments-app.md` for the full design.
 
 pub mod auth;
+pub mod chain;
 pub mod config;
 pub mod db;
 pub mod mail;

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -7,3 +7,4 @@ pub mod config;
 pub mod db;
 pub mod mail;
 pub mod portal;
+pub mod rate;

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use lit_billing_core::StripeClient;
 use lit_payments::auth::routes as auth_routes;
 use lit_payments::portal::routes as portal_routes;
+use lit_payments::rate;
 use lit_payments::{auth, config, db, mail};
 use rocket::fs::{FileServer, NamedFile};
 use rocket::http::Status;
@@ -27,6 +28,7 @@ async fn rocket() -> _ {
         mail::Mailer::new(cfg.resend_api_key.clone(), cfg.mail_from.clone()).expect("mailer");
     let rate_limit = auth::rate_limit::RateLimiter::new();
     let stripe = StripeClient::new(cfg.stripe_secret_key.clone()).expect("stripe client");
+    rate::spawn_rate_poller(pool.clone());
 
     rocket::build()
         .manage(pool)
@@ -47,6 +49,8 @@ async fn rocket() -> _ {
                 portal_routes::lookup_customer,
                 portal_routes::grant_credit,
                 portal_routes::list_grants,
+                rate::get_rate,
+                rate::override_rate,
             ],
         )
         .mount("/static", FileServer::from("static"))

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -50,6 +50,7 @@ async fn rocket() -> _ {
                 portal_routes::grant_credit,
                 portal_routes::list_grants,
                 rate::get_rate,
+                rate::get_quote,
                 rate::override_rate,
             ],
         )

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -5,7 +5,7 @@ use lit_billing_core::StripeClient;
 use lit_payments::auth::routes as auth_routes;
 use lit_payments::portal::routes as portal_routes;
 use lit_payments::rate;
-use lit_payments::{auth, config, db, mail};
+use lit_payments::{auth, chain, config, db, mail};
 use rocket::fs::{FileServer, NamedFile};
 use rocket::http::Status;
 use rocket::response::Redirect;
@@ -29,6 +29,12 @@ async fn rocket() -> _ {
     let rate_limit = auth::rate_limit::RateLimiter::new();
     let stripe = StripeClient::new(cfg.stripe_secret_key.clone()).expect("stripe client");
     rate::spawn_rate_poller(pool.clone());
+    chain::spawn_litkey_listener(
+        pool.clone(),
+        stripe.clone(),
+        cfg.litkey_chain.clone(),
+        cfg.litkey_discount_basis_points,
+    );
 
     rocket::build()
         .manage(pool)

--- a/lit-payments/src/rate.rs
+++ b/lit-payments/src/rate.rs
@@ -1,0 +1,366 @@
+//! LITKEY/USD rate parsing, validation, persistence, admin API, and polling.
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::Client;
+use rocket::State;
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+
+use crate::auth::Operator;
+use crate::auth::operator::Role;
+use crate::portal::types::ErrorResponse;
+
+pub const COINGECKO_URL: &str =
+    "https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd";
+pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+pub const STALE_AFTER: Duration = Duration::hours(1);
+pub const MAX_CENTS_PER_LITKEY: i64 = 1_000_000; // $10,000/LITKEY: reject obvious feed nonsense.
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LitkeyRate {
+    pub cents_per_litkey: i64,
+    pub source: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub fetched_at: OffsetDateTime,
+    pub updated_by_operator_id: Option<i64>,
+    pub stale: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RateResponse {
+    pub rate: Option<LitkeyRate>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OverrideRateRequest {
+    pub cents_per_litkey: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateValidation {
+    Accept,
+    RejectInvalid,
+    RejectAbsurdJump,
+}
+
+type ApiError = (Status, Json<ErrorResponse>);
+type ApiResult<T> = Result<Json<T>, ApiError>;
+
+fn err(status: Status, message: impl Into<String>) -> ApiError {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn server_err(e: impl std::fmt::Display) -> ApiError {
+    tracing::warn!("rate route: {e}");
+    err(Status::InternalServerError, "internal error")
+}
+
+/// Parse CoinGecko's `simple/price` response and convert USD to integer cents.
+pub fn parse_coingecko_cents(body: &str) -> Result<i64> {
+    let v: serde_json::Value = serde_json::from_str(body).context("parsing CoinGecko JSON")?;
+    let usd = v
+        .get("lit-protocol")
+        .and_then(|obj| obj.get("usd"))
+        .and_then(|usd| usd.as_f64())
+        .ok_or_else(|| anyhow!("CoinGecko response missing lit-protocol.usd"))?;
+
+    if !usd.is_finite() || usd <= 0.0 {
+        anyhow::bail!("CoinGecko returned non-positive or non-finite USD rate: {usd}");
+    }
+
+    let cents = (usd * 100.0).round();
+    if !cents.is_finite() || cents < 1.0 || cents > MAX_CENTS_PER_LITKEY as f64 {
+        anyhow::bail!("CoinGecko USD rate converts to invalid cents value: {cents}");
+    }
+    Ok(cents as i64)
+}
+
+pub fn validate_manual_cents(cents: i64) -> Result<()> {
+    if !(1..=MAX_CENTS_PER_LITKEY).contains(&cents) {
+        anyhow::bail!(
+            "cents_per_litkey must be between 1 and {}",
+            MAX_CENTS_PER_LITKEY
+        );
+    }
+    Ok(())
+}
+
+/// Reject invalid candidates and feed spikes above 100x the most recent valid row.
+pub fn validate_candidate_cents(candidate: i64, recent_cents: Option<i64>) -> RateValidation {
+    if validate_manual_cents(candidate).is_err() {
+        return RateValidation::RejectInvalid;
+    }
+    if let Some(recent) = recent_cents.filter(|r| *r > 0)
+        && candidate > recent.saturating_mul(100)
+    {
+        return RateValidation::RejectAbsurdJump;
+    }
+    RateValidation::Accept
+}
+
+pub fn is_stale(fetched_at: OffsetDateTime, now: OffsetDateTime) -> bool {
+    now - fetched_at > STALE_AFTER
+}
+
+pub fn should_poll_coingecko(current: Option<&LitkeyRate>) -> bool {
+    // A fresh manual override is intentionally authoritative. Let it stand
+    // until it becomes stale; after that, CoinGecko may refresh the row so
+    // crediting is not paused indefinitely.
+    !matches!(current, Some(rate) if rate.source == "manual" && !rate.stale)
+}
+
+pub async fn fetch_coingecko_cents(client: &Client) -> Result<i64> {
+    let body = client
+        .get(COINGECKO_URL)
+        .send()
+        .await
+        .context("fetching CoinGecko LIT price")?
+        .error_for_status()
+        .context("CoinGecko returned non-success status")?
+        .text()
+        .await
+        .context("reading CoinGecko response body")?;
+    parse_coingecko_cents(&body)
+}
+
+pub async fn get_current(pool: &PgPool) -> Result<Option<LitkeyRate>> {
+    let row = sqlx::query_as::<_, (i64, String, OffsetDateTime, Option<i64>)>(
+        "SELECT cents_per_litkey, source, fetched_at, updated_by_operator_id \
+         FROM litkey_rate WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .context("selecting litkey_rate")?;
+
+    let now = OffsetDateTime::now_utc();
+    Ok(row.map(
+        |(cents_per_litkey, source, fetched_at, updated_by_operator_id)| LitkeyRate {
+            cents_per_litkey,
+            source,
+            fetched_at,
+            updated_by_operator_id,
+            stale: is_stale(fetched_at, now),
+        },
+    ))
+}
+
+pub async fn upsert_coingecko(
+    pool: &PgPool,
+    cents_per_litkey: i64,
+    fetched_at: OffsetDateTime,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO litkey_rate (id, cents_per_litkey, source, fetched_at, updated_by_operator_id) \
+         VALUES (1, $1, 'coingecko', $2, NULL) \
+         ON CONFLICT (id) DO UPDATE SET \
+           cents_per_litkey = EXCLUDED.cents_per_litkey, \
+           source = EXCLUDED.source, \
+           fetched_at = EXCLUDED.fetched_at, \
+           updated_by_operator_id = NULL",
+    )
+    .bind(cents_per_litkey)
+    .bind(fetched_at)
+    .execute(pool)
+    .await
+    .context("upserting CoinGecko litkey_rate")?;
+    Ok(())
+}
+
+pub async fn set_manual(pool: &PgPool, cents_per_litkey: i64, operator_id: i64) -> Result<()> {
+    validate_manual_cents(cents_per_litkey)?;
+    sqlx::query(
+        "INSERT INTO litkey_rate (id, cents_per_litkey, source, fetched_at, updated_by_operator_id) \
+         VALUES (1, $1, 'manual', now(), $2) \
+         ON CONFLICT (id) DO UPDATE SET \
+           cents_per_litkey = EXCLUDED.cents_per_litkey, \
+           source = EXCLUDED.source, \
+           fetched_at = EXCLUDED.fetched_at, \
+           updated_by_operator_id = EXCLUDED.updated_by_operator_id",
+    )
+    .bind(cents_per_litkey)
+    .bind(operator_id)
+    .execute(pool)
+    .await
+    .context("setting manual litkey_rate")?;
+    Ok(())
+}
+
+pub fn spawn_rate_poller(pool: PgPool) {
+    tokio::spawn(async move {
+        let client = Client::new();
+        loop {
+            poll_once(&pool, &client).await;
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    });
+}
+
+async fn poll_once(pool: &PgPool, client: &Client) {
+    let current = match get_current(pool).await {
+        Ok(rate) => rate,
+        Err(e) => {
+            tracing::warn!("litkey rate poller could not read current rate: {e}");
+            None
+        }
+    };
+
+    if !should_poll_coingecko(current.as_ref()) {
+        tracing::info!("LITKEY rate poller skipping CoinGecko; fresh manual override is active");
+        return;
+    }
+
+    match fetch_coingecko_cents(client).await {
+        Ok(cents) => {
+            match validate_candidate_cents(cents, current.as_ref().map(|r| r.cents_per_litkey)) {
+                RateValidation::Accept => {
+                    if let Err(e) = upsert_coingecko(pool, cents, OffsetDateTime::now_utc()).await {
+                        tracing::warn!("litkey rate poller failed to save CoinGecko rate: {e}");
+                    } else {
+                        tracing::info!(
+                            cents_per_litkey = cents,
+                            "updated LITKEY rate from CoinGecko"
+                        );
+                    }
+                }
+                RateValidation::RejectInvalid | RateValidation::RejectAbsurdJump => {
+                    tracing::warn!(
+                        candidate_cents = cents,
+                        recent_cents = current.as_ref().map(|r| r.cents_per_litkey),
+                        "CoinGecko LITKEY rate looked invalid/absurd; keeping last-known rate"
+                    );
+                }
+            }
+        }
+        Err(e) => tracing::warn!("litkey rate poller fetch failed; keeping last-known rate: {e}"),
+    }
+
+    if let Ok(Some(rate)) = get_current(pool).await
+        && rate.stale
+    {
+        tracing::warn!(
+            fetched_at = %rate.fetched_at,
+            cents_per_litkey = rate.cents_per_litkey,
+            source = %rate.source,
+            "LITKEY rate is stale (>1h); future payment crediting must pause"
+        );
+    }
+}
+
+/// `GET /api/litkey/rate` — current LITKEY/USD rate, if one exists.
+#[rocket::get("/api/litkey/rate")]
+pub async fn get_rate(_operator: Operator, pool: &State<PgPool>) -> ApiResult<RateResponse> {
+    let rate = get_current(pool).await.map_err(server_err)?;
+    Ok(Json(RateResponse { rate }))
+}
+
+/// `POST /api/litkey/rate/override` — admin-only manual rate override.
+#[rocket::post("/api/litkey/rate/override", format = "json", data = "<req>")]
+pub async fn override_rate(
+    operator: Operator,
+    req: Json<OverrideRateRequest>,
+    pool: &State<PgPool>,
+) -> ApiResult<RateResponse> {
+    if operator.role != Role::Admin {
+        return Err(err(Status::Forbidden, "admin role required"));
+    }
+    let cents = req.cents_per_litkey;
+    validate_manual_cents(cents).map_err(|e| err(Status::BadRequest, e.to_string()))?;
+    set_manual(pool, cents, operator.id)
+        .await
+        .map_err(server_err)?;
+    let rate = get_current(pool).await.map_err(server_err)?;
+    Ok(Json(RateResponse { rate }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::{Duration, OffsetDateTime};
+
+    #[test]
+    fn parses_coingecko_usd_to_integer_cents_with_rounding() {
+        assert_eq!(
+            parse_coingecko_cents(r#"{"lit-protocol":{"usd":0.124}}"#).unwrap(),
+            12
+        );
+        assert_eq!(
+            parse_coingecko_cents(r#"{"lit-protocol":{"usd":0.125}}"#).unwrap(),
+            13
+        );
+    }
+
+    #[test]
+    fn rejects_missing_zero_negative_non_finite_and_absurd_rates() {
+        assert!(parse_coingecko_cents(r#"{}"#).is_err());
+        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":0}}"#).is_err());
+        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":-1}}"#).is_err());
+        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":1e309}}"#).is_err());
+        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":10001}}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_candidate_more_than_100x_recent_rate() {
+        assert_eq!(
+            validate_candidate_cents(1_001, Some(10)),
+            RateValidation::RejectAbsurdJump
+        );
+        assert_eq!(
+            validate_candidate_cents(1_000, Some(10)),
+            RateValidation::Accept
+        );
+        assert_eq!(validate_candidate_cents(50, None), RateValidation::Accept);
+    }
+
+    #[test]
+    fn stale_is_strictly_older_than_one_hour() {
+        let now = OffsetDateTime::now_utc();
+        assert!(!is_stale(now - Duration::hours(1), now));
+        assert!(is_stale(
+            now - Duration::hours(1) - Duration::seconds(1),
+            now
+        ));
+    }
+
+    #[test]
+    fn fresh_manual_override_pauses_coingecko_polling_until_stale() {
+        let now = OffsetDateTime::now_utc();
+        let fresh_manual = LitkeyRate {
+            cents_per_litkey: 12,
+            source: "manual".to_string(),
+            fetched_at: now,
+            updated_by_operator_id: Some(1),
+            stale: false,
+        };
+        let stale_manual = LitkeyRate {
+            stale: true,
+            ..fresh_manual.clone()
+        };
+        let coingecko = LitkeyRate {
+            source: "coingecko".to_string(),
+            updated_by_operator_id: None,
+            stale: false,
+            ..fresh_manual.clone()
+        };
+
+        assert!(!should_poll_coingecko(Some(&fresh_manual)));
+        assert!(should_poll_coingecko(Some(&stale_manual)));
+        assert!(should_poll_coingecko(Some(&coingecko)));
+        assert!(should_poll_coingecko(None));
+    }
+
+    #[test]
+    fn manual_override_validation_accepts_positive_reasonable_cents_only() {
+        assert!(validate_manual_cents(1).is_ok());
+        assert!(validate_manual_cents(1_000_000).is_ok());
+        assert!(validate_manual_cents(0).is_err());
+        assert!(validate_manual_cents(1_000_001).is_err());
+    }
+}

--- a/lit-payments/src/rate.rs
+++ b/lit-payments/src/rate.rs
@@ -1,5 +1,7 @@
 //! LITKEY/USD rate parsing, validation, persistence, admin API, and polling.
 
+use std::time::Duration as StdDuration;
+
 use anyhow::{Context, Result, anyhow};
 use reqwest::Client;
 use rocket::State;
@@ -36,6 +38,7 @@ pub struct RateResponse {
     pub rate: Option<LitkeyRate>,
     pub discount_basis_points: i64,
     pub effective_cents_per_litkey: Option<i64>,
+    pub crediting_paused: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,10 +144,10 @@ pub fn is_stale(fetched_at: OffsetDateTime, now: OffsetDateTime) -> bool {
 }
 
 pub fn should_poll_coingecko(current: Option<&LitkeyRate>) -> bool {
-    // A fresh manual override is intentionally authoritative. Let it stand
-    // until it becomes stale; after that, CoinGecko may refresh the row so
-    // crediting is not paused indefinitely.
-    !matches!(current, Some(rate) if rate.source == "manual" && !rate.stale)
+    // A manual override is intentionally authoritative until an admin changes
+    // it. It may become stale (and therefore pause crediting), but the poller
+    // should not automatically overwrite it with the source the admin overrode.
+    !matches!(current, Some(rate) if rate.source == "manual")
 }
 
 pub async fn fetch_coingecko_cents(client: &Client) -> Result<i64> {
@@ -223,9 +226,23 @@ pub async fn set_manual(pool: &PgPool, cents_per_litkey: i64, operator_id: i64) 
     Ok(())
 }
 
+fn coingecko_client() -> Result<Client> {
+    Client::builder()
+        .connect_timeout(StdDuration::from_secs(5))
+        .timeout(StdDuration::from_secs(10))
+        .build()
+        .context("building CoinGecko HTTP client")
+}
+
 pub fn spawn_rate_poller(pool: PgPool) {
     tokio::spawn(async move {
-        let client = Client::new();
+        let client = match coingecko_client() {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::warn!("litkey rate poller could not start: {e}");
+                return;
+            }
+        };
         loop {
             poll_once(&pool, &client).await;
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -298,6 +315,16 @@ pub async fn get_rate(
     )?))
 }
 
+/// `GET /api/litkey/quote` — public quote for the end-user pay-with-LITKEY page.
+#[rocket::get("/api/litkey/quote")]
+pub async fn get_quote(pool: &State<PgPool>, config: &State<Config>) -> ApiResult<RateResponse> {
+    let rate = get_current(pool).await.map_err(server_err)?;
+    Ok(Json(build_rate_response(
+        rate,
+        config.litkey_discount_basis_points,
+    )?))
+}
+
 /// `POST /api/litkey/rate/override` — admin-only manual rate override.
 #[rocket::post("/api/litkey/rate/override", format = "json", data = "<req>")]
 pub async fn override_rate(
@@ -325,8 +352,10 @@ fn build_rate_response(
     rate: Option<LitkeyRate>,
     discount_basis_points: i64,
 ) -> Result<RateResponse, ApiError> {
+    let crediting_paused = rate.as_ref().is_none_or(|r| r.stale);
     let effective_cents_per_litkey = rate
         .as_ref()
+        .filter(|_| !crediting_paused)
         .map(|r| apply_discount_to_cents(r.cents_per_litkey, discount_basis_points))
         .transpose()
         .map_err(server_err)?;
@@ -334,6 +363,7 @@ fn build_rate_response(
         rate,
         discount_basis_points,
         effective_cents_per_litkey,
+        crediting_paused,
     })
 }
 
@@ -387,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_manual_override_pauses_coingecko_polling_until_stale() {
+    fn manual_override_pauses_coingecko_polling_until_admin_changes_it() {
         let now = OffsetDateTime::now_utc();
         let fresh_manual = LitkeyRate {
             cents_per_litkey: 12,
@@ -408,9 +438,45 @@ mod tests {
         };
 
         assert!(!should_poll_coingecko(Some(&fresh_manual)));
-        assert!(should_poll_coingecko(Some(&stale_manual)));
+        assert!(!should_poll_coingecko(Some(&stale_manual)));
         assert!(should_poll_coingecko(Some(&coingecko)));
         assert!(should_poll_coingecko(None));
+    }
+
+    #[test]
+    fn stale_or_missing_rate_pauses_crediting_and_hides_effective_rate() {
+        let now = OffsetDateTime::now_utc();
+        let stale_rate = LitkeyRate {
+            cents_per_litkey: 100,
+            source: "coingecko".to_string(),
+            fetched_at: now - Duration::hours(2),
+            updated_by_operator_id: None,
+            stale: true,
+        };
+
+        let missing = build_rate_response(None, 2_000).unwrap();
+        assert!(missing.crediting_paused);
+        assert_eq!(missing.effective_cents_per_litkey, None);
+
+        let stale = build_rate_response(Some(stale_rate), 2_000).unwrap();
+        assert!(stale.crediting_paused);
+        assert_eq!(stale.effective_cents_per_litkey, None);
+    }
+
+    #[test]
+    fn fresh_rate_exposes_discount_adjusted_effective_rate() {
+        let now = OffsetDateTime::now_utc();
+        let fresh_rate = LitkeyRate {
+            cents_per_litkey: 100,
+            source: "coingecko".to_string(),
+            fetched_at: now,
+            updated_by_operator_id: None,
+            stale: false,
+        };
+
+        let response = build_rate_response(Some(fresh_rate), 2_000).unwrap();
+        assert!(!response.crediting_paused);
+        assert_eq!(response.effective_cents_per_litkey, Some(125));
     }
 
     #[test]

--- a/lit-payments/src/rate.rs
+++ b/lit-payments/src/rate.rs
@@ -11,6 +11,7 @@ use time::{Duration, OffsetDateTime};
 
 use crate::auth::Operator;
 use crate::auth::operator::Role;
+use crate::config::Config;
 use crate::portal::types::ErrorResponse;
 
 pub const COINGECKO_URL: &str =
@@ -18,6 +19,7 @@ pub const COINGECKO_URL: &str =
 pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 pub const STALE_AFTER: Duration = Duration::hours(1);
 pub const MAX_CENTS_PER_LITKEY: i64 = 1_000_000; // $10,000/LITKEY: reject obvious feed nonsense.
+pub const MAX_DISCOUNT_BASIS_POINTS: i64 = 9_000; // Cap at 90% off to avoid effectively-free credits.
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LitkeyRate {
@@ -32,6 +34,8 @@ pub struct LitkeyRate {
 #[derive(Debug, Serialize)]
 pub struct RateResponse {
     pub rate: Option<LitkeyRate>,
+    pub discount_basis_points: i64,
+    pub effective_cents_per_litkey: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -91,6 +95,32 @@ pub fn validate_manual_cents(cents: i64) -> Result<()> {
         );
     }
     Ok(())
+}
+
+pub fn validate_discount_basis_points(discount_basis_points: i64) -> Result<()> {
+    if !(0..=MAX_DISCOUNT_BASIS_POINTS).contains(&discount_basis_points) {
+        anyhow::bail!(
+            "LITKEY_DISCOUNT_BASIS_POINTS must be between 0 and {} basis points",
+            MAX_DISCOUNT_BASIS_POINTS
+        );
+    }
+    Ok(())
+}
+
+/// Convert market cents/LITKEY into Stripe credit cents/LITKEY after discount.
+///
+/// A 20% discount means paying $0.80 worth of LITKEY should buy $1.00 of
+/// Stripe credit, so the credit rate is market_rate / (1 - discount).
+pub fn apply_discount_to_cents(
+    market_cents_per_litkey: i64,
+    discount_basis_points: i64,
+) -> Result<i64> {
+    validate_manual_cents(market_cents_per_litkey)?;
+    validate_discount_basis_points(discount_basis_points)?;
+    let denominator = 10_000_i128 - i128::from(discount_basis_points);
+    let numerator = i128::from(market_cents_per_litkey) * 10_000_i128;
+    let rounded = (numerator + denominator / 2) / denominator;
+    i64::try_from(rounded).context("discount-adjusted LITKEY cents overflowed i64")
 }
 
 /// Reject invalid candidates and feed spikes above 100x the most recent valid row.
@@ -256,9 +286,16 @@ async fn poll_once(pool: &PgPool, client: &Client) {
 
 /// `GET /api/litkey/rate` — current LITKEY/USD rate, if one exists.
 #[rocket::get("/api/litkey/rate")]
-pub async fn get_rate(_operator: Operator, pool: &State<PgPool>) -> ApiResult<RateResponse> {
+pub async fn get_rate(
+    _operator: Operator,
+    pool: &State<PgPool>,
+    config: &State<Config>,
+) -> ApiResult<RateResponse> {
     let rate = get_current(pool).await.map_err(server_err)?;
-    Ok(Json(RateResponse { rate }))
+    Ok(Json(build_rate_response(
+        rate,
+        config.litkey_discount_basis_points,
+    )?))
 }
 
 /// `POST /api/litkey/rate/override` — admin-only manual rate override.
@@ -267,6 +304,7 @@ pub async fn override_rate(
     operator: Operator,
     req: Json<OverrideRateRequest>,
     pool: &State<PgPool>,
+    config: &State<Config>,
 ) -> ApiResult<RateResponse> {
     if operator.role != Role::Admin {
         return Err(err(Status::Forbidden, "admin role required"));
@@ -277,7 +315,26 @@ pub async fn override_rate(
         .await
         .map_err(server_err)?;
     let rate = get_current(pool).await.map_err(server_err)?;
-    Ok(Json(RateResponse { rate }))
+    Ok(Json(build_rate_response(
+        rate,
+        config.litkey_discount_basis_points,
+    )?))
+}
+
+fn build_rate_response(
+    rate: Option<LitkeyRate>,
+    discount_basis_points: i64,
+) -> Result<RateResponse, ApiError> {
+    let effective_cents_per_litkey = rate
+        .as_ref()
+        .map(|r| apply_discount_to_cents(r.cents_per_litkey, discount_basis_points))
+        .transpose()
+        .map_err(server_err)?;
+    Ok(RateResponse {
+        rate,
+        discount_basis_points,
+        effective_cents_per_litkey,
+    })
 }
 
 #[cfg(test)]
@@ -362,5 +419,23 @@ mod tests {
         assert!(validate_manual_cents(1_000_000).is_ok());
         assert!(validate_manual_cents(0).is_err());
         assert!(validate_manual_cents(1_000_001).is_err());
+    }
+
+    #[test]
+    fn applies_litkey_discount_as_extra_credit_per_token() {
+        assert_eq!(apply_discount_to_cents(100, 0).unwrap(), 100);
+        // 20% off means paying $0.80 worth of LITKEY buys $1.00 credit,
+        // so each token credits 1 / (1 - 0.20) = 1.25x spot value.
+        assert_eq!(apply_discount_to_cents(100, 2_000).unwrap(), 125);
+        assert_eq!(apply_discount_to_cents(33, 2_000).unwrap(), 41);
+    }
+
+    #[test]
+    fn validates_litkey_discount_basis_points() {
+        assert!(validate_discount_basis_points(0).is_ok());
+        assert!(validate_discount_basis_points(2_000).is_ok());
+        assert!(validate_discount_basis_points(9_000).is_ok());
+        assert!(validate_discount_basis_points(-1).is_err());
+        assert!(validate_discount_basis_points(9_001).is_err());
     }
 }

--- a/lit-payments/src/rate.rs
+++ b/lit-payments/src/rate.rs
@@ -1,8 +1,11 @@
 //! LITKEY/USD rate parsing, validation, persistence, admin API, and polling.
 
+use std::str::FromStr;
 use std::time::Duration as StdDuration;
 
 use anyhow::{Context, Result, anyhow};
+use num_bigint::BigUint;
+use num_traits::ToPrimitive;
 use reqwest::Client;
 use rocket::State;
 use rocket::http::Status;
@@ -20,12 +23,12 @@ pub const COINGECKO_URL: &str =
     "https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd";
 pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 pub const STALE_AFTER: Duration = Duration::hours(1);
-pub const MAX_CENTS_PER_LITKEY: i64 = 1_000_000; // $10,000/LITKEY: reject obvious feed nonsense.
+pub const MAX_USD_WEI_PER_LITKEY: &str = "10000000000000000000000"; // $10,000/LITKEY scaled by 1e18: reject obvious feed nonsense.
 pub const MAX_DISCOUNT_BASIS_POINTS: i64 = 9_000; // Cap at 90% off to avoid effectively-free credits.
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LitkeyRate {
-    pub cents_per_litkey: i64,
+    pub usd_wei_per_litkey: String,
     pub source: String,
     #[serde(with = "time::serde::rfc3339")]
     pub fetched_at: OffsetDateTime,
@@ -37,13 +40,13 @@ pub struct LitkeyRate {
 pub struct RateResponse {
     pub rate: Option<LitkeyRate>,
     pub discount_basis_points: i64,
-    pub effective_cents_per_litkey: Option<i64>,
+    pub effective_usd_wei_per_litkey: Option<String>,
     pub crediting_paused: bool,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct OverrideRateRequest {
-    pub cents_per_litkey: i64,
+    pub usd_wei_per_litkey: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,31 +73,105 @@ fn server_err(e: impl std::fmt::Display) -> ApiError {
     err(Status::InternalServerError, "internal error")
 }
 
-/// Parse CoinGecko's `simple/price` response and convert USD to integer cents.
-pub fn parse_coingecko_cents(body: &str) -> Result<i64> {
+const USD_FIXED_POINT_DECIMALS: usize = 18;
+const USD_FIXED_POINT_SCALE: &str = "1000000000000000000";
+const LITKEY_WEI_PER_TOKEN: &str = "1000000000000000000";
+
+fn max_usd_wei_per_litkey() -> BigUint {
+    BigUint::from_str(MAX_USD_WEI_PER_LITKEY).expect("valid MAX_USD_WEI_PER_LITKEY")
+}
+
+fn usd_scale() -> BigUint {
+    BigUint::from_str(USD_FIXED_POINT_SCALE).expect("valid USD_FIXED_POINT_SCALE")
+}
+
+fn litkey_scale() -> BigUint {
+    BigUint::from_str(LITKEY_WEI_PER_TOKEN).expect("valid LITKEY_WEI_PER_TOKEN")
+}
+
+fn parse_biguint_decimal(raw: &str, field: &str) -> Result<BigUint> {
+    if raw.is_empty() || raw.starts_with('+') || raw.starts_with('-') {
+        anyhow::bail!("{field} must be an unsigned integer string");
+    }
+    if !raw.bytes().all(|b| b.is_ascii_digit()) {
+        anyhow::bail!("{field} must contain only decimal digits");
+    }
+    BigUint::from_str(raw).with_context(|| format!("parsing {field}"))
+}
+
+fn parse_decimal_to_scaled_units(raw: &str, decimals: usize) -> Result<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.starts_with('+') || raw.starts_with('-') {
+        anyhow::bail!("USD rate must be positive, got {raw:?}");
+    }
+
+    let (mantissa, exponent) = if let Some((mantissa, exponent)) = raw.split_once(['e', 'E']) {
+        let exponent = exponent
+            .parse::<i32>()
+            .with_context(|| format!("USD rate has invalid exponent: {raw:?}"))?;
+        (mantissa, exponent)
+    } else {
+        (raw, 0)
+    };
+
+    let (whole, fractional) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    if whole.is_empty() && fractional.is_empty() {
+        anyhow::bail!("USD rate is empty");
+    }
+    if !whole.bytes().all(|b| b.is_ascii_digit()) || !fractional.bytes().all(|b| b.is_ascii_digit())
+    {
+        anyhow::bail!(
+            "USD rate must contain only digits, one decimal point, and optional exponent"
+        );
+    }
+
+    let mut digits = format!("{whole}{fractional}");
+    digits = digits.trim_start_matches('0').to_string();
+    if digits.is_empty() {
+        anyhow::bail!("USD rate is zero");
+    }
+
+    let power = exponent - i32::try_from(fractional.len()).expect("fraction length fits i32")
+        + i32::try_from(decimals).expect("scale decimals fit i32");
+    let units = if power >= 0 {
+        format!("{}{}", digits, "0".repeat(power as usize))
+    } else {
+        let keep_len = digits.len().saturating_sub((-power) as usize);
+        digits[..keep_len].to_string()
+    };
+    let units = units.trim_start_matches('0');
+    if units.is_empty() {
+        anyhow::bail!("USD rate rounds/truncates to zero at {decimals} decimals");
+    }
+    Ok(units.to_string())
+}
+
+/// Parse CoinGecko's `simple/price` response and convert USD to integer
+/// 18-decimal USD fixed-point units per 1 whole LITKEY.
+///
+/// Example: `$0.006/LITKEY` becomes `6000000000000000`.
+pub fn parse_coingecko_usd_wei(body: &str) -> Result<String> {
     let v: serde_json::Value = serde_json::from_str(body).context("parsing CoinGecko JSON")?;
     let usd = v
         .get("lit-protocol")
         .and_then(|obj| obj.get("usd"))
-        .and_then(|usd| usd.as_f64())
         .ok_or_else(|| anyhow!("CoinGecko response missing lit-protocol.usd"))?;
-
-    if !usd.is_finite() || usd <= 0.0 {
-        anyhow::bail!("CoinGecko returned non-positive or non-finite USD rate: {usd}");
-    }
-
-    let cents = (usd * 100.0).round();
-    if !cents.is_finite() || cents < 1.0 || cents > MAX_CENTS_PER_LITKEY as f64 {
-        anyhow::bail!("CoinGecko USD rate converts to invalid cents value: {cents}");
-    }
-    Ok(cents as i64)
+    let usd = match usd {
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => s.clone(),
+        _ => anyhow::bail!("CoinGecko lit-protocol.usd was not a number"),
+    };
+    let usd_wei = parse_decimal_to_scaled_units(&usd, USD_FIXED_POINT_DECIMALS)?;
+    validate_manual_usd_wei(&usd_wei)?;
+    Ok(usd_wei)
 }
 
-pub fn validate_manual_cents(cents: i64) -> Result<()> {
-    if !(1..=MAX_CENTS_PER_LITKEY).contains(&cents) {
+pub fn validate_manual_usd_wei(usd_wei_per_litkey: &str) -> Result<()> {
+    let value = parse_biguint_decimal(usd_wei_per_litkey, "usd_wei_per_litkey")?;
+    if value == BigUint::from(0_u8) || value > max_usd_wei_per_litkey() {
         anyhow::bail!(
-            "cents_per_litkey must be between 1 and {}",
-            MAX_CENTS_PER_LITKEY
+            "usd_wei_per_litkey must be between 1 and {}",
+            MAX_USD_WEI_PER_LITKEY
         );
     }
     Ok(())
@@ -110,31 +187,62 @@ pub fn validate_discount_basis_points(discount_basis_points: i64) -> Result<()> 
     Ok(())
 }
 
-/// Convert market cents/LITKEY into Stripe credit cents/LITKEY after discount.
-///
-/// A 20% discount means paying $0.80 worth of LITKEY should buy $1.00 of
-/// Stripe credit, so the credit rate is market_rate / (1 - discount).
-pub fn apply_discount_to_cents(
-    market_cents_per_litkey: i64,
+fn div_round_half_up(numerator: BigUint, denominator: BigUint) -> BigUint {
+    (&numerator + (&denominator / 2_u8)) / denominator
+}
+
+/// Convert market USD wei/LITKEY into effective credit USD wei/LITKEY after
+/// the configured discount. A 20% discount means paying $0.80 worth of
+/// LITKEY buys $1.00 Stripe credit, so effective rate is market/(1-discount).
+pub fn apply_discount_to_usd_wei(
+    market_usd_wei_per_litkey: &str,
+    discount_basis_points: i64,
+) -> Result<String> {
+    validate_manual_usd_wei(market_usd_wei_per_litkey)?;
+    validate_discount_basis_points(discount_basis_points)?;
+    let denominator_bps = 10_000_i64 - discount_basis_points;
+    let numerator = parse_biguint_decimal(market_usd_wei_per_litkey, "usd_wei_per_litkey")?
+        * BigUint::from(10_000_u32);
+    let rounded = div_round_half_up(numerator, BigUint::from(denominator_bps as u32));
+    Ok(rounded.to_string())
+}
+
+/// Compute final Stripe credit cents from native token units and 18-decimal
+/// USD fixed-point price. This is the settlement helper for the future
+/// listener: keep LITKEY wei and USD wei as integers, apply discount, then
+/// round once at the final Stripe-cent boundary.
+pub fn litkey_wei_to_credit_cents(
+    litkey_amount_wei: &str,
+    usd_wei_per_litkey: &str,
     discount_basis_points: i64,
 ) -> Result<i64> {
-    validate_manual_cents(market_cents_per_litkey)?;
+    validate_manual_usd_wei(usd_wei_per_litkey)?;
     validate_discount_basis_points(discount_basis_points)?;
-    let denominator = 10_000_i128 - i128::from(discount_basis_points);
-    let numerator = i128::from(market_cents_per_litkey) * 10_000_i128;
-    let rounded = (numerator + denominator / 2) / denominator;
-    i64::try_from(rounded).context("discount-adjusted LITKEY cents overflowed i64")
+    let denominator_bps = 10_000_i64 - discount_basis_points;
+    let numerator = parse_biguint_decimal(litkey_amount_wei, "litkey_amount_wei")?
+        * parse_biguint_decimal(usd_wei_per_litkey, "usd_wei_per_litkey")?
+        * BigUint::from(100_u32)
+        * BigUint::from(10_000_u32);
+    let denominator = litkey_scale() * usd_scale() * BigUint::from(denominator_bps as u32);
+    let cents = div_round_half_up(numerator, denominator);
+    cents
+        .to_i64()
+        .context("computed Stripe cents overflowed i64")
 }
 
 /// Reject invalid candidates and feed spikes above 100x the most recent valid row.
-pub fn validate_candidate_cents(candidate: i64, recent_cents: Option<i64>) -> RateValidation {
-    if validate_manual_cents(candidate).is_err() {
+pub fn validate_candidate_usd_wei(candidate: &str, recent_usd_wei: Option<&str>) -> RateValidation {
+    if validate_manual_usd_wei(candidate).is_err() {
         return RateValidation::RejectInvalid;
     }
-    if let Some(recent) = recent_cents.filter(|r| *r > 0)
-        && candidate > recent.saturating_mul(100)
-    {
-        return RateValidation::RejectAbsurdJump;
+    if let Some(recent) = recent_usd_wei {
+        let candidate = parse_biguint_decimal(candidate, "candidate usd_wei_per_litkey")
+            .expect("already validated candidate");
+        if let Ok(recent) = parse_biguint_decimal(recent, "recent usd_wei_per_litkey")
+            && candidate > recent * BigUint::from(100_u32)
+        {
+            return RateValidation::RejectAbsurdJump;
+        }
     }
     RateValidation::Accept
 }
@@ -150,7 +258,7 @@ pub fn should_poll_coingecko(current: Option<&LitkeyRate>) -> bool {
     !matches!(current, Some(rate) if rate.source == "manual")
 }
 
-pub async fn fetch_coingecko_cents(client: &Client) -> Result<i64> {
+pub async fn fetch_coingecko_usd_wei(client: &Client) -> Result<String> {
     let body = client
         .get(COINGECKO_URL)
         .send()
@@ -161,12 +269,12 @@ pub async fn fetch_coingecko_cents(client: &Client) -> Result<i64> {
         .text()
         .await
         .context("reading CoinGecko response body")?;
-    parse_coingecko_cents(&body)
+    parse_coingecko_usd_wei(&body)
 }
 
 pub async fn get_current(pool: &PgPool) -> Result<Option<LitkeyRate>> {
-    let row = sqlx::query_as::<_, (i64, String, OffsetDateTime, Option<i64>)>(
-        "SELECT cents_per_litkey, source, fetched_at, updated_by_operator_id \
+    let row = sqlx::query_as::<_, (String, String, OffsetDateTime, Option<i64>)>(
+        "SELECT usd_wei_per_litkey::text, source, fetched_at, updated_by_operator_id \
          FROM litkey_rate WHERE id = 1",
     )
     .fetch_optional(pool)
@@ -175,8 +283,8 @@ pub async fn get_current(pool: &PgPool) -> Result<Option<LitkeyRate>> {
 
     let now = OffsetDateTime::now_utc();
     Ok(row.map(
-        |(cents_per_litkey, source, fetched_at, updated_by_operator_id)| LitkeyRate {
-            cents_per_litkey,
+        |(usd_wei_per_litkey, source, fetched_at, updated_by_operator_id)| LitkeyRate {
+            usd_wei_per_litkey,
             source,
             fetched_at,
             updated_by_operator_id,
@@ -187,19 +295,19 @@ pub async fn get_current(pool: &PgPool) -> Result<Option<LitkeyRate>> {
 
 pub async fn upsert_coingecko(
     pool: &PgPool,
-    cents_per_litkey: i64,
+    usd_wei_per_litkey: &str,
     fetched_at: OffsetDateTime,
 ) -> Result<()> {
     sqlx::query(
-        "INSERT INTO litkey_rate (id, cents_per_litkey, source, fetched_at, updated_by_operator_id) \
-         VALUES (1, $1, 'coingecko', $2, NULL) \
+        "INSERT INTO litkey_rate (id, usd_wei_per_litkey, source, fetched_at, updated_by_operator_id) \
+         VALUES (1, $1::numeric, 'coingecko', $2, NULL) \
          ON CONFLICT (id) DO UPDATE SET \
-           cents_per_litkey = EXCLUDED.cents_per_litkey, \
+           usd_wei_per_litkey = EXCLUDED.usd_wei_per_litkey, \
            source = EXCLUDED.source, \
            fetched_at = EXCLUDED.fetched_at, \
            updated_by_operator_id = NULL",
     )
-    .bind(cents_per_litkey)
+    .bind(usd_wei_per_litkey)
     .bind(fetched_at)
     .execute(pool)
     .await
@@ -207,18 +315,18 @@ pub async fn upsert_coingecko(
     Ok(())
 }
 
-pub async fn set_manual(pool: &PgPool, cents_per_litkey: i64, operator_id: i64) -> Result<()> {
-    validate_manual_cents(cents_per_litkey)?;
+pub async fn set_manual(pool: &PgPool, usd_wei_per_litkey: &str, operator_id: i64) -> Result<()> {
+    validate_manual_usd_wei(usd_wei_per_litkey)?;
     sqlx::query(
-        "INSERT INTO litkey_rate (id, cents_per_litkey, source, fetched_at, updated_by_operator_id) \
-         VALUES (1, $1, 'manual', now(), $2) \
+        "INSERT INTO litkey_rate (id, usd_wei_per_litkey, source, fetched_at, updated_by_operator_id) \
+         VALUES (1, $1::numeric, 'manual', now(), $2) \
          ON CONFLICT (id) DO UPDATE SET \
-           cents_per_litkey = EXCLUDED.cents_per_litkey, \
+           usd_wei_per_litkey = EXCLUDED.usd_wei_per_litkey, \
            source = EXCLUDED.source, \
            fetched_at = EXCLUDED.fetched_at, \
            updated_by_operator_id = EXCLUDED.updated_by_operator_id",
     )
-    .bind(cents_per_litkey)
+    .bind(usd_wei_per_litkey)
     .bind(operator_id)
     .execute(pool)
     .await
@@ -264,23 +372,28 @@ async fn poll_once(pool: &PgPool, client: &Client) {
         return;
     }
 
-    match fetch_coingecko_cents(client).await {
-        Ok(cents) => {
-            match validate_candidate_cents(cents, current.as_ref().map(|r| r.cents_per_litkey)) {
+    match fetch_coingecko_usd_wei(client).await {
+        Ok(usd_wei) => {
+            match validate_candidate_usd_wei(
+                &usd_wei,
+                current.as_ref().map(|r| r.usd_wei_per_litkey.as_str()),
+            ) {
                 RateValidation::Accept => {
-                    if let Err(e) = upsert_coingecko(pool, cents, OffsetDateTime::now_utc()).await {
+                    if let Err(e) =
+                        upsert_coingecko(pool, &usd_wei, OffsetDateTime::now_utc()).await
+                    {
                         tracing::warn!("litkey rate poller failed to save CoinGecko rate: {e}");
                     } else {
                         tracing::info!(
-                            cents_per_litkey = cents,
+                            usd_wei_per_litkey = %usd_wei,
                             "updated LITKEY rate from CoinGecko"
                         );
                     }
                 }
                 RateValidation::RejectInvalid | RateValidation::RejectAbsurdJump => {
                     tracing::warn!(
-                        candidate_cents = cents,
-                        recent_cents = current.as_ref().map(|r| r.cents_per_litkey),
+                        candidate_usd_wei_per_litkey = %usd_wei,
+                        recent_usd_wei_per_litkey = current.as_ref().map(|r| r.usd_wei_per_litkey.as_str()),
                         "CoinGecko LITKEY rate looked invalid/absurd; keeping last-known rate"
                     );
                 }
@@ -294,7 +407,7 @@ async fn poll_once(pool: &PgPool, client: &Client) {
     {
         tracing::warn!(
             fetched_at = %rate.fetched_at,
-            cents_per_litkey = rate.cents_per_litkey,
+            usd_wei_per_litkey = rate.usd_wei_per_litkey,
             source = %rate.source,
             "LITKEY rate is stale (>1h); future payment crediting must pause"
         );
@@ -336,9 +449,9 @@ pub async fn override_rate(
     if operator.role != Role::Admin {
         return Err(err(Status::Forbidden, "admin role required"));
     }
-    let cents = req.cents_per_litkey;
-    validate_manual_cents(cents).map_err(|e| err(Status::BadRequest, e.to_string()))?;
-    set_manual(pool, cents, operator.id)
+    let usd_wei = req.usd_wei_per_litkey.trim();
+    validate_manual_usd_wei(usd_wei).map_err(|e| err(Status::BadRequest, e.to_string()))?;
+    set_manual(pool, usd_wei, operator.id)
         .await
         .map_err(server_err)?;
     let rate = get_current(pool).await.map_err(server_err)?;
@@ -353,16 +466,16 @@ fn build_rate_response(
     discount_basis_points: i64,
 ) -> Result<RateResponse, ApiError> {
     let crediting_paused = rate.as_ref().is_none_or(|r| r.stale);
-    let effective_cents_per_litkey = rate
+    let effective_usd_wei_per_litkey = rate
         .as_ref()
         .filter(|_| !crediting_paused)
-        .map(|r| apply_discount_to_cents(r.cents_per_litkey, discount_basis_points))
+        .map(|r| apply_discount_to_usd_wei(&r.usd_wei_per_litkey, discount_basis_points))
         .transpose()
         .map_err(server_err)?;
     Ok(RateResponse {
         rate,
         discount_basis_points,
-        effective_cents_per_litkey,
+        effective_usd_wei_per_litkey,
         crediting_paused,
     })
 }
@@ -373,37 +486,64 @@ mod tests {
     use time::{Duration, OffsetDateTime};
 
     #[test]
-    fn parses_coingecko_usd_to_integer_cents_with_rounding() {
+    fn parses_coingecko_usd_to_18_decimal_usd_wei_without_losing_sub_cent_prices() {
         assert_eq!(
-            parse_coingecko_cents(r#"{"lit-protocol":{"usd":0.124}}"#).unwrap(),
-            12
+            parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":0.006}}"#).unwrap(),
+            "6000000000000000"
         );
         assert_eq!(
-            parse_coingecko_cents(r#"{"lit-protocol":{"usd":0.125}}"#).unwrap(),
-            13
+            parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":0.000000000000000001}}"#).unwrap(),
+            "1"
+        );
+        assert_eq!(
+            parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":0.1234567891234567894}}"#).unwrap(),
+            "123456789123456789"
+        );
+    }
+
+    #[test]
+    fn computes_stripe_cents_from_litkey_wei_with_final_step_rounding() {
+        let one_litkey_wei = "1000000000000000000";
+        let usd_wei_per_litkey = "6000000000000000"; // $0.006/LITKEY
+
+        assert_eq!(
+            litkey_wei_to_credit_cents(one_litkey_wei, usd_wei_per_litkey, 0).unwrap(),
+            1
+        );
+        assert_eq!(
+            litkey_wei_to_credit_cents(
+                "1000000000000000000000", // 1,000 LITKEY
+                usd_wei_per_litkey,
+                2_000,
+            )
+            .unwrap(),
+            750
         );
     }
 
     #[test]
     fn rejects_missing_zero_negative_non_finite_and_absurd_rates() {
-        assert!(parse_coingecko_cents(r#"{}"#).is_err());
-        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":0}}"#).is_err());
-        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":-1}}"#).is_err());
-        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":1e309}}"#).is_err());
-        assert!(parse_coingecko_cents(r#"{"lit-protocol":{"usd":10001}}"#).is_err());
+        assert!(parse_coingecko_usd_wei(r#"{}"#).is_err());
+        assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":0}}"#).is_err());
+        assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":-1}}"#).is_err());
+        assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":1e309}}"#).is_err());
+        assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":10001}}"#).is_err());
     }
 
     #[test]
     fn rejects_candidate_more_than_100x_recent_rate() {
         assert_eq!(
-            validate_candidate_cents(1_001, Some(10)),
+            validate_candidate_usd_wei("1001", Some("10")),
             RateValidation::RejectAbsurdJump
         );
         assert_eq!(
-            validate_candidate_cents(1_000, Some(10)),
+            validate_candidate_usd_wei("1000", Some("10")),
             RateValidation::Accept
         );
-        assert_eq!(validate_candidate_cents(50, None), RateValidation::Accept);
+        assert_eq!(
+            validate_candidate_usd_wei("50", None),
+            RateValidation::Accept
+        );
     }
 
     #[test]
@@ -420,7 +560,7 @@ mod tests {
     fn manual_override_pauses_coingecko_polling_until_admin_changes_it() {
         let now = OffsetDateTime::now_utc();
         let fresh_manual = LitkeyRate {
-            cents_per_litkey: 12,
+            usd_wei_per_litkey: "12".to_string(),
             source: "manual".to_string(),
             fetched_at: now,
             updated_by_operator_id: Some(1),
@@ -447,7 +587,7 @@ mod tests {
     fn stale_or_missing_rate_pauses_crediting_and_hides_effective_rate() {
         let now = OffsetDateTime::now_utc();
         let stale_rate = LitkeyRate {
-            cents_per_litkey: 100,
+            usd_wei_per_litkey: "100".to_string(),
             source: "coingecko".to_string(),
             fetched_at: now - Duration::hours(2),
             updated_by_operator_id: None,
@@ -456,18 +596,18 @@ mod tests {
 
         let missing = build_rate_response(None, 2_000).unwrap();
         assert!(missing.crediting_paused);
-        assert_eq!(missing.effective_cents_per_litkey, None);
+        assert_eq!(missing.effective_usd_wei_per_litkey, None);
 
         let stale = build_rate_response(Some(stale_rate), 2_000).unwrap();
         assert!(stale.crediting_paused);
-        assert_eq!(stale.effective_cents_per_litkey, None);
+        assert_eq!(stale.effective_usd_wei_per_litkey, None);
     }
 
     #[test]
     fn fresh_rate_exposes_discount_adjusted_effective_rate() {
         let now = OffsetDateTime::now_utc();
         let fresh_rate = LitkeyRate {
-            cents_per_litkey: 100,
+            usd_wei_per_litkey: "100".to_string(),
             source: "coingecko".to_string(),
             fetched_at: now,
             updated_by_operator_id: None,
@@ -476,24 +616,27 @@ mod tests {
 
         let response = build_rate_response(Some(fresh_rate), 2_000).unwrap();
         assert!(!response.crediting_paused);
-        assert_eq!(response.effective_cents_per_litkey, Some(125));
+        assert_eq!(
+            response.effective_usd_wei_per_litkey,
+            Some("125".to_string())
+        );
     }
 
     #[test]
-    fn manual_override_validation_accepts_positive_reasonable_cents_only() {
-        assert!(validate_manual_cents(1).is_ok());
-        assert!(validate_manual_cents(1_000_000).is_ok());
-        assert!(validate_manual_cents(0).is_err());
-        assert!(validate_manual_cents(1_000_001).is_err());
+    fn manual_override_validation_accepts_positive_reasonable_usd_wei_only() {
+        assert!(validate_manual_usd_wei("1").is_ok());
+        assert!(validate_manual_usd_wei(MAX_USD_WEI_PER_LITKEY).is_ok());
+        assert!(validate_manual_usd_wei("0").is_err());
+        assert!(validate_manual_usd_wei("10000000000000000000001").is_err());
     }
 
     #[test]
     fn applies_litkey_discount_as_extra_credit_per_token() {
-        assert_eq!(apply_discount_to_cents(100, 0).unwrap(), 100);
+        assert_eq!(apply_discount_to_usd_wei("100", 0).unwrap(), "100");
         // 20% off means paying $0.80 worth of LITKEY buys $1.00 credit,
         // so each token credits 1 / (1 - 0.20) = 1.25x spot value.
-        assert_eq!(apply_discount_to_cents(100, 2_000).unwrap(), 125);
-        assert_eq!(apply_discount_to_cents(33, 2_000).unwrap(), 41);
+        assert_eq!(apply_discount_to_usd_wei("100", 2_000).unwrap(), "125");
+        assert_eq!(apply_discount_to_usd_wei("33", 2_000).unwrap(), "41");
     }
 
     #[test]

--- a/lit-payments/static/index.html
+++ b/lit-payments/static/index.html
@@ -32,10 +32,10 @@
     <!-- ── LITKEY rate ──────────────────────────────────────────── -->
     <section class="card">
       <h2>LITKEY rate</h2>
-      <p class="muted">CoinGecko polls every 5 minutes. Admins can override the current cents-per-LITKEY rate.</p>
+      <p class="muted">CoinGecko polls every 5 minutes. Admins can override the current USD-per-LITKEY rate. Internally this is stored as 18-decimal USD fixed point.</p>
       <div id="rate-current" class="rate-current muted">Loading…</div>
       <form id="rate-form" class="row-form">
-        <input id="rate-cents" type="number" min="1" step="1" placeholder="cents per LITKEY" required>
+        <input id="rate-usd" type="text" inputmode="decimal" placeholder="USD per LITKEY, e.g. 0.006" required>
         <button type="submit">Override rate</button>
       </form>
       <div id="rate-status" class="status" role="status" aria-live="polite"></div>
@@ -136,7 +136,7 @@
     const matchTpl     = document.getElementById('match-template');
     const rateCurrent  = document.getElementById('rate-current');
     const rateForm     = document.getElementById('rate-form');
-    const rateCents    = document.getElementById('rate-cents');
+    const rateUsd      = document.getElementById('rate-usd');
     const rateStatus   = document.getElementById('rate-status');
 
     lookupForm.addEventListener('submit', async (e) => {
@@ -225,6 +225,23 @@
     }
 
     /* ── LITKEY rate display + admin override ───────────────────── */
+    function usdWeiToDisplay(raw) {
+      if (raw == null) return 'unavailable';
+      const wei = BigInt(raw);
+      const scale = 1000000000000000000n;
+      const whole = wei / scale;
+      const frac = (wei % scale).toString().padStart(18, '0').replace(/0+$/, '');
+      return `$${whole.toString()}${frac ? '.' + frac : ''}`;
+    }
+    function parseUsdToWei(raw) {
+      const value = raw.trim();
+      if (!/^\d+(\.\d+)?$/.test(value)) throw new Error('Rate must be a positive decimal USD amount.');
+      const [whole, fracRaw = ''] = value.split('.');
+      const frac = (fracRaw + '0'.repeat(18)).slice(0, 18);
+      const wei = BigInt(whole) * 1000000000000000000n + BigInt(frac || '0');
+      if (wei <= 0n) throw new Error('Rate must be greater than zero at 18-decimal precision.');
+      return wei.toString();
+    }
     function renderRate(payload) {
       const rate = payload.rate;
       if (!rate) {
@@ -236,12 +253,12 @@
         ? `manual override by operator #${rate.updated_by_operator_id}`
         : 'CoinGecko';
       const discountPct = (payload.discount_basis_points / 100).toFixed(2).replace(/\.00$/, '');
-      const effective = payload.effective_cents_per_litkey != null
-        ? ` Effective credit rate: ${fmtCents(payload.effective_cents_per_litkey)} per LITKEY after ${discountPct}% discount.`
+      const effective = payload.effective_usd_wei_per_litkey != null
+        ? ` Effective credit rate: ${usdWeiToDisplay(payload.effective_usd_wei_per_litkey)} per LITKEY after ${discountPct}% discount.`
         : ' Crediting is paused until a fresh rate is available.';
-      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} market rate per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}.${effective}${payload.crediting_paused ? ' — CREDITING PAUSED' : ''}`;
+      rateCurrent.textContent = `${usdWeiToDisplay(rate.usd_wei_per_litkey)} market rate per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}.${effective}${payload.crediting_paused ? ' — CREDITING PAUSED' : ''}`;
       rateCurrent.className = 'rate-current' + (rate.stale ? ' error' : ' ok');
-      rateCents.value = rate.cents_per_litkey;
+      rateUsd.value = usdWeiToDisplay(rate.usd_wei_per_litkey).replace(/^\$/, '');
     }
 
     async function loadRate() {
@@ -257,9 +274,11 @@
 
     rateForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const cents = Number.parseInt(rateCents.value, 10);
-      if (!Number.isInteger(cents) || cents <= 0) {
-        setStatus(rateStatus, 'Rate must be a positive integer number of cents.', 'error');
+      let usdWei;
+      try {
+        usdWei = parseUsdToWei(rateUsd.value);
+      } catch (err) {
+        setStatus(rateStatus, err.message, 'error');
         return;
       }
       const button = rateForm.querySelector('button');
@@ -270,7 +289,7 @@
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ cents_per_litkey: cents }),
+          body: JSON.stringify({ usd_wei_per_litkey: usdWei }),
         });
         const body = await resp.json();
         if (!resp.ok) { setStatus(rateStatus, body.error || `Failed (HTTP ${resp.status})`, 'error'); return; }

--- a/lit-payments/static/index.html
+++ b/lit-payments/static/index.html
@@ -225,7 +225,8 @@
     }
 
     /* ── LITKEY rate display + admin override ───────────────────── */
-    function renderRate(rate) {
+    function renderRate(payload) {
+      const rate = payload.rate;
       if (!rate) {
         rateCurrent.textContent = 'No rate has been fetched yet. Crediting must remain paused.';
         rateCurrent.className = 'rate-current error';
@@ -234,7 +235,11 @@
       const source = rate.source === 'manual'
         ? `manual override by operator #${rate.updated_by_operator_id}`
         : 'CoinGecko';
-      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}${rate.stale ? ' — STALE (>1h), crediting paused' : ''}`;
+      const discountPct = (payload.discount_basis_points / 100).toFixed(2).replace(/\.00$/, '');
+      const effective = payload.effective_cents_per_litkey != null
+        ? ` Effective credit rate: ${fmtCents(payload.effective_cents_per_litkey)} per LITKEY after ${discountPct}% discount.`
+        : '';
+      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} market rate per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}.${effective}${rate.stale ? ' — STALE (>1h), crediting paused' : ''}`;
       rateCurrent.className = 'rate-current' + (rate.stale ? ' error' : ' ok');
       rateCents.value = rate.cents_per_litkey;
     }
@@ -244,7 +249,7 @@
         const resp = await fetch('/api/litkey/rate', { credentials: 'same-origin' });
         const body = await resp.json();
         if (!resp.ok) { setStatus(rateStatus, body.error || 'Failed to load rate', 'error'); return; }
-        renderRate(body.rate);
+        renderRate(body);
       } catch (err) {
         setStatus(rateStatus, 'Rate load failed: ' + err, 'error');
       }
@@ -269,7 +274,7 @@
         });
         const body = await resp.json();
         if (!resp.ok) { setStatus(rateStatus, body.error || `Failed (HTTP ${resp.status})`, 'error'); return; }
-        renderRate(body.rate);
+        renderRate(body);
         setStatus(rateStatus, 'Manual rate override saved.', 'ok');
       } catch (err) {
         setStatus(rateStatus, 'Override failed: ' + err, 'error');

--- a/lit-payments/static/index.html
+++ b/lit-payments/static/index.html
@@ -238,8 +238,8 @@
       const discountPct = (payload.discount_basis_points / 100).toFixed(2).replace(/\.00$/, '');
       const effective = payload.effective_cents_per_litkey != null
         ? ` Effective credit rate: ${fmtCents(payload.effective_cents_per_litkey)} per LITKEY after ${discountPct}% discount.`
-        : '';
-      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} market rate per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}.${effective}${rate.stale ? ' — STALE (>1h), crediting paused' : ''}`;
+        : ' Crediting is paused until a fresh rate is available.';
+      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} market rate per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}.${effective}${payload.crediting_paused ? ' — CREDITING PAUSED' : ''}`;
       rateCurrent.className = 'rate-current' + (rate.stale ? ' error' : ' ok');
       rateCents.value = rate.cents_per_litkey;
     }
@@ -286,25 +286,54 @@
     /* ── recent grants table ────────────────────────────────────── */
     const grantsTbody = document.getElementById('grants-tbody');
 
+    function renderGrantsMessage(text, className = 'muted') {
+      grantsTbody.replaceChildren();
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 4;
+      td.className = className;
+      td.textContent = text;
+      tr.appendChild(td);
+      grantsTbody.appendChild(tr);
+    }
+
+    function renderGrantRow(g) {
+      const tr = document.createElement('tr');
+      const when = document.createElement('td');
+      when.textContent = fmtTime(g.created_at);
+
+      const customer = document.createElement('td');
+      const email = document.createElement('div');
+      email.textContent = g.email || '(no email)';
+      const wallet = document.createElement('div');
+      wallet.className = 'muted';
+      wallet.textContent = g.wallet_address || '(no wallet)';
+      customer.append(email, wallet);
+
+      const amount = document.createElement('td');
+      amount.textContent = fmtCents(g.cents);
+      const note = document.createElement('td');
+      note.textContent = g.note || '';
+
+      tr.append(when, customer, amount, note);
+      return tr;
+    }
+
     async function loadGrants() {
       try {
         const resp = await fetch('/api/grants', { credentials: 'same-origin' });
         const body = await resp.json();
-        if (!resp.ok || !body.grants.length) {
-          grantsTbody.innerHTML =
-            `<tr><td colspan="4" class="muted">${resp.ok ? 'No grants yet.' : (body.error || 'Failed to load')}</td></tr>`;
+        if (!resp.ok) {
+          renderGrantsMessage(body.error || 'Failed to load', 'muted');
           return;
         }
-        grantsTbody.innerHTML = body.grants.map(g => `
-          <tr>
-            <td>${fmtTime(g.created_at)}</td>
-            <td><div>${g.email || '(no email)'}</div><div class="muted">${g.wallet_address}</div></td>
-            <td>${fmtCents(g.cents)}</td>
-            <td>${g.note || ''}</td>
-          </tr>
-        `).join('');
+        if (!body.grants.length) {
+          renderGrantsMessage('No grants yet.');
+          return;
+        }
+        grantsTbody.replaceChildren(...body.grants.map(renderGrantRow));
       } catch (err) {
-        grantsTbody.innerHTML = `<tr><td colspan="4" class="error">Load failed: ${err}</td></tr>`;
+        renderGrantsMessage('Load failed: ' + err, 'error');
       }
     }
 

--- a/lit-payments/static/index.html
+++ b/lit-payments/static/index.html
@@ -29,6 +29,18 @@
       <div id="matches"></div>
     </section>
 
+    <!-- ── LITKEY rate ──────────────────────────────────────────── -->
+    <section class="card">
+      <h2>LITKEY rate</h2>
+      <p class="muted">CoinGecko polls every 5 minutes. Admins can override the current cents-per-LITKEY rate.</p>
+      <div id="rate-current" class="rate-current muted">Loading…</div>
+      <form id="rate-form" class="row-form">
+        <input id="rate-cents" type="number" min="1" step="1" placeholder="cents per LITKEY" required>
+        <button type="submit">Override rate</button>
+      </form>
+      <div id="rate-status" class="status" role="status" aria-live="polite"></div>
+    </section>
+
     <!-- ── Recent grants ────────────────────────────────────────── -->
     <section class="card">
       <h2>Your recent grants</h2>
@@ -122,6 +134,10 @@
     const lookupStatus = document.getElementById('lookup-status');
     const matchesEl    = document.getElementById('matches');
     const matchTpl     = document.getElementById('match-template');
+    const rateCurrent  = document.getElementById('rate-current');
+    const rateForm     = document.getElementById('rate-form');
+    const rateCents    = document.getElementById('rate-cents');
+    const rateStatus   = document.getElementById('rate-status');
 
     lookupForm.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -208,6 +224,60 @@
       matchesEl.appendChild(node);
     }
 
+    /* ── LITKEY rate display + admin override ───────────────────── */
+    function renderRate(rate) {
+      if (!rate) {
+        rateCurrent.textContent = 'No rate has been fetched yet. Crediting must remain paused.';
+        rateCurrent.className = 'rate-current error';
+        return;
+      }
+      const source = rate.source === 'manual'
+        ? `manual override by operator #${rate.updated_by_operator_id}`
+        : 'CoinGecko';
+      rateCurrent.textContent = `${fmtCents(rate.cents_per_litkey)} per LITKEY — ${source}, fetched ${fmtTime(rate.fetched_at)}${rate.stale ? ' — STALE (>1h), crediting paused' : ''}`;
+      rateCurrent.className = 'rate-current' + (rate.stale ? ' error' : ' ok');
+      rateCents.value = rate.cents_per_litkey;
+    }
+
+    async function loadRate() {
+      try {
+        const resp = await fetch('/api/litkey/rate', { credentials: 'same-origin' });
+        const body = await resp.json();
+        if (!resp.ok) { setStatus(rateStatus, body.error || 'Failed to load rate', 'error'); return; }
+        renderRate(body.rate);
+      } catch (err) {
+        setStatus(rateStatus, 'Rate load failed: ' + err, 'error');
+      }
+    }
+
+    rateForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const cents = Number.parseInt(rateCents.value, 10);
+      if (!Number.isInteger(cents) || cents <= 0) {
+        setStatus(rateStatus, 'Rate must be a positive integer number of cents.', 'error');
+        return;
+      }
+      const button = rateForm.querySelector('button');
+      button.disabled = true;
+      setStatus(rateStatus, 'Saving override…', '');
+      try {
+        const resp = await fetch('/api/litkey/rate/override', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cents_per_litkey: cents }),
+        });
+        const body = await resp.json();
+        if (!resp.ok) { setStatus(rateStatus, body.error || `Failed (HTTP ${resp.status})`, 'error'); return; }
+        renderRate(body.rate);
+        setStatus(rateStatus, 'Manual rate override saved.', 'ok');
+      } catch (err) {
+        setStatus(rateStatus, 'Override failed: ' + err, 'error');
+      } finally {
+        button.disabled = false;
+      }
+    });
+
     /* ── recent grants table ────────────────────────────────────── */
     const grantsTbody = document.getElementById('grants-tbody');
 
@@ -233,6 +303,7 @@
       }
     }
 
+    loadRate();
     loadGrants();
   </script>
 </body>

--- a/lit-payments/static/style.css
+++ b/lit-payments/static/style.css
@@ -120,7 +120,8 @@ button.ghost {
   gap: 8px;
   margin-top: 12px;
 }
-.row-form input[type=text] {
+.row-form input[type=text],
+.row-form input[type=number] {
   flex: 1;
   width: auto;
   margin: 0;
@@ -134,6 +135,10 @@ button.ghost {
 .row-form button {
   width: auto;
   padding: 10px 16px;
+}
+.rate-current {
+  margin-top: 12px;
+  font-size: 14px;
 }
 
 /* Match cards */

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -162,7 +162,7 @@ litkey_payments(
   credited_wallet,                -- event.wallet
   litkey_amount,
   cents_credited,
-  rate_used,                      -- cents per LITKEY at credit time
+  rate_used,                      -- snapshot of usd_wei_per_litkey at credit time
   stripe_customer_id,
   stripe_balance_transaction_id,
   credited_at,
@@ -172,7 +172,7 @@ litkey_payments(
 
 litkey_rate(
   id PRIMARY KEY DEFAULT 1 CHECK (id = 1),  -- single-row table
-  cents_per_litkey,
+  usd_wei_per_litkey,            -- 18-decimal USD fixed point per 1 whole LITKEY
   source,                         -- 'coingecko' | 'manual'
   fetched_at,
   updated_by_operator_id          -- null when source='coingecko'
@@ -289,7 +289,7 @@ WebSocket primary + 60s reconciliation poll:
 1. `Payment` event observed at confirmation depth.
 2. Idempotency check on `(tx_hash, log_index)`.
 3. Look up Stripe customer by `metadata.wallet_address == event.wallet`. If none: log a warning and skip — do not credit, do not alert. Anyone calling `pay()` directly with a wallet that isn't a Lit customer is off the supported path; they'll reach out to support if it matters.
-4. Read `cents_per_litkey` from `litkey_rate`. Compute `cents = litkey_amount * rate`.
+4. Read `usd_wei_per_litkey` from `litkey_rate` (`1 USD = 1e18` fixed-point units). Compute Stripe cents from native `Payment.amount` LITKEY wei with BigInt-style integer math: `amount_wei * usd_wei_per_litkey * 100 * 10000 / (1e18 token scale * 1e18 USD scale * (10000 - discount_bps))`, rounded once at the final Stripe-cent boundary.
 5. Write `balance_transaction` with `amount = -cents`, description `"LITKEY payment: tx {tx_hash}"`.
 6. Insert row into `litkey_payments` (rate snapshotted in `rate_used`).
 
@@ -302,6 +302,7 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 ```
 
 - Background task polls every 5 min, upserts the single-row `litkey_rate` table.
+- Rates are stored as `usd_wei_per_litkey`: 18-decimal USD fixed point per 1 whole LITKEY (`1 USD = 1e18`; `$0.006/LITKEY = 6000000000000000`). This deliberately mirrors token-native integer accounting so sub-cent LITKEY prices are not rounded to whole cents.
 - If a fetch fails or returns nonsense (zero / null / >100× recent value): keep the last-known rate, log a warning.
 - If the row's `fetched_at` is older than 1 hour: pause crediting and log a warning. Stuck payments will surface via user reports; mod can grant manually in the meantime.
 - Admin can override the rate from the admin UI (updates the same row with `source='manual'` + operator id). Manual override is authoritative until another admin changes it; the poller does not overwrite manual values. Stale manual values still pause crediting so an operator has to deliberately refresh the override during an oracle incident. Override is recorded on the row itself — no separate notification.
@@ -385,7 +386,7 @@ All questions are closed. Plan is ready to start building.
 
    **3b.** ✅ CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI — IMPLEMENTED IN PR WORKTREE
    - [x] Background task in `lit-payments` polling `https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd` every 5 min.
-   - [x] Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `cents_per_litkey`, `source`, `fetched_at`, `updated_by_operator_id`).
+   - [x] Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `usd_wei_per_litkey NUMERIC(78,0)`, `source`, `fetched_at`, `updated_by_operator_id`).
    - [x] Stale (>1hr) is surfaced on the API/UI and logs a warning so future 3c crediting can pause (no Slack alert — `fly logs` only).
    - [x] Admin UI section on the dashboard to view the current rate + override it (`source='manual'`).
    - [x] Env-configured LITKEY payment discount (`LITKEY_DISCOUNT_BASIS_POINTS`, default `0`; `2000` = 20% off vs credit card) exposed in the rate API/UI as the discount-adjusted effective credit rate.
@@ -396,8 +397,8 @@ All questions are closed. Plan is ready to start building.
    - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
    - 5-confirmation depth on Base before crediting.
    - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.
-   - For each Payment event: read `litkey_rate`, reject/hold crediting if `crediting_paused` is true, apply `LITKEY_DISCOUNT_BASIS_POINTS` to compute the effective credit rate, compute `cents = litkey_amount * effective_rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
-   - Before production listener crediting, upgrade rate math from whole cents/LITKEY to a higher-precision fixed-point representation and round only once at the final Stripe-cent amount. The current 3b admin UI/API is acceptable for quoting visibility, but final crediting should avoid systematic over/under-crediting from whole-cent spot-rate rounding.
+   - For each Payment event: read `litkey_rate`, reject/hold crediting if `crediting_paused` is true, apply `LITKEY_DISCOUNT_BASIS_POINTS`, compute Stripe cents from native LITKEY wei + `usd_wei_per_litkey` using BigInt-style integer math, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
+   - [x] Rate precision prerequisite is handled in 3b: `litkey_rate.usd_wei_per_litkey` stores 18-decimal USD fixed point, CoinGecko parsing preserves arbitrary-precision JSON numbers, and the settlement helper rounds only once at final Stripe cents. Do not reintroduce whole-cent/LITKEY math in the listener.
    - Migrations: `litkey_payments`, `chain_checkpoint`.
    - **Depends on**: 3a contract deployed + address known (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3b rate table existing.
 

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -392,8 +392,11 @@ All questions are closed. Plan is ready to start building.
    - [x] Env-configured LITKEY payment discount (`LITKEY_DISCOUNT_BASIS_POINTS`, default `0`; `2000` = 20% off vs credit card) exposed in the rate API/UI as the discount-adjusted effective credit rate.
    - [x] **No on-chain dependency** — can ship before 3c.
 
-   **3c.** ⏭️ Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — NOT STARTED
-   - WSS subscription to `Payment` events from the deployed gateway contract; exponential backoff reconnect.
+   **3c.** 🚧 Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — STARTED IN PR WORKTREE
+   - [x] Added phase-3c schema: `litkey_payments` with `UNIQUE(chain_id, tx_hash, log_index)` and `chain_checkpoint` with per-chain `last_processed_block`.
+   - [x] Added listener configuration/env parsing for `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, `LITKEY_GATEWAY_ADDRESS`, `LITKEY_CHAIN_ID` (default Base `8453`), `LITKEY_CONFIRMATIONS` (default `5`), and `LITKEY_RECONCILIATION_INTERVAL_SECS` (default `60`). If the chain env vars are absent, the portal/rate poller still boot and LITKEY crediting stays disabled.
+   - [x] Added shared listener primitives/tests for deterministic Stripe idempotency keys, address normalization, confirmation depth, reconciliation ranges, reconnect backoff, and native wei amount formatting.
+   - [ ] WSS subscription to `Payment` events from the deployed gateway contract; exponential backoff reconnect.
    - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
    - 5-confirmation depth on Base before crediting.
    - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -1,0 +1,420 @@
+# Lit Payments App — Design Plan
+
+Status: implementation in progress — see Sequencing section for what's shipped vs. remaining
+Author: Chris (with Claude)
+Date: 2026-05-18 (last updated: 2026-05-21)
+
+## Current state (TL;DR for a new session)
+
+- **Shipped to `next`**: `lit-billing-core` extraction (PR #358), `lit-payments` foundation + magic-link auth (PR #359), admin credit portal + Fly.io deploy target (PR #370).
+- **Open**: `LitkeyPaymentGateway` Solidity contract + Hardhat project (PR #373).
+- **Not yet started**: rate poller (3b), Alchemy WSS listener (3c), Wagmi payment page + dashboard link (3d). See the Sequencing section near the bottom for what each entails and recommended order — start with 3b.
+
+The rest of this doc is the original design + decisions, kept for context. Implementation details that diverged from the plan are noted inline.
+
+## Goal
+
+Build a separate, ops-facing app that handles billing operations the main `lit-api-server` shouldn't carry:
+
+1. **Admin credit portal** — a logged-in moderator (Discord support, etc.) can credit a customer's Stripe balance by email or wallet address.
+2. **LITKEY → Stripe credit** — let users pay with LITKEY tokens from the dashboard via a "Pay with tokens" button; auto-credit their Stripe balance. Replaces today's manual flow.
+
+## Non-goals
+
+- Replacing the existing customer dashboard (`lit-static/dapps/dashboard/`). End users still top up there.
+- Running inside the TEE. This is a normal cloud service.
+- Subscription billing. Out of scope for this plan.
+
+## Architecture overview
+
+```
+┌────────────────────────────────────┐
+│  TEE: lit-api-server               │
+│  - /billing/*  (customer top-up,   │
+│    balance read, charges)          │
+│  - depends on lit-billing-core     │
+│  - Stripe secret key #1            │
+└────────────────────────────────────┘
+                  │
+                  │ shares: lit-billing-core
+                  │ (customer identity + Stripe HTTP)
+                  ▼
+┌────────────────────────────────────┐
+│  lit-billing-core (NEW crate)      │
+│  - Stripe HTTP client              │
+│  - get_customer_by_wallet          │
+│  - balance_transaction helpers     │
+│  - search customers by email       │
+└────────────────────────────────────┘
+                  ▲
+                  │
+┌────────────────────────────────────┐
+│  Non-TEE: lit-payments (NEW)       │
+│  - Admin portal (mod credits)      │
+│  - LITKEY listener + gateway       │
+│  - Stripe restricted key #2        │
+│  - Postgres                        │
+└────────────────────────────────────┘
+                  │
+                  ▼
+         Stripe + Base RPC
+```
+
+### Repo layout
+
+Same monorepo, two new top-level crates. `lit-billing-core` holds the customer-identity invariant (`metadata.wallet_address` keys the Stripe customer) and the raw HTTP plumbing. Both services depend on it — single source of truth.
+
+```
+lit-node-express/
+├── lit-api-server/         ← existing (TEE); now depends on lit-billing-core
+├── lit-billing-core/       ← NEW shared crate
+│   └── src/
+│       ├── lib.rs
+│       ├── client.rs       ← StripeClient (creds + HTTP, no caches)
+│       ├── customer.rs     ← get_customer_by_wallet, search_by_email,
+│       │                     set_customer_email
+│       ├── balance.rs      ← read balance, write balance_transactions
+│       └── types.rs        ← ReportCustomer, ReportBalanceTx, etc.
+├── lit-payments/           ← NEW (non-TEE)
+│   ├── src/
+│   │   ├── main.rs
+│   │   ├── chain.rs        ← LITKEY listener (WSS + poll)
+│   │   ├── db.rs           ← Postgres
+│   │   ├── auth.rs         ← magic-link
+│   │   └── endpoints/
+│   │       ├── portal.rs
+│   │       └── pay_with_litkey.rs
+│   ├── static/             ← admin UI + payWithLitkey page
+│   ├── contracts/          ← LitkeyPaymentGateway.sol
+│   ├── migrations/
+│   └── Cargo.toml
+└── lit-static/dapps/dashboard/   ← unchanged
+```
+
+### Extracting lit-billing-core
+
+The existing `lit-api-server/src/stripe.rs` mixes three concerns:
+1. Stripe HTTP + customer identity + balance primitives → **move to `lit-billing-core`**
+2. Caching layer (`customer_cache`, `balance_cache`, `wallet_cache`, `balance_refresh_in_flight`) → **stays in `lit-api-server`**, wraps the core's `StripeClient`
+3. API-server-specific flows (`charge`, `charge_management`, `charge_lit_action_time`, `create_payment_intent`, `confirm_payment_and_credit`, `resolve_wallet_address`) → **stays in `lit-api-server`**
+
+`lit-payments` uses `lit-billing-core` directly with no caching layer (not hot-path). `lit-api-server` keeps its existing `StripeState` but it now composes a `StripeClient` from the core + the existing caches.
+
+Risk: the extraction touches existing production code (`lit-api-server`). Mitigation: pure refactor in a single PR with no behavior change, full test pass before lit-payments starts.
+
+Tech stack: **Rust + Rocket + vanilla HTML/JS**. Matches existing repo conventions.
+
+### Deployment
+
+- **Hostname**: `payments.litprotocol.com`.
+- **Platform**: Fly.io (app + Fly Postgres, or external Postgres via Supabase/Neon). `fly.toml` lives at the repo root so the Dockerfile can pull in the sibling `lit-billing-core/` crate via the repo-root build context.
+- **Outside the TEE.** No attestation pain; operators can `fly logs` / `fly ssh console` for diagnostics.
+- **Ingress**: Fly's default TLS + `fly certs create payments.litprotocol.com`.
+- **Secrets** (`fly secrets set …`): Stripe restricted key, DB URL, magic-link signing key, Resend API key, Alchemy WSS + HTTPS URLs, gateway contract address, treasury Safe address, LITKEY token address, CoinGecko ID. Plus `ROCKET_SECRET_KEY` for Rocket's private-cookie encryption.
+
+### Auth tiers
+
+Two roles, both authenticated against the Postgres `operators` table:
+
+- **`mod`** — grant credits up to per-grant/daily caps. Cannot change config or resolve unattributed payments.
+- **`admin`** — everything: change LITKEY rate, manage operators, resolve unattributed payments.
+
+**Mechanism: magic link via email, from day 1.** Operator enters email → Resend sends a link with a signed, short-lived (15 min) token → click sets a session cookie (~7 days). Magic-link requests for emails not in the `operators` table are silently dropped (same response as success, to prevent enumeration).
+
+### Stripe key scopes
+
+`lit-payments` uses a **separate Stripe restricted key** with scopes:
+- `customers:read` + `customers:write`
+- `customer_balance_transactions:read` + `customer_balance_transactions:write`
+
+That's it — no subscription or webhook scopes needed for this plan.
+
+## Data model (Postgres) — minimal
+
+```
+operators(
+  id, email, role, created_at, last_login_at
+)
+
+sessions(
+  token, operator_id, expires_at
+)
+
+grants(
+  id,
+  operator_id,
+  stripe_customer_id,
+  wallet_address,
+  email,                          -- snapshot at grant time
+  cents,
+  note,
+  stripe_balance_transaction_id,
+  idempotency_key,
+  created_at
+)
+-- audit trail = SELECT * FROM grants
+
+litkey_payments(
+  id,
+  tx_hash,
+  log_index,
+  payer_wallet,                   -- msg.sender on the contract call
+  credited_wallet,                -- event.wallet
+  litkey_amount,
+  cents_credited,
+  rate_used,                      -- cents per LITKEY at credit time
+  stripe_customer_id,
+  stripe_balance_transaction_id,
+  credited_at,
+  UNIQUE(tx_hash, log_index)
+)
+-- audit trail = SELECT * FROM litkey_payments
+
+litkey_rate(
+  id PRIMARY KEY DEFAULT 1 CHECK (id = 1),  -- single-row table
+  cents_per_litkey,
+  source,                         -- 'coingecko' | 'manual'
+  fetched_at,
+  updated_by_operator_id          -- null when source='coingecko'
+)
+
+chain_checkpoint(
+  chain_id PRIMARY KEY,
+  last_processed_block,
+  updated_at
+)
+```
+
+Six tables, each justified:
+- `operators` + `sessions` — magic-link auth.
+- `grants` — portal action log + idempotency.
+- `litkey_payments` — credit record + idempotency.
+- `litkey_rate` — current rate (single row) + who last touched it.
+- `chain_checkpoint` — listener resume point.
+
+No separate `audit_log` table: every state-changing action is recorded on its own resource row with the actor (`operator_id`) and timestamp. Logins are server logs only.
+
+## Feature 1 — Admin credit portal
+
+**API**:
+- `POST /admin/grant_credit` — body: `{ email?, wallet_address?, cents, note }`, session cookie.
+  - Look up Stripe customer by email or wallet (via `lit-billing-core`).
+  - Validate caps.
+  - Write `balance_transaction` with `amount = -cents`, description `"Discord grant: {note} (op:{email}, {ISO date})"`.
+  - Persist to `grants` with idempotency key.
+- `GET /admin/grants?limit=50` — recent grants by the current operator.
+- `GET /admin/customer/lookup?email=…` or `?wallet=…` — preview balance before granting.
+
+**Lookup branching by email**:
+- 0 results → "no Stripe customer with that email. Ask the user to log into the dashboard and set their email under settings."
+- 1 result → proceed.
+- 2+ results → return all matches with wallet + balance; mod picks by wallet.
+
+**UI**: one page, three sections — Lookup, Grant form, Recent grants. Vanilla HTML/JS.
+
+**Caps**:
+- Per-grant: $20 (env-configurable).
+- Daily per operator: $100 (env-configurable).
+- No global cross-operator cap.
+
+**Audit**: every grant logs operator email + timestamp to the `grants` table and to the Stripe description field (visible in `stripe_report`).
+
+## Feature 2 — LITKEY → Stripe credit
+
+### Locked-in answers
+
+- **Chain**: Base.
+- **Token**: LITKEY at `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49` (Base bridge deployment, `OptimismMintableERC20`).
+- **No `permit` / no EIP-3009.** Two-tx flow: `approve` then `pay`.
+- **Approval pattern**: exact-amount only.
+- **Confirmation depth**: 5 blocks.
+- **Treasury**: existing company Safe on Base.
+- **Listener**: Alchemy WSS primary + 60s reconciliation poll.
+- **Rate source**: CoinGecko free public API, `id=lit-protocol`, polled every 5 min.
+- **Minimum payment**: $5 equivalent.
+- **Audit**: internal review (Chris) on the contract.
+
+### User flow
+
+User in the dashboard at `dashboard.litprotocol.com` clicks "Pay with tokens" → opens `payments.litprotocol.com/payWithLitkey?wallet=<address>` in a new tab.
+
+1. Page reads the wallet from the URL → looks up the Stripe customer → **prominently displays the account that will be credited** (email + wallet) for the user to confirm.
+2. User connects their paying wallet (Wagmi). May be the same as the credited wallet or a different one (e.g., a separate Metamask holding LITKEY).
+3. Page shows "You'll send N LITKEY (~$X credit at current rate)."
+4. User clicks Pay → wallet pops up twice (`approve`, then `pay`).
+5. Page polls for credit confirmation. On success: confirmation + link back to dashboard.
+
+**Note on URL spoofing.** The wallet in the URL is unauthenticated — anyone can craft a link to credit any account. We don't try to prevent that. The worst case is one of:
+- Someone gifts a credit to another account (no harm).
+- A phishing attacker tricks a victim into paying with an attacker-chosen `wallet=` param, sending the credit to the attacker. Mitigation: the page shows the account-to-be-credited prominently and asks the user to confirm before the wallet pop-up. A user who reads the screen catches this.
+
+### Attribution architecture
+
+Single company wallet receiving from many users = attribution ambiguity. Solved with a payment gateway contract — direct sends to the Safe are unsupported.
+
+```solidity
+contract LitkeyPaymentGateway {
+    IERC20 public immutable litkey;
+    address public immutable treasury;
+
+    event Payment(
+        address indexed wallet,  // wallet to credit (== Lit account wallet)
+        address indexed payer,
+        uint256 amount
+    );
+
+    function pay(uint256 amount, address wallet) external {
+        litkey.transferFrom(msg.sender, treasury, amount);
+        emit Payment(wallet, msg.sender, amount);
+    }
+}
+```
+
+Dashboard Pay button calls `litkey.approve(gateway, amount)` then `gateway.pay(amount, walletToCredit)`. Listener watches `Payment` — `wallet` (which maps to a Stripe customer via `metadata.wallet_address`) is baked into every event. Zero ambiguity even under concurrent payments. Funds land directly in the Safe.
+
+**Direct sends to the Safe are unsupported.** If a user pastes the Safe address and sends LITKEY directly (skipping the contract), they bypass the listener entirely. Those tokens just sit in the Safe as company income. If a user complains, the mod uses the admin credit portal (Feature 1) to grant credit manually. The portal exists for exactly these one-off cases — we don't need a second machinery for them.
+
+### Listener
+
+WebSocket primary + 60s reconciliation poll:
+
+- **WSS subscription** (Alchemy) to `Payment` events from the gateway contract. Reconnect with exponential backoff (1s → 2s → 4s → … cap 30s).
+- **60s poll** for `Payment` logs in `(last_processed_block, latest_block - 5)`. Same handler, same idempotency check.
+- **Checkpoint**: `chain_checkpoint.last_processed_block` advanced only by the poll path.
+- **Confirmation depth**: defer crediting until `latest_block - event_block >= 5`.
+- **Idempotency**: `(tx_hash, log_index)` unique in `litkey_payments`.
+
+### Credit flow
+
+1. `Payment` event observed at confirmation depth.
+2. Idempotency check on `(tx_hash, log_index)`.
+3. Look up Stripe customer by `metadata.wallet_address == event.wallet`. If none: log a warning and skip — do not credit, do not alert. Anyone calling `pay()` directly with a wallet that isn't a Lit customer is off the supported path; they'll reach out to support if it matters.
+4. Read `cents_per_litkey` from `litkey_rate`. Compute `cents = litkey_amount * rate`.
+5. Write `balance_transaction` with `amount = -cents`, description `"LITKEY payment: tx {tx_hash}"`.
+6. Insert row into `litkey_payments` (rate snapshotted in `rate_used`).
+
+### Rate management
+
+**CoinGecko free public API**, no key required:
+
+```
+GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd
+```
+
+- Background task polls every 5 min, upserts the single-row `litkey_rate` table.
+- If a fetch fails or returns nonsense (zero / null / >100× recent value): keep the last-known rate, log a warning.
+- If the row's `fetched_at` is older than 1 hour: pause crediting and log a warning. Stuck payments will surface via user reports; mod can grant manually in the meantime.
+- Admin can override the rate from the admin UI (updates the same row with `source='manual'` + operator id). Override is recorded on the row itself — no separate notification.
+
+**Quote vs. credit semantics**: the payment page shows the rate at page-load and refreshes the quote every 30s. Once the user starts the `approve` tx, the LITKEY amount is frozen. At confirmation we credit using the rate **in effect at the on-chain `Payment` event** (the most recent value of `litkey_rate`). Page says "estimated credit, finalized at confirmation."
+
+### Edge cases
+
+- **`event.wallet` doesn't match any Stripe customer** → log + skip. No alert. If the payer cares, they'll contact support and a mod can grant via the credit portal.
+- **Direct send to the Safe** → unsupported; tokens just sit in the Safe. User contacts support → mod uses the credit portal.
+- **Reorgs** → 5-confirmation depth on Base prevents.
+- **Overpayment** → credit at current rate; no refund flow in v1.
+- **Rate drift between approve and pay** → contract executes whatever amount was approved; we credit at rate-at-event-time. Page warns "finalized at confirmation."
+- **Contract upgrade** → contract is intentionally minimal & immutable; if behavior changes, deploy a new contract and update the listener.
+
+## Decisions (locked in)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Hostname | `payments.litprotocol.com` |
+| 2 | Cloud provider | Fly.io (app + Fly Postgres, or external Postgres) |
+| 3 | Shared crate | Extract `lit-billing-core` now; both services depend on it |
+| 4 | Operator auth | Magic link via Resend, day 1; 15-min token, 7-day session |
+| 5 | Alerting | None — rely on server logs (`fly logs`) |
+| 6 | Reconciliation report | Deferred |
+| 7 | Refund / clawback flow | Deferred — handle manually in Stripe dashboard |
+| 8 | LITKEY chain | Base |
+| 9 | `permit` / 3009 | Not supported; two-tx flow |
+| 10 | Rate source | CoinGecko free public API (`id=lit-protocol`), 5-min poll; manual override |
+| 11 | Minimum payment | $5 equivalent |
+| 12 | Treasury | Existing company Safe on Base |
+| 13 | Contract audit | Internal review only (Chris) |
+| 14 | Approval pattern | Exact-amount only |
+| 15 | RPC provider | Alchemy (WSS primary + HTTPS poll fallback) |
+
+## Decisions table — extended (build-time config)
+
+| Item | Value |
+|---|---|
+| CoinGecko ID | `lit-protocol` |
+| Magic-link sender | `noreply@mail.litprotocol.com` (subdomain) |
+| Initial operators | `chris@litprotocol.com` (admin); `Salamiademola73@gmail.com` (mod) |
+| Per-grant cap | $20 |
+| Per-operator daily cap | $100 |
+| Global cap | none |
+
+## Open questions
+
+All questions are closed. Plan is ready to start building.
+
+## Sequencing
+
+### ✅ 1. Extract `lit-billing-core` — DONE (PR #358, merged to `next`)
+   - [x] Moved Stripe HTTP + customer-identity primitives from `lit-api-server/src/stripe.rs` into a new shared `lit-billing-core` crate.
+   - [x] `lit-api-server` keeps its caching layer + charge/payment-intent flows, rewires through `lit-billing-core::StripeClient`.
+   - [x] Pure refactor: 211 lit-api-server lib tests + 14 stripe_report bin tests + 15 lit-billing-core tests all green.
+   - [x] CI wired into `rust-ci.yml` matrix.
+
+### ✅ 2. Foundation + Feature 1: admin credit portal — DONE (PRs #359 + #370, merged to `next`)
+   - [x] `lit-payments` crate skeleton (Rocket + sqlx-postgres + Dockerfile). Sibling crate to `lit-billing-core`.
+   - [x] Fly.io deploy config (`fly.toml` at the repo root). Originally targeted Railway; switched to Fly.io because Railway's reliability has degraded.
+   - [x] Magic-link auth end-to-end (Resend, HMAC-signed tokens, 15-min expiry, 7-day session cookies, operators + sessions Postgres tables, per-email rate limit, spawned email send for timing-leak resistance).
+   - [x] Login UI (`/login` + `/`) in vanilla HTML/JS.
+   - [x] Admin credit portal: `GET /api/customer/lookup`, `POST /api/grant`, `GET /api/grants`. Caps enforced (default $20/grant, $100/operator/day). End-to-end UUID idempotency (client → server → Stripe Idempotency-Key + DB `UNIQUE(idempotency_key)` + `ON CONFLICT DO NOTHING`).
+   - [x] Three-section dashboard at `/`: lookup → match cards with inline grant form → recent grants table.
+   - [x] `lit-billing-core` additions for the portal: `customer::find_by_wallet` (non-creating), `customer::search_by_email` + `CustomerSummary`, `balance::write_transaction`.
+   - **Milestone hit**: Discord mod can sign in via magic link and grant credits once the Fly app is provisioned.
+
+### 🚧 3. Feature 2: LITKEY → Stripe credit — IN PROGRESS
+
+   **3a.** ✅ `LitkeyPaymentGateway` contract + Hardhat project — DONE (PR #373, open against `next`)
+   - [x] Solidity 0.8.28 contract at `lit-payments/contracts/contracts/LitkeyPaymentGateway.sol`. Immutable; `pay(amount, wallet)` pulls LITKEY via `SafeERC20.safeTransferFrom`, forwards to treasury, emits `Payment(indexed wallet, indexed payer, amount)`. Custom-error reverts on zero treasury / wallet / amount.
+   - [x] Self-contained Hardhat + TS project at `lit-payments/contracts/` (matches `lit_node_express` conventions). Networks: `hardhat`, `baseSepolia`, `base`.
+   - [x] 12 unit tests passing — constructor guards, every revert path, balance + event-arg assertions, multi-payer attribution, cross-wallet payments (payer ≠ credited), indexed-topic filtering.
+   - [x] `scripts/deploy.ts` (env-driven, optional Basescan auto-verify) + README.
+   - [x] CI workflow `.github/workflows/lit-payments-contracts-ci.yml`.
+   - [ ] Manual: deploy to Base Sepolia with a throwaway treasury, confirm `Payment` event shape via Basescan.
+   - [ ] Manual: deploy to Base mainnet with the company Safe as treasury after #373 merges and Sepolia testing is clean.
+
+   **3b.** ⏭️ CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI — NOT STARTED
+   - Background task in `lit-payments` polling `https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd` every 5 min.
+   - Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `cents_per_litkey`, `source`, `fetched_at`, `updated_by_operator_id`).
+   - Stale (>1hr) pauses crediting + logs a warning (no Slack alert — `fly logs` only).
+   - Admin UI section on the dashboard to view the current rate + override it (`source='manual'`).
+   - **No on-chain dependency** — can ship before 3c.
+
+   **3c.** ⏭️ Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — NOT STARTED
+   - WSS subscription to `Payment` events from the deployed gateway contract; exponential backoff reconnect.
+   - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
+   - 5-confirmation depth on Base before crediting.
+   - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.
+   - For each Payment event: read `litkey_rate`, compute `cents = litkey_amount * rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
+   - Migrations: `litkey_payments`, `chain_checkpoint`.
+   - **Depends on**: 3a contract deployed + address known; 3b rate table existing.
+
+   **3d.** ⏭️ Wagmi `/payWithLitkey` page + dashboard "Pay with tokens" link — NOT STARTED
+   - New page at `payments.litprotocol.com/payWithLitkey?wallet=<address>`. Wallet param is plain (no HMAC — see "URL spoofing" risk).
+   - Flow: page validates the wallet has a Stripe customer → prominently shows the account-to-be-credited (email + wallet) → user confirms → Wagmi wallet connect → quote (refreshed every 30s, frozen at approve) → approve → pay → poll the listener's grants for credit confirmation.
+   - Small change to `lit-static/dapps/dashboard/` to add the "Pay with tokens" button.
+   - **Depends on**: 3a contract address; 3c listener handling the resulting `Payment` events.
+
+   **Milestone (when 3a-d ship)**: users self-serve LITKEY payments end-to-end on Base mainnet; the manual "send LITKEY to the wallet and I'll credit you in Stripe" flow is retired.
+
+### Suggested ordering for the remaining PRs
+
+`3b` (rate poller) → `3c` (listener) → `3d` (payment page). 3b is fully independent so it's the cleanest next slice. 3c needs the contract address (deploy on Sepolia first) and the rate table from 3b. 3d depends on both.
+
+## Risks
+
+- **`lit-billing-core` extraction breaks `lit-api-server`** — pure refactor, single PR, gated on full test pass.
+- **Mod auth abuse** — magic link + daily caps + per-row audit trail. Even a leaked operator account is capped at $100/day.
+- **URL spoofing / phishing the credited wallet** — attacker tricks user into paying with an attacker-chosen `wallet=` param, sending credit to the attacker. Mitigation: page prominently displays the account-to-be-credited (email + wallet) and requires confirmation before the wallet pop-up. We accept residual risk; HMAC-signing the URL is not worth the complexity for the impact.
+- **PaymentGateway contract bug** — small surface but real money. Mitigations: keep contract minimal & immutable, internal review, deploy to Base Sepolia first, monitor on-chain.
+- **Rate staleness** — `>1hr` since `fetched_at` pauses crediting and logs a warning; admins manually update via the rate-override UI when they notice (via user reports or log monitoring).
+- **User sends LITKEY directly to the Safe** — funds sit unattributed in the Safe. Mitigation: mod uses the credit portal to grant manually when a user complains. Documented as unsupported.
+- **Reorg risk** — 5-confirmation depth on Base mitigates; risk is already near-zero past a handful of blocks.

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -304,7 +304,7 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 - Background task polls every 5 min, upserts the single-row `litkey_rate` table.
 - If a fetch fails or returns nonsense (zero / null / >100× recent value): keep the last-known rate, log a warning.
 - If the row's `fetched_at` is older than 1 hour: pause crediting and log a warning. Stuck payments will surface via user reports; mod can grant manually in the meantime.
-- Admin can override the rate from the admin UI (updates the same row with `source='manual'` + operator id). Override is recorded on the row itself — no separate notification.
+- Admin can override the rate from the admin UI (updates the same row with `source='manual'` + operator id). Manual override is authoritative until another admin changes it; the poller does not overwrite manual values. Stale manual values still pause crediting so an operator has to deliberately refresh the override during an oracle incident. Override is recorded on the row itself — no separate notification.
 - `LITKEY_DISCOUNT_BASIS_POINTS` configures an incentive discount for LITKEY payments. Default `0` means no discount. Example: `2000` means "20% off vs credit card", so the effective credit rate is `market_rate / (1 - 0.20)`; users receive 1.25× the market-rate Stripe credit per LITKEY. This is intentionally an env var rather than a DB setting for v1 simplicity.
 
 **Quote vs. credit semantics**: the payment page shows the rate at page-load and refreshes the quote every 30s. Once the user starts the `approve` tx, the LITKEY amount is frozen. At confirmation we credit using the rate **in effect at the on-chain `Payment` event** (the most recent value of `litkey_rate`) plus the configured `LITKEY_DISCOUNT_BASIS_POINTS` multiplier. Page says "estimated credit, finalized at confirmation."
@@ -396,7 +396,8 @@ All questions are closed. Plan is ready to start building.
    - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
    - 5-confirmation depth on Base before crediting.
    - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.
-   - For each Payment event: read `litkey_rate`, apply `LITKEY_DISCOUNT_BASIS_POINTS` to compute the effective credit rate, compute `cents = litkey_amount * effective_rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
+   - For each Payment event: read `litkey_rate`, reject/hold crediting if `crediting_paused` is true, apply `LITKEY_DISCOUNT_BASIS_POINTS` to compute the effective credit rate, compute `cents = litkey_amount * effective_rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
+   - Before production listener crediting, upgrade rate math from whole cents/LITKEY to a higher-precision fixed-point representation and round only once at the final Stripe-cent amount. The current 3b admin UI/API is acceptable for quoting visibility, but final crediting should avoid systematic over/under-crediting from whole-cent spot-rate rounding.
    - Migrations: `litkey_payments`, `chain_checkpoint`.
    - **Depends on**: 3a contract deployed + address known (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3b rate table existing.
 

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -305,8 +305,9 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 - If a fetch fails or returns nonsense (zero / null / >100× recent value): keep the last-known rate, log a warning.
 - If the row's `fetched_at` is older than 1 hour: pause crediting and log a warning. Stuck payments will surface via user reports; mod can grant manually in the meantime.
 - Admin can override the rate from the admin UI (updates the same row with `source='manual'` + operator id). Override is recorded on the row itself — no separate notification.
+- `LITKEY_DISCOUNT_BASIS_POINTS` configures an incentive discount for LITKEY payments. Default `0` means no discount. Example: `2000` means "20% off vs credit card", so the effective credit rate is `market_rate / (1 - 0.20)`; users receive 1.25× the market-rate Stripe credit per LITKEY. This is intentionally an env var rather than a DB setting for v1 simplicity.
 
-**Quote vs. credit semantics**: the payment page shows the rate at page-load and refreshes the quote every 30s. Once the user starts the `approve` tx, the LITKEY amount is frozen. At confirmation we credit using the rate **in effect at the on-chain `Payment` event** (the most recent value of `litkey_rate`). Page says "estimated credit, finalized at confirmation."
+**Quote vs. credit semantics**: the payment page shows the rate at page-load and refreshes the quote every 30s. Once the user starts the `approve` tx, the LITKEY amount is frozen. At confirmation we credit using the rate **in effect at the on-chain `Payment` event** (the most recent value of `litkey_rate`) plus the configured `LITKEY_DISCOUNT_BASIS_POINTS` multiplier. Page says "estimated credit, finalized at confirmation."
 
 ### Edge cases
 
@@ -347,6 +348,7 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 | Per-grant cap | $20 |
 | Per-operator daily cap | $100 |
 | Global cap | none |
+| LITKEY payment discount | Env var `LITKEY_DISCOUNT_BASIS_POINTS`, default `0`; `2000` = 20% off vs credit card |
 
 ## Open questions
 
@@ -386,6 +388,7 @@ All questions are closed. Plan is ready to start building.
    - [x] Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `cents_per_litkey`, `source`, `fetched_at`, `updated_by_operator_id`).
    - [x] Stale (>1hr) is surfaced on the API/UI and logs a warning so future 3c crediting can pause (no Slack alert — `fly logs` only).
    - [x] Admin UI section on the dashboard to view the current rate + override it (`source='manual'`).
+   - [x] Env-configured LITKEY payment discount (`LITKEY_DISCOUNT_BASIS_POINTS`, default `0`; `2000` = 20% off vs credit card) exposed in the rate API/UI as the discount-adjusted effective credit rate.
    - [x] **No on-chain dependency** — can ship before 3c.
 
    **3c.** ⏭️ Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — NOT STARTED
@@ -393,7 +396,7 @@ All questions are closed. Plan is ready to start building.
    - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
    - 5-confirmation depth on Base before crediting.
    - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.
-   - For each Payment event: read `litkey_rate`, compute `cents = litkey_amount * rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
+   - For each Payment event: read `litkey_rate`, apply `LITKEY_DISCOUNT_BASIS_POINTS` to compute the effective credit rate, compute `cents = litkey_amount * effective_rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
    - Migrations: `litkey_payments`, `chain_checkpoint`.
    - **Depends on**: 3a contract deployed + address known (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3b rate table existing.
 

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -393,9 +393,10 @@ All questions are closed. Plan is ready to start building.
    - [x] **No on-chain dependency** — can ship before 3c.
 
    **3c.** 🚧 Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — STARTED IN PR WORKTREE
-   - [x] Added phase-3c schema: `litkey_payments` with `UNIQUE(chain_id, tx_hash, log_index)` and `chain_checkpoint` with per-chain `last_processed_block`.
-   - [x] Added listener configuration/env parsing for `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, `LITKEY_GATEWAY_ADDRESS`, `LITKEY_CHAIN_ID` (default Base `8453`), `LITKEY_CONFIRMATIONS` (default `5`), and `LITKEY_RECONCILIATION_INTERVAL_SECS` (default `60`). If the chain env vars are absent, the portal/rate poller still boot and LITKEY crediting stays disabled.
+   - [x] Added phase-3c schema: `litkey_payments` with `UNIQUE(chain_id, tx_hash, log_index)`, canonical address/hash checks, explicit `status` (`credited`, `dust`, `paused`, `no_customer`) so dust/paused/skipped events can still be audited, and `chain_checkpoint` keyed by `(chain_id, gateway_address)` so a replacement gateway cannot inherit the old checkpoint.
+   - [x] Added listener configuration/env parsing for `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, `LITKEY_GATEWAY_ADDRESS`, `LITKEY_CHAIN_ID` (Base mainnet `8453` only), `LITKEY_CONFIRMATIONS` (default `5`, must be >0), and `LITKEY_RECONCILIATION_INTERVAL_SECS` (default `60`, must be >0). If the chain env vars are absent, the portal/rate poller still boot and LITKEY crediting stays disabled.
    - [x] Added shared listener primitives/tests for deterministic Stripe idempotency keys, address normalization, confirmation depth, reconciliation ranges, reconnect backoff, and native wei amount formatting.
+   - [x] Added DB helper layer for payment idempotency inserts and checkpoint read/advance; checkpoint advancement uses `GREATEST` so retries cannot move a gateway checkpoint backwards.
    - [ ] WSS subscription to `Payment` events from the deployed gateway contract; exponential backoff reconnect.
    - 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
    - 5-confirmation depth on Base before crediting.

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -8,7 +8,7 @@ Date: 2026-05-18 (last updated: 2026-05-21)
 
 - **Shipped to `next`**: `lit-billing-core` extraction (PR #358), `lit-payments` foundation + magic-link auth (PR #359), admin credit portal + Fly.io deploy target (PR #370).
 - **Open**: `LitkeyPaymentGateway` Solidity contract + Hardhat project (PR #373).
-- **Not yet started**: rate poller (3b), Alchemy WSS listener (3c), Wagmi payment page + dashboard link (3d). See the Sequencing section near the bottom for what each entails and recommended order — start with 3b.
+- **In progress**: rate poller (3b) implemented in this PR worktree; Alchemy WSS listener (3c) and Wagmi payment page + dashboard link (3d) remain. See the Sequencing section near the bottom for what each entails and recommended order.
 
 The rest of this doc is the original design + decisions, kept for context. Implementation details that diverged from the plan are noted inline.
 
@@ -378,15 +378,15 @@ All questions are closed. Plan is ready to start building.
    - [x] 12 unit tests passing — constructor guards, every revert path, balance + event-arg assertions, multi-payer attribution, cross-wallet payments (payer ≠ credited), indexed-topic filtering.
    - [x] `scripts/deploy.ts` (env-driven, optional Basescan auto-verify) + README.
    - [x] CI workflow `.github/workflows/lit-payments-contracts-ci.yml`.
-   - [ ] Manual: deploy to Base Sepolia with a throwaway treasury, confirm `Payment` event shape via Basescan.
-   - [ ] Manual: deploy to Base mainnet with the company Safe as treasury after #373 merges and Sepolia testing is clean.
+   - [x] Manual: deployed to Base mainnet at `0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` with the company Safe as treasury. Smoke test: 1 wei of LITKEY sent through the gateway arrived in the company Safe.
+   - [x] Deployment invariant documented: `litkey` and `treasury` are immutable constructor args. Changing the token or recipient Safe requires deploying a new `LitkeyPaymentGateway` and updating listener/dashboard config to the new address.
 
-   **3b.** ⏭️ CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI — NOT STARTED
-   - Background task in `lit-payments` polling `https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd` every 5 min.
-   - Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `cents_per_litkey`, `source`, `fetched_at`, `updated_by_operator_id`).
-   - Stale (>1hr) pauses crediting + logs a warning (no Slack alert — `fly logs` only).
-   - Admin UI section on the dashboard to view the current rate + override it (`source='manual'`).
-   - **No on-chain dependency** — can ship before 3c.
+   **3b.** ✅ CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI — IMPLEMENTED IN PR WORKTREE
+   - [x] Background task in `lit-payments` polling `https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd` every 5 min.
+   - [x] Migration adding the single-row `litkey_rate` table (`id PRIMARY KEY DEFAULT 1 CHECK (id = 1)`, `cents_per_litkey`, `source`, `fetched_at`, `updated_by_operator_id`).
+   - [x] Stale (>1hr) is surfaced on the API/UI and logs a warning so future 3c crediting can pause (no Slack alert — `fly logs` only).
+   - [x] Admin UI section on the dashboard to view the current rate + override it (`source='manual'`).
+   - [x] **No on-chain dependency** — can ship before 3c.
 
    **3c.** ⏭️ Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — NOT STARTED
    - WSS subscription to `Payment` events from the deployed gateway contract; exponential backoff reconnect.
@@ -395,13 +395,13 @@ All questions are closed. Plan is ready to start building.
    - Idempotency on `(tx_hash, log_index)` unique in `litkey_payments`.
    - For each Payment event: read `litkey_rate`, compute `cents = litkey_amount * rate`, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
    - Migrations: `litkey_payments`, `chain_checkpoint`.
-   - **Depends on**: 3a contract deployed + address known; 3b rate table existing.
+   - **Depends on**: 3a contract deployed + address known (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3b rate table existing.
 
    **3d.** ⏭️ Wagmi `/payWithLitkey` page + dashboard "Pay with tokens" link — NOT STARTED
    - New page at `payments.litprotocol.com/payWithLitkey?wallet=<address>`. Wallet param is plain (no HMAC — see "URL spoofing" risk).
    - Flow: page validates the wallet has a Stripe customer → prominently shows the account-to-be-credited (email + wallet) → user confirms → Wagmi wallet connect → quote (refreshed every 30s, frozen at approve) → approve → pay → poll the listener's grants for credit confirmation.
    - Small change to `lit-static/dapps/dashboard/` to add the "Pay with tokens" button.
-   - **Depends on**: 3a contract address; 3c listener handling the resulting `Payment` events.
+   - **Depends on**: 3a contract address (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3c listener handling the resulting `Payment` events.
 
    **Milestone (when 3a-d ship)**: users self-serve LITKEY payments end-to-end on Base mainnet; the manual "send LITKEY to the wallet and I'll credit you in Stripe" flow is retired.
 


### PR DESCRIPTION
## Summary
- First slice of Feature 2 from `plans/lit-payments-app.md`: the on-chain piece the LITKEY → Stripe credit listener and payment page will both depend on.
- New self-contained Hardhat project at `lit-payments/contracts/` (Solidity 0.8.28, matches the existing `lit_node_express` conventions). `LitkeyPaymentGateway` is immutable — `pay(amount, wallet)` pulls LITKEY via `SafeERC20.safeTransferFrom`, forwards to the treasury (company Safe on Base), and emits `Payment(indexed wallet, indexed payer, amount)`. Reverts on zero treasury / wallet / amount via custom errors.
- 12 Hardhat tests covering deploy guards, every revert path, happy-path balance + event assertions, multi-payer attribution, cross-wallet payments, and indexed-topic filtering.
- `scripts/deploy.ts` deploys + (optionally) Basescan-verifies. README walks through Base Sepolia → mainnet.
- New CI workflow `.github/workflows/lit-payments-contracts-ci.yml` runs `hardhat compile` + `hardhat test` on PRs touching `lit-payments/contracts/`.

## Test plan
- [x] `npm test` in `lit-payments/contracts/` — 12 / 12 passing locally
- [x] `npx hardhat compile` clean
- [ ] Deploy to Base Sepolia with a throwaway treasury, confirm `Payment` event shape via Basescan (manual step before merging)

## Follow-up PRs (Feature 2 remaining)
1. CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI
2. Alchemy WSS listener + 60s reconciliation poll + `litkey_payments` schema
3. Wagmi `/payWithLitkey` payment page + dashboard "Pay with tokens" link