### PR TITLE
fix(lit-payments): harden litkey payment flow

### DIFF
--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -77,6 +77,9 @@ ROCKET_PORT=8000
 # LITKEY_CHAIN_ID=8453
 # LITKEY_CONFIRMATIONS=5
 # LITKEY_RECONCILIATION_INTERVAL_SECS=60
+# Optional deploy/redeploy catch-up floor. Set near the gateway deploy block or
+# just before a known missed payment block to avoid crawling Base from genesis.
+# LITKEY_RECONCILIATION_START_BLOCK=46516000
 ```
 
 ## LITKEY listener runtime status
@@ -97,7 +100,11 @@ smoke testing; for now operators can test the standalone page directly.
 
 When `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, and `LITKEY_GATEWAY_ADDRESS` are
 configured, the app spawns both an Alchemy WSS logs subscription fast path and a
-confirmed-block HTTPS reconciliation loop. WSS waits for the `eth_subscribe`
+confirmed-block HTTPS reconciliation loop. Set `LITKEY_RECONCILIATION_START_BLOCK`
+to the gateway deploy block (or just before a known missed payment block) before
+first production deploy; without it, an empty checkpoint starts at block `1` and
+may spend a long time crawling old Base history in 2,000-block chunks before it
+reaches current payments. WSS waits for the `eth_subscribe`
 acknowledgement, subscribes to the configured gateway address plus the exact
 `Payment(indexed wallet,indexed payer,uint256 amount)` topic, buffers near-head
 logs until they reach the configured confirmation depth, evicts pending logs when

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -38,6 +38,7 @@ pub struct ChainConfig {
     pub gateway_address: Address,
     pub confirmations: u64,
     pub reconciliation_interval_secs: u64,
+    pub reconciliation_start_block: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -968,9 +969,10 @@ where
     R: ChainRpc,
     P: ConfirmedPaymentProcessor,
 {
-    let checkpoint = store
+    let stored_checkpoint = store
         .current_checkpoint(config.chain_id, config.gateway_address)
         .await?;
+    let checkpoint = stored_checkpoint.max(config.reconciliation_start_block.saturating_sub(1));
     let latest_block = rpc.latest_block().await?;
     let Some((from_block, to_block)) =
         reconciliation_range(checkpoint, latest_block, config.confirmations)
@@ -982,6 +984,15 @@ where
         from_block
             .saturating_add(MAX_RECONCILIATION_BLOCK_RANGE)
             .saturating_sub(1),
+    );
+    tracing::debug!(
+        stored_checkpoint,
+        effective_checkpoint = checkpoint,
+        from_block,
+        to_block = chunk_to_block,
+        latest_block,
+        confirmations = config.confirmations,
+        "LITKEY reconciliation scanning confirmed range"
     );
     let mut logs = rpc.payment_logs(from_block, chunk_to_block).await?;
     logs.sort_by_key(|log| (log.block_number, log.log_index));
@@ -1160,6 +1171,7 @@ pub fn spawn_litkey_listener(
         gateway_address = %format_address(config.gateway_address),
         confirmations = config.confirmations,
         reconciliation_interval_secs = config.reconciliation_interval_secs,
+        reconciliation_start_block = config.reconciliation_start_block,
         discount_basis_points,
         "LITKEY listener started with Alchemy WSS fast path and HTTPS reconciliation fallback"
     );
@@ -1619,6 +1631,7 @@ mod tests {
                 .unwrap(),
             confirmations: 5,
             reconciliation_interval_secs: 60,
+            reconciliation_start_block: 0,
         }
     }
 
@@ -1832,6 +1845,32 @@ mod tests {
             *store.advanced_to.lock().unwrap(),
             vec![MAX_RECONCILIATION_BLOCK_RANGE]
         );
+    }
+
+    #[tokio::test]
+    async fn reconciliation_once_uses_configured_start_block_when_checkpoint_is_behind() {
+        let store = FakeStore {
+            checkpoint: 2_000,
+            advanced_to: std::sync::Mutex::new(Vec::new()),
+        };
+        let rpc = FakeRpc {
+            latest: 46_516_500,
+            logs: vec![],
+            ranges: std::sync::Mutex::new(Vec::new()),
+        };
+        let processor = FakeProcessor {
+            processed: std::sync::Mutex::new(Vec::new()),
+            fail: false,
+        };
+        let mut config = sample_chain_config();
+        config.reconciliation_start_block = 46_516_000;
+
+        process_reconciliation_once(&store, &rpc, &processor, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(*rpc.ranges.lock().unwrap(), vec![(46_516_000, 46_516_495)]);
+        assert_eq!(*store.advanced_to.lock().unwrap(), vec![46_516_495]);
     }
 
     #[tokio::test]

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -134,6 +134,7 @@ fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
         "LITKEY_RECONCILIATION_INTERVAL_SECS",
         chain::DEFAULT_RECONCILIATION_INTERVAL_SECS,
     )?;
+    let reconciliation_start_block = optional_u64("LITKEY_RECONCILIATION_START_BLOCK", 0)?;
     validate_chain_runtime_config(chain_id, confirmations, reconciliation_interval_secs)?;
 
     Ok(Some(chain::ChainConfig {
@@ -143,6 +144,7 @@ fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
         gateway_address,
         confirmations,
         reconciliation_interval_secs,
+        reconciliation_start_block,
     }))
 }
 

--- a/lit-payments/static/pay-with-litkey.js
+++ b/lit-payments/static/pay-with-litkey.js
@@ -37,6 +37,15 @@
   const isAddress = (value) => /^0x[0-9a-fA-F]{40}$/.test(value || '');
   const fmtUsd = (cents) => '$' + (Number(cents) / 100).toFixed(2);
 
+  function formatUsdWei(usdWei) {
+    const value = BigInt(usdWei);
+    const whole = value / USD;
+    const fraction = value % USD;
+    if (fraction === 0n) return '$' + whole.toString();
+    const decimals = fraction.toString().padStart(18, '0').slice(0, 6).replace(/0+$/, '');
+    return '$' + whole.toString() + (decimals ? '.' + decimals : '');
+  }
+
   function parseCents(value) {
     const trimmed = String(value || '').trim();
     const match = trimmed.match(/^(\d+)(?:\.(\d{0,2}))?$/);
@@ -103,7 +112,7 @@
     if (state.frozenAmountWei !== null) {
       state.amountWei = state.frozenAmountWei;
       setText('litkey-amount', formatToken(state.frozenAmountWei) + ' LITKEY');
-      setText('rate-display', fmtUsd(creditCentsForAmount(WEI, quote.effective_usd_wei_per_litkey)) + ' credit / LITKEY');
+      setText('rate-display', formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY');
       setText('quote-status', 'Frozen for approval');
       $('approve').disabled = true;
       $('pay').disabled = state.approvedAmountWei === null;
@@ -120,7 +129,7 @@
     }
     state.amountWei = amountWeiForCents(cents, quote.effective_usd_wei_per_litkey);
     setText('litkey-amount', formatToken(state.amountWei) + ' LITKEY');
-    setText('rate-display', fmtUsd(creditCentsForAmount(WEI, quote.effective_usd_wei_per_litkey)) + ' credit / LITKEY');
+    setText('rate-display', formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY');
     setText('quote-status', 'Live');
     $('approve').disabled = !$('confirm-account').checked || !state.signer;
     $('pay').disabled = true;
@@ -157,12 +166,26 @@
 
   async function connectWallet() {
     if (!window.ethereum) throw new Error('No browser wallet found.');
-    await ensureBase();
-    state.provider = new ethers.BrowserProvider(window.ethereum);
-    await state.provider.send('eth_requestAccounts', []);
-    state.signer = await state.provider.getSigner();
-    setStatus('Wallet connected. Confirm the credited account, then approve exact LITKEY.', 'success');
-    renderQuote();
+    const button = $('connect-wallet');
+    if (button) button.disabled = true;
+    try {
+      setStatus('Opening wallet…', 'info');
+      await window.ethereum.request({ method: 'eth_requestAccounts' });
+      await ensureBase();
+      // Re-read accounts after a possible network switch. Some injected wallets
+      // briefly expose a null selected account/provider during the switch, which
+      // made ethers BrowserProvider.getSigner() throw on the first click.
+      const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+      const account = Array.isArray(accounts) && accounts[0] ? accounts[0] : null;
+      if (!account) throw new Error('No wallet account selected.');
+      state.provider = new ethers.BrowserProvider(window.ethereum);
+      await state.provider.getNetwork();
+      state.signer = await state.provider.getSigner(account);
+      setStatus('Wallet connected. Confirm the credited account, then approve exact LITKEY.', 'success');
+      renderQuote();
+    } finally {
+      if (button) button.disabled = false;
+    }
   }
 
   async function approve() {


### PR DESCRIPTION
## Summary
- Fix the first-click wallet connect race by requesting accounts before and after any Base chain switch, then binding `BrowserProvider.getSigner(account)` to the selected account
- Display the effective LITKEY rate directly from the 18-decimal USD fixed-point quote instead of rounding a sub-cent token price up to whole cents
- Add `LITKEY_RECONCILIATION_START_BLOCK` so first deploys/redeploys can start reconciliation near the gateway/missed-payment block instead of crawling Base from genesis

## Production context
A successful test payment landed in block `46516459`:

```text
0x9caf3cebc541099ae941c69af45defbc3915c1efd0075f92b37ee3e2fdf2bf13
```

If the prod listener checkpoint is still near genesis/empty after this deploy, set:

```text
LITKEY_RECONCILIATION_START_BLOCK=46516000
```

That starts confirmed reconciliation just before the missed payment while keeping the existing DB checkpoint if it is already ahead.

## Test Plan
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `node --check static/pay-with-litkey.js`
- [x] `git diff --check`
