### PR TITLE
fix(lit-payments): restore applied migration checksum

### DIFF
--- a/lit-payments/migrations/20260522000001_litkey_listener.sql
+++ b/lit-payments/migrations/20260522000001_litkey_listener.sql
@@ -1,6 +1,6 @@
 -- LITKEY on-chain payment records. Successful credits are idempotent by
--- chain + tx hash + log index so repeated browser tx-claim submissions cannot
--- double-credit a payment.
+-- chain + tx hash + log index so WSS and reconciliation poller races cannot
+-- double-credit the same Payment event.
 CREATE TABLE litkey_payments (
     id BIGSERIAL PRIMARY KEY,
     chain_id BIGINT NOT NULL,

--- a/lit-payments/migrations/20260526000001_drop_litkey_listener_checkpoint.sql
+++ b/lit-payments/migrations/20260526000001_drop_litkey_listener_checkpoint.sql
@@ -1,0 +1,8 @@
+-- The browser LITKEY payment flow now verifies the submitted transaction hash
+-- directly with eth_getTransactionReceipt. The background WSS/reconciliation
+-- listener is no longer started, so its checkpoint table is obsolete.
+--
+-- This is intentionally a new migration instead of editing
+-- 20260522000001_litkey_listener.sql: that migration has already been applied in
+-- deployed databases and sqlx verifies applied migration checksums at startup.
+DROP TABLE IF EXISTS chain_checkpoint;


### PR DESCRIPTION
## Summary
- Restore `lit-payments/migrations/20260522000001_litkey_listener.sql` to its original contents/checksum so deployed databases that already applied it can boot
- Add a new follow-up migration `20260526000001_drop_litkey_listener_checkpoint.sql` to drop the obsolete listener checkpoint table for the tx-hash claim flow

## Root cause
PR #390 changed comments in an already-applied SQLx migration. SQLx stores migration checksums in `_sqlx_migrations`, so the app panicked on startup with:

```text
migration 20260522000001 was previously applied but has been modified
```

## Test Plan
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --locked --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `git diff --check`
- [x] Verified the restored `20260522000001_litkey_listener.sql` checksum matches the pre-#390 migration checksum
