### PR TITLE
feat: add lit-triggers chain event triggers

### DIFF
--- a/lit-triggers/Cargo.lock
+++ b/lit-triggers/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -53,6 +53,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash 0.2.0",
+ "indexmap",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.4",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1",
+ "serde",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bytes",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +105,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +304,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-lock"
@@ -109,7 +341,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -120,7 +352,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -154,6 +386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +407,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -184,6 +433,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,13 +473,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -210,7 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -234,6 +526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +545,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -307,7 +614,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -321,16 +628,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -342,7 +691,7 @@ dependencies = [
  "base64",
  "hkdf",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "subtle",
  "time",
@@ -380,6 +729,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -444,14 +802,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -486,7 +871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -508,6 +893,40 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -540,7 +959,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -560,8 +979,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -572,7 +1001,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -580,6 +1009,32 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "either"
@@ -591,12 +1046,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -612,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -654,6 +1148,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +1210,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +1243,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -729,6 +1273,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -796,7 +1346,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -849,6 +1399,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -864,13 +1415,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -890,6 +1453,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -937,7 +1511,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -972,6 +1546,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec 0.7.6",
+]
 
 [[package]]
 name = "hkdf"
@@ -1066,6 +1649,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1302,6 +1894,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,7 +1977,25 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1387,13 +2017,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1455,14 +2133,16 @@ name = "lit-triggers"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "alloy-primitives",
  "anyhow",
  "base64",
  "chrono",
  "cron",
+ "hex",
  "hmac",
  "ipfs-hasher",
  "moka",
- "rand",
+ "rand 0.8.6",
  "reqwest",
  "rocket",
  "serde",
@@ -1621,7 +2301,7 @@ dependencies = [
  "digest 0.9.0",
  "sha-1",
  "sha2 0.9.9",
- "sha3",
+ "sha3 0.9.1",
  "unsigned-varint 0.5.1",
 ]
 
@@ -1662,6 +2342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,7 +2362,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1757,7 +2447,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1776,6 +2466,34 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1808,6 +2526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,7 +2551,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1844,6 +2568,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1891,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1933,7 +2667,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -1953,10 +2707,35 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -1978,9 +2757,21 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1989,8 +2780,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2000,7 +2801,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2010,6 +2821,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2047,7 +2885,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2108,6 +2946,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2967,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -2142,7 +3000,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.6",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -2171,7 +3029,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
  "version_check",
 ]
@@ -2216,11 +3074,75 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ruint"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -2233,7 +3155,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2276,6 +3198,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +3237,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,9 +3295,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2358,7 +3344,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2403,7 +3389,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -2415,7 +3401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -2427,7 +3413,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -2439,7 +3425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -2451,8 +3437,28 @@ checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
- "keccak",
+ "keccak 0.1.6",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2487,7 +3493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2603,7 +3609,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2626,7 +3632,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2660,7 +3666,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2700,7 +3706,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2765,6 +3771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +3792,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2809,7 +3832,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2840,6 +3863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,7 +3878,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2869,7 +3898,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2962,7 +3991,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3017,8 +4046,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3031,6 +4060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,9 +4077,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3115,7 +4174,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3179,6 +4238,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3216,6 +4299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,7 +4316,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3296,6 +4385,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -3378,7 +4476,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3422,7 +4520,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3475,7 +4573,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3486,7 +4584,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3682,6 +4780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,7 +4824,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3733,7 +4840,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3767,7 +4874,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3780,6 +4887,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yansi"
@@ -3809,7 +4925,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3830,7 +4946,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3850,7 +4966,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3859,6 +4975,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3890,7 +5020,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/lit-triggers/Cargo.toml
+++ b/lit-triggers/Cargo.toml
@@ -15,6 +15,8 @@ hmac = "0.12"
 moka = { version = "0.12", features = ["future"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
+alloy-primitives = { version = "1", default-features = false, features = ["std"] }
+hex = "0.4"
 rocket = { version = "0.5.1", features = ["json", "secrets"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lit-triggers/migrations/20260522000003_chain_event_deliveries.sql
+++ b/lit-triggers/migrations/20260522000003_chain_event_deliveries.sql
@@ -1,0 +1,12 @@
+CREATE TABLE chain_event_deliveries (
+  id BIGSERIAL PRIMARY KEY,
+  trigger_id UUID NOT NULL REFERENCES triggers(id) ON DELETE CASCADE,
+  chain_id BIGINT NOT NULL,
+  tx_hash TEXT NOT NULL,
+  log_index BIGINT NOT NULL,
+  delivery_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (trigger_id, chain_id, tx_hash, log_index)
+);
+CREATE INDEX chain_event_deliveries_trigger_id_created_at_idx
+  ON chain_event_deliveries(trigger_id, created_at DESC);

--- a/lit-triggers/src/chain_events.rs
+++ b/lit-triggers/src/chain_events.rs
@@ -1,0 +1,776 @@
+//! EVM chain-event trigger polling listener.
+//!
+//! Phase 4 intentionally implements the durable polling path first. WebSocket
+//! endpoint names are present in chain specs/config for a follow-up listener,
+//! but this module only uses JSON-RPC HTTP polling.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use alloy_primitives::keccak256;
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::config::{chain_spec_by_id, chain_spec_by_key, ChainSpec, Config};
+
+const CHAIN_EVENTS_LOCK_KEY: i64 = 0x6c69_745f_6368_6169; // "lit_chai" prefix, arbitrary app lock.
+
+#[derive(Clone, Debug)]
+struct ActiveChain {
+    spec: &'static ChainSpec,
+    rpc_url: String,
+}
+
+#[derive(Debug)]
+struct ChainEventTrigger {
+    id: Uuid,
+    config: Value,
+    max_queued_runs: Option<i32>,
+    last_block: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedChainEventConfig {
+    pub chain_key: &'static str,
+    pub chain_id: u64,
+    pub contract_address: String,
+    pub event_signature: String,
+    pub topic0: String,
+    pub topic_filters: Vec<Value>,
+    pub start_block: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RpcResponse<T> {
+    result: Option<T>,
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct EvmLog {
+    pub address: String,
+    pub topics: Vec<String>,
+    pub data: String,
+    #[serde(rename = "blockNumber")]
+    pub block_number: String,
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: String,
+    #[serde(rename = "logIndex")]
+    pub log_index: String,
+}
+
+pub async fn run(pool: PgPool, config: Config) {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(config.chain_rpc_timeout_secs))
+        .build()
+        .expect("chain RPC client");
+
+    loop {
+        if let Err(e) = scan_once(&pool, &config, &client).await {
+            tracing::warn!("chain event scan failed: {e}");
+        }
+        tokio::time::sleep(Duration::from_secs(config.chain_poll_interval_secs)).await;
+    }
+}
+
+async fn scan_once(pool: &PgPool, config: &Config, client: &Client) -> Result<()> {
+    let mut lock_conn = pool.acquire().await?;
+    let locked = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+        .bind(CHAIN_EVENTS_LOCK_KEY)
+        .fetch_one(&mut *lock_conn)
+        .await?;
+    if !locked {
+        return Ok(());
+    }
+
+    let result = async {
+        let active_chains = active_chains(pool, config).await?;
+        for chain in active_chains {
+            if let Err(e) = scan_chain(pool, config, client, &chain).await {
+                tracing::warn!(
+                    chain_key = chain.spec.key,
+                    chain_id = chain.spec.chain_id,
+                    "chain event chain scan skipped: {e}"
+                );
+            }
+        }
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = sqlx::query_scalar::<_, bool>("SELECT pg_advisory_unlock($1)")
+        .bind(CHAIN_EVENTS_LOCK_KEY)
+        .fetch_one(&mut *lock_conn)
+        .await
+    {
+        tracing::warn!("failed to release chain event advisory lock: {e}");
+    }
+
+    result
+}
+
+async fn active_chains(pool: &PgPool, config: &Config) -> Result<Vec<ActiveChain>> {
+    let rows =
+        sqlx::query("SELECT config FROM triggers WHERE kind = 'chain_event' AND enabled = true")
+            .fetch_all(pool)
+            .await?;
+
+    let mut chains: BTreeMap<u64, ActiveChain> = BTreeMap::new();
+    for row in rows {
+        let cfg: Value = row.get("config");
+        let parsed = match parse_chain_event_config(&cfg) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                tracing::warn!("enabled chain_event trigger has invalid config; skipping: {e}");
+                continue;
+            }
+        };
+        let Some(spec) = chain_spec_by_id(parsed.chain_id) else {
+            continue;
+        };
+        let Some(rpc_url) = std::env::var(spec.default_rpc_envvar)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+        else {
+            tracing::warn!(
+                chain_key = spec.key,
+                chain_id = spec.chain_id,
+                rpc_envvar = spec.default_rpc_envvar,
+                "chain RPC env var missing; skipping active chain_event triggers for chain"
+            );
+            continue;
+        };
+        chains
+            .entry(spec.chain_id)
+            .or_insert(ActiveChain { spec, rpc_url });
+    }
+
+    let _ = config; // keep signature symmetric with other worker helpers and future config resolution.
+    Ok(chains.into_values().collect())
+}
+
+async fn scan_chain(
+    pool: &PgPool,
+    config: &Config,
+    client: &Client,
+    chain: &ActiveChain,
+) -> Result<()> {
+    let head = eth_block_number(client, &chain.rpc_url).await?;
+    if head < config.chain_confirmation_depth {
+        return Ok(());
+    }
+    let confirmed_head = head - config.chain_confirmation_depth;
+
+    let rows = sqlx::query(
+        "SELECT t.id, t.config, t.max_queued_runs, w.last_block
+         FROM triggers t
+         LEFT JOIN chain_watermarks w ON w.trigger_id = t.id
+         WHERE t.kind = 'chain_event' AND t.enabled = true
+         ORDER BY t.created_at ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for row in rows {
+        let trigger = ChainEventTrigger {
+            id: row.get("id"),
+            config: row.get("config"),
+            max_queued_runs: row.get("max_queued_runs"),
+            last_block: row.get("last_block"),
+        };
+        let parsed = match parse_chain_event_config(&trigger.config) {
+            Ok(parsed) if parsed.chain_id == chain.spec.chain_id => parsed,
+            Ok(_) => continue,
+            Err(e) => {
+                tracing::warn!(trigger_id = %trigger.id, "invalid chain_event config skipped: {e}");
+                continue;
+            }
+        };
+        if let Err(e) = scan_trigger(
+            pool,
+            config,
+            client,
+            chain,
+            &trigger,
+            &parsed,
+            confirmed_head,
+        )
+        .await
+        {
+            tracing::warn!(trigger_id = %trigger.id, chain_key = chain.spec.key, "chain_event trigger scan skipped: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn scan_trigger(
+    pool: &PgPool,
+    config: &Config,
+    client: &Client,
+    chain: &ActiveChain,
+    trigger: &ChainEventTrigger,
+    parsed: &ParsedChainEventConfig,
+    confirmed_head: u64,
+) -> Result<()> {
+    let start_from = match trigger.last_block {
+        Some(last) => (last.max(0) as u64).saturating_add(1),
+        None => parsed
+            .start_block
+            .unwrap_or_else(|| confirmed_head.saturating_sub(config.chain_initial_lookback_blocks)),
+    };
+    if start_from > confirmed_head {
+        return Ok(());
+    }
+    let to_block = confirmed_head
+        .min(start_from.saturating_add(config.chain_max_block_range.saturating_sub(1)));
+
+    let logs = eth_get_logs(client, &chain.rpc_url, parsed, start_from, to_block).await?;
+
+    let mut tx = pool.begin().await?;
+    let mut queue_saturated = false;
+    for log in logs {
+        let block_number = parse_hex_u64(&log.block_number).context("log blockNumber")?;
+        let log_index = parse_hex_u64(&log.log_index).context("log logIndex")?;
+
+        if queue_depth(&mut tx, trigger.id).await? >= max_queued_runs(trigger, config) {
+            tracing::warn!(trigger_id = %trigger.id, "chain_event trigger queue is full; committing queued prefix and leaving watermark unchanged");
+            queue_saturated = true;
+            break;
+        }
+
+        let delivery_key = delivery_key(parsed.chain_id, &log.transaction_hash, log_index);
+        let inserted_delivery = sqlx::query_scalar::<_, bool>(
+            "INSERT INTO chain_event_deliveries (trigger_id, chain_id, tx_hash, log_index, delivery_key)
+             VALUES ($1, $2, $3, $4, $5)
+             ON CONFLICT DO NOTHING
+             RETURNING true",
+        )
+        .bind(trigger.id)
+        .bind(parsed.chain_id as i64)
+        .bind(normalize_hex(&log.transaction_hash))
+        .bind(log_index as i64)
+        .bind(delivery_key)
+        .fetch_optional(&mut *tx)
+        .await?
+        .unwrap_or(false);
+
+        if !inserted_delivery {
+            continue;
+        }
+
+        let input = build_chain_event_input(parsed, &log, block_number, log_index)?;
+        let run_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO trigger_runs (id, trigger_id, status, input, attempt)
+             VALUES ($1, $2, 'queued', $3, 1)",
+        )
+        .bind(run_id)
+        .bind(trigger.id)
+        .bind(input)
+        .execute(&mut *tx)
+        .await?;
+        tracing::info!(trigger_id = %trigger.id, run_id = %run_id, block_number, "queued chain_event trigger run");
+    }
+
+    if !queue_saturated {
+        sqlx::query(
+            "INSERT INTO chain_watermarks (trigger_id, last_block, updated_at)
+             VALUES ($1, $2, now())
+             ON CONFLICT (trigger_id) DO UPDATE
+             SET last_block = EXCLUDED.last_block, updated_at = now()",
+        )
+        .bind(trigger.id)
+        .bind(to_block as i64)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn queue_depth(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    trigger_id: Uuid,
+) -> Result<i64> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM trigger_runs
+         WHERE trigger_id = $1 AND status IN ('queued','running','retrying')",
+    )
+    .bind(trigger_id)
+    .fetch_one(&mut **tx)
+    .await
+    .context("checking chain_event trigger queue depth")
+}
+
+fn max_queued_runs(trigger: &ChainEventTrigger, config: &Config) -> i64 {
+    trigger
+        .max_queued_runs
+        .unwrap_or(config.webhook_default_max_queued_runs as i32)
+        .max(0) as i64
+}
+
+async fn eth_block_number(client: &Client, rpc_url: &str) -> Result<u64> {
+    let resp: RpcResponse<String> = client
+        .post(rpc_url)
+        .json(&json!({"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    rpc_result(resp).and_then(|hex| parse_hex_u64(&hex))
+}
+
+async fn eth_get_logs(
+    client: &Client,
+    rpc_url: &str,
+    parsed: &ParsedChainEventConfig,
+    from_block: u64,
+    to_block: u64,
+) -> Result<Vec<EvmLog>> {
+    let mut topics = vec![Value::String(parsed.topic0.clone())];
+    topics.extend(parsed.topic_filters.iter().cloned());
+    let filter = json!({
+        "fromBlock": u64_to_hex(from_block),
+        "toBlock": u64_to_hex(to_block),
+        "address": parsed.contract_address,
+        "topics": topics,
+    });
+    let resp: RpcResponse<Vec<EvmLog>> = client
+        .post(rpc_url)
+        .json(&json!({"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[filter]}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    rpc_result(resp)
+}
+
+fn rpc_result<T>(resp: RpcResponse<T>) -> Result<T> {
+    match (resp.result, resp.error) {
+        (Some(result), _) => Ok(result),
+        (_, Some(err)) => anyhow::bail!("rpc error {}: {}", err.code, err.message),
+        _ => anyhow::bail!("rpc response missing result"),
+    }
+}
+
+pub fn parse_chain_event_config(config: &Value) -> Result<ParsedChainEventConfig> {
+    let obj = config
+        .as_object()
+        .context("chain_event config must be object")?;
+    let spec = if let Some(key) = obj.get("chain").and_then(Value::as_str) {
+        chain_spec_by_key(key.trim()).context("unknown chain")?
+    } else if let Some(id) = obj.get("chain_id").and_then(Value::as_u64) {
+        chain_spec_by_id(id).context("unknown chain_id")?
+    } else {
+        anyhow::bail!("chain or chain_id required");
+    };
+    if let Some(id) = obj.get("chain_id").and_then(Value::as_u64) {
+        if id != spec.chain_id {
+            anyhow::bail!("chain and chain_id disagree");
+        }
+    }
+
+    let contract_address = obj
+        .get("contract_address")
+        .or_else(|| obj.get("address"))
+        .and_then(Value::as_str)
+        .map(normalize_hex)
+        .context("contract_address required")?;
+    validate_hex_len(&contract_address, 20).context("invalid contract_address")?;
+
+    let event_signature = obj
+        .get("event_signature")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .context("event_signature required")?
+        .to_string();
+    validate_event_signature(&event_signature)?;
+    let topic0 = event_topic0(&event_signature);
+
+    let topic_filters = match obj.get("topic_filters") {
+        Some(Value::Array(filters)) => {
+            if filters.len() > 3 {
+                anyhow::bail!("topic_filters can include at most 3 entries after topic0");
+            }
+            filters
+                .iter()
+                .map(normalize_topic_filter)
+                .collect::<Result<Vec<_>>>()?
+        }
+        Some(_) => anyhow::bail!("topic_filters must be an array"),
+        None => Vec::new(),
+    };
+
+    let start_block = match obj.get("start_block") {
+        Some(Value::Number(n)) => Some(n.as_u64().context("start_block must be u64")?),
+        Some(Value::String(s)) => Some(parse_hex_or_dec_u64(s).context("invalid start_block")?),
+        Some(_) => anyhow::bail!("start_block must be integer or hex string"),
+        None => None,
+    };
+
+    Ok(ParsedChainEventConfig {
+        chain_key: spec.key,
+        chain_id: spec.chain_id,
+        contract_address,
+        event_signature,
+        topic0,
+        topic_filters,
+        start_block,
+    })
+}
+
+pub fn event_topic0(event_signature: &str) -> String {
+    format!("0x{}", hex::encode(keccak256(event_signature.as_bytes())))
+}
+
+fn validate_event_signature(sig: &str) -> Result<()> {
+    let open = sig.find('(').context("event signature missing '('")?;
+    let close = sig.rfind(')').context("event signature missing ')'")?;
+    if open == 0 || close != sig.len() - 1 || close < open {
+        anyhow::bail!("invalid event signature");
+    }
+    for ty in event_param_types(sig)? {
+        validate_abi_type(&ty)?;
+    }
+    Ok(())
+}
+
+fn validate_abi_type(ty: &str) -> Result<()> {
+    if matches!(ty, "address" | "bool" | "string" | "bytes" | "bytes32") {
+        return Ok(());
+    }
+    if ty.starts_with("uint") || ty.starts_with("int") {
+        let bits = &ty[ty.find('t').unwrap() + 1..];
+        if bits.is_empty()
+            || (bits
+                .parse::<u16>()
+                .is_ok_and(|b| b > 0 && b <= 256 && b % 8 == 0))
+        {
+            return Ok(());
+        }
+    }
+    anyhow::bail!("unsupported abi type: {ty}")
+}
+
+pub fn validate_topic_filter(value: &Value) -> Result<()> {
+    normalize_topic_filter(value).map(|_| ())
+}
+
+fn normalize_topic_filter(value: &Value) -> Result<Value> {
+    match value {
+        Value::Null => Ok(Value::Null),
+        Value::String(s) => normalize_topic(s).map(Value::String),
+        Value::Array(items) => {
+            if items.is_empty() {
+                anyhow::bail!("topic filter alternatives cannot be empty");
+            }
+            let mut normalized = Vec::with_capacity(items.len());
+            for item in items {
+                let s = item
+                    .as_str()
+                    .context("topic filter alternatives must be strings")?;
+                normalized.push(Value::String(normalize_topic(s)?));
+            }
+            Ok(Value::Array(normalized))
+        }
+        _ => anyhow::bail!("topic filter must be null, string, or string array"),
+    }
+}
+
+fn normalize_topic(topic: &str) -> Result<String> {
+    let normalized = normalize_hex(topic);
+    validate_hex_len(&normalized, 32)?;
+    Ok(normalized)
+}
+
+fn validate_hex_len(value: &str, bytes: usize) -> Result<()> {
+    let hex = value
+        .strip_prefix("0x")
+        .context("hex value must be 0x-prefixed")?;
+    if hex.len() != bytes * 2 {
+        anyhow::bail!("hex value must be {bytes} bytes");
+    }
+    hex::decode(hex).context("invalid hex")?;
+    Ok(())
+}
+
+fn normalize_hex(value: &str) -> String {
+    let trimmed = value.trim();
+    if let Some(rest) = trimmed.strip_prefix("0X") {
+        format!("0x{}", rest.to_ascii_lowercase())
+    } else if let Some(rest) = trimmed.strip_prefix("0x") {
+        format!("0x{}", rest.to_ascii_lowercase())
+    } else {
+        format!("0x{}", trimmed.to_ascii_lowercase())
+    }
+}
+
+pub fn parse_hex_u64(value: &str) -> Result<u64> {
+    let hex = value
+        .strip_prefix("0x")
+        .context("hex quantity must be 0x-prefixed")?;
+    u64::from_str_radix(hex, 16).context("invalid hex quantity")
+}
+
+fn parse_hex_or_dec_u64(value: &str) -> Result<u64> {
+    if value.trim_start().starts_with("0x") {
+        parse_hex_u64(value.trim())
+    } else {
+        value
+            .trim()
+            .parse::<u64>()
+            .context("invalid decimal quantity")
+    }
+}
+
+pub fn u64_to_hex(value: u64) -> String {
+    format!("0x{value:x}")
+}
+
+pub fn delivery_key(chain_id: u64, tx_hash: &str, log_index: u64) -> String {
+    format!("{chain_id}:{}:{log_index}", normalize_hex(tx_hash))
+}
+
+pub fn build_chain_event_input(
+    parsed: &ParsedChainEventConfig,
+    log: &EvmLog,
+    block_number: u64,
+    log_index: u64,
+) -> Result<Value> {
+    Ok(json!({
+        "source": "chain_event",
+        "event": {
+            "source": "chain_event",
+            "chain_key": parsed.chain_key,
+            "chain_id": parsed.chain_id,
+            "contract_address": parsed.contract_address,
+            "event_signature": parsed.event_signature,
+            "topic0": parsed.topic0,
+            "block_number": block_number,
+            "transaction_hash": normalize_hex(&log.transaction_hash),
+            "log_index": log_index,
+            "address": normalize_hex(&log.address),
+            "topics": log.topics.iter().map(|t| normalize_hex(t)).collect::<Vec<_>>(),
+            "data": normalize_hex(&log.data),
+            "decoded": decode_event_best_effort(&parsed.event_signature, log),
+            "raw_log": log,
+        }
+    }))
+}
+
+pub fn decode_event_best_effort(event_signature: &str, log: &EvmLog) -> Value {
+    let Ok(types) = event_param_types(event_signature) else {
+        return Value::Null;
+    };
+    let indexed_count = log.topics.len().saturating_sub(1).min(types.len());
+    let mut params = serde_json::Map::new();
+    for (i, ty) in types.iter().take(indexed_count).enumerate() {
+        let value = decode_topic_value(ty, &log.topics[i + 1]);
+        params.insert(format!("arg{i}"), value);
+    }
+    let data_words = decode_data_words(&log.data);
+    for (offset, (i, ty)) in types.iter().enumerate().skip(indexed_count).enumerate() {
+        let value = decode_data_value(ty, &data_words, offset);
+        params.insert(format!("arg{i}"), value);
+    }
+    Value::Object(params)
+}
+
+fn event_param_types(sig: &str) -> Result<Vec<String>> {
+    let open = sig.find('(').context("event signature missing '('")?;
+    let close = sig.rfind(')').context("event signature missing ')'")?;
+    let inner = &sig[open + 1..close];
+    if inner.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(inner.split(',').map(|s| s.trim().to_string()).collect())
+}
+
+fn decode_topic_value(ty: &str, topic: &str) -> Value {
+    let topic = normalize_hex(topic);
+    match ty {
+        "address" => Value::String(format!("0x{}", &topic[topic.len() - 40..])),
+        "bool" => Value::Bool(parse_hex_u64(&topic).unwrap_or(0) != 0),
+        _ => Value::String(topic),
+    }
+}
+
+fn decode_data_words(data: &str) -> Vec<String> {
+    let data = normalize_hex(data);
+    let Some(hex) = data.strip_prefix("0x") else {
+        return Vec::new();
+    };
+    hex.as_bytes()
+        .chunks(64)
+        .filter(|chunk| chunk.len() == 64)
+        .map(|chunk| format!("0x{}", std::str::from_utf8(chunk).unwrap_or_default()))
+        .collect()
+}
+
+fn decode_data_value(ty: &str, words: &[String], index: usize) -> Value {
+    let Some(word) = words.get(index) else {
+        return Value::Null;
+    };
+    match ty {
+        "address" => Value::String(format!("0x{}", &word[word.len() - 40..])),
+        "bool" => Value::Bool(parse_hex_u64(word).unwrap_or(0) != 0),
+        "string" | "bytes" => {
+            decode_dynamic_value(ty, words, index).unwrap_or(Value::String(word.clone()))
+        }
+        _ if ty.starts_with("uint") => Value::String(
+            parse_hex_u128(word)
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| word.clone()),
+        ),
+        _ if ty.starts_with("int") || ty == "bytes32" => Value::String(word.clone()),
+        _ => Value::String(word.clone()),
+    }
+}
+
+fn parse_hex_u128(value: &str) -> Option<u128> {
+    u128::from_str_radix(value.strip_prefix("0x")?, 16).ok()
+}
+
+fn decode_dynamic_value(ty: &str, words: &[String], index: usize) -> Option<Value> {
+    let offset_bytes = parse_hex_u128(words.get(index)?)? as usize;
+    let offset_words = offset_bytes / 32;
+    let len = parse_hex_u128(words.get(offset_words)?)? as usize;
+    let mut bytes = Vec::new();
+    let mut remaining = len;
+    let mut word_index = offset_words + 1;
+    while remaining > 0 {
+        let word_hex = words.get(word_index)?.strip_prefix("0x")?;
+        let chunk = hex::decode(word_hex).ok()?;
+        let take = remaining.min(32);
+        bytes.extend_from_slice(&chunk[..take]);
+        remaining -= take;
+        word_index += 1;
+    }
+    if ty == "string" {
+        String::from_utf8(bytes).ok().map(Value::String)
+    } else {
+        Some(Value::String(format!("0x{}", hex::encode(bytes))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn computes_transfer_topic0() {
+        assert_eq!(
+            event_topic0("Transfer(address,address,uint256)"),
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        );
+    }
+
+    #[test]
+    fn validates_chain_event_config_by_key() {
+        let parsed = parse_chain_event_config(&json!({
+            "chain": "base",
+            "contract_address": "0x0000000000000000000000000000000000000001",
+            "event_signature": "Transfer(address,address,uint256)",
+            "topic_filters": [null, "0X0000000000000000000000000000000000000000000000000000000000000002"],
+            "start_block": "0x10"
+        })).unwrap();
+        assert_eq!(parsed.chain_id, 8453);
+        assert_eq!(parsed.start_block, Some(16));
+        assert_eq!(
+            parsed.topic_filters[1],
+            json!("0x0000000000000000000000000000000000000000000000000000000000000002")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_topics_and_addresses() {
+        assert!(parse_chain_event_config(&json!({
+            "chain_id": 1,
+            "contract_address": "0x1234",
+            "event_signature": "Transfer(address,address,uint256)"
+        }))
+        .is_err());
+        assert!(parse_chain_event_config(&json!({
+            "chain_id": 1,
+            "contract_address": "0x0000000000000000000000000000000000000001",
+            "event_signature": "Transfer(address,address,uint256)",
+            "topic_filters": [null, null, null, null]
+        }))
+        .is_err());
+        assert!(validate_topic_filter(&json!(["0x1234"])).is_err());
+    }
+
+    #[test]
+    fn parses_and_formats_block_hex() {
+        assert_eq!(parse_hex_u64("0x10").unwrap(), 16);
+        assert_eq!(u64_to_hex(500), "0x1f4");
+    }
+
+    #[test]
+    fn delivery_key_is_deterministic_and_normalized() {
+        assert_eq!(delivery_key(1, "0XABC", 7), delivery_key(1, "0xabc", 7));
+    }
+
+    #[test]
+    fn builds_payload_under_params_event() {
+        let parsed = parse_chain_event_config(&json!({
+            "chain": "ethereum",
+            "contract_address": "0x0000000000000000000000000000000000000001",
+            "event_signature": "Transfer(address,address,uint256)"
+        }))
+        .unwrap();
+        let log = EvmLog {
+            address: "0x0000000000000000000000000000000000000001".into(),
+            topics: vec![
+                parsed.topic0.clone(),
+                "0x0000000000000000000000000000000000000000000000000000000000000002".into(),
+                "0x0000000000000000000000000000000000000000000000000000000000000003".into(),
+            ],
+            data: "0x000000000000000000000000000000000000000000000000000000000000007b".into(),
+            block_number: "0x64".into(),
+            transaction_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .into(),
+            log_index: "0x0".into(),
+        };
+        let payload = build_chain_event_input(&parsed, &log, 100, 0).unwrap();
+        assert_eq!(payload["source"], "chain_event");
+        assert_eq!(payload["event"]["decoded"]["arg2"], "123");
+    }
+
+    #[test]
+    fn decodes_dynamic_string_best_effort() {
+        let log = EvmLog {
+            address: "0x0000000000000000000000000000000000000001".into(),
+            topics: vec![event_topic0("Message(string)")],
+            data: concat!(
+                "0x",
+                "0000000000000000000000000000000000000000000000000000000000000020",
+                "0000000000000000000000000000000000000000000000000000000000000002",
+                "6869000000000000000000000000000000000000000000000000000000000000"
+            )
+            .into(),
+            block_number: "0x1".into(),
+            transaction_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .into(),
+            log_index: "0x0".into(),
+        };
+        assert_eq!(
+            decode_event_best_effort("Message(string)", &log)["arg0"],
+            "hi"
+        );
+    }
+}

--- a/lit-triggers/src/config.rs
+++ b/lit-triggers/src/config.rs
@@ -17,6 +17,73 @@ pub struct Config {
     pub webhook_user_max_requests_per_minute: u32,
     pub webhook_trigger_max_requests_per_minute: u32,
     pub webhook_default_max_queued_runs: u32,
+    pub chain_poll_interval_secs: u64,
+    pub chain_confirmation_depth: u64,
+    pub chain_max_block_range: u64,
+    pub chain_rpc_timeout_secs: u64,
+    pub chain_initial_lookback_blocks: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChainKind {
+    Evm,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainSpec {
+    pub key: &'static str,
+    pub chain_id: u64,
+    pub kind: ChainKind,
+    pub default_rpc_envvar: &'static str,
+    pub default_ws_envvar: Option<&'static str>,
+}
+
+pub const CHAIN_SPECS: &[ChainSpec] = &[
+    ChainSpec {
+        key: "ethereum",
+        chain_id: 1,
+        kind: ChainKind::Evm,
+        default_rpc_envvar: "ETHEREUM_RPC_URL",
+        default_ws_envvar: Some("ETHEREUM_WS_RPC_URL"),
+    },
+    ChainSpec {
+        key: "base",
+        chain_id: 8453,
+        kind: ChainKind::Evm,
+        default_rpc_envvar: "BASE_RPC_URL",
+        default_ws_envvar: Some("BASE_WS_RPC_URL"),
+    },
+    ChainSpec {
+        key: "arbitrum",
+        chain_id: 42161,
+        kind: ChainKind::Evm,
+        default_rpc_envvar: "ARBITRUM_RPC_URL",
+        default_ws_envvar: Some("ARBITRUM_WS_RPC_URL"),
+    },
+    ChainSpec {
+        key: "bsc",
+        chain_id: 56,
+        kind: ChainKind::Evm,
+        default_rpc_envvar: "BSC_RPC_URL",
+        default_ws_envvar: Some("BSC_WS_RPC_URL"),
+    },
+    ChainSpec {
+        key: "polygon",
+        chain_id: 137,
+        kind: ChainKind::Evm,
+        default_rpc_envvar: "POLYGON_RPC_URL",
+        default_ws_envvar: Some("POLYGON_WS_RPC_URL"),
+    },
+];
+
+pub fn chain_spec_by_key(key: &str) -> Option<&'static ChainSpec> {
+    CHAIN_SPECS
+        .iter()
+        .find(|spec| spec.key.eq_ignore_ascii_case(key.trim()))
+}
+
+pub fn chain_spec_by_id(chain_id: u64) -> Option<&'static ChainSpec> {
+    CHAIN_SPECS.iter().find(|spec| spec.chain_id == chain_id)
 }
 
 impl Config {
@@ -51,6 +118,11 @@ impl Config {
                 "WEBHOOK_DEFAULT_MAX_QUEUED_RUNS",
                 100,
             )?,
+            chain_poll_interval_secs: optional_parse_min("CHAIN_POLL_INTERVAL_SECS", 15, 1)?,
+            chain_confirmation_depth: optional_parse("CHAIN_CONFIRMATION_DEPTH", 12)?,
+            chain_max_block_range: optional_parse_min("CHAIN_MAX_BLOCK_RANGE", 500, 1)?,
+            chain_rpc_timeout_secs: optional_parse_min("CHAIN_RPC_TIMEOUT_SECS", 10, 1)?,
+            chain_initial_lookback_blocks: optional_parse("CHAIN_INITIAL_LOOKBACK_BLOCKS", 100)?,
         })
     }
 }
@@ -78,6 +150,18 @@ where
             .map_err(|e| anyhow::anyhow!("env var {name} has invalid value: {e}")),
         None => Ok(default),
     }
+}
+
+fn optional_parse_min<T>(name: &str, default: T, min: T) -> Result<T>
+where
+    T: std::str::FromStr + PartialOrd + Copy + std::fmt::Display,
+    T::Err: std::fmt::Display,
+{
+    let value = optional_parse(name, default)?;
+    if value < min {
+        anyhow::bail!("env var {name} must be >= {min}");
+    }
+    Ok(value)
 }
 
 fn parse_b64_key(name: &str) -> Result<Vec<u8>> {

--- a/lit-triggers/src/lib.rs
+++ b/lit-triggers/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod chain_events;
 pub mod chipotle;
 pub mod config;
 pub mod crypto;

--- a/lit-triggers/src/main.rs
+++ b/lit-triggers/src/main.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use anyhow::Result;
 use lit_triggers::auth::routes as auth_routes;
 use lit_triggers::{
-    auth, config, db, dispatcher, mail, scheduler, triggers, webhook, webhook_rate_limit,
+    auth, chain_events, config, db, dispatcher, mail, scheduler, triggers, webhook,
+    webhook_rate_limit,
 };
 use rocket::fs::{FileServer, NamedFile};
 use rocket::http::Status;
@@ -29,6 +30,7 @@ async fn rocket() -> _ {
 
     tokio::spawn(dispatcher::run(pool.clone(), cfg.clone()));
     tokio::spawn(scheduler::run(pool.clone(), cfg.clone()));
+    tokio::spawn(chain_events::run(pool.clone(), cfg.clone()));
 
     rocket::build()
         .manage(pool)

--- a/lit-triggers/src/triggers.rs
+++ b/lit-triggers/src/triggers.rs
@@ -11,6 +11,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::auth::User;
+use crate::chain_events;
 use crate::config::Config;
 use crate::crypto;
 use crate::scheduler;
@@ -238,6 +239,8 @@ pub async fn update_trigger(
 ) -> ApiResult<TriggerResponse> {
     let id = parse_id(id)?;
     let existing = get_existing_for_update(pool.inner(), user.id, id).await?;
+    let existing_kind = existing.kind.clone();
+    let existing_config = existing.config.clone();
     let req = req.into_inner();
     let name = req.name.unwrap_or(existing.name);
     let kind = req.kind.unwrap_or(existing.kind);
@@ -289,15 +292,53 @@ pub async fn update_trigger(
     )
     .bind(req.max_runs_per_minute.or(existing.max_runs_per_minute))
     .bind(req.max_queued_runs.or(existing.max_queued_runs))
-    .bind(config_json)
+    .bind(config_json.clone())
     .bind(req.enabled.unwrap_or(existing.enabled))
     .fetch_one(pool.inner())
     .await
     .map_err(|_| err(Status::InternalServerError, "update_failed"))?;
 
+    if chain_event_watermark_scope_changed(&existing_kind, &existing_config, &kind, &config_json) {
+        reset_chain_event_state(pool.inner(), id).await?;
+    }
+
     row_to_trigger(row)
         .map(Json)
         .map_err(|_| err(Status::InternalServerError, "decode_failed"))
+}
+
+fn chain_event_watermark_scope_changed(
+    old_kind: &TriggerKind,
+    old_config: &Value,
+    new_kind: &TriggerKind,
+    new_config: &Value,
+) -> bool {
+    old_kind == &TriggerKind::ChainEvent
+        && (new_kind != &TriggerKind::ChainEvent || old_config != new_config)
+}
+
+async fn reset_chain_event_state(
+    pool: &PgPool,
+    trigger_id: Uuid,
+) -> Result<(), Custom<Json<ErrorResponse>>> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|_| err(Status::InternalServerError, "chain_state_reset_failed"))?;
+    sqlx::query("DELETE FROM chain_watermarks WHERE trigger_id = $1")
+        .bind(trigger_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|_| err(Status::InternalServerError, "chain_state_reset_failed"))?;
+    sqlx::query("DELETE FROM chain_event_deliveries WHERE trigger_id = $1")
+        .bind(trigger_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|_| err(Status::InternalServerError, "chain_state_reset_failed"))?;
+    tx.commit()
+        .await
+        .map_err(|_| err(Status::InternalServerError, "chain_state_reset_failed"))?;
+    Ok(())
 }
 
 #[delete("/api/triggers/<id>")]
@@ -506,18 +547,22 @@ fn validate_kind_config(
     kind: &TriggerKind,
     config: &Value,
 ) -> Result<(), Custom<Json<ErrorResponse>>> {
-    if kind != &TriggerKind::Schedule {
-        return Ok(());
+    match kind {
+        TriggerKind::Schedule => {
+            let cron = config
+                .get("cron")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| err(Status::BadRequest, "cron_required"))?;
+
+            scheduler::validate_cron(cron).map_err(|_| err(Status::BadRequest, "invalid_cron"))
+        }
+        TriggerKind::ChainEvent => chain_events::parse_chain_event_config(config)
+            .map(|_| ())
+            .map_err(|_| err(Status::BadRequest, "invalid_chain_event_config")),
+        TriggerKind::Webhook => Ok(()),
     }
-
-    let cron = config
-        .get("cron")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| err(Status::BadRequest, "cron_required"))?;
-
-    scheduler::validate_cron(cron).map_err(|_| err(Status::BadRequest, "invalid_cron"))
 }
 
 #[cfg(test)]
@@ -603,6 +648,73 @@ mod tests {
             config: empty_object(),
         };
         assert!(validate_create(&req).is_ok());
+    }
+
+    #[test]
+    fn chain_event_create_validation_accepts_valid_config() {
+        let req = CreateTriggerRequest {
+            name: "n".into(),
+            kind: TriggerKind::ChainEvent,
+            action_code: "code".into(),
+            default_params: empty_object(),
+            usage_api_key: "usage".into(),
+            chipotle_account_address: None,
+            max_runs_per_minute: None,
+            max_queued_runs: None,
+            config: json!({
+                "chain": "ethereum",
+                "contract_address": "0x0000000000000000000000000000000000000001",
+                "event_signature": "Transfer(address,address,uint256)",
+                "topic_filters": [null, "0x0000000000000000000000000000000000000000000000000000000000000002"]
+            }),
+        };
+        assert!(validate_create(&req).is_ok());
+    }
+
+    #[test]
+    fn chain_event_create_validation_rejects_invalid_config() {
+        let req = CreateTriggerRequest {
+            name: "n".into(),
+            kind: TriggerKind::ChainEvent,
+            action_code: "code".into(),
+            default_params: empty_object(),
+            usage_api_key: "usage".into(),
+            chipotle_account_address: None,
+            max_runs_per_minute: None,
+            max_queued_runs: None,
+            config: json!({
+                "chain": "tron",
+                "contract_address": "0x1234",
+                "event_signature": "Transfer(address,address,uint256)"
+            }),
+        };
+        assert!(validate_create(&req).is_err());
+    }
+
+    #[test]
+    fn chain_event_state_reset_detects_scope_changes() {
+        let old_config = json!({
+            "chain": "ethereum",
+            "contract_address": "0x0000000000000000000000000000000000000001",
+            "event_signature": "Transfer(address,address,uint256)",
+        });
+        let new_config = json!({
+            "chain": "ethereum",
+            "contract_address": "0x0000000000000000000000000000000000000002",
+            "event_signature": "Transfer(address,address,uint256)",
+        });
+        assert!(chain_event_watermark_scope_changed(
+            &TriggerKind::ChainEvent,
+            &old_config,
+            &TriggerKind::ChainEvent,
+            &new_config
+        ));
+        assert!(!chain_event_watermark_scope_changed(
+            &TriggerKind::Webhook,
+            &old_config,
+            &TriggerKind::ChainEvent,
+            &new_config
+        ));
     }
 
     #[test]

--- a/plans/lit-triggers.md
+++ b/plans/lit-triggers.md
@@ -340,8 +340,7 @@ Confirmed.
    basic IP/user/trigger rate limits + async enqueue + call out to Chipotle.
    End-to-end first trigger type working.
 3. ✅ **PR 3 — scheduled trigger (implemented 2026-05-22).** Cron scheduler + worker integration.
-4. **PR 4 — chain event trigger.** EVM listener with watermarks. Biggest
-   chunk by far.
+4. ✅ **PR 4 — chain event trigger (implemented 2026-05-22).** EVM polling listener with watermarks, idempotent deliveries, chain-event validation, and best-effort decoding.
 5. **PR 5 — admin UI.** Static HTML/JS dashboard for managing triggers, in
    the same spirit as `lit-payments/static/`.
 6. **PR 6 — fly.io deploy.** `fly.toml`, secrets, health checks, docs.


### PR DESCRIPTION
## Summary
- add a durable EVM chain-event polling worker for lit-triggers
- add chain specs/RPC config for Ethereum, Base, Arbitrum, BSC, and Polygon
- validate chain_event trigger config and compute event topic0
- enqueue matching logs through the existing dispatcher with queue-depth protection
- add watermarks and idempotent delivery tracking for chain events
- mark PR 4 complete in the lit-triggers plan

## Test Plan
- cargo +1.91 fmt --check
- cargo +1.91 test
- verified lit-triggers dependency tree has no ethers-rs packages (`cargo +1.91 tree -i ethers` returns no match)

## Notes
- This PR intentionally uses Alloy for chain primitives (`alloy-primitives::keccak256`) and does not add ethers-rs.
- This PR implements the durable polling fallback. WebSocket subscriptions remain a follow-up.
- ABI decoding is best-effort from the event signature; the raw log is always included.

Remaining phases: PR 5 admin UI and PR 6 fly deploy.
