### PR TITLE
fix(lit-payments): claim payments by tx hash

### DIFF
--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -858,12 +858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,9 +2075,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "anyhow",
- "async-trait",
  "base64",
- "futures-util",
  "hex",
  "hmac",
  "lit-billing-core",
@@ -2099,7 +2091,6 @@ dependencies = [
  "sqlx",
  "time",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3933,22 +3924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,24 +4119,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror",
-]
 
 [[package]]
 name = "typenum"
@@ -4460,24 +4417,6 @@ checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -7,12 +7,10 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 base64 = "0.22"
 alloy-dyn-abi = "1.0"
 alloy-primitives = "1.0"
 alloy-serde = "1.0"
-futures-util = { version = "0.3.32", features = ["sink"] }
 hex = "0.4"
 hmac = "0.12"
 lit-billing-core = { path = "../lit-billing-core" }
@@ -34,7 +32,6 @@ sqlx = { version = "0.8", features = [
 ] }
 time = { version = "0.3", features = ["serde", "formatting", "macros"] }
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -15,8 +15,8 @@ Public:
 - `GET /auth/verify?token=…` — validate token, set session cookie, redirect.
 - `GET /api/customer/preview?wallet=0x…` — wallet-scoped customer identity preview for the LITKEY payment page. Returns only `found`, `email`, and `wallet_address`; it does not expose Stripe customer ids or balances.
 - `GET /api/litkey/quote` — public LITKEY quote for the end-user payment page; includes `crediting_paused` and omits an effective credit rate while paused.
-- `GET /api/litkey/payment-config` — public Base mainnet payment config: chain id, LITKEY token address, and payment gateway address. Fails closed with `503` if the on-chain listener is not configured.
-- `GET /api/litkey/payment-status?tx_hash=0x…&wallet=0x…` — wallet-scoped listener status for a submitted transaction; used by the payment page to poll for `credited`, `dust`, `paused`, or `no_customer` after submission.
+- `GET /api/litkey/payment-config` — public Base mainnet payment config: chain id, LITKEY token address, and payment gateway address. Fails closed with `503` if chain verification is not configured.
+- `POST /api/litkey/payment-claim` — wallet-scoped transaction claim for the browser payment page. Accepts `{ "tx_hash": "0x…", "wallet": "0x…" }`, fetches the transaction receipt, verifies the configured gateway emitted the expected `Payment` event for that wallet, and applies credit idempotently from that receipt.
 
 Authenticated (operator session cookie required):
 - `GET /` — admin dashboard.
@@ -30,7 +30,7 @@ Authenticated (operator session cookie required):
 
 ## LITKEY rate precision
 
-LITKEY pricing is intentionally stored as 18-decimal USD fixed point instead of whole cents because LITKEY can trade below one cent. Example: `$0.006/LITKEY` is stored as `6000000000000000` (`0.006 * 1e18`). The listener settlement helper keeps the on-chain `Payment.amount` in native LITKEY wei, multiplies by `usd_wei_per_litkey` with `num-bigint`, applies `LITKEY_DISCOUNT_BASIS_POINTS`, and rounds only once at the final Stripe-cent boundary.
+LITKEY pricing is intentionally stored as 18-decimal USD fixed point instead of whole cents because LITKEY can trade below one cent. Example: `$0.006/LITKEY` is stored as `6000000000000000` (`0.006 * 1e18`). The settlement helper keeps the on-chain `Payment.amount` in native LITKEY wei, multiplies by `usd_wei_per_litkey` with `num-bigint`, applies `LITKEY_DISCOUNT_BASIS_POINTS`, and rounds only once at the final Stripe-cent boundary.
 
 ## Local development
 
@@ -69,58 +69,38 @@ ROCKET_PORT=8000
 # 1 / (1 - 0.20) = 1.25x the market-rate Stripe credit per LITKEY.
 # LITKEY_DISCOUNT_BASIS_POINTS=0
 
-# Optional — enable the LITKEY on-chain listener. The current 3c slice starts
-# the Alchemy WSS fast path plus HTTPS reconciliation fallback.
-# ALCHEMY_WSS_URL=wss://base-mainnet.g.alchemy.com/v2/...
+# Optional — enable LITKEY browser payment verification.
 # ALCHEMY_HTTPS_URL=https://base-mainnet.g.alchemy.com/v2/...
 # LITKEY_GATEWAY_ADDRESS=0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b
 # LITKEY_CHAIN_ID=8453
-# LITKEY_CONFIRMATIONS=5
-# LITKEY_RECONCILIATION_INTERVAL_SECS=60
-# Optional deploy/redeploy catch-up floor. Set near the gateway deploy block or
-# just before a known missed payment block to avoid crawling Base from genesis.
-# LITKEY_RECONCILIATION_START_BLOCK=46516000
 ```
 
-## LITKEY listener runtime status
+## LITKEY browser payment claim flow
 
 `/payWithLitkey?wallet=0x…` lets a user credit an existing Stripe customer by
 paying LITKEY to the deployed gateway on Base mainnet. The page validates that
 the URL wallet maps to a customer, prominently displays the email and wallet that
 will be credited, refreshes the quote every 30 seconds until approval starts,
 freezes the quote and LITKEY amount for exact-amount approval, calls
-`pay(amount, wallet)`, and polls the listener status endpoint scoped by
-transaction hash plus credited wallet. The public preview endpoint intentionally
+`pay(amount, wallet)`, then posts the resulting transaction hash plus credited
+wallet to `/api/litkey/payment-claim`. The claim endpoint fetches that exact
+transaction receipt, verifies the configured gateway emitted the expected
+`Payment` log for the wallet, and runs the idempotent crediting handler. There is
+no browser status poller and no background WSS/reconciliation loop in the running
+service; the user's known transaction hash is the source of truth. The public
+preview endpoint intentionally
 reveals whether the supplied wallet has a Stripe customer and the email that will
 be credited so payment-link recipients can verify the destination before
-spending. The payment config endpoint fails closed when the listener is disabled,
-so users cannot be directed to send LITKEY while automatic crediting is offline.
+spending. The payment config endpoint fails closed when chain verification is
+disabled, so users cannot be directed to send LITKEY while automatic crediting is
+offline.
 The main dashboard entry point is intentionally deferred until after production
 smoke testing; for now operators can test the standalone page directly.
 
-When `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, and `LITKEY_GATEWAY_ADDRESS` are
-configured, the app spawns both an Alchemy WSS logs subscription fast path and a
-confirmed-block HTTPS reconciliation loop. Set `LITKEY_RECONCILIATION_START_BLOCK`
-to the gateway deploy block (or just before a known missed payment block) before
-first production deploy; without it, an empty checkpoint starts at block `1` and
-may spend a long time crawling old Base history in 2,000-block chunks before it
-reaches current payments. WSS waits for the `eth_subscribe`
-acknowledgement, subscribes to the configured gateway address plus the exact
-`Payment(indexed wallet,indexed payer,uint256 amount)` topic, buffers near-head
-logs until they reach the configured confirmation depth, evicts pending logs when
-Alchemy sends `removed: true` reorg notifications, credits confirmed logs through
-the shared handler, and never advances reconciliation checkpoints. Reconciliation
-remains the fallback: each
-pass reads the checkpoint, fetches Base logs for the safe range
-`(last_processed_block, latest - confirmations)`, processes decoded gateway
-`Payment` events through the shared crediting handler, and advances the checkpoint
-only after the whole range succeeds.
-
 Crediting pauses when the LITKEY rate row is missing or stale, records dust and
 no-customer events without a Stripe balance write, and credits known customers
-with the deterministic `PaymentLog::idempotency_key()`. WSS and reconciliation
-share the same parser, crediting handler, and `(chain_id, tx_hash, log_index)`
-idempotency.
+with the deterministic `PaymentLog::idempotency_key()` based on
+`(chain_id, tx_hash, log_index)`.
 
 ### 3. Run
 
@@ -140,9 +120,8 @@ Railway services can add their own subfolder configs later. For this service,
 keep the Railway service root/build context at the repo root and set the service
 config file path to `lit-payments/railway.json`: the Dockerfile needs repo-root
 build context because `lit-payments` depends on the sibling `lit-billing-core`
-crate. The service must keep at least one replica running: the LITKEY listener
-includes WSS and reconciliation background loops, so do not enable
-scale-to-zero/sleep mode for production.
+crate. Keep the service awake in production for fastest user-facing payment
+confirmation after a wallet transaction is mined.
 
 ### 1. Create the Railway project/service
 
@@ -154,8 +133,8 @@ In the Railway dashboard:
    - **Root Directory / build context:** repo root (`/`), not `lit-payments`.
    - **Config file path:** `lit-payments/railway.json`.
    - `lit-payments/railway.json` points at `lit-payments/Dockerfile`.
-4. In service settings, confirm the service is not configured to sleep/scale to
-   zero.
+4. In service settings, keep the service awake for fastest user-facing payment
+   confirmation.
 
 Equivalent CLI flow if you prefer:
 
@@ -199,14 +178,11 @@ RESEND_API_KEY=re_...
 MAIL_FROM=noreply@mail.litprotocol.com
 STRIPE_SECRET_KEY=rk_live_...   # restricted key: Customers Read + Billing > Customer Balance Transaction Write
 
-# LITKEY pricing / listener
+# LITKEY pricing / browser payment verification
 LITKEY_DISCOUNT_BASIS_POINTS=0
-ALCHEMY_WSS_URL=wss://base-mainnet.g.alchemy.com/v2/...
 ALCHEMY_HTTPS_URL=https://base-mainnet.g.alchemy.com/v2/...
 LITKEY_GATEWAY_ADDRESS=0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b
 LITKEY_CHAIN_ID=8453
-LITKEY_CONFIRMATIONS=5
-LITKEY_RECONCILIATION_INTERVAL_SECS=60
 ```
 
 Optional operator caps if you want non-default values:
@@ -235,14 +211,13 @@ curl -fsS 'https://<your-railway-domain-or-payments-domain>/api/litkey/payment-c
 Expected:
 
 - `/health` returns `ok`.
-- `/api/litkey/payment-config` returns Base mainnet config when the listener env
-  is present; it returns `503` if listener config is intentionally absent.
+- `/api/litkey/payment-config` returns Base mainnet config when chain verification
+  env is present; it returns `503` if that config is intentionally absent.
 - `/payWithLitkey?wallet=0x...` loads the standalone payment page for smoke
   testing.
 
-Railway deploys should run the binary continuously. If a smoke test submits a
-Base payment but status never changes, check Railway logs first for listener WSS
-or reconciliation errors.
+If a smoke test submits a Base payment but credit is not applied, keep the tx hash
+from the page and check Railway logs for `/api/litkey/payment-claim` errors.
 
 ### Mail sender setup
 

--- a/lit-payments/migrations/20260522000001_litkey_listener.sql
+++ b/lit-payments/migrations/20260522000001_litkey_listener.sql
@@ -1,6 +1,6 @@
 -- LITKEY on-chain payment records. Successful credits are idempotent by
--- chain + tx hash + log index so WSS and reconciliation poller races cannot
--- double-credit the same Payment event.
+-- chain + tx hash + log index so repeated browser tx-claim submissions cannot
+-- double-credit a payment.
 CREATE TABLE litkey_payments (
     id BIGSERIAL PRIMARY KEY,
     chain_id BIGINT NOT NULL,

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -1,44 +1,30 @@
-//! LITKEY on-chain payment listener primitives.
+//! LITKEY on-chain payment helpers.
 //!
-//! Phase 3c uses these helpers from both the WSS fast path and the HTTPS
-//! reconciliation poller so confirmation depth, idempotency, and checkpoint
-//! behavior cannot drift between paths.
+//! Browser payments submit the exact transaction hash to the backend. The backend
+//! fetches that receipt, verifies the configured gateway emitted the expected
+//! `Payment` event, and credits idempotently from that event.
 
 use alloy_dyn_abi::DynSolType;
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use anyhow::{Context, Result};
-use async_trait::async_trait;
-use futures_util::{SinkExt, StreamExt};
 use lit_billing_core::{StripeClient, balance, customer};
 use reqwest::Client;
 use rocket::State;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::json;
 use sqlx::PgPool;
-use std::{collections::HashMap, time::Duration as StdDuration};
-use tokio::time::{Duration, sleep, timeout};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use std::time::Duration as StdDuration;
 pub const BASE_CHAIN_ID: i64 = 8453;
 pub const LITKEY_TOKEN_ADDRESS: &str = "0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49";
 pub const DEFAULT_GATEWAY_ADDRESS: &str = "0xa2d54cd1d1df1735718a857ac49caf9ecab0093b";
-pub const DEFAULT_CONFIRMATIONS: u64 = 5;
-pub const DEFAULT_RECONCILIATION_INTERVAL_SECS: u64 = 60;
-pub const MAX_RECONCILIATION_BLOCK_RANGE: u64 = 2_000;
-const WSS_CONNECT_TIMEOUT_SECS: u64 = 15;
-const WSS_SUBSCRIBE_ACK_TIMEOUT_SECS: u64 = 15;
-const WSS_READ_IDLE_TIMEOUT_SECS: u64 = 20;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChainConfig {
     pub chain_id: i64,
-    pub alchemy_wss_url: String,
     pub alchemy_https_url: String,
     pub gateway_address: Address,
-    pub confirmations: u64,
-    pub reconciliation_interval_secs: u64,
-    pub reconciliation_start_block: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -51,12 +37,6 @@ pub struct PaymentLog {
     pub tx_hash: B256,
     pub log_index: u64,
     pub block_number: u64,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum WssPaymentNotification {
-    Added(PaymentLog),
-    Removed(PaymentLog),
 }
 
 impl PaymentLog {
@@ -87,24 +67,6 @@ pub fn payment_idempotency_key(chain_id: i64, tx_hash: B256, log_index: u64) -> 
 
 pub fn format_address(address: Address) -> String {
     format!("{address:#x}")
-}
-
-pub fn is_confirmed(event_block: u64, latest_block: u64, confirmations: u64) -> bool {
-    latest_block.saturating_sub(event_block) >= confirmations
-}
-
-pub fn reconciliation_range(
-    last_processed_block: u64,
-    latest_block: u64,
-    confirmations: u64,
-) -> Option<(u64, u64)> {
-    let safe_to_block = latest_block.checked_sub(confirmations)?;
-    let from_block = last_processed_block.saturating_add(1);
-    (from_block <= safe_to_block).then_some((from_block, safe_to_block))
-}
-
-pub fn backoff_delay_secs(attempt: u32) -> u64 {
-    2_u64.saturating_pow(attempt).clamp(1, 30)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -319,6 +281,12 @@ pub struct LitkeyPaymentStatusResponse {
     pub credited_at: Option<time::OffsetDateTime>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LitkeyPaymentClaimRequest {
+    pub tx_hash: String,
+    pub wallet: String,
+}
+
 type ApiError = (Status, Json<crate::portal::types::ErrorResponse>);
 type ApiResult<T> = std::result::Result<Json<T>, ApiError>;
 
@@ -360,7 +328,7 @@ pub fn get_payment_config(
     let Some(chain) = config.litkey_chain.as_ref() else {
         return Err(api_err(
             Status::ServiceUnavailable,
-            "LITKEY payments are not configured",
+            "LITKEY chain verification is not configured",
         ));
     };
     Ok(Json(LitkeyPaymentConfigResponse {
@@ -390,150 +358,43 @@ pub async fn lookup_payment_status(
     .context("looking up litkey payment status")
 }
 
-/// `GET /api/litkey/payment-status?tx_hash=…&wallet=…` — public status poller.
-#[rocket::get("/api/litkey/payment-status?<tx_hash>&<wallet>")]
-pub async fn get_payment_status(
-    tx_hash: Option<&str>,
-    wallet: Option<&str>,
+/// `POST /api/litkey/payment-claim` — verify a submitted tx hash and credit it.
+///
+/// The browser already has the exact payment tx hash after `gateway.pay(...)`.
+/// This endpoint fetches that receipt directly, verifies the configured gateway
+/// emitted `Payment(wallet, payer, amount)`, and then runs the shared idempotent
+/// crediting handler. Base reorg risk is intentionally not modeled in this
+/// browser-driven claim path.
+#[rocket::post("/api/litkey/payment-claim", format = "json", data = "<req>")]
+pub async fn claim_payment(
+    req: Json<LitkeyPaymentClaimRequest>,
     pool: &State<PgPool>,
+    stripe: &State<StripeClient>,
+    config: &State<crate::config::Config>,
 ) -> ApiResult<LitkeyPaymentStatusResponse> {
-    let Some(tx_hash) = tx_hash else {
-        return Err(api_err(Status::BadRequest, "tx_hash is required"));
+    let Some(chain_config) = config.litkey_chain.as_ref() else {
+        return Err(api_err(
+            Status::ServiceUnavailable,
+            "LITKEY chain verification is not configured",
+        ));
     };
-    let Some(wallet) = wallet else {
-        return Err(api_err(Status::BadRequest, "wallet is required"));
-    };
-    let tx_hash = canonical_tx_hash_param(tx_hash).map_err(|e| api_err(Status::BadRequest, e))?;
-    let wallet = canonical_wallet_param(wallet).map_err(|e| api_err(Status::BadRequest, e))?;
-    let row = lookup_payment_status(pool, &tx_hash, &wallet)
-        .await
-        .map_err(api_server_err)?;
-    Ok(Json(match row {
-        Some((status, cents_credited, credited_at)) => LitkeyPaymentStatusResponse {
-            found: true,
-            status: Some(status),
-            cents_credited: Some(cents_credited),
-            credited_at: Some(credited_at),
-        },
-        None => LitkeyPaymentStatusResponse {
-            found: false,
-            status: None,
-            cents_credited: None,
-            credited_at: None,
-        },
-    }))
-}
+    let tx_hash =
+        canonical_tx_hash_param(&req.tx_hash).map_err(|e| api_err(Status::BadRequest, e))?;
+    let wallet = canonical_wallet_param(&req.wallet).map_err(|e| api_err(Status::BadRequest, e))?;
 
-pub async fn current_checkpoint(
-    pool: &PgPool,
-    chain_id: i64,
-    gateway_address: Address,
-) -> Result<u64> {
-    let block = sqlx::query_scalar::<_, Option<i64>>(
-        "SELECT last_processed_block FROM chain_checkpoint WHERE chain_id = $1 AND gateway_address = $2",
+    let rpc = HttpGatewayRpc::new(chain_config);
+    let claimed = claim_litkey_payment_tx(
+        pool,
+        stripe,
+        &rpc,
+        chain_config,
+        &tx_hash,
+        &wallet,
+        config.litkey_discount_basis_points,
     )
-    .bind(chain_id)
-    .bind(format_address(gateway_address))
-    .fetch_optional(pool)
     .await
-    .context("reading chain checkpoint")?
-    .flatten()
-    .unwrap_or(0);
-    u64::try_from(block).context("chain checkpoint was negative")
-}
-
-pub async fn advance_checkpoint(
-    pool: &PgPool,
-    chain_id: i64,
-    gateway_address: Address,
-    last_processed_block: u64,
-) -> Result<()> {
-    sqlx::query(
-        "INSERT INTO chain_checkpoint (chain_id, gateway_address, last_processed_block)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (chain_id, gateway_address) DO UPDATE SET
-           last_processed_block = GREATEST(chain_checkpoint.last_processed_block, EXCLUDED.last_processed_block),
-           updated_at = now()",
-    )
-    .bind(chain_id)
-    .bind(format_address(gateway_address))
-    .bind(last_processed_block as i64)
-    .execute(pool)
-    .await
-    .context("advancing chain checkpoint")?;
-    Ok(())
-}
-
-#[async_trait]
-pub trait ChainRpc: Send + Sync {
-    async fn latest_block(&self) -> Result<u64>;
-    async fn payment_logs(&self, from_block: u64, to_block: u64) -> Result<Vec<PaymentLog>>;
-}
-
-#[async_trait]
-pub trait ReconciliationStore: Send + Sync {
-    async fn current_checkpoint(&self, chain_id: i64, gateway_address: Address) -> Result<u64>;
-    async fn advance_checkpoint(
-        &self,
-        chain_id: i64,
-        gateway_address: Address,
-        last_processed_block: u64,
-    ) -> Result<()>;
-}
-
-#[async_trait]
-pub trait ConfirmedPaymentProcessor: Send + Sync {
-    async fn process_confirmed_payment(&self, log: PaymentLog) -> Result<()>;
-}
-
-pub struct PgReconciliationStore {
-    pool: PgPool,
-}
-
-impl PgReconciliationStore {
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
-    }
-}
-
-#[async_trait]
-impl ReconciliationStore for PgReconciliationStore {
-    async fn current_checkpoint(&self, chain_id: i64, gateway_address: Address) -> Result<u64> {
-        current_checkpoint(&self.pool, chain_id, gateway_address).await
-    }
-
-    async fn advance_checkpoint(
-        &self,
-        chain_id: i64,
-        gateway_address: Address,
-        last_processed_block: u64,
-    ) -> Result<()> {
-        advance_checkpoint(&self.pool, chain_id, gateway_address, last_processed_block).await
-    }
-}
-
-pub struct StripePaymentProcessor {
-    pool: PgPool,
-    stripe: StripeClient,
-    discount_basis_points: i64,
-}
-
-impl StripePaymentProcessor {
-    pub fn new(pool: PgPool, stripe: StripeClient, discount_basis_points: i64) -> Self {
-        Self {
-            pool,
-            stripe,
-            discount_basis_points,
-        }
-    }
-}
-
-#[async_trait]
-impl ConfirmedPaymentProcessor for StripePaymentProcessor {
-    async fn process_confirmed_payment(&self, log: PaymentLog) -> Result<()> {
-        handle_confirmed_litkey_payment(&self.pool, &self.stripe, &log, self.discount_basis_points)
-            .await
-    }
+    .map_err(api_server_err)?;
+    Ok(Json(claimed))
 }
 
 #[derive(Debug, Deserialize)]
@@ -564,6 +425,13 @@ struct RpcLog {
     removed: Option<bool>,
 }
 
+#[derive(Debug, Deserialize)]
+struct RpcReceipt {
+    #[serde(with = "alloy_serde::quantity::opt")]
+    status: Option<u64>,
+    logs: Vec<RpcLog>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Log {
     pub address: Address,
@@ -592,8 +460,6 @@ impl From<RpcLog> for Log {
 pub struct HttpGatewayRpc {
     client: Client,
     https_url: String,
-    chain_id: i64,
-    gateway_address: Address,
 }
 
 impl HttpGatewayRpc {
@@ -601,8 +467,6 @@ impl HttpGatewayRpc {
         Self {
             client: rpc_http_client(),
             https_url: config.alchemy_https_url.clone(),
-            chain_id: config.chain_id,
-            gateway_address: config.gateway_address,
         }
     }
 }
@@ -652,36 +516,10 @@ impl HttpGatewayRpc {
     }
 }
 
-#[async_trait]
-impl ChainRpc for HttpGatewayRpc {
-    async fn latest_block(&self) -> Result<u64> {
-        #[derive(Deserialize)]
-        struct BlockNumber(#[serde(with = "alloy_serde::quantity")] u64);
-
-        let block: BlockNumber = self.rpc("eth_blockNumber", json!([])).await?;
-        Ok(block.0)
-    }
-
-    async fn payment_logs(&self, from_block: u64, to_block: u64) -> Result<Vec<PaymentLog>> {
-        let logs: Vec<RpcLog> = self
-            .rpc(
-                "eth_getLogs",
-                json!([{
-                    "address": format_address(self.gateway_address),
-                    "fromBlock": format!("0x{from_block:x}"),
-                    "toBlock": format!("0x{to_block:x}"),
-                    "topics": [format!("{:#x}", payment_event_topic())]
-                }]),
-            )
-            .await?;
-        logs.into_iter()
-            .map(|log| parse_gateway_payment_log(self.chain_id, self.gateway_address, log.into()))
-            .filter_map(|result| match result {
-                Ok(Some(payment)) => Some(Ok(payment)),
-                Ok(None) => None,
-                Err(err) => Some(Err(err)),
-            })
-            .collect()
+impl HttpGatewayRpc {
+    async fn transaction_receipt(&self, tx_hash: &str) -> Result<Option<RpcReceipt>> {
+        self.rpc("eth_getTransactionReceipt", json!([tx_hash]))
+            .await
     }
 }
 
@@ -689,188 +527,6 @@ pub const PAYMENT_EVENT_SIGNATURE: &str = "Payment(address,address,uint256)";
 
 pub fn payment_event_topic() -> B256 {
     keccak256(PAYMENT_EVENT_SIGNATURE.as_bytes())
-}
-
-pub fn wss_payment_log_subscribe_request(gateway_address: Address) -> Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "eth_subscribe",
-        "params": [
-            "logs",
-            {
-                "address": format_address(gateway_address),
-                "topics": [format!("{:#x}", payment_event_topic())]
-            }
-        ]
-    })
-}
-
-pub fn parse_wss_subscription_ack(message: &str, request_id: u64) -> Result<Option<String>> {
-    let value: Value = serde_json::from_str(message).context("decoding LITKEY WSS JSON message")?;
-    if value.get("id").and_then(Value::as_u64) != Some(request_id) {
-        return Ok(None);
-    }
-
-    if let Some(error) = value.get("error") {
-        let message = error
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown JSON-RPC error");
-        let code = error
-            .get("code")
-            .and_then(Value::as_i64)
-            .unwrap_or_default();
-        anyhow::bail!("LITKEY WSS eth_subscribe failed: {message} ({code})");
-    }
-
-    let subscription_id = value
-        .get("result")
-        .and_then(Value::as_str)
-        .context("LITKEY WSS eth_subscribe response missing subscription id")?;
-    Ok(Some(subscription_id.to_string()))
-}
-
-fn wss_notification_result(message: &str, subscription_id: &str) -> Result<Option<Value>> {
-    let value: Value = serde_json::from_str(message).context("decoding LITKEY WSS JSON message")?;
-    if value.get("method").and_then(Value::as_str) != Some("eth_subscription") {
-        return Ok(None);
-    }
-
-    let params = value
-        .get("params")
-        .context("LITKEY WSS subscription message missing params")?;
-    let actual_subscription = params
-        .get("subscription")
-        .and_then(Value::as_str)
-        .context("LITKEY WSS subscription message missing subscription id")?;
-    if actual_subscription != subscription_id {
-        return Ok(None);
-    }
-
-    Ok(Some(params.get("result").cloned().context(
-        "LITKEY WSS subscription message missing result",
-    )?))
-}
-
-pub fn parse_wss_payment_log_notification(
-    chain_id: i64,
-    gateway_address: Address,
-    subscription_id: &str,
-    message: &str,
-) -> Result<Option<WssPaymentNotification>> {
-    let Some(result) = wss_notification_result(message, subscription_id)? else {
-        return Ok(None);
-    };
-
-    let removed = result
-        .get("removed")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let rpc_log: RpcLog =
-        serde_json::from_value(result).context("decoding LITKEY WSS payment log")?;
-    let Some(payment_log) = parse_gateway_payment_log(chain_id, gateway_address, rpc_log.into())?
-    else {
-        return Ok(None);
-    };
-    if removed {
-        tracing::warn!(
-            tx_hash = %format!("{:#x}", payment_log.tx_hash),
-            log_index = payment_log.log_index,
-            block_number = payment_log.block_number,
-            "LITKEY WSS received removed/reorged payment log"
-        );
-        return Ok(Some(WssPaymentNotification::Removed(payment_log)));
-    }
-    Ok(Some(WssPaymentNotification::Added(payment_log)))
-}
-
-fn pending_payment_key(log: &PaymentLog) -> String {
-    log.idempotency_key()
-}
-
-pub async fn drain_confirmed_wss_payments<R, P>(
-    rpc: &R,
-    processor: &P,
-    config: &ChainConfig,
-    pending: &mut HashMap<String, PaymentLog>,
-) -> Result<usize>
-where
-    R: ChainRpc,
-    P: ConfirmedPaymentProcessor,
-{
-    if pending.is_empty() {
-        return Ok(0);
-    }
-
-    let latest_block = rpc.latest_block().await?;
-    let mut confirmed_keys = Vec::new();
-    for (key, log) in pending.iter() {
-        if is_confirmed(log.block_number, latest_block, config.confirmations) {
-            confirmed_keys.push(key.clone());
-        }
-    }
-    confirmed_keys.sort();
-
-    let mut processed = 0;
-    for key in confirmed_keys {
-        let Some(log) = pending.get(&key).cloned() else {
-            continue;
-        };
-        processor.process_confirmed_payment(log).await?;
-        pending.remove(&key);
-        processed += 1;
-    }
-    Ok(processed)
-}
-
-pub async fn process_wss_payment_notification<R, P>(
-    rpc: &R,
-    processor: &P,
-    config: &ChainConfig,
-    subscription_id: &str,
-    message: &str,
-    pending: &mut HashMap<String, PaymentLog>,
-) -> Result<bool>
-where
-    R: ChainRpc,
-    P: ConfirmedPaymentProcessor,
-{
-    let Some(notification) = parse_wss_payment_log_notification(
-        config.chain_id,
-        config.gateway_address,
-        subscription_id,
-        message,
-    )?
-    else {
-        return Ok(false);
-    };
-
-    let log = match notification {
-        WssPaymentNotification::Added(log) => log,
-        WssPaymentNotification::Removed(log) => {
-            pending.remove(&pending_payment_key(&log));
-            return Ok(false);
-        }
-    };
-
-    let latest_block = rpc.latest_block().await?;
-    if is_confirmed(log.block_number, latest_block, config.confirmations) {
-        processor.process_confirmed_payment(log).await?;
-        return Ok(true);
-    }
-
-    let key = pending_payment_key(&log);
-    tracing::debug!(
-        tx_hash = %format!("{:#x}", log.tx_hash),
-        log_index = log.log_index,
-        block_number = log.block_number,
-        latest_block,
-        confirmations = config.confirmations,
-        "LITKEY WSS payment log is pending confirmations"
-    );
-    pending.insert(key, log);
-    Ok(false)
 }
 
 pub fn parse_gateway_payment_log(
@@ -921,6 +577,106 @@ pub fn parse_gateway_payment_log(
     }))
 }
 
+pub fn select_matching_payment_log(
+    chain_id: i64,
+    gateway_address: Address,
+    logs: Vec<Log>,
+    wallet: Address,
+) -> Result<Option<PaymentLog>> {
+    let mut matches = Vec::new();
+    for log in logs {
+        let Some(payment) = parse_gateway_payment_log(chain_id, gateway_address, log)? else {
+            continue;
+        };
+        if payment.wallet == wallet {
+            matches.push(payment);
+        }
+    }
+    matches.sort_by_key(|log| log.log_index);
+    Ok(matches.into_iter().next())
+}
+
+fn payment_status_response_from_row(
+    row: Option<(String, i64, time::OffsetDateTime)>,
+) -> LitkeyPaymentStatusResponse {
+    match row {
+        Some((status, cents_credited, credited_at)) => LitkeyPaymentStatusResponse {
+            found: true,
+            status: Some(status),
+            cents_credited: Some(cents_credited),
+            credited_at: Some(credited_at),
+        },
+        None => LitkeyPaymentStatusResponse {
+            found: false,
+            status: None,
+            cents_credited: None,
+            credited_at: None,
+        },
+    }
+}
+
+async fn claim_litkey_payment_tx(
+    pool: &PgPool,
+    stripe: &StripeClient,
+    rpc: &HttpGatewayRpc,
+    config: &ChainConfig,
+    tx_hash: &str,
+    wallet: &str,
+    discount_basis_points: i64,
+) -> Result<LitkeyPaymentStatusResponse> {
+    if let Some(row) = lookup_payment_status(pool, tx_hash, wallet).await? {
+        return Ok(payment_status_response_from_row(Some(row)));
+    }
+
+    let Some(receipt) = rpc.transaction_receipt(tx_hash).await? else {
+        return Ok(LitkeyPaymentStatusResponse {
+            found: false,
+            status: Some("pending_receipt".to_string()),
+            cents_credited: None,
+            credited_at: None,
+        });
+    };
+    if receipt.status != Some(1) {
+        return Ok(LitkeyPaymentStatusResponse {
+            found: false,
+            status: Some("tx_failed".to_string()),
+            cents_credited: None,
+            credited_at: None,
+        });
+    }
+
+    let wallet_address = wallet
+        .parse::<Address>()
+        .context("canonical wallet failed to parse as address")?;
+    let logs = receipt.logs.into_iter().map(Into::into).collect();
+    let Some(payment) = select_matching_payment_log(
+        config.chain_id,
+        config.gateway_address,
+        logs,
+        wallet_address,
+    )?
+    else {
+        return Ok(LitkeyPaymentStatusResponse {
+            found: false,
+            status: None,
+            cents_credited: None,
+            credited_at: None,
+        });
+    };
+
+    tracing::info!(
+        tx_hash,
+        log_index = payment.log_index,
+        block_number = payment.block_number,
+        wallet,
+        "claiming LITKEY payment from submitted tx hash"
+    );
+    handle_confirmed_litkey_payment(pool, stripe, &payment, discount_basis_points).await?;
+    Ok(payment_status_response_from_row(
+        lookup_payment_status(pool, tx_hash, wallet).await?,
+    ))
+}
+
 pub async fn handle_confirmed_litkey_payment(
     pool: &PgPool,
     stripe: &StripeClient,
@@ -956,225 +712,6 @@ pub async fn handle_confirmed_litkey_payment(
 
     insert_payment(pool, &decision.payment).await?;
     Ok(())
-}
-
-pub async fn process_reconciliation_once<S, R, P>(
-    store: &S,
-    rpc: &R,
-    processor: &P,
-    config: &ChainConfig,
-) -> Result<()>
-where
-    S: ReconciliationStore,
-    R: ChainRpc,
-    P: ConfirmedPaymentProcessor,
-{
-    let stored_checkpoint = store
-        .current_checkpoint(config.chain_id, config.gateway_address)
-        .await?;
-    let checkpoint = stored_checkpoint.max(config.reconciliation_start_block.saturating_sub(1));
-    let latest_block = rpc.latest_block().await?;
-    let Some((from_block, to_block)) =
-        reconciliation_range(checkpoint, latest_block, config.confirmations)
-    else {
-        return Ok(());
-    };
-
-    let chunk_to_block = to_block.min(
-        from_block
-            .saturating_add(MAX_RECONCILIATION_BLOCK_RANGE)
-            .saturating_sub(1),
-    );
-    tracing::debug!(
-        stored_checkpoint,
-        effective_checkpoint = checkpoint,
-        from_block,
-        to_block = chunk_to_block,
-        latest_block,
-        confirmations = config.confirmations,
-        "LITKEY reconciliation scanning confirmed range"
-    );
-    let mut logs = rpc.payment_logs(from_block, chunk_to_block).await?;
-    logs.sort_by_key(|log| (log.block_number, log.log_index));
-    for log in logs {
-        processor.process_confirmed_payment(log).await?;
-    }
-    store
-        .advance_checkpoint(config.chain_id, config.gateway_address, chunk_to_block)
-        .await?;
-    Ok(())
-}
-
-pub async fn reconciliation_loop<S, R, P>(store: S, rpc: R, processor: P, config: ChainConfig)
-where
-    S: ReconciliationStore,
-    R: ChainRpc,
-    P: ConfirmedPaymentProcessor,
-{
-    let mut attempt = 0_u32;
-    loop {
-        match process_reconciliation_once(&store, &rpc, &processor, &config).await {
-            Ok(()) => {
-                attempt = 0;
-                sleep(Duration::from_secs(config.reconciliation_interval_secs)).await;
-            }
-            Err(err) => {
-                tracing::warn!(error = %err, "LITKEY reconciliation pass failed");
-                let delay = backoff_delay_secs(attempt);
-                attempt = attempt.saturating_add(1);
-                sleep(Duration::from_secs(delay)).await;
-            }
-        }
-    }
-}
-
-async fn next_wss_text<S>(socket: &mut S) -> Result<String>
-where
-    S: StreamExt<Item = std::result::Result<Message, tokio_tungstenite::tungstenite::Error>>
-        + Unpin,
-{
-    let message = timeout(
-        Duration::from_secs(WSS_READ_IDLE_TIMEOUT_SECS),
-        socket.next(),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("LITKEY WSS read timed out"))?
-    .context("LITKEY WSS stream ended")?
-    .context("reading LITKEY WSS message")?;
-
-    match message {
-        Message::Text(text) => Ok(text.to_string()),
-        Message::Binary(bytes) => std::str::from_utf8(&bytes)
-            .context("decoding LITKEY WSS binary JSON")
-            .map(str::to_owned),
-        Message::Close(frame) => anyhow::bail!("LITKEY WSS closed: {frame:?}"),
-        Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => Ok(String::new()),
-    }
-}
-
-async fn wait_for_wss_subscription_ack<S>(socket: &mut S, request_id: u64) -> Result<String>
-where
-    S: StreamExt<Item = std::result::Result<Message, tokio_tungstenite::tungstenite::Error>>
-        + Unpin,
-{
-    timeout(Duration::from_secs(WSS_SUBSCRIBE_ACK_TIMEOUT_SECS), async {
-        loop {
-            let text = next_wss_text(socket).await?;
-            if text.is_empty() {
-                continue;
-            }
-            if let Some(subscription_id) = parse_wss_subscription_ack(&text, request_id)? {
-                return Ok(subscription_id);
-            }
-        }
-    })
-    .await
-    .context("timed out waiting for LITKEY WSS subscription ack")?
-}
-
-async fn wss_listener_connection_once<P>(processor: &P, config: &ChainConfig) -> Result<()>
-where
-    P: ConfirmedPaymentProcessor,
-{
-    let latest_rpc = HttpGatewayRpc::new(config);
-    let (mut socket, _) = timeout(
-        Duration::from_secs(WSS_CONNECT_TIMEOUT_SECS),
-        connect_async(&config.alchemy_wss_url),
-    )
-    .await
-    .context("timed out connecting LITKEY Alchemy WSS")?
-    .context("connecting LITKEY Alchemy WSS")?;
-
-    socket
-        .send(Message::Text(
-            wss_payment_log_subscribe_request(config.gateway_address)
-                .to_string()
-                .into(),
-        ))
-        .await
-        .context("subscribing to LITKEY Payment logs over WSS")?;
-
-    let subscription_id = wait_for_wss_subscription_ack(&mut socket, 1).await?;
-    tracing::info!(subscription_id, "LITKEY WSS subscription acknowledged");
-
-    let mut pending = HashMap::new();
-    loop {
-        let text = next_wss_text(&mut socket).await?;
-        if text.is_empty() {
-            drain_confirmed_wss_payments(&latest_rpc, processor, config, &mut pending).await?;
-            continue;
-        }
-        process_wss_payment_notification(
-            &latest_rpc,
-            processor,
-            config,
-            &subscription_id,
-            &text,
-            &mut pending,
-        )
-        .await?;
-        drain_confirmed_wss_payments(&latest_rpc, processor, config, &mut pending).await?;
-    }
-}
-
-pub async fn wss_listener_loop<P>(processor: P, config: ChainConfig)
-where
-    P: ConfirmedPaymentProcessor,
-{
-    let mut attempt = 0_u32;
-    loop {
-        match wss_listener_connection_once(&processor, &config).await {
-            Ok(()) => attempt = 0,
-            Err(err) => {
-                tracing::warn!(error = %err, "LITKEY WSS listener connection failed");
-                let delay = backoff_delay_secs(attempt);
-                attempt = attempt.saturating_add(1);
-                sleep(Duration::from_secs(delay)).await;
-            }
-        }
-    }
-}
-
-/// Register the phase-3c LITKEY listener when chain config is present.
-///
-/// Starts both the Alchemy WSS fast path and the confirmed-block HTTPS
-/// reconciliation poller. Both paths share the same parser, handler, and
-/// idempotency key; WSS never advances reconciliation checkpoints.
-pub fn spawn_litkey_listener(
-    pool: PgPool,
-    stripe: StripeClient,
-    config: Option<ChainConfig>,
-    discount_basis_points: i64,
-) {
-    let Some(config) = config else {
-        tracing::info!("LITKEY listener disabled; ALCHEMY_* and LITKEY_GATEWAY_ADDRESS not set");
-        return;
-    };
-
-    let rpc = HttpGatewayRpc::new(&config);
-    let store = PgReconciliationStore::new(pool.clone());
-    let reconciliation_processor =
-        StripePaymentProcessor::new(pool.clone(), stripe.clone(), discount_basis_points);
-    let task_config = config.clone();
-    tokio::spawn(async move {
-        reconciliation_loop(store, rpc, reconciliation_processor, task_config).await;
-    });
-
-    let wss_processor = StripePaymentProcessor::new(pool, stripe, discount_basis_points);
-    let task_config = config.clone();
-    tokio::spawn(async move {
-        wss_listener_loop(wss_processor, task_config).await;
-    });
-
-    tracing::info!(
-        chain_id = config.chain_id,
-        gateway_address = %format_address(config.gateway_address),
-        confirmations = config.confirmations,
-        reconciliation_interval_secs = config.reconciliation_interval_secs,
-        reconciliation_start_block = config.reconciliation_start_block,
-        discount_basis_points,
-        "LITKEY listener started with Alchemy WSS fast path and HTTPS reconciliation fallback"
-    );
 }
 
 #[cfg(test)]
@@ -1218,174 +755,6 @@ mod tests {
         );
         assert!(canonical_wallet_param("not-a-wallet").is_err());
         assert!(canonical_tx_hash_param("0x1234").is_err());
-    }
-
-    #[test]
-    fn confirmation_depth_is_inclusive() {
-        assert!(is_confirmed(100, 105, 5));
-        assert!(!is_confirmed(100, 104, 5));
-        assert!(is_confirmed(100, 100, 0));
-    }
-
-    #[test]
-    fn reconciliation_range_starts_after_checkpoint_and_stops_at_safe_block() {
-        assert_eq!(reconciliation_range(100, 110, 5), Some((101, 105)));
-        assert_eq!(reconciliation_range(100, 105, 5), None);
-        assert_eq!(reconciliation_range(0, 3, 5), None);
-        assert_eq!(reconciliation_range(0, 5, 5), None);
-        assert_eq!(reconciliation_range(0, 6, 5), Some((1, 1)));
-    }
-
-    #[test]
-    fn reconnect_backoff_caps_at_thirty_seconds() {
-        let delays: Vec<u64> = (0..8).map(backoff_delay_secs).collect();
-        assert_eq!(delays, vec![1, 2, 4, 8, 16, 30, 30, 30]);
-    }
-
-    #[test]
-    fn builds_alchemy_wss_payment_log_subscription_for_configured_gateway() {
-        let config = sample_chain_config();
-        let payload = wss_payment_log_subscribe_request(config.gateway_address);
-
-        assert_eq!(payload["jsonrpc"], "2.0");
-        assert_eq!(payload["id"], 1);
-        assert_eq!(payload["method"], "eth_subscribe");
-        assert_eq!(payload["params"][0], "logs");
-        assert_eq!(
-            payload["params"][1]["address"],
-            format_address(config.gateway_address)
-        );
-        assert_eq!(
-            payload["params"][1]["topics"][0],
-            format!("{:#x}", payment_event_topic())
-        );
-    }
-
-    #[test]
-    fn parses_wss_subscription_ack_and_errors() {
-        assert_eq!(
-            parse_wss_subscription_ack(r#"{"jsonrpc":"2.0","id":1,"result":"0xsub"}"#, 1).unwrap(),
-            Some("0xsub".to_string())
-        );
-        assert!(
-            parse_wss_subscription_ack(r#"{"jsonrpc":"2.0","id":2,"result":"0xother"}"#, 1)
-                .unwrap()
-                .is_none()
-        );
-        let err = parse_wss_subscription_ack(
-            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"nope"}}"#,
-            1,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("eth_subscribe failed"));
-    }
-
-    #[test]
-    fn parses_eth_subscription_payment_log_notification_with_existing_parser() {
-        let expected = sample_payment_log();
-        let message = sample_subscription_message(&expected);
-
-        let parsed = parse_wss_payment_log_notification(
-            expected.chain_id,
-            expected.gateway_address,
-            "0xsub",
-            &message.to_string(),
-        )
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(parsed, WssPaymentNotification::Added(expected));
-    }
-
-    #[test]
-    fn ignores_unrelated_wss_messages_but_errors_on_malformed_subscribed_logs() {
-        let expected = sample_payment_log();
-        assert!(
-            parse_wss_payment_log_notification(
-                expected.chain_id,
-                expected.gateway_address,
-                "0xsub",
-                r#"{"jsonrpc":"2.0","id":1,"result":"0xsub"}"#,
-            )
-            .unwrap()
-            .is_none()
-        );
-        assert!(
-            parse_wss_payment_log_notification(
-                expected.chain_id,
-                expected.gateway_address,
-                "0xsub",
-                r#"{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0xother","result":{}}}"#,
-            )
-            .unwrap()
-            .is_none()
-        );
-
-        let missing_topics = json!({
-            "jsonrpc": "2.0",
-            "method": "eth_subscription",
-            "params": {
-                "subscription": "0xsub",
-                "result": {
-                    "address": format_address(expected.gateway_address),
-                    "blockNumber": format!("0x{:x}", expected.block_number),
-                    "logIndex": format!("0x{:x}", expected.log_index),
-                    "transactionHash": format!("{:#x}", expected.tx_hash),
-                    "data": format!("0x{}", hex::encode(encode_uint256(expected.amount_wei)))
-                }
-            }
-        });
-        let err = parse_wss_payment_log_notification(
-            expected.chain_id,
-            expected.gateway_address,
-            "0xsub",
-            &missing_topics.to_string(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("decoding LITKEY WSS payment log"));
-
-        let malformed = json!({
-            "jsonrpc": "2.0",
-            "method": "eth_subscription",
-            "params": {
-                "subscription": "0xsub",
-                "result": {
-                    "address": format_address(expected.gateway_address),
-                    "blockNumber": format!("0x{:x}", expected.block_number),
-                    "logIndex": format!("0x{:x}", expected.log_index),
-                    "transactionHash": format!("{:#x}", expected.tx_hash),
-                    "topics": [format!("{:#x}", payment_event_topic()), indexed_address_topic(expected.wallet)],
-                    "data": format!("0x{}", hex::encode(encode_uint256(expected.amount_wei)))
-                }
-            }
-        });
-
-        let err = parse_wss_payment_log_notification(
-            expected.chain_id,
-            expected.gateway_address,
-            "0xsub",
-            &malformed.to_string(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("exactly 3 topics"));
-    }
-
-    #[test]
-    fn parses_removed_wss_logs_for_pending_eviction() {
-        let expected = sample_payment_log();
-        let mut message = sample_subscription_message(&expected);
-        message["params"]["result"]["removed"] = json!(true);
-
-        assert_eq!(
-            parse_wss_payment_log_notification(
-                expected.chain_id,
-                expected.gateway_address,
-                "0xsub",
-                &message.to_string(),
-            )
-            .unwrap(),
-            Some(WssPaymentNotification::Removed(expected))
-        );
     }
 
     #[test]
@@ -1446,6 +815,54 @@ mod tests {
             .unwrap();
 
         assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn selects_matching_payment_log_from_submitted_tx_receipt() {
+        let expected = sample_payment_log();
+        let wrong_wallet = Address::from_str("0x9999999999999999999999999999999999999999").unwrap();
+        let unrelated_transfer = Log {
+            address: Address::from_str(LITKEY_TOKEN_ADDRESS).unwrap(),
+            topics: vec![B256::ZERO],
+            ..Default::default()
+        };
+        let wrong_wallet_payment = Log {
+            address: expected.gateway_address,
+            topics: vec![
+                payment_event_topic(),
+                indexed_address_topic(wrong_wallet),
+                indexed_address_topic(expected.payer),
+            ],
+            data: encode_uint256(expected.amount_wei).into(),
+            transaction_hash: Some(expected.tx_hash),
+            log_index: Some((expected.log_index - 1).into()),
+            block_number: Some(expected.block_number.into()),
+            ..Default::default()
+        };
+        let matching_payment = Log {
+            address: expected.gateway_address,
+            topics: vec![
+                payment_event_topic(),
+                indexed_address_topic(expected.wallet),
+                indexed_address_topic(expected.payer),
+            ],
+            data: encode_uint256(expected.amount_wei).into(),
+            transaction_hash: Some(expected.tx_hash),
+            log_index: Some(expected.log_index.into()),
+            block_number: Some(expected.block_number.into()),
+            ..Default::default()
+        };
+
+        let selected = select_matching_payment_log(
+            expected.chain_id,
+            expected.gateway_address,
+            vec![unrelated_transfer, wrong_wallet_payment, matching_payment],
+            expected.wallet,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(selected, expected);
     }
 
     #[test]
@@ -1527,28 +944,6 @@ mod tests {
         }
     }
 
-    fn sample_subscription_message(log: &PaymentLog) -> Value {
-        json!({
-            "jsonrpc": "2.0",
-            "method": "eth_subscription",
-            "params": {
-                "subscription": "0xsub",
-                "result": {
-                    "address": format_address(log.gateway_address),
-                    "blockNumber": format!("0x{:x}", log.block_number),
-                    "logIndex": format!("0x{:x}", log.log_index),
-                    "transactionHash": format!("{:#x}", log.tx_hash),
-                    "topics": [
-                        format!("{:#x}", payment_event_topic()),
-                        format!("{:#x}", indexed_address_topic(log.wallet)),
-                        format!("{:#x}", indexed_address_topic(log.payer))
-                    ],
-                    "data": format!("0x{}", hex::encode(encode_uint256(log.amount_wei)))
-                }
-            }
-        })
-    }
-
     fn fresh_rate() -> crate::rate::LitkeyRate {
         crate::rate::LitkeyRate {
             usd_wei_per_litkey: "1000000000000000000".to_string(),
@@ -1557,344 +952,6 @@ mod tests {
             updated_by_operator_id: Some(1),
             stale: false,
         }
-    }
-
-    struct FakeStore {
-        checkpoint: u64,
-        advanced_to: std::sync::Mutex<Vec<u64>>,
-    }
-
-    #[async_trait]
-    impl ReconciliationStore for FakeStore {
-        async fn current_checkpoint(
-            &self,
-            _chain_id: i64,
-            _gateway_address: Address,
-        ) -> Result<u64> {
-            Ok(self.checkpoint)
-        }
-
-        async fn advance_checkpoint(
-            &self,
-            _chain_id: i64,
-            _gateway_address: Address,
-            last_processed_block: u64,
-        ) -> Result<()> {
-            self.advanced_to.lock().unwrap().push(last_processed_block);
-            Ok(())
-        }
-    }
-
-    struct FakeRpc {
-        latest: u64,
-        logs: Vec<PaymentLog>,
-        ranges: std::sync::Mutex<Vec<(u64, u64)>>,
-    }
-
-    #[async_trait]
-    impl ChainRpc for FakeRpc {
-        async fn latest_block(&self) -> Result<u64> {
-            Ok(self.latest)
-        }
-
-        async fn payment_logs(&self, from_block: u64, to_block: u64) -> Result<Vec<PaymentLog>> {
-            self.ranges.lock().unwrap().push((from_block, to_block));
-            Ok(self.logs.clone())
-        }
-    }
-
-    struct FakeProcessor {
-        processed: std::sync::Mutex<Vec<(u64, u64)>>,
-        fail: bool,
-    }
-
-    #[async_trait]
-    impl ConfirmedPaymentProcessor for FakeProcessor {
-        async fn process_confirmed_payment(&self, log: PaymentLog) -> Result<()> {
-            if self.fail {
-                anyhow::bail!("boom");
-            }
-            self.processed
-                .lock()
-                .unwrap()
-                .push((log.block_number, log.log_index));
-            Ok(())
-        }
-    }
-
-    fn sample_chain_config() -> ChainConfig {
-        ChainConfig {
-            chain_id: 8453,
-            alchemy_wss_url: "wss://example.invalid".to_string(),
-            alchemy_https_url: "https://example.invalid".to_string(),
-            gateway_address: Address::from_str("0x1000000000000000000000000000000000000000")
-                .unwrap(),
-            confirmations: 5,
-            reconciliation_interval_secs: 60,
-            reconciliation_start_block: 0,
-        }
-    }
-
-    #[tokio::test]
-    async fn wss_notification_processes_only_confirmed_payment_logs() {
-        let log = sample_payment_log();
-        let message = sample_subscription_message(&log).to_string();
-        let mut config = sample_chain_config();
-        config.gateway_address = log.gateway_address;
-
-        let rpc = FakeRpc {
-            latest: log.block_number + config.confirmations,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-        let mut pending = HashMap::new();
-
-        assert!(
-            process_wss_payment_notification(
-                &rpc,
-                &processor,
-                &config,
-                "0xsub",
-                &message,
-                &mut pending,
-            )
-            .await
-            .unwrap()
-        );
-        assert_eq!(
-            *processor.processed.lock().unwrap(),
-            vec![(log.block_number, log.log_index)]
-        );
-        assert!(pending.is_empty());
-        assert!(rpc.ranges.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn wss_notification_buffers_unconfirmed_logs_and_drains_when_confirmed() {
-        let log = sample_payment_log();
-        let message = sample_subscription_message(&log).to_string();
-        let mut config = sample_chain_config();
-        config.gateway_address = log.gateway_address;
-
-        let unconfirmed_rpc = FakeRpc {
-            latest: log.block_number + config.confirmations - 1,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-        let mut pending = HashMap::new();
-
-        assert!(
-            !process_wss_payment_notification(
-                &unconfirmed_rpc,
-                &processor,
-                &config,
-                "0xsub",
-                &message,
-                &mut pending,
-            )
-            .await
-            .unwrap()
-        );
-        assert!(processor.processed.lock().unwrap().is_empty());
-        assert_eq!(pending.len(), 1);
-        assert!(unconfirmed_rpc.ranges.lock().unwrap().is_empty());
-
-        let confirmed_rpc = FakeRpc {
-            latest: log.block_number + config.confirmations,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        assert_eq!(
-            drain_confirmed_wss_payments(&confirmed_rpc, &processor, &config, &mut pending)
-                .await
-                .unwrap(),
-            1
-        );
-        assert_eq!(
-            *processor.processed.lock().unwrap(),
-            vec![(log.block_number, log.log_index)]
-        );
-        assert!(pending.is_empty());
-    }
-
-    #[tokio::test]
-    async fn wss_removed_notification_evicts_pending_log_before_drain() {
-        let log = sample_payment_log();
-        let message = sample_subscription_message(&log).to_string();
-        let mut removed_message = sample_subscription_message(&log);
-        removed_message["params"]["result"]["removed"] = json!(true);
-        let mut config = sample_chain_config();
-        config.gateway_address = log.gateway_address;
-
-        let unconfirmed_rpc = FakeRpc {
-            latest: log.block_number + config.confirmations - 1,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-        let mut pending = HashMap::new();
-
-        process_wss_payment_notification(
-            &unconfirmed_rpc,
-            &processor,
-            &config,
-            "0xsub",
-            &message,
-            &mut pending,
-        )
-        .await
-        .unwrap();
-        assert_eq!(pending.len(), 1);
-
-        process_wss_payment_notification(
-            &unconfirmed_rpc,
-            &processor,
-            &config,
-            "0xsub",
-            &removed_message.to_string(),
-            &mut pending,
-        )
-        .await
-        .unwrap();
-        assert!(pending.is_empty());
-
-        let confirmed_rpc = FakeRpc {
-            latest: log.block_number + config.confirmations,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        assert_eq!(
-            drain_confirmed_wss_payments(&confirmed_rpc, &processor, &config, &mut pending)
-                .await
-                .unwrap(),
-            0
-        );
-        assert!(processor.processed.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn reconciliation_once_processes_safe_range_and_advances_checkpoint_after_success() {
-        let mut later = sample_payment_log();
-        later.block_number = 105;
-        later.log_index = 2;
-        let mut earlier = sample_payment_log();
-        earlier.block_number = 101;
-        earlier.log_index = 1;
-        let store = FakeStore {
-            checkpoint: 100,
-            advanced_to: std::sync::Mutex::new(Vec::new()),
-        };
-        let rpc = FakeRpc {
-            latest: 110,
-            logs: vec![later, earlier],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-
-        process_reconciliation_once(&store, &rpc, &processor, &sample_chain_config())
-            .await
-            .unwrap();
-
-        assert_eq!(*rpc.ranges.lock().unwrap(), vec![(101, 105)]);
-        assert_eq!(
-            *processor.processed.lock().unwrap(),
-            vec![(101, 1), (105, 2)]
-        );
-        assert_eq!(*store.advanced_to.lock().unwrap(), vec![105]);
-    }
-
-    #[tokio::test]
-    async fn reconciliation_once_chunks_large_catchup_ranges() {
-        let store = FakeStore {
-            checkpoint: 0,
-            advanced_to: std::sync::Mutex::new(Vec::new()),
-        };
-        let rpc = FakeRpc {
-            latest: MAX_RECONCILIATION_BLOCK_RANGE + 10,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-
-        process_reconciliation_once(&store, &rpc, &processor, &sample_chain_config())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            *rpc.ranges.lock().unwrap(),
-            vec![(1, MAX_RECONCILIATION_BLOCK_RANGE)]
-        );
-        assert_eq!(
-            *store.advanced_to.lock().unwrap(),
-            vec![MAX_RECONCILIATION_BLOCK_RANGE]
-        );
-    }
-
-    #[tokio::test]
-    async fn reconciliation_once_uses_configured_start_block_when_checkpoint_is_behind() {
-        let store = FakeStore {
-            checkpoint: 2_000,
-            advanced_to: std::sync::Mutex::new(Vec::new()),
-        };
-        let rpc = FakeRpc {
-            latest: 46_516_500,
-            logs: vec![],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: false,
-        };
-        let mut config = sample_chain_config();
-        config.reconciliation_start_block = 46_516_000;
-
-        process_reconciliation_once(&store, &rpc, &processor, &config)
-            .await
-            .unwrap();
-
-        assert_eq!(*rpc.ranges.lock().unwrap(), vec![(46_516_000, 46_516_495)]);
-        assert_eq!(*store.advanced_to.lock().unwrap(), vec![46_516_495]);
-    }
-
-    #[tokio::test]
-    async fn reconciliation_once_does_not_advance_checkpoint_when_processing_fails() {
-        let store = FakeStore {
-            checkpoint: 100,
-            advanced_to: std::sync::Mutex::new(Vec::new()),
-        };
-        let rpc = FakeRpc {
-            latest: 110,
-            logs: vec![sample_payment_log()],
-            ranges: std::sync::Mutex::new(Vec::new()),
-        };
-        let processor = FakeProcessor {
-            processed: std::sync::Mutex::new(Vec::new()),
-            fail: true,
-        };
-
-        let err = process_reconciliation_once(&store, &rpc, &processor, &sample_chain_config())
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("boom"));
-        assert!(store.advanced_to.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -35,8 +35,9 @@ pub struct Config {
     /// Discount for LITKEY payments, in basis points. Default 0. Example:
     /// 2000 = "20% off vs credit card".
     pub litkey_discount_basis_points: i64,
-    /// Optional Base LITKEY listener configuration. If unset, the admin portal
-    /// and rate poller run but on-chain payment processing stays disabled.
+    /// Optional Base LITKEY chain verification configuration. If unset, the
+    /// admin portal and rate poller run but LITKEY browser payments stay
+    /// disabled.
     pub litkey_chain: Option<chain::ChainConfig>,
 }
 
@@ -75,16 +76,6 @@ fn optional_i64(name: &str, default: i64) -> Result<i64> {
     }
 }
 
-fn optional_u64(name: &str, default: u64) -> Result<u64> {
-    match std::env::var(name) {
-        Ok(v) if !v.trim().is_empty() => v
-            .trim()
-            .parse::<u64>()
-            .with_context(|| format!("env var {name} must be an unsigned integer; got {v:?}")),
-        _ => Ok(default),
-    }
-}
-
 fn optional_trimmed(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
@@ -92,59 +83,38 @@ fn optional_trimmed(name: &str) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
-pub fn validate_chain_runtime_config(
-    chain_id: i64,
-    confirmations: u64,
-    reconciliation_interval_secs: u64,
-) -> Result<()> {
+pub fn validate_chain_runtime_config(chain_id: i64) -> Result<()> {
     if chain_id != chain::BASE_CHAIN_ID {
         anyhow::bail!(
             "LITKEY_CHAIN_ID must be {} (Base mainnet)",
             chain::BASE_CHAIN_ID
         );
     }
-    if confirmations == 0 {
-        anyhow::bail!("LITKEY_CONFIRMATIONS must be greater than zero");
-    }
-    if reconciliation_interval_secs == 0 {
-        anyhow::bail!("LITKEY_RECONCILIATION_INTERVAL_SECS must be greater than zero");
-    }
     Ok(())
 }
 
 fn parse_litkey_chain_config() -> Result<Option<chain::ChainConfig>> {
-    let wss = optional_trimmed("ALCHEMY_WSS_URL");
     let https = optional_trimmed("ALCHEMY_HTTPS_URL");
     let gateway = optional_trimmed("LITKEY_GATEWAY_ADDRESS");
 
-    if wss.is_none() && https.is_none() && gateway.is_none() {
+    if https.is_none() && gateway.is_none() {
         return Ok(None);
     }
 
-    let wss = wss.context("ALCHEMY_WSS_URL is required when enabling LITKEY listener")?;
-    let https = https.context("ALCHEMY_HTTPS_URL is required when enabling LITKEY listener")?;
-    let gateway =
-        gateway.context("LITKEY_GATEWAY_ADDRESS is required when enabling LITKEY listener")?;
+    let https =
+        https.context("ALCHEMY_HTTPS_URL is required when enabling LITKEY chain verification")?;
+    let gateway = gateway
+        .context("LITKEY_GATEWAY_ADDRESS is required when enabling LITKEY chain verification")?;
     let gateway_address = Address::from_str(&gateway)
         .with_context(|| format!("LITKEY_GATEWAY_ADDRESS must be a 0x address; got {gateway:?}"))?;
 
     let chain_id = optional_i64("LITKEY_CHAIN_ID", chain::BASE_CHAIN_ID)?;
-    let confirmations = optional_u64("LITKEY_CONFIRMATIONS", chain::DEFAULT_CONFIRMATIONS)?;
-    let reconciliation_interval_secs = optional_u64(
-        "LITKEY_RECONCILIATION_INTERVAL_SECS",
-        chain::DEFAULT_RECONCILIATION_INTERVAL_SECS,
-    )?;
-    let reconciliation_start_block = optional_u64("LITKEY_RECONCILIATION_START_BLOCK", 0)?;
-    validate_chain_runtime_config(chain_id, confirmations, reconciliation_interval_secs)?;
+    validate_chain_runtime_config(chain_id)?;
 
     Ok(Some(chain::ChainConfig {
         chain_id,
-        alchemy_wss_url: wss,
         alchemy_https_url: https,
         gateway_address,
-        confirmations,
-        reconciliation_interval_secs,
-        reconciliation_start_block,
     }))
 }
 
@@ -178,9 +148,7 @@ mod tests {
 
     #[test]
     fn validates_litkey_chain_runtime_config_bounds() {
-        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 5, 60).is_ok());
-        assert!(validate_chain_runtime_config(0, 5, 60).is_err());
-        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 0, 60).is_err());
-        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID, 5, 0).is_err());
+        assert!(validate_chain_runtime_config(chain::BASE_CHAIN_ID).is_ok());
+        assert!(validate_chain_runtime_config(0).is_err());
     }
 }

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -29,13 +29,6 @@ async fn rocket() -> _ {
     let rate_limit = auth::rate_limit::RateLimiter::new();
     let stripe = StripeClient::new(cfg.stripe_secret_key.clone()).expect("stripe client");
     rate::spawn_rate_poller(pool.clone());
-    chain::spawn_litkey_listener(
-        pool.clone(),
-        stripe.clone(),
-        cfg.litkey_chain.clone(),
-        cfg.litkey_discount_basis_points,
-    );
-
     rocket::build()
         .manage(pool)
         .manage(cfg)
@@ -60,7 +53,7 @@ async fn rocket() -> _ {
                 rate::get_rate,
                 rate::get_quote,
                 chain::get_payment_config,
-                chain::get_payment_status,
+                chain::claim_payment,
                 rate::override_rate,
             ],
         )

--- a/lit-payments/static/pay-with-litkey.html
+++ b/lit-payments/static/pay-with-litkey.html
@@ -42,7 +42,7 @@
       <button type="button" id="approve" class="btn btn-primary" disabled>Approve exact LITKEY</button>
       <button type="button" id="pay" class="btn btn-primary" disabled>Pay</button>
     </div>
-    <p class="fine-print">Final credit is estimated in the browser and finalized by the confirmation listener after the transaction is confirmed.</p>
+    <p class="fine-print">Final credit is estimated in the browser and finalized by backend verification of your payment transaction receipt.</p>
   </main>
 </body>
 </html>

--- a/lit-payments/static/pay-with-litkey.js
+++ b/lit-payments/static/pay-with-litkey.js
@@ -6,8 +6,7 @@
   const MIN_CENTS = 500n;
   const WEI = 1000000000000000000n;
   const USD = 1000000000000000000n;
-  const POLL_INTERVAL_MS = 5000;
-  const POLL_SUPPORT_AFTER_MS = 5 * 60 * 1000;
+
   const ERC20_ABI = [
     'function approve(address spender,uint256 amount) returns (bool)',
     'function decimals() view returns (uint8)',
@@ -27,8 +26,7 @@
     signer: null,
     amountWei: 0n,
     txHash: null,
-    pollTimer: null,
-    pollStartedAt: null,
+
   };
 
   const $ = (id) => document.getElementById(id);
@@ -60,6 +58,18 @@
 
   async function fetchJson(url) {
     const res = await fetch(url, { credentials: 'omit' });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(body.error || ('Request failed: ' + res.status));
+    return body;
+  }
+
+  async function postJson(url, payload) {
+    const res = await fetch(url, {
+      method: 'POST',
+      credentials: 'omit',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
     const body = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(body.error || ('Request failed: ' + res.status));
     return body;
@@ -225,29 +235,22 @@
     setStatus('Submit payment in your wallet…', 'info');
     const tx = await gateway.pay(state.approvedAmountWei, state.wallet);
     state.txHash = tx.hash;
-    state.pollStartedAt = Date.now();
     $('pay').disabled = true;
-    setStatus('Payment submitted. Waiting for confirmation listener…', 'info');
-    pollStatus();
-  }
-
-  async function pollStatus() {
-    clearTimeout(state.pollTimer);
-    try {
-      const data = await fetchJson('/api/litkey/payment-status?tx_hash=' + encodeURIComponent(state.txHash) + '&wallet=' + encodeURIComponent(state.wallet));
-      if (data.found) {
-        if (data.status === 'credited') setStatus('Credited ' + fmtUsd(data.cents_credited || 0) + ' to the account.', 'success');
-        else setStatus('Payment recorded with status: ' + data.status, 'warning');
-        return;
-      }
-    } catch (e) {
-      console.error(e);
-      setStatus('Still waiting for listener status. If this persists, contact support with tx ' + state.txHash + '.', 'warning');
+    setStatus('Payment submitted. Waiting for transaction receipt…', 'info');
+    await tx.wait();
+    setStatus('Payment mined. Verifying transaction and applying credit…', 'info');
+    const data = await postJson('/api/litkey/payment-claim', {
+      tx_hash: state.txHash,
+      wallet: state.wallet,
+    });
+    if (data.found) {
+      if (data.status === 'credited') setStatus('Credited ' + fmtUsd(data.cents_credited || 0) + ' to the account.', 'success');
+      else setStatus('Payment recorded with status: ' + data.status, 'warning');
+    } else if (data.status === 'tx_failed') {
+      setStatus('Payment transaction failed on-chain. No credit was applied.', 'error');
+    } else {
+      setStatus('Payment was mined, but the backend did not find the gateway event. Contact support with tx ' + state.txHash + '.', 'warning');
     }
-    if (state.pollStartedAt && Date.now() - state.pollStartedAt > POLL_SUPPORT_AFTER_MS) {
-      setStatus('Still waiting for listener confirmation. Keep this transaction hash for support: ' + state.txHash + '.', 'warning');
-    }
-    state.pollTimer = setTimeout(pollStatus, POLL_INTERVAL_MS);
   }
 
   function installWalletGuards() {

--- a/plans/lit-payments-app.md
+++ b/plans/lit-payments-app.md
@@ -78,7 +78,7 @@ lit-node-express/
 ├── lit-payments/           ← NEW (non-TEE)
 │   ├── src/
 │   │   ├── main.rs
-│   │   ├── chain.rs        ← LITKEY listener (WSS + poll)
+│   │   ├── chain.rs        ← LITKEY tx-hash claim verification
 │   │   ├── db.rs           ← Postgres
 │   │   ├── auth.rs         ← magic-link
 │   │   └── endpoints/
@@ -108,9 +108,9 @@ Tech stack: **Rust + Rocket + vanilla HTML/JS**. Matches existing repo conventio
 
 - **Hostname**: `payments.litprotocol.com`.
 - **Platform**: Railway (service + Railway Postgres, or external Postgres via Supabase/Neon). `lit-payments/railway.json` keeps this service's Railway config scoped to the subfolder while pointing at `lit-payments/Dockerfile`; keep the Railway service build context at repo root so Docker can copy the sibling `lit-billing-core/` crate.
-- **Outside the TEE.** No attestation pain; operators can use Railway logs / shell for diagnostics. Keep one replica continuously running; do not sleep/scale-to-zero because the listener has WSS/reconciliation background loops.
+- **Outside the TEE.** No attestation pain; operators can use Railway logs / shell for diagnostics. Keep one replica warm for user-facing payment confirmation latency; the browser claim path no longer depends on background listener loops.
 - **Ingress**: Railway-generated domain initially, then custom domain `payments.litprotocol.com` once smoke tests pass.
-- **Secrets** (Railway service variables): Stripe restricted key, DB URL, magic-link signing key, Resend API key, Alchemy WSS + HTTPS URLs, gateway contract address, and `ROCKET_SECRET_KEY` for Rocket's private-cookie encryption. LITKEY token address is fixed in the payment config endpoint for the current Base deployment; CoinGecko uses the hardcoded `lit-protocol` id.
+- **Secrets** (Railway service variables): Stripe restricted key, DB URL, magic-link signing key, Resend API key, Alchemy HTTPS URL, gateway contract address, and `ROCKET_SECRET_KEY` for Rocket's private-cookie encryption. LITKEY token address is fixed in the payment config endpoint for the current Base deployment; CoinGecko uses the hardcoded `lit-protocol` id.
 
 ### Auth tiers
 
@@ -190,7 +190,7 @@ Six tables, each justified:
 - `grants` — portal action log + idempotency.
 - `litkey_payments` — credit record + idempotency.
 - `litkey_rate` — current rate (single row) + who last touched it.
-- `chain_checkpoint` — listener resume point.
+- `chain_checkpoint` — legacy listener resume point; not used by the simplified browser tx-claim path.
 
 No separate `audit_log` table: every state-changing action is recorded on its own resource row with the actor (`operator_id`) and timestamp. Logins are server logs only.
 
@@ -227,9 +227,9 @@ No separate `audit_log` table: every state-changing action is recorded on its ow
 - **Token**: LITKEY at `0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49` (Base bridge deployment, `OptimismMintableERC20`).
 - **No `permit` / no EIP-3009.** Two-tx flow: `approve` then `pay`.
 - **Approval pattern**: exact-amount only.
-- **Confirmation depth**: 5 blocks.
+- **Confirmation depth**: no separate backend confirmation wait for the browser claim path; the page waits for the wallet transaction receipt, then the backend verifies that exact receipt.
 - **Treasury**: existing company Safe on Base.
-- **Listener**: Alchemy WSS primary + 60s reconciliation poll.
+- **Crediting trigger**: browser submits the known gateway transaction hash to the backend; the backend fetches the receipt and verifies the `Payment` event directly.
 - **Rate source**: CoinGecko free public API, `id=lit-protocol`, polled every 5 min.
 - **Minimum payment**: $5 equivalent.
 - **Audit**: internal review (Chris) on the contract.
@@ -242,7 +242,7 @@ User in the dashboard at `dashboard.litprotocol.com` clicks "Pay with tokens" �
 2. User connects their paying wallet (Wagmi). May be the same as the credited wallet or a different one (e.g., a separate Metamask holding LITKEY).
 3. Page shows "You'll send N LITKEY (~$X credit at current rate)."
 4. User clicks Pay → wallet pops up twice (`approve`, then `pay`).
-5. Page polls for credit confirmation. On success: confirmation + link back to dashboard.
+5. Page waits for the transaction receipt, posts the tx hash to the backend once, and shows the credit result.
 
 **Note on URL spoofing.** The wallet in the URL is unauthenticated — anyone can craft a link to credit any account. We don't try to prevent that. The worst case is one of:
 - Someone gifts a credit to another account (no harm).
@@ -270,23 +270,22 @@ contract LitkeyPaymentGateway {
 }
 ```
 
-Dashboard Pay button calls `litkey.approve(gateway, amount)` then `gateway.pay(amount, walletToCredit)`. Listener watches `Payment` — `wallet` (which maps to a Stripe customer via `metadata.wallet_address`) is baked into every event. Zero ambiguity even under concurrent payments. Funds land directly in the Safe.
+Dashboard Pay button calls `litkey.approve(gateway, amount)` then `gateway.pay(amount, walletToCredit)`. The browser sends the resulting tx hash to the backend; `wallet` (which maps to a Stripe customer via `metadata.wallet_address`) is baked into the emitted `Payment` event. Zero ambiguity even under concurrent payments. Funds land directly in the Safe.
 
-**Direct sends to the Safe are unsupported.** If a user pastes the Safe address and sends LITKEY directly (skipping the contract), they bypass the listener entirely. Those tokens just sit in the Safe as company income. If a user complains, the mod uses the admin credit portal (Feature 1) to grant credit manually. The portal exists for exactly these one-off cases — we don't need a second machinery for them.
+**Direct sends to the Safe are unsupported.** If a user pastes the Safe address and sends LITKEY directly (skipping the contract), they bypass the gateway event entirely. Those tokens just sit in the Safe as company income. If a user complains, the mod uses the admin credit portal (Feature 1) to grant credit manually. The portal exists for exactly these one-off cases — we don't need a second machinery for them.
 
-### Listener
+### Payment claim
 
-WebSocket primary + 60s reconciliation poll:
+Browser-submitted tx hash, no background listener/poller:
 
-- **WSS subscription** (Alchemy) to `Payment` events from the gateway contract. Reconnect with exponential backoff (1s → 2s → 4s → … cap 30s).
-- **60s poll** for `Payment` logs in `(last_processed_block, latest_block - 5)`. Same handler, same idempotency check.
-- **Checkpoint**: `chain_checkpoint.last_processed_block` advanced only by the poll path.
-- **Confirmation depth**: defer crediting until `latest_block - event_block >= 5`.
-- **Idempotency**: `(tx_hash, log_index)` unique in `litkey_payments`.
+- **Claim endpoint**: `POST /api/litkey/payment-claim` with `{ tx_hash, wallet }`.
+- **Receipt verification**: backend fetches `eth_getTransactionReceipt`, rejects failed txs, and selects the configured gateway's `Payment(indexed wallet,indexed payer,uint256 amount)` log matching the credited wallet.
+- **No status endpoint / no polling loop**: the browser waits for its wallet receipt and submits the exact tx hash once.
+- **Idempotency**: `(chain_id, tx_hash, log_index)` unique in `litkey_payments`.
 
 ### Credit flow
 
-1. `Payment` event observed at confirmation depth.
+1. `Payment` event found in the submitted transaction receipt.
 2. Idempotency check on `(tx_hash, log_index)`.
 3. Look up Stripe customer by `metadata.wallet_address == event.wallet`. If none: log a warning and skip — do not credit, do not alert. Anyone calling `pay()` directly with a wallet that isn't a Lit customer is off the supported path; they'll reach out to support if it matters.
 4. Read `usd_wei_per_litkey` from `litkey_rate` (`1 USD = 1e18` fixed-point units). Compute Stripe cents from native `Payment.amount` LITKEY wei with BigInt-style integer math: `amount_wei * usd_wei_per_litkey * 100 * 10000 / (1e18 token scale * 1e18 USD scale * (10000 - discount_bps))`, rounded once at the final Stripe-cent boundary.
@@ -314,10 +313,10 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 
 - **`event.wallet` doesn't match any Stripe customer** → log + skip. No alert. If the payer cares, they'll contact support and a mod can grant via the credit portal.
 - **Direct send to the Safe** → unsupported; tokens just sit in the Safe. User contacts support → mod uses the credit portal.
-- **Reorgs** → 5-confirmation depth on Base prevents.
+- **Reorgs** → intentionally not modeled for the browser claim path; Base reorg risk is accepted here.
 - **Overpayment** → credit at current rate; no refund flow in v1.
 - **Rate drift between approve and pay** → contract executes whatever amount was approved; we credit at rate-at-event-time. Page warns "finalized at confirmation."
-- **Contract upgrade** → contract is intentionally minimal & immutable; if behavior changes, deploy a new contract and update the listener.
+- **Contract upgrade** → contract is intentionally minimal & immutable; if behavior changes, deploy a new contract and update the browser payment config.
 
 ## Decisions (locked in)
 
@@ -337,7 +336,7 @@ GET https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies
 | 12 | Treasury | Existing company Safe on Base |
 | 13 | Contract audit | Internal review only (Chris) |
 | 14 | Approval pattern | Exact-amount only |
-| 15 | RPC provider | Alchemy (WSS primary + HTTPS poll fallback) |
+| 15 | RPC provider | Alchemy HTTPS for tx receipt verification |
 
 ## Decisions table — extended (build-time config)
 
@@ -382,7 +381,7 @@ All questions are closed. Plan is ready to start building.
    - [x] `scripts/deploy.ts` (env-driven, optional Basescan auto-verify) + README.
    - [x] CI workflow `.github/workflows/lit-payments-contracts-ci.yml`.
    - [x] Manual: deployed to Base mainnet at `0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` with the company Safe as treasury. Smoke test: 1 wei of LITKEY sent through the gateway arrived in the company Safe.
-   - [x] Deployment invariant documented: `litkey` and `treasury` are immutable constructor args. Changing the token or recipient Safe requires deploying a new `LitkeyPaymentGateway` and updating listener/dashboard config to the new address.
+   - [x] Deployment invariant documented: `litkey` and `treasury` are immutable constructor args. Changing the token or recipient Safe requires deploying a new `LitkeyPaymentGateway` and updating browser payment config to the new address.
 
    **3b.** ✅ CoinGecko rate poller + `litkey_rate` schema + admin rate-override UI — IMPLEMENTED IN PR WORKTREE
    - [x] Background task in `lit-payments` polling `https://api.coingecko.com/api/v3/simple/price?ids=lit-protocol&vs_currencies=usd` every 5 min.
@@ -392,35 +391,32 @@ All questions are closed. Plan is ready to start building.
    - [x] Env-configured LITKEY payment discount (`LITKEY_DISCOUNT_BASIS_POINTS`, default `0`; `2000` = 20% off vs credit card) exposed in the rate API/UI as the discount-adjusted effective credit rate.
    - [x] **No on-chain dependency** — can ship before 3c.
 
-   **3c.** 🚧 Alchemy WSS listener + `litkey_payments` + `chain_checkpoint` — STARTED IN PR WORKTREE
+   **3c.** 🚧 Browser tx-hash claim verification + `litkey_payments` — STARTED IN PR WORKTREE
    - [x] Added phase-3c schema: `litkey_payments` with `UNIQUE(chain_id, tx_hash, log_index)`, canonical address/hash checks, explicit `status` (`credited`, `dust`, `paused`, `no_customer`) so dust/paused/skipped events can still be audited, and `chain_checkpoint` keyed by `(chain_id, gateway_address)` so a replacement gateway cannot inherit the old checkpoint.
-   - [x] Added listener configuration/env parsing for `ALCHEMY_WSS_URL`, `ALCHEMY_HTTPS_URL`, `LITKEY_GATEWAY_ADDRESS`, `LITKEY_CHAIN_ID` (Base mainnet `8453` only), `LITKEY_CONFIRMATIONS` (default `5`, must be >0), and `LITKEY_RECONCILIATION_INTERVAL_SECS` (default `60`, must be >0). If the chain env vars are absent, the portal/rate poller still boot and LITKEY crediting stays disabled.
-   - [x] Added shared listener primitives/tests for deterministic Stripe idempotency keys, address normalization, confirmation depth, reconciliation ranges, reconnect backoff, and native wei amount formatting.
+   - [x] Added chain verification env parsing for `ALCHEMY_HTTPS_URL`, `LITKEY_GATEWAY_ADDRESS`, and `LITKEY_CHAIN_ID` (Base mainnet `8453` only). If the chain env vars are absent, the portal/rate poller still boot and LITKEY crediting stays disabled.
+   - [x] Added shared payment primitives/tests for deterministic Stripe idempotency keys, address normalization, and native wei amount formatting.
    - [x] Added pure payment classification/crediting helpers: missing/stale rate pauses crediting; zero-cent payments record as `dust`; missing Stripe customers record as `no_customer`; positive known-customer payments produce a Stripe credit action with deterministic idempotency and an audit-friendly description.
    - [x] Added DB helper layer for payment idempotency inserts and checkpoint read/advance; checkpoint advancement uses `GREATEST` so retries cannot move a gateway checkpoint backwards.
-   - [x] Started the runtime slice: `spawn_litkey_listener` now starts an HTTPS reconciliation loop when config exists. The loop reads the current checkpoint, computes the safe confirmed range, fetches latest block/logs through a testable RPC abstraction, processes each decoded gateway `Payment` event through the shared handler, and advances the checkpoint only after the full range succeeds.
-   - [x] WSS subscription to `Payment` events from the deployed gateway contract with subscription acknowledgement validation, removed-log pending eviction, pending-confirmation buffering, read/connect timeouts, and exponential backoff reconnect. WSS never advances checkpoints; it shares the parser, idempotency, and crediting handler with reconciliation.
-   - [x] 60s reconciliation poll for logs in `(last_processed_block, latest_block - 5)` as a safety net for WS gaps.
-   - [x] 5-confirmation depth on Base before crediting.
+   - [x] Runtime simplified after production smoke testing: the running app no longer starts the WSS/reconciliation listener. Browser payments submit the exact tx hash to `/api/litkey/payment-claim`, which fetches the receipt and credits from the matching gateway event.
    - [x] Idempotency on `(chain_id, tx_hash, log_index)` unique in `litkey_payments`.
    - [x] For each Payment event: read `litkey_rate`, reject/hold crediting if `crediting_paused` is true, apply `LITKEY_DISCOUNT_BASIS_POINTS`, compute Stripe cents from native LITKEY wei + `usd_wei_per_litkey` using BigInt-style integer math, look up Stripe customer by `metadata.wallet_address == event.wallet`, write the credit via `lit_billing_core::balance::write_transaction`, persist a `litkey_payments` row.
-   - [x] Rate precision prerequisite is handled in 3b: `litkey_rate.usd_wei_per_litkey` stores 18-decimal USD fixed point, CoinGecko parsing preserves arbitrary-precision JSON numbers, and the settlement helper rounds only once at final Stripe cents. Do not reintroduce whole-cent/LITKEY math in the listener.
+   - [x] Rate precision prerequisite is handled in 3b: `litkey_rate.usd_wei_per_litkey` stores 18-decimal USD fixed point, CoinGecko parsing preserves arbitrary-precision JSON numbers, and the settlement helper rounds only once at final Stripe cents. Do not reintroduce whole-cent/LITKEY math in the claim handler.
    - Migrations: `litkey_payments`, `chain_checkpoint`.
    - **Depends on**: 3a contract deployed + address known (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3b rate table existing.
 
    **3d.** 🚧 `/payWithLitkey` page — IMPLEMENTED IN THIS PR WORKTREE
    - [x] New public page at `payments.litprotocol.com/payWithLitkey?wallet=<address>`. Wallet param is plain (no HMAC — see "URL spoofing" risk).
    - [x] Public wallet-only account preview API exposes `{found,email,wallet_address}` without Stripe customer id or balance.
-   - [x] Public payment config/status APIs expose browser payment config and allow polling `litkey_payments` by `(tx_hash, wallet)` without leaking other customers' status.
-   - [x] Vanilla ethers/EIP-1193 page validates the account, prominently displays email + wallet, requires confirmation, switches to Base mainnet, refreshes the quote every 30s until approval starts, approves exact LITKEY, pays the gateway, and polls listener status.
+   - [x] Public payment config and payment-claim APIs expose browser payment config and allow a one-shot wallet-scoped tx claim without leaking other customers' status.
+   - [x] Vanilla ethers/EIP-1193 page validates the account, prominently displays email + wallet, requires confirmation, switches to Base mainnet, refreshes the quote every 30s until approval starts, approves exact LITKEY, pays the gateway, waits for the receipt, and submits the tx hash once for backend crediting.
    - [ ] Dashboard `Pay with LITKEY` entry point is intentionally deferred until after production smoke testing so the new flow does not go live in the main dashboard before it is fully tested.
-   - **Depends on**: 3a contract address (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3c listener handling the resulting `Payment` events.
+   - **Depends on**: 3a contract address (`0xa2d54cd1D1dF1735718A857aC49CaF9ECaB0093b` on Base mainnet); 3c claim handler verifying submitted tx receipts.
 
    **Milestone (when 3a-d ship)**: users self-serve LITKEY payments end-to-end on Base mainnet; the manual "send LITKEY to the wallet and I'll credit you in Stripe" flow is retired.
 
 ### Follow-up after phase 3d
 
-After this PR lands, the remaining work is operational plus a small rollout slice: deploy the payments app with listener env configured, smoke-test a small Base mainnet LITKEY payment against the deployed gateway, verify Stripe crediting, then add the dashboard `Pay with LITKEY` entry point once Chris has fully tested the standalone page. After rollout, add monitoring/runbook coverage for stuck listener status or paused pricing.
+After this PR lands, the remaining work is operational plus a small rollout slice: deploy the payments app with chain verification env configured, smoke-test a small Base mainnet LITKEY payment against the deployed gateway, verify Stripe crediting, then add the dashboard `Pay with LITKEY` entry point once Chris has fully tested the standalone page. After rollout, add monitoring/runbook coverage for failed tx-claim attempts or paused pricing.
 
 ## Risks
 
@@ -430,4 +426,4 @@ After this PR lands, the remaining work is operational plus a small rollout slic
 - **PaymentGateway contract bug** — small surface but real money. Mitigations: keep contract minimal & immutable, internal review, deploy to Base Sepolia first, monitor on-chain.
 - **Rate staleness** — `>1hr` since `fetched_at` pauses crediting and logs a warning; admins manually update via the rate-override UI when they notice (via user reports or log monitoring).
 - **User sends LITKEY directly to the Safe** — funds sit unattributed in the Safe. Mitigation: mod uses the credit portal to grant manually when a user complains. Documented as unsupported.
-- **Reorg risk** — 5-confirmation depth on Base mitigates; risk is already near-zero past a handful of blocks.
+- **Reorg risk** — accepted for the simplified browser claim path on Base; if this becomes a concern later, reintroduce delayed confirmations rather than browser/status polling.


### PR DESCRIPTION
## Summary
- Simplify `/payWithLitkey` so the browser waits for the wallet tx receipt and submits the exact tx hash once to `/api/litkey/payment-claim`
- Remove the public `/api/litkey/payment-status` endpoint and all browser status polling code
- Stop starting the LITKEY WSS/reconciliation background listener, remove the listener/poller implementation and unused websocket deps from `lit-payments`
- Keep tx-hash claim crediting idempotent via `(chain_id, tx_hash, log_index)` and backend receipt verification of the configured gateway `Payment` event
- Keep the already-applied `20260522000001_litkey_listener.sql` migration byte-for-byte unchanged and add a new `20260526000001_drop_litkey_listener_checkpoint.sql` migration to remove the obsolete checkpoint table
- Update README/plan/static copy to document the one-shot tx claim flow instead of listener/status polling

## Test Plan
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --all-targets -q`
- [x] `cargo +1.91 test --locked --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `node --check static/pay-with-litkey.js`
- [x] `git diff --check`
- [x] Confirmed `lit-payments/migrations/20260522000001_litkey_listener.sql` matches `origin/main` checksum

## Notes
- The only remaining poller in `lit-payments` is the CoinGecko LITKEY rate poller; the payment listener/status poller path is removed.
