### PR TITLE
fix(lit-payments): improve prod diagnostics

### DIFF
--- a/lit-billing-core/src/http.rs
+++ b/lit-billing-core/src/http.rs
@@ -23,7 +23,25 @@ pub fn parse_stripe_response(status: StatusCode, body_text: &str) -> Result<Stri
             .get("message")
             .and_then(|m| m.as_str())
             .unwrap_or("unknown error");
-        anyhow::bail!("Stripe error (HTTP {status}): {msg}");
+        let error_type = e
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown_type");
+        let code = e
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown_code");
+        let param = e
+            .get("param")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown_param");
+        let permission = e
+            .get("permission")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown_permission");
+        anyhow::bail!(
+            "Stripe error (HTTP {status}, type={error_type}, code={code}, param={param}, permission={permission}): {msg}"
+        );
     }
 
     Ok(StripeResponse { status, body })
@@ -47,11 +65,26 @@ mod tests {
 
     #[test]
     fn parse_stripe_response_4xx_with_error() {
-        let body =
-            r#"{"error": {"message": "Invalid API Key provided", "type": "authentication_error"}}"#;
+        let body = r#"{"error": {"message": "Invalid API Key provided", "type": "authentication_error", "code": "api_key_invalid", "param": "api_key", "permission": "customers_read"}}"#;
         let err = parse_stripe_response(StatusCode::UNAUTHORIZED, body).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("HTTP 401"), "expected HTTP 401 in: {msg}");
+        assert!(
+            msg.contains("type=authentication_error"),
+            "expected error type in: {msg}"
+        );
+        assert!(
+            msg.contains("code=api_key_invalid"),
+            "expected error code in: {msg}"
+        );
+        assert!(
+            msg.contains("param=api_key"),
+            "expected error param in: {msg}"
+        );
+        assert!(
+            msg.contains("permission=customers_read"),
+            "expected missing permission in: {msg}"
+        );
         assert!(
             msg.contains("Invalid API Key provided"),
             "expected error message in: {msg}"

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -56,7 +56,7 @@ MAGIC_LINK_SIGNING_KEY=$(openssl rand -base64 32)
 RESEND_API_KEY=re_...                    # https://resend.com → API keys
 MAIL_FROM=noreply@mail.litprotocol.com   # must be a verified Resend sender
 PUBLIC_BASE_URL=http://localhost:8000
-STRIPE_SECRET_KEY=rk_test_...            # Stripe restricted key
+STRIPE_SECRET_KEY=rk_test_...            # Stripe restricted key; needs Customers: Read plus Billing > Customer Balance Transaction: Write
 ROCKET_SECRET_KEY=$(openssl rand -base64 32)  # required for private cookies in release
 ROCKET_PORT=8000
 
@@ -190,7 +190,7 @@ MAGIC_LINK_SIGNING_KEY=<openssl rand -base64 32>
 ROCKET_SECRET_KEY=<openssl rand -base64 32>
 RESEND_API_KEY=re_...
 MAIL_FROM=noreply@mail.litprotocol.com
-STRIPE_SECRET_KEY=rk_live_...
+STRIPE_SECRET_KEY=rk_live_...   # restricted key: Customers Read + Billing > Customer Balance Transaction Write
 
 # LITKEY pricing / listener
 LITKEY_DISCOUNT_BASIS_POINTS=0

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -330,8 +330,8 @@ fn api_err(status: Status, message: impl Into<String>) -> ApiError {
     )
 }
 
-fn api_server_err(e: impl std::fmt::Display) -> ApiError {
-    tracing::warn!("litkey public route: {e}");
+fn api_server_err(e: impl std::fmt::Display + std::fmt::Debug) -> ApiError {
+    tracing::warn!(error = %e, error_debug = ?e, "litkey payment API route internal error");
     api_err(Status::InternalServerError, "internal error")
 }
 

--- a/lit-payments/src/portal/routes.rs
+++ b/lit-payments/src/portal/routes.rs
@@ -40,8 +40,8 @@ fn err(status: Status, message: impl Into<String>) -> ApiError {
     )
 }
 
-fn server_err(e: impl std::fmt::Display) -> ApiError {
-    tracing::warn!("portal route: {e}");
+fn server_err(e: impl std::fmt::Display + std::fmt::Debug) -> ApiError {
+    tracing::warn!(error = %e, error_debug = ?e, "portal route internal error");
     err(Status::InternalServerError, "internal error")
 }
 

--- a/lit-payments/src/rate.rs
+++ b/lit-payments/src/rate.rs
@@ -19,8 +19,8 @@ use crate::auth::operator::Role;
 use crate::config::Config;
 use crate::portal::types::ErrorResponse;
 
-pub const COINGECKO_URL: &str =
-    "https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd";
+pub const LITKEY_BASE_TOKEN_ADDRESS: &str = "0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49";
+pub const COINGECKO_URL: &str = "https://api.coingecko.com/api/v3/simple/token_price/base?contract_addresses=0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49&vs_currencies=usd";
 pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 pub const STALE_AFTER: Duration = Duration::hours(1);
 pub const MAX_USD_WEI_PER_LITKEY: &str = "10000000000000000000000"; // $10,000/LITKEY scaled by 1e18: reject obvious feed nonsense.
@@ -68,8 +68,8 @@ fn err(status: Status, message: impl Into<String>) -> ApiError {
     )
 }
 
-fn server_err(e: impl std::fmt::Display) -> ApiError {
-    tracing::warn!("rate route: {e}");
+fn server_err(e: impl std::fmt::Display + std::fmt::Debug) -> ApiError {
+    tracing::warn!(error = %e, error_debug = ?e, "rate route internal error");
     err(Status::InternalServerError, "internal error")
 }
 
@@ -153,9 +153,15 @@ fn parse_decimal_to_scaled_units(raw: &str, decimals: usize) -> Result<String> {
 pub fn parse_coingecko_usd_wei(body: &str) -> Result<String> {
     let v: serde_json::Value = serde_json::from_str(body).context("parsing CoinGecko JSON")?;
     let usd = v
-        .get("lit-protocol")
+        .get(LITKEY_BASE_TOKEN_ADDRESS)
+        .or_else(|| v.get("lit-protocol"))
         .and_then(|obj| obj.get("usd"))
-        .ok_or_else(|| anyhow!("CoinGecko response missing lit-protocol.usd"))?;
+        .ok_or_else(|| {
+            anyhow!(
+                "CoinGecko response missing {}.usd / lit-protocol.usd",
+                LITKEY_BASE_TOKEN_ADDRESS
+            )
+        })?;
     let usd = match usd {
         serde_json::Value::Number(n) => n.to_string(),
         serde_json::Value::String(s) => s.clone(),
@@ -259,17 +265,32 @@ pub fn should_poll_coingecko(current: Option<&LitkeyRate>) -> bool {
 }
 
 pub async fn fetch_coingecko_usd_wei(client: &Client) -> Result<String> {
-    let body = client
+    let resp = client
         .get(COINGECKO_URL)
+        .header(reqwest::header::ACCEPT, "application/json")
         .send()
         .await
-        .context("fetching CoinGecko LIT price")?
-        .error_for_status()
-        .context("CoinGecko returned non-success status")?
+        .context("fetching CoinGecko LIT price")?;
+    let status = resp.status();
+    let body = resp
         .text()
         .await
         .context("reading CoinGecko response body")?;
+    if !status.is_success() {
+        anyhow::bail!(
+            "CoinGecko returned non-success status {status}: {}",
+            truncate_for_log(&body, 500)
+        );
+    }
     parse_coingecko_usd_wei(&body)
+}
+
+fn truncate_for_log(s: &str, max_chars: usize) -> String {
+    let mut out = s.chars().take(max_chars).collect::<String>();
+    if s.chars().count() > max_chars {
+        out.push('…');
+    }
+    out
 }
 
 pub async fn get_current(pool: &PgPool) -> Result<Option<LitkeyRate>> {
@@ -336,6 +357,7 @@ pub async fn set_manual(pool: &PgPool, usd_wei_per_litkey: &str, operator_id: i6
 
 fn coingecko_client() -> Result<Client> {
     Client::builder()
+        .user_agent("lit-payments/0.1 (+https://litprotocol.com)")
         .connect_timeout(StdDuration::from_secs(5))
         .timeout(StdDuration::from_secs(10))
         .build()
@@ -492,6 +514,13 @@ mod tests {
             "6000000000000000"
         );
         assert_eq!(
+            parse_coingecko_usd_wei(
+                r#"{"0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49":{"usd":0.00568693}}"#,
+            )
+            .unwrap(),
+            "5686930000000000"
+        );
+        assert_eq!(
             parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":0.000000000000000001}}"#).unwrap(),
             "1"
         );
@@ -528,6 +557,12 @@ mod tests {
         assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":-1}}"#).is_err());
         assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":1e309}}"#).is_err());
         assert!(parse_coingecko_usd_wei(r#"{"lit-protocol":{"usd":10001}}"#).is_err());
+    }
+
+    #[test]
+    fn truncates_long_external_error_bodies_for_logs() {
+        assert_eq!(truncate_for_log("abcdef", 3), "abc…");
+        assert_eq!(truncate_for_log("abc", 3), "abc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- switches the LITKEY CoinGecko poller to the Base token-price endpoint for the deployed LITKEY token and sends a service User-Agent
- logs CoinGecko non-2xx status plus truncated response body instead of only "non-success status"
- logs structured/debug internal errors for lit-payments admin/public routes so production 500s show the underlying cause in Railway logs
- preserves Stripe restricted-key error details (`type`, `code`, `param`, `permission`) in server logs
- documents the needed Stripe restricted key permissions and clarifies this uses customer balance transactions, not Credit Grants

## Notes
- Current app code calls `POST /v1/customers/:id/balance_transactions`, so `Credit Grants: Write` is not the right permission for manual grants/LITKEY credits.
- If the restricted key is still missing a Stripe permission after this deploy, the Railway log should include Stripe's `permission=...` field from the error body.

## Validation
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `git diff --check`
- [x] manually verified CoinGecko Base token-price endpoint returns 200 for `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49`
