### PR TITLE
docs: add lit-triggers agent setup guide

### DIFF
--- a/lit-triggers/Dockerfile
+++ b/lit-triggers/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/lit-triggers/target/release/lit-triggers /app/lit-triggers
+COPY SKILL.md ./SKILL.md
 COPY static ./static
 COPY migrations ./migrations
 

--- a/lit-triggers/README.md
+++ b/lit-triggers/README.md
@@ -44,6 +44,8 @@ Run Postgres locally and set the environment above before starting the server. M
 
 `SKILL.md` is a handoff file for agents that need to test a deployed `lit-triggers` instance. It covers magic-link authentication, trigger CRUD, webhook firing, schedule polling, chain-event setup, run inspection, and cleanup.
 
+It is exposed publicly at `https://triggers.litprotocol.com/SKILL.md` and linked from the app as **Give this to your agent to get started**.
+
 Give a testing agent:
 
 - `lit-triggers/SKILL.md`
@@ -73,7 +75,7 @@ USAGE_KEY_ENCRYPTION_KEY='<base64-32-byte-key>'
 ROCKET_SECRET_KEY='<base64-32-byte-key>'
 RESEND_API_KEY='<resend-api-key>'
 MAIL_FROM='Lit Triggers <triggers@example.com>'
-PUBLIC_BASE_URL='https://<your-railway-domain>'
+PUBLIC_BASE_URL='https://triggers.litprotocol.com'
 RUST_LOG='info,lit_triggers=info'
 CHIPOTLE_API_BASE_URL='https://api.chipotle.litprotocol.com'
 ```
@@ -113,7 +115,7 @@ Deploy from the Railway UI or CLI after variables are set. Migrations run on boo
 Health check / smoke test:
 
 ```bash
-curl https://<your-railway-domain>/health
+curl https://triggers.litprotocol.com/health
 ```
 
 Operational notes:

--- a/lit-triggers/README.md
+++ b/lit-triggers/README.md
@@ -40,18 +40,17 @@ cargo +1.91 run
 
 Run Postgres locally and set the environment above before starting the server. Migrations run on boot.
 
-## Agent-consumable testing docs
+## Agent-consumable setup docs
 
-`SKILL.md` is a handoff file for agents that need to test a deployed `lit-triggers` instance. It covers magic-link authentication, trigger CRUD, webhook firing, schedule polling, chain-event setup, run inspection, and cleanup.
+`SKILL.md` is a handoff file for agents that need to help users set up triggers on the deployed `lit-triggers` instance. It covers browser-based agent authorization, trigger CRUD, webhook URLs, schedule config, chain-event config, run inspection, and cleanup.
 
 It is exposed publicly at `https://triggers.litprotocol.com/SKILL.md` and linked from the app as **Give this to your agent to get started**.
 
-Give a testing agent:
+Give a setup agent:
 
-- `lit-triggers/SKILL.md`
-- the deployed `LT_BASE_URL`
-- a test email that can receive magic links
-- a scoped Chipotle usage API key for the target group/action permissions
+- `https://triggers.litprotocol.com/SKILL.md`
+- the trigger goal/action the user wants
+- a scoped Chipotle usage API key, or have the user mint one in the browser UI
 
 ## Railway deployment
 

--- a/lit-triggers/README.md
+++ b/lit-triggers/README.md
@@ -40,6 +40,17 @@ cargo +1.91 run
 
 Run Postgres locally and set the environment above before starting the server. Migrations run on boot.
 
+## Agent-consumable testing docs
+
+`SKILL.md` is a handoff file for agents that need to test a deployed `lit-triggers` instance. It covers magic-link authentication, trigger CRUD, webhook firing, schedule polling, chain-event setup, run inspection, and cleanup.
+
+Give a testing agent:
+
+- `lit-triggers/SKILL.md`
+- the deployed `LT_BASE_URL`
+- a test email that can receive magic links
+- a scoped Chipotle usage API key for the target group/action permissions
+
 ## Railway deployment
 
 The service owns its Railway config at `lit-triggers/railway.json`. In Railway, set this service's root directory to `lit-triggers` so multiple Railway services/projects can coexist in the monorepo without sharing one root config.

--- a/lit-triggers/SKILL.md
+++ b/lit-triggers/SKILL.md
@@ -38,7 +38,7 @@ Do not use this for:
 Set these locally before using the examples:
 
 ```bash
-export LT_BASE_URL='https://<deployed-lit-triggers-domain>'
+export LT_BASE_URL='https://triggers.litprotocol.com'
 export LT_EMAIL='<your-test-email>'
 export SCOPED_USAGE_API_KEY='<chipotle-usage-key-scoped-to-execute-in-the-target-group>'
 export COOKIE_JAR="$(mktemp)"

--- a/lit-triggers/SKILL.md
+++ b/lit-triggers/SKILL.md
@@ -1,326 +1,262 @@
 ---
-name: lit-triggers-testing
-description: "Use when an agent needs to smoke test or operate the deployed lit-triggers service API: authenticate, create webhook/schedule/chain-event triggers, fire test inputs, inspect runs, and clean up."
-version: 1.0.0
+name: lit-triggers-setup
+description: "Use when an agent needs to help a user set up Lit Triggers at triggers.litprotocol.com: authorize the agent from a logged-in browser session, create webhook/schedule/chain-event triggers, inspect runs, and clean up."
+version: 1.1.0
 author: Lit Protocol
 license: MIT
 metadata:
   hermes:
-    tags: [lit-protocol, chipotle, lit-triggers, api-testing, railway]
+    tags: [lit-protocol, chipotle, lit-triggers, agents, triggers]
     related_skills: []
 ---
 
-# lit-triggers Testing Skill
+# Lit Triggers Setup Skill
 
 ## Overview
 
-`lit-triggers` is an outside-the-TEE service that runs Lit Actions in response to webhooks, cron schedules, or EVM chain events. It stores only scoped Chipotle usage API keys, encrypted at rest. It does **not** store a Chipotle admin API key, and the backend does not mint usage keys.
-
-Use this file as agent-consumable instructions for testing a deployed `lit-triggers` instance. It is intentionally operational: define the environment variables, log in with a magic-link session cookie, create triggers through the JSON API, fire inputs, inspect run history, and delete test triggers.
-
-## When to Use
-
-Use this when:
-
-- A new agent needs to test the deployed Railway service.
-- You need API examples for webhook, schedule, or chain-event trigger creation.
-- You need to verify the public `/health`, auth, trigger CRUD, dispatcher, scheduler, or chain listener behavior.
-- You want to hand an agent a single file and ask it to test the service without reading the whole codebase.
-
-Do not use this for:
-
-- Minting a scoped usage API key from a Chipotle admin key on the backend. That is intentionally browser-only or done externally.
-- Testing `/api/triggers/<id>/test` as a real execution path. It currently returns `501 Not Implemented`.
-- Assuming bearer-token auth for the lit-triggers API. API auth is a Rocket private session cookie from magic-link login.
-
-## Required Test Inputs
-
-Set these locally before using the examples:
-
-```bash
-export LT_BASE_URL='https://triggers.litprotocol.com'
-export LT_EMAIL='<your-test-email>'
-export SCOPED_USAGE_API_KEY='<chipotle-usage-key-scoped-to-execute-in-the-target-group>'
-export COOKIE_JAR="$(mktemp)"
-```
-
-Optional:
-
-```bash
-export CHIPOTLE_ACCOUNT_ADDRESS='<display-only-account-address>'
-export TEST_GROUP_ID='<chipotle-group-id-used-when-the-usage-key-was-minted>'
-```
-
-Important constraints:
-
-- `SCOPED_USAGE_API_KEY` must be able to execute the action code/CID in the target Chipotle group. If it is invalid or under-scoped, trigger creation can still succeed, but runs will fail when the dispatcher calls Chipotle.
-- `action_cid` is derived server-side from `action_code`. CIDs identify action code content, not ownership.
-- The service never returns stored usage API keys in API responses.
-
-## Smoke Test the Deployment
-
-```bash
-curl -fsS "$LT_BASE_URL/health"
-```
-
-Expected response:
+Lit Triggers runs Lit Actions when something happens: an inbound webhook, a cron tick, or a matching EVM chain event. The service is available at:
 
 ```text
-ok
+https://triggers.litprotocol.com
 ```
 
-## Authenticate
+This skill is written for agents. Your job is to help the user set up real triggers, not just smoke-test the service. Start by authorizing yourself through the user's logged-in browser session, then use the API with your local bearer token.
 
-Request a magic link:
+Security model:
+
+- The user's Lit/Chipotle admin API key should stay in the browser or with the user. Do not ask the backend to store it.
+- `lit-triggers` stores only scoped Chipotle usage API keys, encrypted at rest.
+- A scoped usage key must have permission to execute the target action/group. If you do not have one, ask the user to mint one in the dashboard or provide a pre-minted scoped usage key.
+- `action_cid` is computed by `lit-triggers` from `action_code`; CIDs identify code content, not ownership.
+
+## 1. Authorize This Agent
+
+Generate a local random bearer token and save it somewhere only this agent/session can read:
 
 ```bash
-curl -fsS -X POST "$LT_BASE_URL/auth/request" \
-  -H 'content-type: application/x-www-form-urlencoded' \
-  --data-urlencode "email=$LT_EMAIL"
+mkdir -p ~/.lit-triggers
+python3 - <<'PY'
+import pathlib, secrets
+path = pathlib.Path.home() / '.lit-triggers' / 'agent-token'
+if not path.exists():
+    path.write_text(secrets.token_urlsafe(48))
+    path.chmod(0o600)
+print(path.read_text().strip())
+PY
 ```
 
-Expected JSON:
+Build an authorization URL. The URL contains only a hash challenge, not the raw bearer token:
+
+```bash
+python3 - <<'PY'
+import base64, hashlib, pathlib, urllib.parse
+raw = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+challenge = base64.urlsafe_b64encode(hashlib.sha256(raw.encode()).digest()).rstrip(b'=').decode()
+print('https://triggers.litprotocol.com/agent/authorize?' + urllib.parse.urlencode({'challenge': challenge}))
+PY
+```
+
+Open that URL in the user's browser, or send it to the user and ask them to open it.
+
+Expected browser flow:
+
+1. If the user is not logged in, the site asks for email magic-link login.
+2. After login, the site redirects back to the agent authorization page.
+3. The user clicks **Authorize agent**.
+4. The page says the agent is authorized.
+
+After approval, verify API access:
+
+```bash
+python3 - <<'PY'
+import pathlib, subprocess
+raw = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+auth = 'authorization: ' + 'Bearer ' + raw
+subprocess.run([
+    'curl', '-fsS',
+    '-H', auth,
+    'https://triggers.litprotocol.com/api/me',
+], check=True)
+PY
+```
+
+If verification returns `401`, ask the user to repeat the authorization flow with the generated URL. Do not generate a new token unless the user wants to replace the old one.
+
+## 2. Decide What Trigger to Create
+
+Ask the user for the trigger goal:
+
+- **Webhook:** external service POSTs JSON or text to a generated URL.
+- **Schedule:** cron expression fires automatically.
+- **Chain event:** EVM logs matching a chain/contract/event signature fire the action.
+
+You also need:
+
+- Trigger name.
+- Action code to run.
+- Default params JSON, usually `{}`.
+- A scoped Chipotle usage API key that can execute the action/group.
+- Optional run limits (`max_runs_per_minute`, `max_queued_runs`).
+
+If the user has only a Lit/Chipotle admin API key, prefer telling them to use the dashboard's browser-only mint flow, then give you the scoped usage key. Do not send an admin API key to the `lit-triggers` backend.
+
+## 3. API Helper Pattern
+
+Use this helper pattern in scripts so the bearer token stays local:
+
+```bash
+python3 - <<'PY'
+import json, pathlib, subprocess
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+BASE = 'https://triggers.litprotocol.com'
+
+def curl_json(method, path, body=None):
+    cmd = ['curl', '-fsS', '-X', method, '-H', AUTH]
+    if body is not None:
+        cmd += ['-H', 'content-type: application/json', '-d', json.dumps(body)]
+    cmd.append(BASE + path)
+    out = subprocess.check_output(cmd, text=True)
+    return json.loads(out) if out.strip() else None
+
+print(json.dumps(curl_json('GET', '/api/me'), indent=2))
+PY
+```
+
+For longer workflows, put the helper in a temporary script and delete it after use if it includes sensitive values.
+
+## 4. Create a Webhook Trigger
+
+Payload shape:
 
 ```json
-{"ok":true}
+{
+  "name": "Example webhook",
+  "kind": "webhook",
+  "action_code": "...Lit Action JS...",
+  "default_params": {},
+  "usage_api_key": "scoped Chipotle usage key",
+  "max_runs_per_minute": 10,
+  "max_queued_runs": 20,
+  "config": {}
+}
 ```
 
-Open the magic link from the email in a browser, or paste the full magic-link URL into curl to create a cookie session:
+Example agent script:
 
 ```bash
-export MAGIC_LINK='<full https://.../auth/verify?token=... link from email>'
-curl -fsSL -c "$COOKIE_JAR" -b "$COOKIE_JAR" "$MAGIC_LINK" >/dev/null
-```
-
-Verify the session:
-
-```bash
-curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/me" | jq .
-```
-
-If this returns `401`, the cookie was not captured. Re-run the verify URL with `-L -c "$COOKIE_JAR" -b "$COOKIE_JAR"`, or log in in a browser and use the UI instead.
-
-## Common API Shapes
-
-Create trigger:
-
-```http
-POST /api/triggers
-content-type: application/json
-cookie: private session cookie
-```
-
-Required JSON fields:
-
-- `name` string
-- `kind` one of `webhook`, `schedule`, `chain_event`
-- `action_code` string
-- `default_params` object, usually `{}`
-- `usage_api_key` string, only accepted on create/update and never returned
-- `config` object, shape depends on `kind`
-
-Optional JSON fields:
-
-- `chipotle_account_address` string or null, display/debug only
-- `max_runs_per_minute` integer
-- `max_queued_runs` integer
-
-Read/list/update/delete:
-
-```bash
-curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers" | jq .
-curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" | jq .
-curl -fsS -X PATCH -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" \
-  -H 'content-type: application/json' \
-  -d '{"enabled":false}' | jq .
-curl -fsS -X DELETE -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" -i
-```
-
-List runs:
-
-```bash
-curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID/runs?limit=20&offset=0" | jq .
-```
-
-Run statuses are typically `queued`, `running`, `success`, `failed`, or `retrying`.
-
-## Test Action Code
-
-Use a harmless Lit Action that echoes `js_params`/`params` back through `Lit.Actions.setResponse`. Adjust if Chipotle's Lit Action runtime changes its globals.
-
-```bash
-read -r -d '' TEST_ACTION_CODE <<'EOF'
+python3 - <<'PY'
+import json, pathlib, subprocess
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+BASE = 'https://triggers.litprotocol.com'
+USAGE_KEY = input('Paste scoped Chipotle usage key: ').strip()
+ACTION = r'''
 (async () => {
-  const input = typeof params !== 'undefined' ? params : {};
-  Lit.Actions.setResponse({
-    response: JSON.stringify({ ok: true, input })
-  });
+  Lit.Actions.setResponse({ response: JSON.stringify({ ok: true, params }) });
 })();
-EOF
+'''.strip()
+body = {
+    'name': 'Agent-created webhook',
+    'kind': 'webhook',
+    'action_code': ACTION,
+    'default_params': {'created_by': 'agent'},
+    'usage_api_key': USAGE_KEY,
+    'max_runs_per_minute': 10,
+    'max_queued_runs': 20,
+    'config': {},
+}
+out = subprocess.check_output([
+    'curl', '-fsS', '-X', 'POST',
+    '-H', AUTH,
+    '-H', 'content-type: application/json',
+    '-d', json.dumps(body),
+    BASE + '/api/triggers',
+], text=True)
+trigger = json.loads(out)
+print(json.dumps(trigger, indent=2))
+print('Webhook URL:', BASE + '/webhook/' + trigger['id'])
+PY
 ```
 
-If this action fails in Chipotle, use a known-good action from the target Chipotle group and keep the rest of the trigger payloads the same.
-
-## Webhook Trigger Test
-
-Create a webhook trigger:
+The webhook receives JSON bodies as `params.event`, and selected safe headers as `params.headers`. Fire it with:
 
 ```bash
-WEBHOOK_CREATE_PAYLOAD=$(jq -n \
-  --arg name "agent webhook smoke $(date -u +%Y%m%dT%H%M%SZ)" \
-  --arg action_code "$TEST_ACTION_CODE" \
-  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
-  --arg account "${CHIPOTLE_ACCOUNT_ADDRESS:-}" \
-  '{
-    name: $name,
-    kind: "webhook",
-    action_code: $action_code,
-    default_params: { agent_smoke: true, trigger_type: "webhook" },
-    usage_api_key: $usage_api_key,
-    chipotle_account_address: (if $account == "" then null else $account end),
-    max_runs_per_minute: 10,
-    max_queued_runs: 20,
-    config: {}
-  }')
-
-WEBHOOK_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
-  -H 'content-type: application/json' \
-  -d "$WEBHOOK_CREATE_PAYLOAD")
-
-echo "$WEBHOOK_TRIGGER" | jq .
-export WEBHOOK_TRIGGER_ID=$(echo "$WEBHOOK_TRIGGER" | jq -r '.id')
+curl -fsS -X POST 'https://triggers.litprotocol.com/webhook/<trigger-id>'   -H 'content-type: application/json'   -d '{"hello":"world"}'
 ```
 
-Fire it:
+## 5. Create a Schedule Trigger
 
-```bash
-curl -fsS -X POST "$LT_BASE_URL/webhook/$WEBHOOK_TRIGGER_ID" \
-  -H 'content-type: application/json' \
-  -d '{"hello":"from-agent","trigger":"webhook"}' | jq .
-```
-
-Expected webhook response:
+Schedule config requires a cron expression:
 
 ```json
-{"run_id":"<uuid>","status":"queued"}
+{ "cron": "* * * * *" }
 ```
 
-Inspect runs until terminal:
+Use 5-field cron or 6-field cron with seconds. Sub-30-second schedules are rejected because the scheduler scans every 30 seconds.
 
-```bash
-for i in $(seq 1 20); do
-  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$WEBHOOK_TRIGGER_ID/runs?limit=5" | jq .
-  sleep 3
-done
+Example body differences from webhook:
+
+```json
+{
+  "kind": "schedule",
+  "config": { "cron": "*/5 * * * *" }
+}
 ```
 
-Expected result if the scoped usage key and action are valid: latest run eventually reaches `success`. If it reaches `failed`, inspect `.runs[0].error` and `.runs[0].response`.
-
-## Schedule Trigger Test
-
-Create a schedule trigger. Use a cron expression no more frequent than once per minute. Sub-30-second schedules are intentionally rejected.
-
-```bash
-SCHEDULE_CREATE_PAYLOAD=$(jq -n \
-  --arg name "agent schedule smoke $(date -u +%Y%m%dT%H%M%SZ)" \
-  --arg action_code "$TEST_ACTION_CODE" \
-  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
-  '{
-    name: $name,
-    kind: "schedule",
-    action_code: $action_code,
-    default_params: { agent_smoke: true, trigger_type: "schedule" },
-    usage_api_key: $usage_api_key,
-    max_runs_per_minute: 5,
-    max_queued_runs: 10,
-    config: { cron: "* * * * *" }
-  }')
-
-SCHEDULE_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
-  -H 'content-type: application/json' \
-  -d "$SCHEDULE_CREATE_PAYLOAD")
-
-echo "$SCHEDULE_TRIGGER" | jq .
-export SCHEDULE_TRIGGER_ID=$(echo "$SCHEDULE_TRIGGER" | jq -r '.id')
-```
-
-Wait up to two minutes and inspect runs:
-
-```bash
-for i in $(seq 1 40); do
-  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$SCHEDULE_TRIGGER_ID/runs?limit=5" | jq .
-  sleep 3
-done
-```
-
-Expected input shape for schedule runs includes:
+Schedule runs include input like:
 
 ```json
 {
   "source": "schedule",
   "event": {
     "scheduled_at": "<RFC3339 timestamp>",
-    "cron": "* * * * *"
+    "cron": "*/5 * * * *"
   }
 }
 ```
 
-## Chain Event Trigger Test
+## 6. Create a Chain Event Trigger
 
-Prerequisites:
+Supported chains:
 
-- Railway env var for the target chain RPC is set, e.g. `BASE_RPC_URL` for `base`.
-- The target contract emits events often enough to observe.
-- The scoped usage key can execute the action.
+- `ethereum`
+- `base`
+- `arbitrum`
+- `bsc`
+- `polygon`
 
-Supported chain keys and RPC env vars:
+The deployment must have the corresponding RPC variable configured. If no runs appear for a chain, ask the operator to verify the Railway variable (`BASE_RPC_URL`, `ETHEREUM_RPC_URL`, etc.).
 
-- `ethereum` / `ETHEREUM_RPC_URL`
-- `base` / `BASE_RPC_URL`
-- `arbitrum` / `ARBITRUM_RPC_URL`
-- `bsc` / `BSC_RPC_URL`
-- `polygon` / `POLYGON_RPC_URL`
+Required chain-event config:
 
-Create a Base USDC `Transfer(address,address,uint256)` trigger. Use a recent `start_block` if you know one; otherwise omit it and the service starts from its configured initial lookback window.
-
-```bash
-CHAIN_CREATE_PAYLOAD=$(jq -n \
-  --arg name "agent chain smoke $(date -u +%Y%m%dT%H%M%SZ)" \
-  --arg action_code "$TEST_ACTION_CODE" \
-  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
-  '{
-    name: $name,
-    kind: "chain_event",
-    action_code: $action_code,
-    default_params: { agent_smoke: true, trigger_type: "chain_event" },
-    usage_api_key: $usage_api_key,
-    max_runs_per_minute: 20,
-    max_queued_runs: 20,
-    config: {
-      chain: "base",
-      contract_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-      event_signature: "Transfer(address,address,uint256)"
-    }
-  }')
-
-CHAIN_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
-  -H 'content-type: application/json' \
-  -d "$CHAIN_CREATE_PAYLOAD")
-
-echo "$CHAIN_TRIGGER" | jq .
-export CHAIN_TRIGGER_ID=$(echo "$CHAIN_TRIGGER" | jq -r '.id')
+```json
+{
+  "chain": "base",
+  "contract_address": "0x...",
+  "event_signature": "Transfer(address,address,uint256)"
+}
 ```
 
-Poll for runs:
+Optional fields:
 
-```bash
-for i in $(seq 1 60); do
-  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$CHAIN_TRIGGER_ID/runs?limit=5" | jq .
-  sleep 5
-done
+- `start_block`: integer or hex string.
+- `topic_filters`: up to three entries after topic0. Entries may be a 32-byte topic string, an array of topic strings, or `null` wildcard.
+
+Base USDC `Transfer` example:
+
+```json
+{
+  "kind": "chain_event",
+  "config": {
+    "chain": "base",
+    "contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "event_signature": "Transfer(address,address,uint256)"
+  }
+}
 ```
 
-Expected input shape for chain-event runs includes:
+Chain-event runs include input like:
 
 ```json
 {
@@ -335,59 +271,96 @@ Expected input shape for chain-event runs includes:
 }
 ```
 
-Topic filters can include up to three entries after topic0. Each entry may be a 32-byte topic string, an array of topic strings, or `null` for wildcard. Example filtering `from` address for an indexed ERC-20 `Transfer` topic:
+## 7. Inspect and Manage Triggers
 
-```json
-{
-  "chain": "base",
-  "contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  "event_signature": "Transfer(address,address,uint256)",
-  "topic_filters": [
-    "0x000000000000000000000000<lowercase-20-byte-address-without-0x>",
-    null
-  ]
-}
-```
-
-## Cleanup
-
-Disable or delete test triggers when done:
+List triggers:
 
 ```bash
-for id in "$WEBHOOK_TRIGGER_ID" "$SCHEDULE_TRIGGER_ID" "$CHAIN_TRIGGER_ID"; do
-  [ -n "$id" ] && [ "$id" != "null" ] || continue
-  curl -fsS -X PATCH -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$id" \
-    -H 'content-type: application/json' \
-    -d '{"enabled":false}' | jq .
-done
+python3 - <<'PY'
+import pathlib, subprocess
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+subprocess.run(['curl', '-fsS', '-H', AUTH, 'https://triggers.litprotocol.com/api/triggers'], check=True)
+PY
 ```
 
-Or delete them permanently:
+Get runs for a trigger:
 
 ```bash
-for id in "$WEBHOOK_TRIGGER_ID" "$SCHEDULE_TRIGGER_ID" "$CHAIN_TRIGGER_ID"; do
-  [ -n "$id" ] && [ "$id" != "null" ] || continue
-  curl -fsS -X DELETE -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$id" -i
-done
+python3 - <<'PY'
+import pathlib, subprocess
+trigger_id = input('Trigger id: ').strip()
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+subprocess.run(['curl', '-fsS', '-H', AUTH, f'https://triggers.litprotocol.com/api/triggers/{trigger_id}/runs?limit=20'], check=True)
+PY
 ```
+
+Disable a trigger:
+
+```bash
+python3 - <<'PY'
+import json, pathlib, subprocess
+trigger_id = input('Trigger id to disable: ').strip()
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+subprocess.run([
+    'curl', '-fsS', '-X', 'PATCH',
+    '-H', AUTH,
+    '-H', 'content-type: application/json',
+    '-d', json.dumps({'enabled': False}),
+    f'https://triggers.litprotocol.com/api/triggers/{trigger_id}',
+], check=True)
+PY
+```
+
+Delete a trigger only when the user explicitly asks:
+
+```bash
+python3 - <<'PY'
+import pathlib, subprocess
+trigger_id = input('Trigger id to delete: ').strip()
+TOKEN = (pathlib.Path.home() / '.lit-triggers' / 'agent-token').read_text().strip()
+AUTH = 'authorization: ' + 'Bearer ' + TOKEN
+subprocess.run(['curl', '-fsS', '-X', 'DELETE', '-H', AUTH, f'https://triggers.litprotocol.com/api/triggers/{trigger_id}'], check=True)
+PY
+```
+
+## API Reference
+
+Authenticated API calls accept either the browser session cookie or:
+
+```http
+Authorization: Bearer LOCAL_AGENT_TOKEN
+```
+
+Endpoints:
+
+- `GET /api/me`
+- `GET /api/triggers`
+- `POST /api/triggers`
+- `GET /api/triggers/<id>`
+- `PATCH /api/triggers/<id>`
+- `DELETE /api/triggers/<id>`
+- `GET /api/triggers/<id>/runs?limit=20&offset=0`
+- `POST /api/triggers/<id>/test` currently returns `501 Not Implemented`; do not rely on it.
+- `POST /webhook/<id>` is public for webhook triggers and returns `202` with a run id when queued.
 
 ## Troubleshooting
 
-- `401` from `/api/*`: session cookie missing/expired. Request a new magic link and verify it with `curl -L -c "$COOKIE_JAR" -b "$COOKIE_JAR"`.
-- `400 {"error":"usage_api_key_required"}`: create payload omitted `usage_api_key` or it was blank.
-- `400 {"error":"cron_required"}` or `invalid_cron`: schedule config must include valid `config.cron`; use `* * * * *` for smoke tests.
-- `400 {"error":"invalid_chain_event_config"}`: check chain key, address length, event signature, `topic_filters`, and `start_block` type.
-- `202` webhook response but no terminal run: dispatcher may still be running, queue may be backed up, or app sleeping/replica settings may be wrong.
-- Run reaches `failed` with Chipotle `401`/`403`: scoped usage key is invalid or lacks permission for this action/group.
-- No chain-event runs: check Railway RPC env var for that chain, app logs, confirmation depth, initial lookback, and whether the contract emitted matching logs.
-- `/api/triggers/<id>/test` returns `501`: expected for now; use webhook firing, schedule waits, or real chain events as test paths.
+- `401` from `/api/*`: the local agent token has not been authorized, was mistyped, or was revoked. Repeat the authorize URL flow.
+- Browser lands on login instead of authorization: expected if the user is logged out. After magic-link login it should return to `/agent/authorize?...`.
+- `400` from `/agent/authorize`: generated challenge was invalid. Regenerate the URL with the command in this skill.
+- `400 {"error":"usage_api_key_required"}`: trigger creation needs a scoped usage key.
+- Run reaches `failed` with Chipotle `401`/`403`: scoped usage key is invalid or not scoped for this action/group.
+- No chain-event runs: verify RPC env var, start block/lookback, confirmation depth, and that matching logs exist.
 
 ## Verification Checklist
 
-- [ ] `/health` returns `ok`.
-- [ ] Magic-link login creates a valid session; `/api/me` returns the test user.
-- [ ] Webhook trigger can be created and `/webhook/<id>` returns `202` with a `run_id`.
-- [ ] Webhook run reaches `success` with a valid scoped usage key/action.
-- [ ] Schedule trigger creates at least one run within two minutes.
-- [ ] Chain-event trigger creates runs when matching logs exist and the chain RPC env var is configured.
-- [ ] Test triggers are disabled or deleted after the smoke test.
+- [ ] User authorized the agent in browser.
+- [ ] `GET /api/me` works with `Authorization: Bearer LOCAL_AGENT_TOKEN`.
+- [ ] Trigger payload uses a scoped usage API key, not an admin key.
+- [ ] Trigger was created and listed by the API.
+- [ ] Webhook/schedule/chain-event behavior matches the user's requested trigger type.
+- [ ] Run history was checked after setup.
+- [ ] Any temporary/test triggers were disabled or deleted when finished.

--- a/lit-triggers/SKILL.md
+++ b/lit-triggers/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: lit-triggers-testing
+description: "Use when an agent needs to smoke test or operate the deployed lit-triggers service API: authenticate, create webhook/schedule/chain-event triggers, fire test inputs, inspect runs, and clean up."
+version: 1.0.0
+author: Lit Protocol
+license: MIT
+metadata:
+  hermes:
+    tags: [lit-protocol, chipotle, lit-triggers, api-testing, railway]
+    related_skills: []
+---
+
+# lit-triggers Testing Skill
+
+## Overview
+
+`lit-triggers` is an outside-the-TEE service that runs Lit Actions in response to webhooks, cron schedules, or EVM chain events. It stores only scoped Chipotle usage API keys, encrypted at rest. It does **not** store a Chipotle admin API key, and the backend does not mint usage keys.
+
+Use this file as agent-consumable instructions for testing a deployed `lit-triggers` instance. It is intentionally operational: define the environment variables, log in with a magic-link session cookie, create triggers through the JSON API, fire inputs, inspect run history, and delete test triggers.
+
+## When to Use
+
+Use this when:
+
+- A new agent needs to test the deployed Railway service.
+- You need API examples for webhook, schedule, or chain-event trigger creation.
+- You need to verify the public `/health`, auth, trigger CRUD, dispatcher, scheduler, or chain listener behavior.
+- You want to hand an agent a single file and ask it to test the service without reading the whole codebase.
+
+Do not use this for:
+
+- Minting a scoped usage API key from a Chipotle admin key on the backend. That is intentionally browser-only or done externally.
+- Testing `/api/triggers/<id>/test` as a real execution path. It currently returns `501 Not Implemented`.
+- Assuming bearer-token auth for the lit-triggers API. API auth is a Rocket private session cookie from magic-link login.
+
+## Required Test Inputs
+
+Set these locally before using the examples:
+
+```bash
+export LT_BASE_URL='https://<deployed-lit-triggers-domain>'
+export LT_EMAIL='<your-test-email>'
+export SCOPED_USAGE_API_KEY='<chipotle-usage-key-scoped-to-execute-in-the-target-group>'
+export COOKIE_JAR="$(mktemp)"
+```
+
+Optional:
+
+```bash
+export CHIPOTLE_ACCOUNT_ADDRESS='<display-only-account-address>'
+export TEST_GROUP_ID='<chipotle-group-id-used-when-the-usage-key-was-minted>'
+```
+
+Important constraints:
+
+- `SCOPED_USAGE_API_KEY` must be able to execute the action code/CID in the target Chipotle group. If it is invalid or under-scoped, trigger creation can still succeed, but runs will fail when the dispatcher calls Chipotle.
+- `action_cid` is derived server-side from `action_code`. CIDs identify action code content, not ownership.
+- The service never returns stored usage API keys in API responses.
+
+## Smoke Test the Deployment
+
+```bash
+curl -fsS "$LT_BASE_URL/health"
+```
+
+Expected response:
+
+```text
+ok
+```
+
+## Authenticate
+
+Request a magic link:
+
+```bash
+curl -fsS -X POST "$LT_BASE_URL/auth/request" \
+  -H 'content-type: application/x-www-form-urlencoded' \
+  --data-urlencode "email=$LT_EMAIL"
+```
+
+Expected JSON:
+
+```json
+{"ok":true}
+```
+
+Open the magic link from the email in a browser, or paste the full magic-link URL into curl to create a cookie session:
+
+```bash
+export MAGIC_LINK='<full https://.../auth/verify?token=... link from email>'
+curl -fsSL -c "$COOKIE_JAR" -b "$COOKIE_JAR" "$MAGIC_LINK" >/dev/null
+```
+
+Verify the session:
+
+```bash
+curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/me" | jq .
+```
+
+If this returns `401`, the cookie was not captured. Re-run the verify URL with `-L -c "$COOKIE_JAR" -b "$COOKIE_JAR"`, or log in in a browser and use the UI instead.
+
+## Common API Shapes
+
+Create trigger:
+
+```http
+POST /api/triggers
+content-type: application/json
+cookie: private session cookie
+```
+
+Required JSON fields:
+
+- `name` string
+- `kind` one of `webhook`, `schedule`, `chain_event`
+- `action_code` string
+- `default_params` object, usually `{}`
+- `usage_api_key` string, only accepted on create/update and never returned
+- `config` object, shape depends on `kind`
+
+Optional JSON fields:
+
+- `chipotle_account_address` string or null, display/debug only
+- `max_runs_per_minute` integer
+- `max_queued_runs` integer
+
+Read/list/update/delete:
+
+```bash
+curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers" | jq .
+curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" | jq .
+curl -fsS -X PATCH -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" \
+  -H 'content-type: application/json' \
+  -d '{"enabled":false}' | jq .
+curl -fsS -X DELETE -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID" -i
+```
+
+List runs:
+
+```bash
+curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$TRIGGER_ID/runs?limit=20&offset=0" | jq .
+```
+
+Run statuses are typically `queued`, `running`, `success`, `failed`, or `retrying`.
+
+## Test Action Code
+
+Use a harmless Lit Action that echoes `js_params`/`params` back through `Lit.Actions.setResponse`. Adjust if Chipotle's Lit Action runtime changes its globals.
+
+```bash
+read -r -d '' TEST_ACTION_CODE <<'EOF'
+(async () => {
+  const input = typeof params !== 'undefined' ? params : {};
+  Lit.Actions.setResponse({
+    response: JSON.stringify({ ok: true, input })
+  });
+})();
+EOF
+```
+
+If this action fails in Chipotle, use a known-good action from the target Chipotle group and keep the rest of the trigger payloads the same.
+
+## Webhook Trigger Test
+
+Create a webhook trigger:
+
+```bash
+WEBHOOK_CREATE_PAYLOAD=$(jq -n \
+  --arg name "agent webhook smoke $(date -u +%Y%m%dT%H%M%SZ)" \
+  --arg action_code "$TEST_ACTION_CODE" \
+  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
+  --arg account "${CHIPOTLE_ACCOUNT_ADDRESS:-}" \
+  '{
+    name: $name,
+    kind: "webhook",
+    action_code: $action_code,
+    default_params: { agent_smoke: true, trigger_type: "webhook" },
+    usage_api_key: $usage_api_key,
+    chipotle_account_address: (if $account == "" then null else $account end),
+    max_runs_per_minute: 10,
+    max_queued_runs: 20,
+    config: {}
+  }')
+
+WEBHOOK_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
+  -H 'content-type: application/json' \
+  -d "$WEBHOOK_CREATE_PAYLOAD")
+
+echo "$WEBHOOK_TRIGGER" | jq .
+export WEBHOOK_TRIGGER_ID=$(echo "$WEBHOOK_TRIGGER" | jq -r '.id')
+```
+
+Fire it:
+
+```bash
+curl -fsS -X POST "$LT_BASE_URL/webhook/$WEBHOOK_TRIGGER_ID" \
+  -H 'content-type: application/json' \
+  -d '{"hello":"from-agent","trigger":"webhook"}' | jq .
+```
+
+Expected webhook response:
+
+```json
+{"run_id":"<uuid>","status":"queued"}
+```
+
+Inspect runs until terminal:
+
+```bash
+for i in $(seq 1 20); do
+  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$WEBHOOK_TRIGGER_ID/runs?limit=5" | jq .
+  sleep 3
+done
+```
+
+Expected result if the scoped usage key and action are valid: latest run eventually reaches `success`. If it reaches `failed`, inspect `.runs[0].error` and `.runs[0].response`.
+
+## Schedule Trigger Test
+
+Create a schedule trigger. Use a cron expression no more frequent than once per minute. Sub-30-second schedules are intentionally rejected.
+
+```bash
+SCHEDULE_CREATE_PAYLOAD=$(jq -n \
+  --arg name "agent schedule smoke $(date -u +%Y%m%dT%H%M%SZ)" \
+  --arg action_code "$TEST_ACTION_CODE" \
+  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
+  '{
+    name: $name,
+    kind: "schedule",
+    action_code: $action_code,
+    default_params: { agent_smoke: true, trigger_type: "schedule" },
+    usage_api_key: $usage_api_key,
+    max_runs_per_minute: 5,
+    max_queued_runs: 10,
+    config: { cron: "* * * * *" }
+  }')
+
+SCHEDULE_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
+  -H 'content-type: application/json' \
+  -d "$SCHEDULE_CREATE_PAYLOAD")
+
+echo "$SCHEDULE_TRIGGER" | jq .
+export SCHEDULE_TRIGGER_ID=$(echo "$SCHEDULE_TRIGGER" | jq -r '.id')
+```
+
+Wait up to two minutes and inspect runs:
+
+```bash
+for i in $(seq 1 40); do
+  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$SCHEDULE_TRIGGER_ID/runs?limit=5" | jq .
+  sleep 3
+done
+```
+
+Expected input shape for schedule runs includes:
+
+```json
+{
+  "source": "schedule",
+  "event": {
+    "scheduled_at": "<RFC3339 timestamp>",
+    "cron": "* * * * *"
+  }
+}
+```
+
+## Chain Event Trigger Test
+
+Prerequisites:
+
+- Railway env var for the target chain RPC is set, e.g. `BASE_RPC_URL` for `base`.
+- The target contract emits events often enough to observe.
+- The scoped usage key can execute the action.
+
+Supported chain keys and RPC env vars:
+
+- `ethereum` / `ETHEREUM_RPC_URL`
+- `base` / `BASE_RPC_URL`
+- `arbitrum` / `ARBITRUM_RPC_URL`
+- `bsc` / `BSC_RPC_URL`
+- `polygon` / `POLYGON_RPC_URL`
+
+Create a Base USDC `Transfer(address,address,uint256)` trigger. Use a recent `start_block` if you know one; otherwise omit it and the service starts from its configured initial lookback window.
+
+```bash
+CHAIN_CREATE_PAYLOAD=$(jq -n \
+  --arg name "agent chain smoke $(date -u +%Y%m%dT%H%M%SZ)" \
+  --arg action_code "$TEST_ACTION_CODE" \
+  --arg usage_api_key "$SCOPED_USAGE_API_KEY" \
+  '{
+    name: $name,
+    kind: "chain_event",
+    action_code: $action_code,
+    default_params: { agent_smoke: true, trigger_type: "chain_event" },
+    usage_api_key: $usage_api_key,
+    max_runs_per_minute: 20,
+    max_queued_runs: 20,
+    config: {
+      chain: "base",
+      contract_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      event_signature: "Transfer(address,address,uint256)"
+    }
+  }')
+
+CHAIN_TRIGGER=$(curl -fsS -b "$COOKIE_JAR" -X POST "$LT_BASE_URL/api/triggers" \
+  -H 'content-type: application/json' \
+  -d "$CHAIN_CREATE_PAYLOAD")
+
+echo "$CHAIN_TRIGGER" | jq .
+export CHAIN_TRIGGER_ID=$(echo "$CHAIN_TRIGGER" | jq -r '.id')
+```
+
+Poll for runs:
+
+```bash
+for i in $(seq 1 60); do
+  curl -fsS -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$CHAIN_TRIGGER_ID/runs?limit=5" | jq .
+  sleep 5
+done
+```
+
+Expected input shape for chain-event runs includes:
+
+```json
+{
+  "source": "chain_event",
+  "event": {
+    "chain": "base",
+    "chain_id": 8453,
+    "contract_address": "0x...",
+    "event_signature": "Transfer(address,address,uint256)",
+    "log": { "transactionHash": "0x...", "logIndex": "0x..." }
+  }
+}
+```
+
+Topic filters can include up to three entries after topic0. Each entry may be a 32-byte topic string, an array of topic strings, or `null` for wildcard. Example filtering `from` address for an indexed ERC-20 `Transfer` topic:
+
+```json
+{
+  "chain": "base",
+  "contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "event_signature": "Transfer(address,address,uint256)",
+  "topic_filters": [
+    "0x000000000000000000000000<lowercase-20-byte-address-without-0x>",
+    null
+  ]
+}
+```
+
+## Cleanup
+
+Disable or delete test triggers when done:
+
+```bash
+for id in "$WEBHOOK_TRIGGER_ID" "$SCHEDULE_TRIGGER_ID" "$CHAIN_TRIGGER_ID"; do
+  [ -n "$id" ] && [ "$id" != "null" ] || continue
+  curl -fsS -X PATCH -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$id" \
+    -H 'content-type: application/json' \
+    -d '{"enabled":false}' | jq .
+done
+```
+
+Or delete them permanently:
+
+```bash
+for id in "$WEBHOOK_TRIGGER_ID" "$SCHEDULE_TRIGGER_ID" "$CHAIN_TRIGGER_ID"; do
+  [ -n "$id" ] && [ "$id" != "null" ] || continue
+  curl -fsS -X DELETE -b "$COOKIE_JAR" "$LT_BASE_URL/api/triggers/$id" -i
+done
+```
+
+## Troubleshooting
+
+- `401` from `/api/*`: session cookie missing/expired. Request a new magic link and verify it with `curl -L -c "$COOKIE_JAR" -b "$COOKIE_JAR"`.
+- `400 {"error":"usage_api_key_required"}`: create payload omitted `usage_api_key` or it was blank.
+- `400 {"error":"cron_required"}` or `invalid_cron`: schedule config must include valid `config.cron`; use `* * * * *` for smoke tests.
+- `400 {"error":"invalid_chain_event_config"}`: check chain key, address length, event signature, `topic_filters`, and `start_block` type.
+- `202` webhook response but no terminal run: dispatcher may still be running, queue may be backed up, or app sleeping/replica settings may be wrong.
+- Run reaches `failed` with Chipotle `401`/`403`: scoped usage key is invalid or lacks permission for this action/group.
+- No chain-event runs: check Railway RPC env var for that chain, app logs, confirmation depth, initial lookback, and whether the contract emitted matching logs.
+- `/api/triggers/<id>/test` returns `501`: expected for now; use webhook firing, schedule waits, or real chain events as test paths.
+
+## Verification Checklist
+
+- [ ] `/health` returns `ok`.
+- [ ] Magic-link login creates a valid session; `/api/me` returns the test user.
+- [ ] Webhook trigger can be created and `/webhook/<id>` returns `202` with a `run_id`.
+- [ ] Webhook run reaches `success` with a valid scoped usage key/action.
+- [ ] Schedule trigger creates at least one run within two minutes.
+- [ ] Chain-event trigger creates runs when matching logs exist and the chain RPC env var is configured.
+- [ ] Test triggers are disabled or deleted after the smoke test.

--- a/lit-triggers/migrations/20260523000001_agent_access_tokens.sql
+++ b/lit-triggers/migrations/20260523000001_agent_access_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS agent_access_tokens (
+  token_hash TEXT PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL DEFAULT 'local-agent',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_access_tokens_user_id
+  ON agent_access_tokens(user_id);
+
+ALTER TABLE magic_links
+  ADD COLUMN IF NOT EXISTS redirect_path TEXT;

--- a/lit-triggers/src/auth/agent.rs
+++ b/lit-triggers/src/auth/agent.rs
@@ -1,0 +1,143 @@
+//! Agent access tokens authorized by a logged-in user.
+
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::token as auth_token;
+
+const MIN_AGENT_TOKEN_LEN: usize = 32;
+const MAX_AGENT_TOKEN_LEN: usize = 512;
+
+const TOKEN_HASH_LEN: usize = 43;
+
+pub fn validate_agent_token(token: &str) -> Result<()> {
+    let len = token.len();
+    if !(MIN_AGENT_TOKEN_LEN..=MAX_AGENT_TOKEN_LEN).contains(&len) {
+        anyhow::bail!("agent token must be 32-512 characters");
+    }
+    if !token
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~'))
+    {
+        anyhow::bail!("agent token contains unsupported characters");
+    }
+    Ok(())
+}
+
+pub fn validate_agent_token_hash(token_hash: &str) -> Result<()> {
+    if token_hash.len() != TOKEN_HASH_LEN {
+        anyhow::bail!("agent token challenge has invalid length");
+    }
+    if !token_hash
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'))
+    {
+        anyhow::bail!("agent token challenge contains unsupported characters");
+    }
+    Ok(())
+}
+
+pub async fn authorize_hash(
+    pool: &PgPool,
+    token_hash: &str,
+    user_id: Uuid,
+    label: Option<&str>,
+) -> Result<()> {
+    validate_agent_token_hash(token_hash)?;
+    let label = label
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("local-agent");
+
+    sqlx::query(
+        "INSERT INTO agent_access_tokens (token_hash, user_id, label)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (token_hash) DO UPDATE
+           SET user_id = EXCLUDED.user_id,
+               label = EXCLUDED.label,
+               revoked_at = NULL",
+    )
+    .bind(token_hash)
+    .bind(user_id)
+    .bind(label)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn authorize(
+    pool: &PgPool,
+    raw_token: &str,
+    user_id: Uuid,
+    label: Option<&str>,
+) -> Result<()> {
+    validate_agent_token(raw_token)?;
+    let token_hash = auth_token::token_hash(raw_token);
+    authorize_hash(pool, &token_hash, user_id, label).await
+}
+
+pub async fn lookup(pool: &PgPool, raw_token: &str) -> Result<Option<Uuid>> {
+    validate_agent_token(raw_token).context("invalid agent bearer token")?;
+    let row = sqlx::query_as::<_, (Uuid,)>(
+        "UPDATE agent_access_tokens
+         SET last_used_at = now()
+         WHERE token_hash = $1 AND revoked_at IS NULL
+         RETURNING user_id",
+    )
+    .bind(auth_token::token_hash(raw_token))
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(user_id,)| user_id))
+}
+
+#[allow(dead_code)]
+pub async fn revoke(pool: &PgPool, raw_token: &str, user_id: Uuid) -> Result<u64> {
+    validate_agent_token(raw_token)?;
+    let result = sqlx::query(
+        "UPDATE agent_access_tokens
+         SET revoked_at = now()
+         WHERE token_hash = $1 AND user_id = $2 AND revoked_at IS NULL",
+    )
+    .bind(auth_token::token_hash(raw_token))
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+pub fn sanitize_next_path(next: Option<&str>) -> Option<String> {
+    let next = next?.trim();
+    if !next.starts_with('/')
+        || next.starts_with("//")
+        || next.contains('\n')
+        || next.contains('\r')
+    {
+        return None;
+    }
+    Some(next.chars().take(512).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_url_safe_agent_tokens() {
+        assert!(validate_agent_token("abcdefghijklmnopqrstuvwxyzABCDEF").is_ok());
+        assert!(validate_agent_token("abcDEF0123456789-_~.abcDEF0123456789").is_ok());
+        assert!(validate_agent_token("short").is_err());
+        assert!(validate_agent_token("abcdefghijklmnopqrstuvwxyzABCDE+").is_err());
+    }
+
+    #[test]
+    fn sanitize_next_path_allows_only_local_paths() {
+        assert_eq!(
+            sanitize_next_path(Some("/agent/authorize?challenge=abc")),
+            Some("/agent/authorize?challenge=abc".to_string())
+        );
+        assert_eq!(sanitize_next_path(Some("https://evil.test")), None);
+        assert_eq!(sanitize_next_path(Some("//evil.test/path")), None);
+        assert_eq!(sanitize_next_path(Some("/ok\nLocation: /evil")), None);
+    }
+}

--- a/lit-triggers/src/auth/mod.rs
+++ b/lit-triggers/src/auth/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod rate_limit;
 pub mod routes;
 pub mod session;

--- a/lit-triggers/src/auth/routes.rs
+++ b/lit-triggers/src/auth/routes.rs
@@ -4,21 +4,22 @@ use rocket::form::Form;
 use rocket::http::{Cookie, CookieJar, SameSite, Status};
 use rocket::response::Redirect;
 use rocket::serde::json::Json;
+use rocket::serde::{Deserialize, Serialize};
 use rocket::State;
 use rocket::{get, post};
-use serde::Serialize;
 use sqlx::PgPool;
 use time::OffsetDateTime;
 
 use super::rate_limit::RateLimiter;
-use super::user::User;
-use super::{session, token, user, MAGIC_LINK_TTL_SECONDS, SESSION_COOKIE_NAME};
+use super::user::{self, User};
+use super::{agent, session, token, MAGIC_LINK_TTL_SECONDS, SESSION_COOKIE_NAME};
 use crate::config::Config;
 use crate::mail::Mailer;
 
 #[derive(rocket::FromForm)]
 pub struct RequestLinkForm<'r> {
     pub email: &'r str,
+    pub next: Option<&'r str>,
 }
 
 #[derive(Serialize)]
@@ -35,6 +36,7 @@ pub async fn request_link(
     rate_limit: &State<RateLimiter>,
 ) -> Json<RequestLinkResponse> {
     let email = form.email.trim().to_lowercase();
+    let redirect_path = agent::sanitize_next_path(form.next);
     if email.is_empty() || rate_limit.check_and_record(&email).await {
         return Json(RequestLinkResponse { ok: true });
     }
@@ -48,7 +50,16 @@ pub async fn request_link(
         expires_at.unix_timestamp(),
         &nonce,
     );
-    match store_magic_link(pool, &tok, &nonce, &email, expires_at).await {
+    match store_magic_link(
+        pool,
+        &tok,
+        &nonce,
+        &email,
+        expires_at,
+        redirect_path.as_deref(),
+    )
+    .await
+    {
         Ok(()) => {
             let link = format!("{}/auth/verify?token={tok}", config.public_base_url);
             let subject = "Sign in to Lit Triggers";
@@ -97,14 +108,14 @@ pub async fn verify_link(
         return Err(Redirect::to("/login?error=invalid"));
     }
 
-    let consumed = match consume_magic_link(pool, token, &claims.nonce, &claims.email).await {
-        Ok(consumed) => consumed,
+    let redirect_path = match consume_magic_link(pool, token, &claims.nonce, &claims.email).await {
+        Ok(redirect_path) => redirect_path,
         Err(e) => {
             tracing::warn!("magic-link consume failed in /auth/verify: {e}");
             return Err(Redirect::to("/login?error=server"));
         }
     };
-    if !consumed {
+    if redirect_path.is_none() {
         tracing::info!("magic-link verify rejected: missing, expired, or already consumed token");
         return Err(Redirect::to("/login?error=invalid"));
     }
@@ -132,7 +143,9 @@ pub async fn verify_link(
         .build();
     cookies.add_private(cookie);
 
-    Ok(Redirect::to("/"))
+    Ok(Redirect::to(
+        redirect_path.unwrap_or_else(|| "/".to_string()),
+    ))
 }
 
 #[post("/auth/logout")]
@@ -147,6 +160,37 @@ pub async fn logout(pool: &State<PgPool>, cookies: &CookieJar<'_>) -> Status {
     Status::NoContent
 }
 
+#[derive(Debug, Deserialize)]
+pub struct AgentAuthorizeRequest {
+    pub challenge: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentAuthorizeResponse {
+    pub ok: bool,
+    pub user_email: String,
+}
+
+#[post("/agent/authorize", data = "<req>")]
+pub async fn authorize_agent(
+    user: User,
+    pool: &State<PgPool>,
+    req: Json<AgentAuthorizeRequest>,
+) -> Result<Json<AgentAuthorizeResponse>, Status> {
+    let req = req.into_inner();
+    agent::authorize_hash(pool.inner(), &req.challenge, user.id, req.label.as_deref())
+        .await
+        .map_err(|e| {
+            tracing::warn!(user_id = %user.id, "agent token authorize failed: {e}");
+            Status::BadRequest
+        })?;
+    Ok(Json(AgentAuthorizeResponse {
+        ok: true,
+        user_email: user.email,
+    }))
+}
+
 #[get("/api/me")]
 pub fn me(user: User) -> Json<User> {
     Json(user)
@@ -158,14 +202,16 @@ async fn store_magic_link(
     nonce: &str,
     email: &str,
     expires_at: OffsetDateTime,
+    redirect_path: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
-        "INSERT INTO magic_links (token_hash, nonce, email, expires_at) VALUES ($1, $2, $3, $4)",
+        "INSERT INTO magic_links (token_hash, nonce, email, expires_at, redirect_path) VALUES ($1, $2, $3, $4, $5)",
     )
     .bind(token::token_hash(raw_token))
     .bind(nonce)
     .bind(email)
     .bind(expires_at)
+    .bind(redirect_path)
     .execute(pool)
     .await?;
     Ok(())
@@ -176,20 +222,21 @@ async fn consume_magic_link(
     raw_token: &str,
     nonce: &str,
     email: &str,
-) -> anyhow::Result<bool> {
-    let result = sqlx::query(
+) -> anyhow::Result<Option<String>> {
+    let row = sqlx::query_as::<_, (Option<String>,)>(
         "UPDATE magic_links
          SET consumed_at = now()
          WHERE token_hash = $1
            AND nonce = $2
            AND email = $3
            AND consumed_at IS NULL
-           AND expires_at > now()",
+           AND expires_at > now()
+         RETURNING redirect_path",
     )
     .bind(token::token_hash(raw_token))
     .bind(nonce)
     .bind(email)
-    .execute(pool)
+    .fetch_optional(pool)
     .await?;
-    Ok(result.rows_affected() == 1)
+    Ok(row.map(|(redirect_path,)| redirect_path.unwrap_or_else(|| "/".to_string())))
 }

--- a/lit-triggers/src/auth/session.rs
+++ b/lit-triggers/src/auth/session.rs
@@ -66,11 +66,6 @@ impl<'r> FromRequest<'r> for User {
     type Error = ();
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let Some(cookie) = req.cookies().get_private(SESSION_COOKIE_NAME) else {
-            return Outcome::Forward(Status::Unauthorized);
-        };
-        let token = cookie.value().to_string();
-
         let pool = match req.rocket().state::<PgPool>() {
             Some(p) => p,
             None => {
@@ -79,12 +74,27 @@ impl<'r> FromRequest<'r> for User {
             }
         };
 
-        let user_id = match lookup(pool, &token).await {
-            Ok(Some(id)) => id,
-            Ok(None) => return Outcome::Forward(Status::Unauthorized),
-            Err(e) => {
-                tracing::warn!("session lookup failed: {e}");
-                return Outcome::Error((Status::InternalServerError, ()));
+        let user_id = if let Some(token) = bearer_token(req) {
+            match super::agent::lookup(pool, token).await {
+                Ok(Some(id)) => id,
+                Ok(None) => return Outcome::Forward(Status::Unauthorized),
+                Err(e) => {
+                    tracing::warn!("agent token lookup failed: {e}");
+                    return Outcome::Forward(Status::Unauthorized);
+                }
+            }
+        } else {
+            let Some(cookie) = req.cookies().get_private(SESSION_COOKIE_NAME) else {
+                return Outcome::Forward(Status::Unauthorized);
+            };
+            let token = cookie.value().to_string();
+            match lookup(pool, &token).await {
+                Ok(Some(id)) => id,
+                Ok(None) => return Outcome::Forward(Status::Unauthorized),
+                Err(e) => {
+                    tracing::warn!("session lookup failed: {e}");
+                    return Outcome::Error((Status::InternalServerError, ()));
+                }
             }
         };
 
@@ -97,4 +107,13 @@ impl<'r> FromRequest<'r> for User {
             }
         }
     }
+}
+
+fn bearer_token<'a>(req: &'a Request<'_>) -> Option<&'a str> {
+    let value = req.headers().get_one("authorization")?.trim();
+    value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
 }

--- a/lit-triggers/src/main.rs
+++ b/lit-triggers/src/main.rs
@@ -44,6 +44,7 @@ async fn rocket() -> _ {
                 index,
                 login_page,
                 health,
+                skill_doc,
                 auth_routes::request_link,
                 auth_routes::verify_link,
                 auth_routes::logout,
@@ -84,6 +85,13 @@ fn init_tracing() {
 #[get("/health")]
 fn health() -> &'static str {
     "ok"
+}
+
+#[get("/SKILL.md")]
+async fn skill_doc() -> Result<NamedFile, Status> {
+    NamedFile::open("SKILL.md")
+        .await
+        .map_err(|_| Status::NotFound)
 }
 
 #[get("/")]

--- a/lit-triggers/src/main.rs
+++ b/lit-triggers/src/main.rs
@@ -45,9 +45,11 @@ async fn rocket() -> _ {
                 login_page,
                 health,
                 skill_doc,
+                agent_authorize_page,
                 auth_routes::request_link,
                 auth_routes::verify_link,
                 auth_routes::logout,
+                auth_routes::authorize_agent,
                 auth_routes::me,
                 triggers::create_trigger,
                 triggers::list_triggers,
@@ -92,6 +94,27 @@ async fn skill_doc() -> Result<NamedFile, Status> {
     NamedFile::open("SKILL.md")
         .await
         .map_err(|_| Status::NotFound)
+}
+
+#[get("/agent/authorize?<challenge>")]
+async fn agent_authorize_page(
+    user: Option<auth::User>,
+    challenge: Option<&str>,
+) -> Result<NamedFile, Redirect> {
+    let Some(challenge) = challenge else {
+        return Err(Redirect::to("/login?error=invalid"));
+    };
+    if auth::agent::validate_agent_token_hash(challenge).is_err() {
+        return Err(Redirect::to("/login?error=invalid"));
+    }
+    match user {
+        Some(_) => NamedFile::open(static_path("agent-authorize.html"))
+            .await
+            .map_err(|_| Redirect::to("/login?error=missing_static")),
+        None => Err(Redirect::to(format!(
+            "/login?next=/agent/authorize%3Fchallenge%3D{challenge}"
+        ))),
+    }
 }
 
 #[get("/")]

--- a/lit-triggers/static/agent-authorize.html
+++ b/lit-triggers/static/agent-authorize.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize Agent — Lit Triggers</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <main class="card">
+    <h1>Authorize your agent</h1>
+    <p class="subtitle">Approve this local agent to manage Lit Triggers using your signed-in account.</p>
+
+    <section class="panel callout">
+      <h2>What this allows</h2>
+      <p>
+        The agent will be able to use the Lit Triggers API as you: create triggers,
+        read trigger status, inspect runs, update triggers, and delete test triggers.
+        It will not receive your Lit/Chipotle admin API key.
+      </p>
+    </section>
+
+    <button id="authorize-btn" type="button">Authorize agent</button>
+    <p id="status" class="status" role="status" aria-live="polite"></p>
+    <p class="note"><a href="/SKILL.md">View the agent setup guide</a></p>
+  </main>
+
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const challenge = params.get('challenge') || '';
+    const button = document.getElementById('authorize-btn');
+    const status = document.getElementById('status');
+
+    if (!challenge) {
+      button.disabled = true;
+      status.textContent = 'Missing agent challenge. Ask your agent to generate a fresh authorize URL.';
+      status.className = 'status error';
+    }
+
+    button.addEventListener('click', async () => {
+      button.disabled = true;
+      status.textContent = 'Authorizing agent…';
+      status.className = 'status';
+      try {
+        const resp = await fetch('/agent/authorize', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ challenge, label: 'local-agent' }),
+        });
+        if (resp.status === 401) {
+          window.location.href = `/login?next=${encodeURIComponent(`/agent/authorize?challenge=${encodeURIComponent(challenge)}`)}`;
+          return;
+        }
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        status.textContent = 'Agent authorized. You can return to your agent now.';
+        status.className = 'status ok';
+      } catch (_err) {
+        status.textContent = 'Could not authorize this agent. Ask it to generate a fresh authorization URL and try again.';
+        status.className = 'status error';
+        button.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/lit-triggers/static/index.html
+++ b/lit-triggers/static/index.html
@@ -12,6 +12,7 @@
       <div>
         <h1>Lit Triggers</h1>
         <p id="who" class="subtitle">Loading profile…</p>
+        <p class="agent-doc-link tight"><a href="/SKILL.md">Give this to your agent to get started</a></p>
       </div>
       <button id="logout-btn" type="button" class="secondary compact">Sign out</button>
     </header>

--- a/lit-triggers/static/login.html
+++ b/lit-triggers/static/login.html
@@ -10,6 +10,7 @@
   <main class="card">
     <h1>Lit Triggers</h1>
     <p class="subtitle">Sign in to manage reactive Lit Action triggers.</p>
+    <p class="agent-doc-link"><a href="/SKILL.md">Give this to your agent to get started</a></p>
 
     <form id="request-form">
       <label for="email">Email</label>

--- a/lit-triggers/static/login.html
+++ b/lit-triggers/static/login.html
@@ -19,6 +19,7 @@
     </form>
 
     <p id="status" class="status" role="status" aria-live="polite"></p>
+    <p id="next-note" class="note hidden">After sign-in, you will return to the agent authorization page.</p>
   </main>
 
   <script>
@@ -27,6 +28,8 @@
     const button = document.getElementById('submit-btn');
 
     const params = new URLSearchParams(window.location.search);
+    const next = params.get('next') || '';
+    if (next) document.getElementById('next-note').classList.remove('hidden');
     if (params.get('error') === 'invalid') {
       status.textContent = 'That link is invalid or expired. Request a new one.';
       status.className = 'status error';
@@ -44,6 +47,7 @@
       status.className = 'status';
       try {
         const body = new URLSearchParams({ email });
+        if (next) body.set('next', next);
         const resp = await fetch('/auth/request', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/lit-triggers/static/style.css
+++ b/lit-triggers/static/style.css
@@ -88,6 +88,9 @@ h3 { margin: 0; font-size: 16px; }
 p { line-height: 1.45; }
 .subtitle { margin: 0 0 24px; color: var(--muted); }
 .subtitle.tight { margin-bottom: 0; }
+.agent-doc-link { margin: -12px 0 24px; font-size: 14px; }
+.agent-doc-link.tight { margin: 6px 0 0; }
+a { color: var(--accent); }
 .note { margin: 8px 0 16px; color: var(--muted); font-size: 14px; }
 .hidden { display: none !important; }
 


### PR DESCRIPTION
## Summary
- Rework the public lit-triggers SKILL.md into an agent setup guide instead of env-var based smoke-test instructions
- Add browser-approved local agent authorization using a locally generated bearer token and URL-safe hash challenge
- Allow authorized agents to call the API with Authorization: Bearer while keeping the raw token out of browser URLs
- Add the authorization page, login redirect support, agent token storage migration, and docs updates

## Validation
- python YAML/frontmatter + snippet syntax checks for SKILL.md
- node --check static/app.js
- cargo +1.91 fmt --check
- cargo +1.91 test
- cargo +1.91 build --release --bin lit-triggers
- git diff --check