### PR TITLE
feat: add lit-triggers admin dashboard

### DIFF
--- a/lit-triggers/README.md
+++ b/lit-triggers/README.md
@@ -42,3 +42,22 @@ Authenticated routes:
 - `POST /api/triggers/<id>/test` — returns `501 Not Implemented` until worker phases
 
 Usage API keys are accepted only on create/update and are never returned by API responses.
+
+## Static admin UI
+
+The dashboard at `/` is a plain HTML/CSS/JS app served from `lit-triggers/static/`.
+It supports profile display, logout, trigger creation/edit/delete, recent run
+inspection, and kind-specific config helpers for webhook, schedule, and EVM chain
+event triggers.
+
+For new triggers, users can either:
+
+1. Paste a Lit/Chipotle admin API key into the browser-only mint flow. The UI
+   calls Chipotle's `add_usage_api_key` endpoint directly with a narrow
+   `execute_in_groups` scope, clears the admin key field after the mint attempt,
+   and sends only the scoped usage key to lit-triggers.
+2. Paste a pre-minted scoped usage key manually and skip browser minting.
+
+The UI phrases CIDs as action code identities: a CID identifies the action code
+content that will be executed with the supplied scoped usage key and group
+permissions; it does not imply ownership of that CID.

--- a/lit-triggers/static/app.js
+++ b/lit-triggers/static/app.js
@@ -1,0 +1,477 @@
+(() => {
+  'use strict';
+
+  const state = {
+    triggers: [],
+    selectedTrigger: null,
+  };
+
+  const $ = (id) => document.getElementById(id);
+  const statusEl = $('status');
+
+  function setStatus(message, cls = '') {
+    statusEl.textContent = message || '';
+    statusEl.className = `status ${cls}`.trim();
+  }
+
+  function clearStatus() {
+    setStatus('');
+  }
+
+  function el(tag, attrs = {}, children = []) {
+    const node = document.createElement(tag);
+    for (const [key, value] of Object.entries(attrs)) {
+      if (value === undefined || value === null || value === false) continue;
+      if (key === 'className') node.className = value;
+      else if (key === 'text') node.textContent = String(value);
+      else if (key === 'dataset') {
+        for (const [dataKey, dataValue] of Object.entries(value)) {
+          node.dataset[dataKey] = String(dataValue);
+        }
+      } else if (key === 'type') node.type = value;
+      else node.setAttribute(key, String(value));
+    }
+    for (const child of children) {
+      if (child === undefined || child === null) continue;
+      node.append(child instanceof Node ? child : document.createTextNode(String(child)));
+    }
+    return node;
+  }
+
+  function prettyJson(value) {
+    if (value === undefined || value === null) return '';
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (_err) {
+      return String(value);
+    }
+  }
+
+  function parseJsonField(value, label, fallback = {}) {
+    const trimmed = (value || '').trim();
+    if (!trimmed) return fallback;
+    try {
+      return JSON.parse(trimmed);
+    } catch (_err) {
+      throw new Error(`${label} must be valid JSON`);
+    }
+  }
+
+  function optionalPositiveInteger(value, label) {
+    const trimmed = String(value || '').trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new Error(`${label} must be a positive integer`);
+    }
+    return parsed;
+  }
+
+  function apiError(prefix, resp) {
+    return new Error(`${prefix} failed (HTTP ${resp.status})`);
+  }
+
+  async function fetchJson(url, options = {}, prefix = 'Request') {
+    const resp = await fetch(url, {
+      credentials: 'same-origin',
+      ...options,
+      headers: {
+        ...(options.headers || {}),
+      },
+    });
+    if (resp.status === 401) {
+      window.location.href = '/login';
+      return null;
+    }
+    if (!resp.ok) throw apiError(prefix, resp);
+    if (resp.status === 204) return null;
+    return resp.json();
+  }
+
+  async function loadProfile() {
+    const me = await fetchJson('/api/me', {}, 'Load profile');
+    if (!me) return null;
+    $('who').textContent = `Signed in as ${me.email || 'unknown user'}`;
+    return me;
+  }
+
+  async function refreshTriggers({ clear = true } = {}) {
+    if (clear) clearStatus();
+    const triggers = await fetchJson('/api/triggers', {}, 'List triggers');
+    state.triggers = Array.isArray(triggers) ? triggers : [];
+    renderTriggers();
+  }
+
+  function kindLabel(kind) {
+    if (kind === 'chain_event') return 'chain event';
+    return kind || 'unknown';
+  }
+
+  function webhookUrl(trigger) {
+    return `${window.location.origin}/webhook/${trigger.id}`;
+  }
+
+  function summaryFor(trigger) {
+    const cfg = trigger.config || {};
+    if (trigger.kind === 'webhook') return `Webhook URL: ${webhookUrl(trigger)}`;
+    if (trigger.kind === 'schedule') return `Cron: ${cfg.cron || 'not configured'}`;
+    if (trigger.kind === 'chain_event') {
+      const chain = cfg.chain || cfg.chain_id || 'unknown chain';
+      const address = cfg.contract_address || cfg.address || 'unknown contract';
+      const event = cfg.event_signature || 'unknown event';
+      return `${chain} · ${address} · ${event}`;
+    }
+    return 'Unknown trigger type';
+  }
+
+  function renderTriggers() {
+    const list = $('triggers-list');
+    list.replaceChildren();
+    $('list-empty').classList.toggle('hidden', state.triggers.length !== 0);
+
+    for (const trigger of state.triggers) {
+      const card = el('article', { className: 'trigger-card' });
+      const title = el('div', { className: 'trigger-title' }, [
+        el('h3', { text: trigger.name || 'Untitled trigger' }),
+        el('span', {
+          className: trigger.enabled ? 'pill ok' : 'pill muted',
+          text: trigger.enabled ? 'enabled' : 'disabled',
+        }),
+      ]);
+
+      const meta = el('dl', { className: 'meta-list' }, [
+        el('div', {}, [el('dt', { text: 'Kind' }), el('dd', { text: kindLabel(trigger.kind) })]),
+        el('div', {}, [el('dt', { text: 'Action CID' }), el('dd', { text: trigger.action_cid || 'pending' })]),
+        el('div', {}, [el('dt', { text: 'Config' }), el('dd', { text: summaryFor(trigger) })]),
+      ]);
+
+      if (trigger.kind === 'chain_event') {
+        const cfg = trigger.config || {};
+        const filters = cfg.topic_filters ? prettyJson(cfg.topic_filters) : 'none';
+        meta.append(el('div', {}, [el('dt', { text: 'Topic filters' }), el('dd', { text: filters })]));
+      }
+
+      const limits = [];
+      if (trigger.max_runs_per_minute) limits.push(`${trigger.max_runs_per_minute}/min`);
+      if (trigger.max_queued_runs) limits.push(`${trigger.max_queued_runs} queued`);
+      meta.append(el('div', {}, [el('dt', { text: 'Limits' }), el('dd', { text: limits.join(', ') || 'service defaults' })]));
+
+      const actions = el('div', { className: 'actions' });
+      actions.append(actionButton('Edit', () => openEdit(trigger)));
+      actions.append(actionButton('Runs', () => loadRuns(trigger)));
+      if (trigger.kind === 'webhook') actions.append(actionButton('Copy webhook URL', () => copyWebhook(trigger)));
+      actions.append(actionButton('Delete', () => deleteTrigger(trigger), 'danger'));
+
+      card.append(title, meta, actions);
+      list.append(card);
+    }
+  }
+
+  function actionButton(text, handler, variant = '') {
+    const button = el('button', { type: 'button', className: `secondary compact ${variant}`.trim(), text });
+    button.addEventListener('click', handler);
+    return button;
+  }
+
+  async function copyWebhook(trigger) {
+    try {
+      await navigator.clipboard.writeText(webhookUrl(trigger));
+      setStatus('Webhook URL copied.', 'ok');
+    } catch (_err) {
+      setStatus('Could not copy automatically. Select the webhook URL from the trigger card.', 'error');
+    }
+  }
+
+  function currentKeyMode(form) {
+    const selected = form.querySelector('input[name="keyMode"]:checked');
+    return selected ? selected.value : 'mint';
+  }
+
+  async function mintUsageKey({ chipotleUrl, adminKey, groupId }) {
+    const adminKeyInput = $('create-admin-key');
+    try {
+      const url = String(chipotleUrl || '').trim();
+      const key = String(adminKey || '').trim();
+      const group = String(groupId || '').trim();
+      if (!url) throw new Error('Chipotle URL is required to mint a scoped usage key');
+      if (!key) throw new Error('Admin API key is required to mint a scoped usage key');
+      if (!group) throw new Error('Group ID is required to mint a scoped usage key');
+
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify({
+          scope: {
+            execute_in_groups: [group],
+            create_pkp: false,
+            manage_groups: false,
+            manage_ipfs_ids_in_groups: false,
+          },
+        }),
+      });
+
+      if (!resp.ok) {
+        throw new Error(`Chipotle usage-key mint failed (HTTP ${resp.status}). Check the admin key, group ID, and CORS settings.`);
+      }
+      const json = await resp.json();
+      const usageKey = json.usage_api_key || json.usageApiKey || json.key;
+      if (!usageKey) throw new Error('Chipotle response did not include a scoped usage key');
+      return usageKey;
+    } finally {
+      adminKeyInput.value = '';
+    }
+  }
+
+  function buildConfig(form, prefix) {
+    const kind = form.get('kind');
+    if (kind === 'webhook') return {};
+    if (kind === 'schedule') {
+      const cron = String(form.get('cron') || '').trim();
+      if (!cron) throw new Error('Cron expression is required for schedule triggers');
+      return { cron };
+    }
+
+    const chain = String(form.get('chain') || '').trim();
+    const contract = String(form.get('contractAddress') || '').trim();
+    const signature = String(form.get('eventSignature') || '').trim();
+    if (!chain || !contract || !signature) {
+      throw new Error('Chain, contract address, and event signature are required for chain event triggers');
+    }
+    const config = {
+      chain,
+      contract_address: contract,
+      event_signature: signature,
+    };
+    const filtersText = String(form.get('topicFilters') || '').trim();
+    if (filtersText) config.topic_filters = parseJsonField(filtersText, 'Topic filters JSON', []);
+    const startBlock = String(form.get('startBlock') || '').trim();
+    if (startBlock) config.start_block = /^0x/i.test(startBlock) ? startBlock : Number(startBlock);
+    if (typeof config.start_block === 'number' && !Number.isSafeInteger(config.start_block)) {
+      throw new Error(`${prefix} start block must be an integer or hex string`);
+    }
+    return config;
+  }
+
+  async function createTrigger(event) {
+    event.preventDefault();
+    const formEl = event.currentTarget;
+    const form = new FormData(formEl);
+    const button = $('create-btn');
+    button.disabled = true;
+    clearStatus();
+
+    try {
+      let usageApiKey;
+      if (currentKeyMode(formEl) === 'manual') {
+        usageApiKey = String(form.get('usageKey') || '').trim();
+        if (!usageApiKey) throw new Error('A scoped usage key is required');
+      } else {
+        setStatus('Minting scoped usage key in browser…');
+        usageApiKey = await mintUsageKey({
+          chipotleUrl: form.get('chipotleUrl'),
+          adminKey: form.get('adminKey'),
+          groupId: form.get('groupId'),
+        });
+      }
+
+      const payload = {
+        name: String(form.get('name') || '').trim(),
+        kind: form.get('kind'),
+        action_code: String(form.get('actionCode') || ''),
+        default_params: parseJsonField(form.get('defaultParams'), 'Default params JSON'),
+        usage_api_key: usageApiKey,
+        config: buildConfig(form, 'Chain event'),
+      };
+      const maxRate = optionalPositiveInteger(form.get('maxRunsPerMinute'), 'Max runs per minute');
+      const maxQueued = optionalPositiveInteger(form.get('maxQueuedRuns'), 'Max queued runs');
+      if (maxRate !== null) payload.max_runs_per_minute = maxRate;
+      if (maxQueued !== null) payload.max_queued_runs = maxQueued;
+
+      setStatus('Creating trigger…');
+      await fetchJson('/api/triggers', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      }, 'Create trigger');
+
+      formEl.reset();
+      $('create-admin-key').value = '';
+      $('create-usage-key').value = '';
+      $('create-default-params').value = '{}';
+      updateKindPanels();
+      updateKeyPanels();
+      setStatus('Trigger created. Only the scoped usage key was sent to lit-triggers.', 'ok');
+      await refreshTriggers({ clear: false });
+    } catch (err) {
+      setStatus(err.message || 'Could not create trigger', 'error');
+    } finally {
+      button.disabled = false;
+      $('create-admin-key').value = '';
+      $('create-usage-key').value = '';
+    }
+  }
+
+  function openEdit(trigger) {
+    state.selectedTrigger = trigger;
+    $('edit-panel').classList.remove('hidden');
+    $('edit-subtitle').textContent = `${kindLabel(trigger.kind)} · CID ${trigger.action_cid || 'pending'}`;
+    $('edit-id').value = trigger.id;
+    $('edit-name').value = trigger.name || '';
+    $('edit-enabled').checked = Boolean(trigger.enabled);
+    $('edit-config').value = prettyJson(trigger.config || {});
+    $('edit-default-params').value = prettyJson(trigger.default_params || {});
+    $('edit-action-code').value = trigger.action_code || '';
+    $('edit-usage-key').value = '';
+    $('edit-max-rate').value = trigger.max_runs_per_minute || '';
+    $('edit-max-queued').value = trigger.max_queued_runs || '';
+    $('edit-panel').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  async function saveEdit(event) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const id = String(form.get('id') || '').trim();
+    if (!id) return;
+    const button = $('edit-save-btn');
+    button.disabled = true;
+    clearStatus();
+    try {
+      const payload = {
+        name: String(form.get('name') || '').trim(),
+        enabled: $('edit-enabled').checked,
+        action_code: String(form.get('actionCode') || ''),
+        config: parseJsonField(form.get('config'), 'Config JSON'),
+        default_params: parseJsonField(form.get('defaultParams'), 'Default params JSON'),
+      };
+      const maxRate = optionalPositiveInteger(form.get('maxRunsPerMinute'), 'Max runs per minute');
+      const maxQueued = optionalPositiveInteger(form.get('maxQueuedRuns'), 'Max queued runs');
+      if (maxRate !== null) payload.max_runs_per_minute = maxRate;
+      if (maxQueued !== null) payload.max_queued_runs = maxQueued;
+      const usageKey = String(form.get('usageKey') || '').trim();
+      if (usageKey) payload.usage_api_key = usageKey;
+
+      await fetchJson(`/api/triggers/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      }, 'Update trigger');
+      $('edit-usage-key').value = '';
+      setStatus('Trigger updated.', 'ok');
+      await refreshTriggers({ clear: false });
+    } catch (err) {
+      setStatus(err.message || 'Could not update trigger', 'error');
+    } finally {
+      button.disabled = false;
+      $('edit-usage-key').value = '';
+    }
+  }
+
+  async function deleteTrigger(trigger) {
+    const ok = window.confirm(`Delete trigger "${trigger.name || trigger.id}"? This also deletes its run history.`);
+    if (!ok) return;
+    try {
+      await fetchJson(`/api/triggers/${encodeURIComponent(trigger.id)}`, { method: 'DELETE' }, 'Delete trigger');
+      setStatus('Trigger deleted.', 'ok');
+      if (state.selectedTrigger && state.selectedTrigger.id === trigger.id) closeEdit();
+      await refreshTriggers({ clear: false });
+    } catch (err) {
+      setStatus(err.message || 'Could not delete trigger', 'error');
+    }
+  }
+
+  async function loadRuns(trigger) {
+    clearStatus();
+    $('runs-panel').classList.remove('hidden');
+    $('runs-subtitle').textContent = trigger.name || trigger.id;
+    $('runs-list').replaceChildren(el('p', { className: 'note', text: 'Loading runs…' }));
+    $('runs-panel').scrollIntoView({ behavior: 'smooth', block: 'start' });
+    try {
+      const result = await fetchJson(`/api/triggers/${encodeURIComponent(trigger.id)}/runs?limit=20&offset=0`, {}, 'Load runs');
+      renderRuns(result && Array.isArray(result.runs) ? result.runs : []);
+    } catch (err) {
+      $('runs-list').replaceChildren(el('p', { className: 'status error', text: err.message || 'Could not load runs' }));
+    }
+  }
+
+  function renderRuns(runs) {
+    const list = $('runs-list');
+    list.replaceChildren();
+    if (runs.length === 0) {
+      list.append(el('p', { className: 'note', text: 'No runs recorded yet.' }));
+      return;
+    }
+
+    for (const run of runs) {
+      const card = el('article', { className: 'run-card' });
+      card.append(el('div', { className: 'trigger-title' }, [
+        el('h3', { text: run.status || 'unknown status' }),
+        el('span', { className: 'pill muted', text: `attempt ${run.attempt || 1}` }),
+      ]));
+      card.append(el('dl', { className: 'meta-list' }, [
+        el('div', {}, [el('dt', { text: 'Started' }), el('dd', { text: run.started_at || 'unknown' })]),
+        el('div', {}, [el('dt', { text: 'Finished' }), el('dd', { text: run.finished_at || 'not finished' })]),
+      ]));
+      card.append(detailsBlock('Input', run.input));
+      card.append(detailsBlock('Response', run.response));
+      if (run.error) card.append(detailsBlock('Error', run.error));
+      list.append(card);
+    }
+  }
+
+  function detailsBlock(label, value) {
+    const details = el('details', { className: 'json-details' });
+    details.append(el('summary', { text: label }));
+    details.append(el('pre', { text: typeof value === 'string' ? value : prettyJson(value) }));
+    return details;
+  }
+
+  function closeEdit() {
+    state.selectedTrigger = null;
+    $('edit-panel').classList.add('hidden');
+    $('edit-form').reset();
+  }
+
+  function updateKindPanels() {
+    const kind = $('create-kind').value;
+    document.querySelectorAll('[data-kind-panel]').forEach((panel) => {
+      panel.classList.toggle('hidden', panel.dataset.kindPanel !== kind);
+    });
+  }
+
+  function updateKeyPanels() {
+    const mode = currentKeyMode($('create-form'));
+    document.querySelectorAll('[data-key-panel]').forEach((panel) => {
+      panel.classList.toggle('hidden', panel.dataset.keyPanel !== mode);
+    });
+  }
+
+  function attachEvents() {
+    $('create-form').addEventListener('submit', createTrigger);
+    $('edit-form').addEventListener('submit', saveEdit);
+    $('edit-cancel-btn').addEventListener('click', closeEdit);
+    $('runs-close-btn').addEventListener('click', () => $('runs-panel').classList.add('hidden'));
+    $('refresh-btn').addEventListener('click', () => refreshTriggers().catch((err) => setStatus(err.message || 'Refresh failed', 'error')));
+    $('logout-btn').addEventListener('click', async () => {
+      await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' });
+      window.location.href = '/login';
+    });
+    $('create-kind').addEventListener('change', updateKindPanels);
+    document.querySelectorAll('input[name="keyMode"]').forEach((input) => input.addEventListener('change', updateKeyPanels));
+  }
+
+  attachEvents();
+  updateKindPanels();
+  updateKeyPanels();
+  loadProfile()
+    .then((me) => {
+      if (me) return refreshTriggers();
+      return null;
+    })
+    .catch((err) => {
+      $('who').textContent = 'Could not load profile';
+      setStatus(err.message || 'Could not load profile', 'error');
+    });
+})();

--- a/lit-triggers/static/index.html
+++ b/lit-triggers/static/index.html
@@ -7,167 +7,192 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <main class="card wide">
-    <h1>Lit Triggers</h1>
-    <p id="who" class="subtitle">Loading…</p>
+  <main class="dashboard">
+    <header class="topbar">
+      <div>
+        <h1>Lit Triggers</h1>
+        <p id="who" class="subtitle">Loading profile…</p>
+      </div>
+      <button id="logout-btn" type="button" class="secondary compact">Sign out</button>
+    </header>
 
-    <section class="panel">
-      <h2>Create trigger</h2>
-      <p class="note">
-        Your Lit/Chipotle admin API key is used only by this browser tab to mint
-        a scoped usage key. The admin key is never sent to lit-triggers.
+    <section class="panel callout">
+      <h2>Scoped usage key safety</h2>
+      <p>
+        Your Lit/Chipotle admin API key is used only in this browser tab to mint
+        a scoped usage key. It is never sent to lit-triggers, never stored, and
+        is cleared after each mint attempt. The trigger stores only the scoped
+        usage key needed to execute the action code identity (CID) with your group permissions.
       </p>
-      <form id="trigger-form">
-        <label for="chipotle-url">Chipotle add_usage_api_key URL</label>
-        <input id="chipotle-url" name="chipotleUrl" type="url" value="https://api.chipotle.litprotocol.com/add_usage_api_key" required>
+    </section>
 
-        <label for="admin-key">Lit/Chipotle admin API key</label>
-        <input id="admin-key" name="adminKey" type="password" autocomplete="off" required>
+    <section class="grid two-columns">
+      <section class="panel">
+        <h2>Create trigger</h2>
+        <form id="create-form">
+          <fieldset>
+            <legend>Trigger details</legend>
+            <label for="create-name">Name</label>
+            <input id="create-name" name="name" type="text" required>
 
-        <label for="group-id">Group ID for execute_in_groups</label>
-        <input id="group-id" name="groupId" type="text" required>
+            <label for="create-kind">Kind</label>
+            <select id="create-kind" name="kind">
+              <option value="webhook">Webhook</option>
+              <option value="schedule">Schedule</option>
+              <option value="chain_event">Chain event</option>
+            </select>
+          </fieldset>
 
-        <label for="name">Trigger name</label>
-        <input id="name" name="name" type="text" required>
+          <fieldset class="kind-fields" data-kind-panel="webhook">
+            <legend>Webhook config</legend>
+            <p class="note">Webhook triggers do not require extra config. The webhook URL appears after creation.</p>
+          </fieldset>
 
-        <label for="kind">Trigger kind</label>
-        <select id="kind" name="kind">
-          <option value="webhook">webhook</option>
-          <option value="schedule">schedule</option>
-          <option value="chain_event">chain_event</option>
-        </select>
+          <fieldset class="kind-fields hidden" data-kind-panel="schedule">
+            <legend>Schedule config</legend>
+            <label for="create-cron">Cron expression</label>
+            <input id="create-cron" name="cron" type="text" placeholder="*/5 * * * *">
+            <p class="note">Use 5-field cron or 6-field cron with seconds.</p>
+          </fieldset>
 
-        <label for="action-code">Action code</label>
-        <textarea id="action-code" name="actionCode" rows="8" required></textarea>
+          <fieldset class="kind-fields hidden" data-kind-panel="chain_event">
+            <legend>Chain event config</legend>
+            <label for="create-chain">Chain</label>
+            <select id="create-chain" name="chain">
+              <option value="ethereum">Ethereum</option>
+              <option value="base">Base</option>
+              <option value="arbitrum">Arbitrum</option>
+              <option value="bsc">BSC</option>
+              <option value="polygon">Polygon</option>
+            </select>
 
-        <label for="trigger-config">Trigger config JSON</label>
-        <textarea id="trigger-config" name="triggerConfig" rows="5">{}</textarea>
+            <label for="create-contract">Contract address</label>
+            <input id="create-contract" name="contractAddress" type="text" placeholder="0x…">
 
-        <button id="create-btn" type="submit">Mint usage key + create trigger</button>
+            <label for="create-event-signature">Event signature</label>
+            <input id="create-event-signature" name="eventSignature" type="text" placeholder="Transfer(address,address,uint256)">
+
+            <label for="create-topic-filters">Topic filters JSON (optional)</label>
+            <textarea id="create-topic-filters" name="topicFilters" rows="3" placeholder="[null, &quot;0x…&quot;]"></textarea>
+
+            <label for="create-start-block">Start block (optional)</label>
+            <input id="create-start-block" name="startBlock" type="text" placeholder="12345678 or 0x…">
+          </fieldset>
+
+          <fieldset>
+            <legend>Action</legend>
+            <label for="create-action-code">Action code</label>
+            <textarea id="create-action-code" name="actionCode" rows="9" required></textarea>
+            <p class="note">The server computes and displays the CID for this code identity. CIDs identify content, not ownership.</p>
+
+            <label for="create-default-params">Default params JSON</label>
+            <textarea id="create-default-params" name="defaultParams" rows="4">{}</textarea>
+          </fieldset>
+
+          <fieldset>
+            <legend>Scoped usage key</legend>
+            <div class="tabs" role="tablist" aria-label="Usage key source">
+              <label><input type="radio" name="keyMode" value="mint" checked> Mint in browser</label>
+              <label><input type="radio" name="keyMode" value="manual"> Paste pre-minted key</label>
+            </div>
+
+            <div data-key-panel="mint">
+              <label for="create-chipotle-url">Chipotle add_usage_api_key URL</label>
+              <input id="create-chipotle-url" name="chipotleUrl" type="url" value="https://api.chipotle.litprotocol.com/add_usage_api_key">
+
+              <label for="create-admin-key">Lit/Chipotle admin API key</label>
+              <input id="create-admin-key" name="adminKey" type="password" autocomplete="off">
+
+              <label for="create-group-id">Group ID for execute_in_groups</label>
+              <input id="create-group-id" name="groupId" type="text">
+            </div>
+
+            <div class="hidden" data-key-panel="manual">
+              <label for="create-usage-key">Pre-minted scoped usage key</label>
+              <input id="create-usage-key" name="usageKey" type="password" autocomplete="off">
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Optional limits</legend>
+            <label for="create-max-rate">Max runs per minute</label>
+            <input id="create-max-rate" name="maxRunsPerMinute" type="number" min="1" step="1">
+
+            <label for="create-max-queued">Max queued runs</label>
+            <input id="create-max-queued" name="maxQueuedRuns" type="number" min="1" step="1">
+          </fieldset>
+
+          <button id="create-btn" type="submit">Create trigger</button>
+        </form>
+      </section>
+
+      <section class="panel">
+        <div class="section-header">
+          <h2>Your triggers</h2>
+          <button id="refresh-btn" type="button" class="secondary compact">Refresh</button>
+        </div>
+        <p id="list-empty" class="note hidden">No triggers yet. Create one to get started.</p>
+        <div id="triggers-list" class="trigger-list" aria-live="polite"></div>
+      </section>
+    </section>
+
+    <section id="edit-panel" class="panel hidden">
+      <div class="section-header">
+        <div>
+          <h2>Edit trigger</h2>
+          <p id="edit-subtitle" class="subtitle tight"></p>
+        </div>
+        <button id="edit-cancel-btn" type="button" class="secondary compact">Close</button>
+      </div>
+      <form id="edit-form">
+        <input id="edit-id" name="id" type="hidden">
+        <div class="grid two-columns form-grid">
+          <div>
+            <label for="edit-name">Name</label>
+            <input id="edit-name" name="name" type="text" required>
+
+            <label class="checkbox-row" for="edit-enabled">
+              <input id="edit-enabled" name="enabled" type="checkbox"> Enabled
+            </label>
+
+            <label for="edit-config">Config JSON</label>
+            <textarea id="edit-config" name="config" rows="8" required></textarea>
+
+            <label for="edit-default-params">Default params JSON</label>
+            <textarea id="edit-default-params" name="defaultParams" rows="6" required></textarea>
+          </div>
+          <div>
+            <label for="edit-action-code">Action code</label>
+            <textarea id="edit-action-code" name="actionCode" rows="12" required></textarea>
+
+            <label for="edit-usage-key">Rotate scoped usage key (optional)</label>
+            <input id="edit-usage-key" name="usageKey" type="password" autocomplete="off" placeholder="Leave blank to keep current key">
+
+            <label for="edit-max-rate">Max runs per minute</label>
+            <input id="edit-max-rate" name="maxRunsPerMinute" type="number" min="1" step="1">
+
+            <label for="edit-max-queued">Max queued runs</label>
+            <input id="edit-max-queued" name="maxQueuedRuns" type="number" min="1" step="1">
+          </div>
+        </div>
+        <button id="edit-save-btn" type="submit">Save changes</button>
       </form>
-      <p id="status" class="status"></p>
     </section>
 
-    <section class="panel">
-      <h2>Your triggers</h2>
-      <button id="refresh-btn" type="button">Refresh triggers</button>
-      <pre id="triggers-list" class="output">[]</pre>
+    <section id="runs-panel" class="panel hidden">
+      <div class="section-header">
+        <div>
+          <h2>Recent runs</h2>
+          <p id="runs-subtitle" class="subtitle tight"></p>
+        </div>
+        <button id="runs-close-btn" type="button" class="secondary compact">Close</button>
+      </div>
+      <div id="runs-list" class="runs-list"></div>
     </section>
 
-    <button id="logout-btn" type="button" class="secondary">Sign out</button>
+    <p id="status" class="status" role="status" aria-live="polite"></p>
   </main>
 
-  <script>
-    const statusEl = document.getElementById('status');
-    const triggersEl = document.getElementById('triggers-list');
-
-    function setStatus(message, cls = '') {
-      statusEl.textContent = message;
-      statusEl.className = `status ${cls}`.trim();
-    }
-
-    async function loadProfile() {
-      const resp = await fetch('/api/me', { credentials: 'same-origin' });
-      if (resp.status === 401) {
-        window.location.href = '/login';
-        return null;
-      }
-      if (!resp.ok) throw new Error(`profile failed: ${resp.status}`);
-      const me = await resp.json();
-      document.getElementById('who').textContent = `Signed in as ${me.email}`;
-      return me;
-    }
-
-    async function refreshTriggers() {
-      const resp = await fetch('/api/triggers', { credentials: 'same-origin' });
-      if (!resp.ok) throw new Error(`list triggers failed: ${resp.status}`);
-      const triggers = await resp.json();
-      triggersEl.textContent = JSON.stringify(triggers, null, 2);
-    }
-
-    async function mintUsageKey({ chipotleUrl, adminKey, groupId }) {
-      const resp = await fetch(chipotleUrl, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'authorization': `Bearer ${adminKey}`
-        },
-        body: JSON.stringify({
-          scope: {
-            execute_in_groups: [groupId],
-            create_pkp: false,
-            manage_groups: false,
-            manage_ipfs_ids_in_groups: false
-          }
-        })
-      });
-      if (!resp.ok) {
-        const body = await resp.text();
-        throw new Error(`Chipotle usage-key mint failed: ${resp.status} ${body}`);
-      }
-      const json = await resp.json();
-      const usageKey = json.usage_api_key || json.usageApiKey || json.key;
-      if (!usageKey) throw new Error('Chipotle response did not include usage_api_key');
-      return usageKey;
-    }
-
-    document.getElementById('trigger-form').addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const form = new FormData(event.currentTarget);
-      const createBtn = document.getElementById('create-btn');
-      createBtn.disabled = true;
-      setStatus('Minting scoped usage key in browser…');
-      try {
-        const usageApiKey = await mintUsageKey({
-          chipotleUrl: form.get('chipotleUrl'),
-          adminKey: form.get('adminKey'),
-          groupId: form.get('groupId')
-        });
-
-        // Drop the admin key from the DOM as soon as the browser-side Chipotle
-        // call succeeds. Only the scoped usage key below is sent to lit-triggers.
-        document.getElementById('admin-key').value = '';
-
-        const config = JSON.parse(form.get('triggerConfig') || '{}');
-        setStatus('Creating trigger…');
-        const resp = await fetch('/api/triggers', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            name: form.get('name'),
-            kind: form.get('kind'),
-            action_code: form.get('actionCode'),
-            default_params: {},
-            usage_api_key: usageApiKey,
-            config
-          })
-        });
-        if (!resp.ok) throw new Error(`create trigger failed: ${resp.status} ${await resp.text()}`);
-        setStatus('Trigger created. The scoped usage key was stored encrypted at rest.', 'ok');
-        await refreshTriggers();
-      } catch (e) {
-        setStatus(e.message || String(e), 'error');
-      } finally {
-        createBtn.disabled = false;
-      }
-    });
-
-    document.getElementById('refresh-btn').addEventListener('click', () => {
-      refreshTriggers().catch((e) => setStatus(e.message || String(e), 'error'));
-    });
-
-    document.getElementById('logout-btn').addEventListener('click', async () => {
-      await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' });
-      window.location.href = '/login';
-    });
-
-    loadProfile()
-      .then((me) => { if (me) return refreshTriggers(); })
-      .catch((e) => {
-        document.getElementById('who').textContent = 'Could not load profile';
-        setStatus(e.message || String(e), 'error');
-      });
-  </script>
+  <script src="/static/app.js" defer></script>
 </body>
 </html>

--- a/lit-triggers/static/style.css
+++ b/lit-triggers/static/style.css
@@ -1,27 +1,33 @@
 :root {
   color-scheme: light dark;
   --bg: #fafafa;
+  --panel: #fff;
   --fg: #111;
   --muted: #666;
   --border: #ddd;
   --accent: #2d3a6b;
+  --danger: #8a1f11;
   --error: #b00020;
   --ok: #1f6b3a;
+  --soft: #f2f4f8;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #111;
+    --panel: #151515;
     --fg: #eee;
-    --muted: #999;
+    --muted: #aaa;
     --border: #333;
     --accent: #88a;
+    --danger: #b94a3a;
     --error: #ff7676;
     --ok: #6fcf97;
+    --soft: #1d1d1d;
   }
 }
 
 * { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; height: 100%; }
+html, body { margin: 0; padding: 0; min-height: 100%; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: var(--bg);
@@ -32,29 +38,103 @@ body {
   padding: 24px;
 }
 
-.card {
+.card,
+.dashboard {
   width: 100%;
-  max-width: 420px;
-  background: var(--bg);
+  background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 32px;
 }
+.card { max-width: 420px; }
 .card.wide { max-width: 860px; }
-.panel { border-top: 1px solid var(--border); margin-top: 24px; padding-top: 20px; }
+.dashboard { max-width: 1180px; }
+
+.topbar,
+.section-header,
+.trigger-title,
+.actions,
+.tabs {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.topbar,
+.section-header,
+.trigger-title { justify-content: space-between; }
+.topbar { margin-bottom: 20px; }
+.section-header { margin-bottom: 12px; }
+.actions { flex-wrap: wrap; align-items: stretch; }
+
+.panel {
+  border-top: 1px solid var(--border);
+  margin-top: 24px;
+  padding-top: 20px;
+}
+.panel.callout {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-top: 0;
+  padding: 16px;
+  background: var(--soft);
+}
+.grid { display: grid; gap: 24px; }
+.two-columns { grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr); }
+.form-grid { align-items: start; }
+
+h1 { margin: 0 0 6px; font-size: 24px; }
 h2 { margin: 0 0 8px; font-size: 18px; }
-
-h1 { margin: 0 0 6px; font-size: 22px; }
+h3 { margin: 0; font-size: 16px; }
+p { line-height: 1.45; }
 .subtitle { margin: 0 0 24px; color: var(--muted); }
-.note { margin: 16px 0 24px; color: var(--muted); font-size: 14px; }
+.subtitle.tight { margin-bottom: 0; }
+.note { margin: 8px 0 16px; color: var(--muted); font-size: 14px; }
+.hidden { display: none !important; }
 
+fieldset {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin: 0 0 16px;
+}
+legend {
+  padding: 0 6px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+}
 label {
   display: block;
   font-size: 13px;
   margin-bottom: 6px;
   color: var(--muted);
 }
-input[type=email], input[type=text], input[type=password], input[type=url], textarea, select {
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 16px;
+  color: var(--fg);
+}
+.tabs {
+  align-items: flex-start;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.tabs label {
+  color: var(--fg);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 0;
+}
+input[type=email],
+input[type=text],
+input[type=password],
+input[type=url],
+input[type=number],
+textarea,
+select {
   width: 100%;
   padding: 10px 12px;
   font-size: 15px;
@@ -64,7 +144,7 @@ input[type=email], input[type=text], input[type=password], input[type=url], text
   color: var(--fg);
   margin-bottom: 16px;
 }
-textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+textarea { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; resize: vertical; }
 button {
   width: 100%;
   padding: 10px 12px;
@@ -77,9 +157,77 @@ button {
   cursor: pointer;
 }
 button:disabled { opacity: 0.6; cursor: not-allowed; }
-button.secondary { margin-top: 24px; background: transparent; color: var(--fg); border: 1px solid var(--border); }
+button.secondary { background: transparent; color: var(--fg); border: 1px solid var(--border); }
+button.compact { width: auto; white-space: nowrap; padding: 8px 10px; font-size: 13px; }
+button.danger { color: var(--danger); border-color: var(--danger); }
 
 .status { margin-top: 16px; font-size: 14px; min-height: 1.2em; }
 .status.error { color: var(--error); }
 .status.ok { color: var(--ok); }
-.output { overflow: auto; max-height: 320px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; }
+.output,
+.json-details pre {
+  overflow: auto;
+  max-height: 320px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--soft);
+}
+
+.trigger-list,
+.runs-list { display: grid; gap: 14px; }
+.trigger-card,
+.run-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px;
+  background: var(--panel);
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.pill.ok { color: var(--ok); border-color: var(--ok); }
+.pill.muted { color: var(--muted); }
+.meta-list {
+  margin: 12px 0;
+  display: grid;
+  gap: 8px;
+}
+.meta-list div {
+  display: grid;
+  grid-template-columns: 105px minmax(0, 1fr);
+  gap: 10px;
+}
+.meta-list dt { color: var(--muted); font-size: 13px; }
+.meta-list dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+.json-details { margin-top: 10px; }
+.json-details summary { cursor: pointer; color: var(--muted); }
+.json-details pre { white-space: pre-wrap; font-size: 13px; }
+
+@media (max-width: 900px) {
+  body { padding: 12px; }
+  .dashboard,
+  .card { padding: 20px; }
+  .two-columns { grid-template-columns: 1fr; }
+  .topbar { align-items: flex-start; }
+}
+
+@media (max-width: 560px) {
+  .topbar,
+  .section-header,
+  .trigger-title { align-items: flex-start; flex-direction: column; }
+  .meta-list div { grid-template-columns: 1fr; gap: 2px; }
+  button.compact { width: 100%; }
+}

--- a/plans/lit-triggers.md
+++ b/plans/lit-triggers.md
@@ -341,6 +341,6 @@ Confirmed.
    End-to-end first trigger type working.
 3. ✅ **PR 3 — scheduled trigger (implemented 2026-05-22).** Cron scheduler + worker integration.
 4. ✅ **PR 4 — chain event trigger (implemented 2026-05-22).** EVM polling listener with watermarks, idempotent deliveries, chain-event validation, and best-effort decoding.
-5. **PR 5 — admin UI.** Static HTML/JS dashboard for managing triggers, in
+5. ✅ **PR 5 — admin UI (implemented 2026-05-22).** Static HTML/JS dashboard for managing triggers, in
    the same spirit as `lit-payments/static/`.
 6. **PR 6 — fly.io deploy.** `fly.toml`, secrets, health checks, docs.


### PR DESCRIPTION
## Summary
- replace the basic lit-triggers JSON dashboard with a static admin UI
- add trigger cards, create/edit/delete flows, recent run inspection, and webhook URL copy support
- add kind-specific helpers for webhook, schedule, and EVM chain event trigger config
- support browser-only Chipotle admin-key minting plus manual scoped usage-key fallback
- document the dashboard behavior and mark PR 5 complete in the lit-triggers plan

## Test Plan
- node --check static/app.js
- grep check for innerHTML/localStorage/sessionStorage/console.log
- cargo +1.91 fmt --check
- cargo +1.91 test

## Notes
- The UI does not use innerHTML for API/user-controlled data.
- Admin API keys are cleared after mint attempts and never sent to lit-triggers.
- Trigger test execution remains unused because the backend test endpoint is still 501.

Remaining phase: PR 6 fly.io deploy.