### PR TITLE
feat(lit-payments): show litkey discount on payment page

### DIFF
--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -81,7 +81,9 @@ ROCKET_PORT=8000
 paying LITKEY to the deployed gateway on Base mainnet. The page validates that
 the URL wallet maps to a customer, prominently displays the email and wallet that
 will be credited, refreshes the quote every 30 seconds until approval starts,
-freezes the quote and LITKEY amount for exact-amount approval, calls
+shows the market LITKEY rate, configured discount percentage, discount-adjusted
+credit rate, and with/without-discount LITKEY amounts, freezes the quote and
+LITKEY amount for exact-amount approval, calls
 `pay(amount, wallet)`, then posts the resulting transaction hash plus credited
 wallet to `/api/litkey/payment-claim`. The claim endpoint fetches that exact
 transaction receipt, verifies the configured gateway emitted the expected

--- a/lit-payments/static/pay-with-litkey.html
+++ b/lit-payments/static/pay-with-litkey.html
@@ -30,8 +30,11 @@
       <div class="amount-row"><span>$</span><input id="credit-dollars" inputmode="decimal" value="5.00" aria-describedby="minimum-copy"></div>
       <p id="minimum-copy" class="hint">Minimum payment is $5.00 equivalent. Quote refreshes every 30 seconds until approval starts.</p>
       <div class="quote-grid">
-        <span>Estimated LITKEY</span><strong id="litkey-amount">—</strong>
-        <span>Effective rate</span><strong id="rate-display">—</strong>
+        <span>Market LITKEY rate</span><strong id="rate-display">—</strong>
+        <span>LITKEY discount</span><strong id="discount-display">—</strong>
+        <span>Discounted credit rate</span><strong id="effective-rate-display">—</strong>
+        <span>LITKEY needed with discount</span><strong id="litkey-amount">—</strong>
+        <span>Without discount</span><strong id="undiscounted-litkey-amount">—</strong>
         <span>Quote status</span><strong id="quote-status">Loading…</strong>
       </div>
     </section>

--- a/lit-payments/static/pay-with-litkey.js
+++ b/lit-payments/static/pay-with-litkey.js
@@ -55,6 +55,30 @@
   function amountWeiForCents(cents, effectiveRate) { return ceilDiv(cents * WEI * USD, BigInt(effectiveRate) * 100n); }
   function creditCentsForAmount(amountWei, effectiveRate) { return (amountWei * BigInt(effectiveRate) * 100n + (WEI * USD / 2n)) / (WEI * USD); }
   function formatToken(amountWei) { return ethers.formatUnits(amountWei, 18).replace(/(\.\d{6})\d+$/, '$1'); }
+  function formatDiscountBps(bps) {
+    const value = Number(bps || 0);
+    if (!Number.isFinite(value) || value <= 0) return 'No discount';
+    const whole = Math.trunc(value / 100);
+    const fractional = Math.abs(value % 100);
+    return (fractional ? whole + '.' + String(fractional).padStart(2, '0').replace(/0+$/, '') : String(whole)) + '% off';
+  }
+
+  function marketRate(quote) {
+    return quote && quote.rate && quote.rate.usd_wei_per_litkey ? quote.rate.usd_wei_per_litkey : null;
+  }
+
+  function setQuoteDisplays(quote, cents) {
+    const market = marketRate(quote);
+    setText('rate-display', market ? formatUsdWei(market) + ' / LITKEY' : '—');
+    setText('discount-display', formatDiscountBps(quote ? quote.discount_basis_points : 0));
+    setText('effective-rate-display', quote && quote.effective_usd_wei_per_litkey ? formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY' : '—');
+    if (!cents || !market || !quote || !quote.effective_usd_wei_per_litkey) {
+      setText('undiscounted-litkey-amount', '—');
+      return;
+    }
+    const undiscounted = amountWeiForCents(cents, market);
+    setText('undiscounted-litkey-amount', formatToken(undiscounted) + ' LITKEY');
+  }
 
   async function fetchJson(url) {
     const res = await fetch(url, { credentials: 'omit' });
@@ -107,6 +131,8 @@
     const quote = state.frozenQuote || state.quote;
     if (!quote || quote.crediting_paused || !quote.effective_usd_wei_per_litkey) {
       setText('quote-status', 'Crediting paused');
+      setQuoteDisplays(quote, null);
+      setText('litkey-amount', '—');
       $('approve').disabled = true;
       $('pay').disabled = true;
       return;
@@ -114,32 +140,36 @@
 
     if (!state.config) {
       setText('quote-status', 'Payments unavailable');
+      setQuoteDisplays(quote, null);
+      setText('litkey-amount', '—');
       $('approve').disabled = true;
       $('pay').disabled = true;
       return;
     }
 
+    const cents = parseCents($('credit-dollars').value);
+
     if (state.frozenAmountWei !== null) {
       state.amountWei = state.frozenAmountWei;
       setText('litkey-amount', formatToken(state.frozenAmountWei) + ' LITKEY');
-      setText('rate-display', formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY');
+      setQuoteDisplays(quote, cents);
       setText('quote-status', 'Frozen for approval');
       $('approve').disabled = true;
       $('pay').disabled = state.approvedAmountWei === null;
       return;
     }
 
-    const cents = parseCents($('credit-dollars').value);
     if (!cents || cents < MIN_CENTS) {
       setText('quote-status', 'Enter at least $5.00');
       setText('litkey-amount', '—');
+      setQuoteDisplays(quote, null);
       $('approve').disabled = true;
       $('pay').disabled = true;
       return;
     }
     state.amountWei = amountWeiForCents(cents, quote.effective_usd_wei_per_litkey);
     setText('litkey-amount', formatToken(state.amountWei) + ' LITKEY');
-    setText('rate-display', formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY');
+    setQuoteDisplays(quote, cents);
     setText('quote-status', 'Live');
     $('approve').disabled = !$('confirm-account').checked || !state.signer;
     $('pay').disabled = true;


### PR DESCRIPTION
## Summary
- Show the configured LITKEY discount percentage on `/payWithLitkey`
- Split quote display into market rate and discount-adjusted credit rate
- Show the LITKEY amount needed with the discount alongside the without-discount amount
- Document the payment page quote display behavior

## Config
For a 20% LITKEY buyer discount, set:

```sh
LITKEY_DISCOUNT_BASIS_POINTS=2000
```

## Test Plan
- [x] `node --check static/pay-with-litkey.js`
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --locked --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `git diff --check`
