### PR TITLE
chore(CPL-328): remove traces of dev network from configs and docs

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -105,7 +105,7 @@ jobs:
             echo "instance_type=tdx.large" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-dev" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.main.toml" >> "$GITHUB_OUTPUT"
-            DOMAIN="api.dev.litprotocol.com"
+            DOMAIN="test.chipotle.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
             # Targets the prod2 instance provisioned via `phala instances add`
             # during the prod6→prod2 migration. Shares the same app_id

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "20"
 
       - name: Inject API URL
-        run: sed -i "s|__LIT_API_BASE_URL__|https://api.dev.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
+        run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -11,7 +11,7 @@ The same workflows can be done via the REST API. The API itself is under `/core/
 - `X-Api-Key: your-api-key`
 - or `Authorization: Bearer your-api-key`
 
-Examples below assume `KEY=your_account_or_usage_api_key`. cURL snippets use `BASE=https://api.chipotle.litprotocol.com` (hosted production API) and JavaScript snippets use `BASE=https://api.dev.litprotocol.com` (hosted dev API); change the `BASE` value if you want to target the other environment. The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
+Examples below assume `KEY=your_account_or_usage_api_key` and `BASE=https://api.chipotle.litprotocol.com` (the hosted production API). The JavaScript examples use the Core SDK (`LitNodeSimpleApiClient`) from `core_sdk.js`.
 
 **API workflow:**
 

--- a/docs/management/crypto.mdx
+++ b/docs/management/crypto.mdx
@@ -36,7 +36,7 @@ You can also initiate crypto payments programmatically using the billing API. Th
 Examples below assume the following setup:
 
 ```javascript
-const BASE = 'https://api.chipotle.litprotocol.com'; // or https://api.dev.litprotocol.com for dev
+const BASE = 'https://api.chipotle.litprotocol.com';
 const accountApiKey = 'your-account-api-key';         // from /new_account
 ```
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ app_name       := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main
 instance_type  := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo tdx.small || echo tdx.small'`
 gcp_project_id := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo chipotle-dev || echo chipotle-next'`
 node_config    := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo NodeConfig.main.toml || echo NodeConfig.next.toml'`
-domain         := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo api.dev.litprotocol.com || echo test.chipotle.litprotocol.com'`
+domain         := 'test.chipotle.litprotocol.com'
 
 import "justfile.deploy"
 import "justfile.sim"

--- a/k6/README.md
+++ b/k6/README.md
@@ -11,7 +11,7 @@ Auto-generated from the OpenAPI spec using [@grafana/openapi-to-k6](https://gith
 
 ```bash
 npm install -g @grafana/openapi-to-k6
-openapi-to-k6 https://api.dev.litprotocol.com/openapi.json \ ./k6
+openapi-to-k6 https://test.chipotle.litprotocol.com/openapi.json \ ./k6
 
 # Note: The OpenAPI spec paths omit the /core/v1 prefix. Set BASE_URL with /core/v1
 # when running against the Phala deployment, e.g. BASE_URL=.../core/v1

--- a/k6/README.md
+++ b/k6/README.md
@@ -11,7 +11,7 @@ Auto-generated from the OpenAPI spec using [@grafana/openapi-to-k6](https://gith
 
 ```bash
 npm install -g @grafana/openapi-to-k6
-openapi-to-k6 https://test.chipotle.litprotocol.com/openapi.json \ ./k6
+openapi-to-k6 https://test.chipotle.litprotocol.com/openapi.json ./k6
 
 # Note: The OpenAPI spec paths omit the /core/v1 prefix. Set BASE_URL with /core/v1
 # when running against the Phala deployment, e.g. BASE_URL=.../core/v1

--- a/k6/defaults.ts
+++ b/k6/defaults.ts
@@ -5,7 +5,7 @@
 import type { Params } from "k6/http";
 
 export const BASE_URL =
-  __ENV.BASE_URL || "https://api.dev.litprotocol.com/core/v1";
+  __ENV.BASE_URL || "https://test.chipotle.litprotocol.com/core/v1";
 
 /**
  * A unique ID for this k6 run, used as the X-Correlation-Id header so that

--- a/k6/justfile
+++ b/k6/justfile
@@ -15,7 +15,7 @@
 #   just NETWORK=main BASE_URL='https://other.example.com/core/v1' spike
 
 NETWORK := 'main'
-_base_url_main := 'https://api.dev.litprotocol.com/core/v1'
+_base_url_main := 'https://test.chipotle.litprotocol.com/core/v1'
 _base_url_next := 'https://test.chipotle.litprotocol.com/core/v1'
 _base_url_prod := 'https://api.chipotle.litprotocol.com/core/v1'
 _accounts_file_main := './data/accounts.dev.json'

--- a/k6/loadtest/README.md
+++ b/k6/loadtest/README.md
@@ -21,7 +21,7 @@ BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/spike.spec.ts
 
 | Variable       | Default | Description              |
 |----------------|---------|--------------------------|
-| `BASE_URL`     | api.dev.litprotocol.com | API base URL          |
+| `BASE_URL`     | test.chipotle.litprotocol.com | API base URL          |
 | `SPIK_VUS`     | `20`    | Peak virtual users       |
 | `SPIK_DURATION`| `2m`    | Sustain duration at peak  |
 
@@ -51,7 +51,7 @@ SOAK_VUS=4 k6 run k6/loadtest/soak.spec.ts
 
 | Variable        | Default | Description                    |
 |----------------|---------|--------------------------------|
-| `BASE_URL`     | api.dev.litprotocol.com | API base URL (include `/core/v1`) |
+| `BASE_URL`     | test.chipotle.litprotocol.com | API base URL (include `/core/v1`) |
 | `SOAK_DURATION`| `30m`    | Steady-state duration          |
 | `SOAK_VUS`     | `3`     | Virtual users                  |
 
@@ -84,7 +84,7 @@ BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/breakpoint.spec.ts
 
 | Variable           | Default | Description                                   |
 |--------------------|---------|-----------------------------------------------|
-| `BASE_URL`         | api.dev.litprotocol.com | API base URL (include `/core/v1`) |
+| `BASE_URL`         | test.chipotle.litprotocol.com | API base URL (include `/core/v1`) |
 | `BPT_MAX_VUS`      | `30`    | Maximum/peak VUs for the test                 |
 | `BPT_STEP_DURATION`| `2m`    | Duration for each load step                   |
 | `BPT_STEPS`        | *none*  | Optional comma-separated list of VU levels    |

--- a/k6/loadtest/breakpoint.spec.ts
+++ b/k6/loadtest/breakpoint.spec.ts
@@ -20,7 +20,7 @@
  *   BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/breakpoint.spec.ts
  *
  * Environment:
- *   BASE_URL          - API base URL (default: test.chipotle.litprotocol.com/core/v1)
+ *   BASE_URL          - API base URL (default: https://test.chipotle.litprotocol.com/core/v1)
  *   BPT_MAX_VUS       - Max/peak virtual users across both scenarios (default: 50)
  *   BPT_STEP_DURATION - Duration for each load step (default: 2m)
  *   BPT_STEPS         - Comma-separated list of VU levels; last one is treated

--- a/k6/loadtest/breakpoint.spec.ts
+++ b/k6/loadtest/breakpoint.spec.ts
@@ -20,7 +20,7 @@
  *   BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/breakpoint.spec.ts
  *
  * Environment:
- *   BASE_URL          - API base URL (default: api.dev.litprotocol.com/core/v1)
+ *   BASE_URL          - API base URL (default: test.chipotle.litprotocol.com/core/v1)
  *   BPT_MAX_VUS       - Max/peak virtual users across both scenarios (default: 50)
  *   BPT_STEP_DURATION - Duration for each load step (default: 2m)
  *   BPT_STEPS         - Comma-separated list of VU levels; last one is treated

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -27,7 +27,7 @@
  *   ramp_* - Gradual load increase: +1 VU per minute for 8 min, then 1 min ramp-down.
  *
  * Environment:
- *   BASE_URL       - API base URL (default: api.dev.litprotocol.com/core/v1)
+ *   BASE_URL       - API base URL (default: test.chipotle.litprotocol.com/core/v1)
  *   SCENARIO       - Run only this scenario group: "soak" or "ramp" (default: both)
  *   SOAK_DURATION  - Total test duration for soak scenario (default: 30m)
  *   SOAK_VUS       - Virtual users for soak scenario (default: 3)

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -27,7 +27,7 @@
  *   ramp_* - Gradual load increase: +1 VU per minute for 8 min, then 1 min ramp-down.
  *
  * Environment:
- *   BASE_URL       - API base URL (default: test.chipotle.litprotocol.com/core/v1)
+ *   BASE_URL       - API base URL (default: https://test.chipotle.litprotocol.com/core/v1)
  *   SCENARIO       - Run only this scenario group: "soak" or "ramp" (default: both)
  *   SOAK_DURATION  - Total test duration for soak scenario (default: 30m)
  *   SOAK_VUS       - Virtual users for soak scenario (default: 3)

--- a/k6/loadtest/spike.spec.ts
+++ b/k6/loadtest/spike.spec.ts
@@ -12,9 +12,9 @@
  *   BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/spike.spec.ts
  *
  * Environment:
- *   BASE_URL        - API base URL (default: test.chipotle.litprotocol.com/core/v1)
- *   SPIK_VUS        - Peak virtual users (default: 20)
- *   SPIK_DURATION   - Sustain duration at peak (default: 2m)
+ *   BASE_URL        - API base URL (default: https://test.chipotle.litprotocol.com/core/v1)
+ *   SPIK_VUS        - Peak virtual users (default: 25)
+ *   SPIK_DURATION   - Sustain duration at peak (default: 1m)
  */
 import { checkAndLog, warnOnHttpFailures } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";

--- a/k6/loadtest/spike.spec.ts
+++ b/k6/loadtest/spike.spec.ts
@@ -12,7 +12,7 @@
  *   BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/spike.spec.ts
  *
  * Environment:
- *   BASE_URL        - API base URL (default: api.dev.litprotocol.com/core/v1)
+ *   BASE_URL        - API base URL (default: test.chipotle.litprotocol.com/core/v1)
  *   SPIK_VUS        - Peak virtual users (default: 20)
  *   SPIK_DURATION   - Sustain duration at peak (default: 2m)
  */

--- a/lit-static/SKILL.md
+++ b/lit-static/SKILL.md
@@ -8,7 +8,6 @@ description: Teaches how to create and configure a Lit Chipotle account (account
 Lit Chipotle is a programmable key management system. Accounts hold wallets (PKPs), IPFS-pinned JavaScript programs (Lit Actions), and permission groups — all enforced on-chain via the `AccountConfig` smart contract and executed inside a TEE (Trusted Execution Environment).
 
 **Production API**: `https://api.chipotle.litprotocol.com`
-**Dev API**: `https://api.dev.litprotocol.com`
 **Dashboard**: `https://dashboard.chipotle.litprotocol.com/dapps/dashboard/`
 **Local dev**: `http://localhost:8000`
 


### PR DESCRIPTION
## Summary
- Replace `api.dev.litprotocol.com` with `test.chipotle.litprotocol.com` across deploy workflows (`deploy-staging.yml`, `deploy-static.yml`), root + k6 `justfile`s, k6 load-test defaults/specs (`defaults.ts`, `loadtest/{spike,soak,breakpoint}.spec.ts`), and k6 READMEs.
- Drop the "Dev API" bullet from `lit-static/SKILL.md` and remove dev-environment callouts from `docs/management/api_direct.mdx` and `docs/management/crypto.mdx`, since we're running solely on production.
- `justfile`'s `domain` is no longer branch-conditional (both main and next resolved to the same target after the swap); other per-branch values (app_name, gcp_project_id, node_config) still differentiate.

## Test plan
- [ ] CI: workflows still parse / lint
- [ ] Verify `just` recipes resolve the new domain on both `main` and `next` checkouts
- [ ] Spot-check rendered docs (`api_direct.mdx`, `crypto.mdx`) for stranded "dev" wording

Linear: https://linear.app/litprotocol/issue/CPL-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)