### PR TITLE
feat: add lit-triggers scheduled triggers

### DIFF
--- a/lit-triggers/Cargo.lock
+++ b/lit-triggers/Cargo.lock
@@ -53,6 +53,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +280,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "cid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +398,17 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -1138,6 +1169,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1457,8 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "base64",
+ "chrono",
+ "cron",
  "hmac",
  "ipfs-hasher",
  "moka",
@@ -1485,6 +1542,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1577,6 +1640,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3379,6 +3452,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/lit-triggers/Cargo.toml
+++ b/lit-triggers/Cargo.toml
@@ -9,6 +9,8 @@ license = "Apache-2.0"
 anyhow = "1.0"
 aes-gcm = "0.10"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+cron = "0.12"
 hmac = "0.12"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.8"

--- a/lit-triggers/migrations/20260522000002_schedule_watermarks.sql
+++ b/lit-triggers/migrations/20260522000002_schedule_watermarks.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schedule_watermarks (
+  trigger_id UUID PRIMARY KEY REFERENCES triggers(id) ON DELETE CASCADE,
+  last_enqueued_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX schedule_watermarks_updated_at_idx ON schedule_watermarks(updated_at);

--- a/lit-triggers/src/lib.rs
+++ b/lit-triggers/src/lib.rs
@@ -5,6 +5,7 @@ pub mod crypto;
 pub mod db;
 pub mod dispatcher;
 pub mod mail;
+pub mod scheduler;
 pub mod triggers;
 pub mod webhook;
 pub mod webhook_rate_limit;

--- a/lit-triggers/src/main.rs
+++ b/lit-triggers/src/main.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use lit_triggers::auth::routes as auth_routes;
-use lit_triggers::{auth, config, db, dispatcher, mail, triggers, webhook, webhook_rate_limit};
+use lit_triggers::{
+    auth, config, db, dispatcher, mail, scheduler, triggers, webhook, webhook_rate_limit,
+};
 use rocket::fs::{FileServer, NamedFile};
 use rocket::http::Status;
 use rocket::response::Redirect;
@@ -26,6 +28,7 @@ async fn rocket() -> _ {
     let webhook_rate_limit = webhook_rate_limit::WebhookRateLimiter::new();
 
     tokio::spawn(dispatcher::run(pool.clone(), cfg.clone()));
+    tokio::spawn(scheduler::run(pool.clone(), cfg.clone()));
 
     rocket::build()
         .manage(pool)

--- a/lit-triggers/src/scheduler.rs
+++ b/lit-triggers/src/scheduler.rs
@@ -1,0 +1,300 @@
+//! Periodic scheduler for `kind = schedule` triggers.
+//!
+//! The scheduler deliberately uses Postgres as the durable source of truth. Each
+//! scan acquires a transaction-scoped advisory lock, computes at most one due
+//! cron tick per trigger from `schedule_watermarks`, enqueues a `trigger_runs`
+//! row, and advances the watermark in the same transaction.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use serde_json::{json, Value};
+use sqlx::{PgPool, Row};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::config::Config;
+
+const SCAN_INTERVAL: Duration = Duration::from_secs(30);
+const SCHEDULER_LOCK_KEY: i64 = 0x6c69_745f_7363_6865; // "lit_sche" prefix, arbitrary app lock.
+
+#[derive(Debug)]
+struct ScheduleTrigger {
+    id: Uuid,
+    config: Value,
+    created_at: OffsetDateTime,
+    max_queued_runs: Option<i32>,
+    last_enqueued_at: Option<OffsetDateTime>,
+}
+
+pub async fn run(pool: PgPool, config: Config) {
+    loop {
+        if let Err(e) = scan_once(&pool, &config).await {
+            tracing::warn!("schedule scan failed: {e}");
+        }
+        tokio::time::sleep(SCAN_INTERVAL).await;
+    }
+}
+
+async fn scan_once(pool: &PgPool, config: &Config) -> Result<()> {
+    let mut tx = pool.begin().await?;
+
+    let locked = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_xact_lock($1)")
+        .bind(SCHEDULER_LOCK_KEY)
+        .fetch_one(&mut *tx)
+        .await?;
+    if !locked {
+        return Ok(());
+    }
+
+    let rows = sqlx::query(
+        "SELECT t.id, t.config, t.created_at, t.max_queued_runs, w.last_enqueued_at
+         FROM triggers t
+         LEFT JOIN schedule_watermarks w ON w.trigger_id = t.id
+         WHERE t.kind = 'schedule' AND t.enabled = true
+         ORDER BY t.created_at ASC
+         FOR UPDATE OF t",
+    )
+    .fetch_all(&mut *tx)
+    .await?;
+
+    let now = OffsetDateTime::now_utc();
+    for row in rows {
+        let trigger = ScheduleTrigger {
+            id: row.get("id"),
+            config: row.get("config"),
+            created_at: row.get("created_at"),
+            max_queued_runs: row.get("max_queued_runs"),
+            last_enqueued_at: row.get("last_enqueued_at"),
+        };
+
+        if let Err(e) = enqueue_if_due(&mut tx, trigger, now, config).await {
+            tracing::warn!("schedule trigger scan skipped: {e}");
+        }
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn enqueue_if_due(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    trigger: ScheduleTrigger,
+    now: OffsetDateTime,
+    config: &Config,
+) -> Result<()> {
+    let cron = cron_expr_from_config(&trigger.config)
+        .with_context(|| format!("trigger {} missing schedule cron", trigger.id))?;
+    let scheduled_at =
+        match next_due_tick(&cron, trigger.last_enqueued_at, trigger.created_at, now)? {
+            Some(tick) => tick,
+            None => return Ok(()),
+        };
+
+    let input = build_schedule_input(&cron, scheduled_at)?;
+
+    if queue_depth(tx, trigger.id).await? >= max_queued_runs(&trigger, config) {
+        tracing::warn!(trigger_id = %trigger.id, scheduled_at = %scheduled_at, "schedule trigger queue is full; leaving watermark unchanged");
+        return Ok(());
+    }
+
+    let run_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO trigger_runs (id, trigger_id, status, input, attempt)
+         VALUES ($1, $2, 'queued', $3, 1)",
+    )
+    .bind(run_id)
+    .bind(trigger.id)
+    .bind(input)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO schedule_watermarks (trigger_id, last_enqueued_at, updated_at)
+         VALUES ($1, $2, now())
+         ON CONFLICT (trigger_id) DO UPDATE
+         SET last_enqueued_at = EXCLUDED.last_enqueued_at,
+             updated_at = now()",
+    )
+    .bind(trigger.id)
+    .bind(scheduled_at)
+    .execute(&mut **tx)
+    .await?;
+
+    tracing::info!(trigger_id = %trigger.id, run_id = %run_id, scheduled_at = %scheduled_at, "queued scheduled trigger run");
+    Ok(())
+}
+
+async fn queue_depth(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    trigger_id: Uuid,
+) -> Result<i64> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM trigger_runs
+         WHERE trigger_id = $1 AND status IN ('queued','running','retrying')",
+    )
+    .bind(trigger_id)
+    .fetch_one(&mut **tx)
+    .await
+    .context("checking schedule trigger queue depth")
+}
+
+fn max_queued_runs(trigger: &ScheduleTrigger, config: &Config) -> i64 {
+    trigger
+        .max_queued_runs
+        .unwrap_or(config.webhook_default_max_queued_runs as i32)
+        .max(0) as i64
+}
+
+pub fn cron_expr_from_config(config: &Value) -> Option<String> {
+    config
+        .get("cron")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+pub fn normalize_cron(expr: &str) -> Result<String> {
+    let fields: Vec<&str> = expr.split_whitespace().collect();
+    let normalized = match fields.len() {
+        5 => format!("0 {expr}"),
+        6 => expr.to_string(),
+        _ => anyhow::bail!("cron expression must have 5 fields or 6 fields with seconds"),
+    };
+    let schedule = Schedule::from_str(&normalized).context("invalid cron expression")?;
+    validate_min_interval(&schedule)?;
+    Ok(normalized)
+}
+
+fn validate_min_interval(schedule: &Schedule) -> Result<()> {
+    let start = DateTime::from_timestamp(1_800_000_000, 0).context("fixed timestamp valid")?;
+    let mut upcoming = schedule.after(&start);
+    let mut prev = upcoming
+        .next()
+        .context("cron expression has no future occurrences")?;
+    for _ in 0..10 {
+        let next = upcoming
+            .next()
+            .context("cron expression has too few future occurrences")?;
+        if next.signed_duration_since(prev).num_seconds() < SCAN_INTERVAL.as_secs() as i64 {
+            anyhow::bail!(
+                "cron interval must be at least {} seconds",
+                SCAN_INTERVAL.as_secs()
+            );
+        }
+        prev = next;
+    }
+    Ok(())
+}
+
+pub fn validate_cron(expr: &str) -> Result<()> {
+    normalize_cron(expr).map(|_| ())
+}
+
+pub fn next_due_tick(
+    expr: &str,
+    last_enqueued_at: Option<OffsetDateTime>,
+    created_at: OffsetDateTime,
+    now: OffsetDateTime,
+) -> Result<Option<OffsetDateTime>> {
+    let normalized = normalize_cron(expr)?;
+    let schedule = Schedule::from_str(&normalized)?;
+    let baseline = last_enqueued_at.unwrap_or(created_at);
+    let Some(next) = schedule.after(&to_chrono(baseline)?).next() else {
+        return Ok(None);
+    };
+    let next = from_chrono(next)?;
+    if next <= now {
+        Ok(Some(next))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn build_schedule_input(expr: &str, scheduled_at: OffsetDateTime) -> Result<Value> {
+    Ok(json!({
+        "source": "schedule",
+        "scheduled_at": scheduled_at.format(&time::format_description::well_known::Rfc3339)?,
+        "cron": expr,
+    }))
+}
+
+fn to_chrono(t: OffsetDateTime) -> Result<DateTime<Utc>> {
+    DateTime::from_timestamp(t.unix_timestamp(), t.nanosecond()).context("timestamp out of range")
+}
+
+fn from_chrono(t: DateTime<Utc>) -> Result<OffsetDateTime> {
+    OffsetDateTime::from_unix_timestamp(t.timestamp())
+        .context("timestamp out of range")?
+        .replace_nanosecond(t.timestamp_subsec_nanos())
+        .context("nanosecond out of range")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use time::macros::datetime;
+
+    #[test]
+    fn normalizes_five_field_cron_by_prefixing_seconds() {
+        assert_eq!(normalize_cron("*/5 * * * *").unwrap(), "0 */5 * * * *");
+    }
+
+    #[test]
+    fn accepts_six_field_cron_with_seconds() {
+        assert_eq!(normalize_cron("30 */5 * * * *").unwrap(), "30 */5 * * * *");
+    }
+
+    #[test]
+    fn rejects_invalid_cron() {
+        assert!(normalize_cron("not a cron").is_err());
+        assert!(normalize_cron("* * * *").is_err());
+    }
+
+    #[test]
+    fn rejects_sub_scan_interval_cron() {
+        assert!(normalize_cron("*/10 * * * * *").is_err());
+    }
+
+    #[test]
+    fn computes_at_most_one_due_tick_after_watermark() {
+        let due = next_due_tick(
+            "*/5 * * * *",
+            Some(datetime!(2026-05-22 13:00 UTC)),
+            datetime!(2026-05-22 12:00 UTC),
+            datetime!(2026-05-22 13:12 UTC),
+        )
+        .unwrap();
+        assert_eq!(due, Some(datetime!(2026-05-22 13:05 UTC)));
+    }
+
+    #[test]
+    fn returns_none_when_next_tick_is_in_future() {
+        let due = next_due_tick(
+            "*/5 * * * *",
+            Some(datetime!(2026-05-22 13:00 UTC)),
+            datetime!(2026-05-22 12:00 UTC),
+            datetime!(2026-05-22 13:04 UTC),
+        )
+        .unwrap();
+        assert_eq!(due, None);
+    }
+
+    #[test]
+    fn builds_schedule_input_payload() {
+        let input = build_schedule_input("*/5 * * * *", datetime!(2026-05-22 13:05 UTC)).unwrap();
+        assert_eq!(
+            input,
+            json!({
+                "source": "schedule",
+                "scheduled_at": "2026-05-22T13:05:00Z",
+                "cron": "*/5 * * * *"
+            })
+        );
+    }
+}

--- a/lit-triggers/src/triggers.rs
+++ b/lit-triggers/src/triggers.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 use crate::auth::User;
 use crate::config::Config;
 use crate::crypto;
+use crate::scheduler;
 use ipfs_hasher::IpfsHasher;
 
 type ApiResult<T> = Result<Json<T>, Custom<Json<ErrorResponse>>>;
@@ -245,6 +246,7 @@ pub async fn update_trigger(
     let default_params = req.default_params.unwrap_or(existing.default_params);
     let config_json = req.config.unwrap_or(existing.config);
     validate_common(&name, &action_code, &default_params, &config_json)?;
+    validate_kind_config(&kind, &config_json)?;
 
     let (nonce, ciphertext) = match req.usage_api_key {
         Some(k) => {
@@ -474,7 +476,8 @@ fn validate_create(req: &CreateTriggerRequest) -> Result<(), Custom<Json<ErrorRe
         &req.action_code,
         &req.default_params,
         &req.config,
-    )
+    )?;
+    validate_kind_config(&req.kind, &req.config)
 }
 
 fn validate_common(
@@ -499,9 +502,28 @@ fn validate_common(
     Ok(())
 }
 
+fn validate_kind_config(
+    kind: &TriggerKind,
+    config: &Value,
+) -> Result<(), Custom<Json<ErrorResponse>>> {
+    if kind != &TriggerKind::Schedule {
+        return Ok(());
+    }
+
+    let cron = config
+        .get("cron")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| err(Status::BadRequest, "cron_required"))?;
+
+    scheduler::validate_cron(cron).map_err(|_| err(Status::BadRequest, "invalid_cron"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn trigger_kind_serializes_as_api_values() {
@@ -533,6 +555,54 @@ mod tests {
             config: empty_object(),
         };
         assert!(validate_create(&req).is_err());
+    }
+
+    #[test]
+    fn schedule_create_validation_requires_cron() {
+        let req = CreateTriggerRequest {
+            name: "n".into(),
+            kind: TriggerKind::Schedule,
+            action_code: "code".into(),
+            default_params: empty_object(),
+            usage_api_key: "usage".into(),
+            chipotle_account_address: None,
+            max_runs_per_minute: None,
+            max_queued_runs: None,
+            config: empty_object(),
+        };
+        assert!(validate_create(&req).is_err());
+    }
+
+    #[test]
+    fn schedule_create_validation_accepts_valid_cron() {
+        let req = CreateTriggerRequest {
+            name: "n".into(),
+            kind: TriggerKind::Schedule,
+            action_code: "code".into(),
+            default_params: empty_object(),
+            usage_api_key: "usage".into(),
+            chipotle_account_address: None,
+            max_runs_per_minute: None,
+            max_queued_runs: None,
+            config: json!({ "cron": "*/5 * * * *" }),
+        };
+        assert!(validate_create(&req).is_ok());
+    }
+
+    #[test]
+    fn webhook_create_validation_does_not_require_cron() {
+        let req = CreateTriggerRequest {
+            name: "n".into(),
+            kind: TriggerKind::Webhook,
+            action_code: "code".into(),
+            default_params: empty_object(),
+            usage_api_key: "usage".into(),
+            chipotle_account_address: None,
+            max_runs_per_minute: None,
+            max_queued_runs: None,
+            config: empty_object(),
+        };
+        assert!(validate_create(&req).is_ok());
     }
 
     #[test]

--- a/plans/lit-triggers.md
+++ b/plans/lit-triggers.md
@@ -339,7 +339,7 @@ Confirmed.
 2. ✅ **PR 2 — webhook trigger (implemented 2026-05-22).** Public webhook endpoint + run dispatcher +
    basic IP/user/trigger rate limits + async enqueue + call out to Chipotle.
    End-to-end first trigger type working.
-3. **PR 3 — scheduled trigger.** Cron scheduler + worker integration.
+3. ✅ **PR 3 — scheduled trigger (implemented 2026-05-22).** Cron scheduler + worker integration.
 4. **PR 4 — chain event trigger.** EVM listener with watermarks. Biggest
    chunk by far.
 5. **PR 5 — admin UI.** Static HTML/JS dashboard for managing triggers, in


### PR DESCRIPTION
## Summary
- add a durable Postgres-backed scheduler for schedule triggers
- validate 5-field and 6-field cron expressions and reject sub-scan interval schedules
- enqueue scheduled trigger runs through the existing dispatcher with queue-depth protection
- add schedule watermarks migration and mark PR 3 complete in the lit-triggers plan

## Test Plan
- cargo +1.91 fmt --check
- cargo +1.91 test

Follow-up phases remain PR 4 chain events, PR 5 admin UI, and PR 6 fly deploy.