### PR TITLE
fix(lit-payments): simplify litkey discount quote

### DIFF
--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -81,9 +81,9 @@ ROCKET_PORT=8000
 paying LITKEY to the deployed gateway on Base mainnet. The page validates that
 the URL wallet maps to a customer, prominently displays the email and wallet that
 will be credited, refreshes the quote every 30 seconds until approval starts,
-shows the market LITKEY rate, configured discount percentage, discount-adjusted
-credit rate, and with/without-discount LITKEY amounts, freezes the quote and
-LITKEY amount for exact-amount approval, calls
+shows the market LITKEY rate, configured discount percentage,
+discount-adjusted credit rate, and discounted LITKEY amount, freezes the quote
+and LITKEY amount for exact-amount approval, calls
 `pay(amount, wallet)`, then posts the resulting transaction hash plus credited
 wallet to `/api/litkey/payment-claim`. The claim endpoint fetches that exact
 transaction receipt, verifies the configured gateway emitted the expected

--- a/lit-payments/static/pay-with-litkey.html
+++ b/lit-payments/static/pay-with-litkey.html
@@ -34,7 +34,6 @@
         <span>LITKEY discount</span><strong id="discount-display">—</strong>
         <span>Discounted credit rate</span><strong id="effective-rate-display">—</strong>
         <span>LITKEY needed with discount</span><strong id="litkey-amount">—</strong>
-        <span>Without discount</span><strong id="undiscounted-litkey-amount">—</strong>
         <span>Quote status</span><strong id="quote-status">Loading…</strong>
       </div>
     </section>

--- a/lit-payments/static/pay-with-litkey.js
+++ b/lit-payments/static/pay-with-litkey.js
@@ -67,17 +67,11 @@
     return quote && quote.rate && quote.rate.usd_wei_per_litkey ? quote.rate.usd_wei_per_litkey : null;
   }
 
-  function setQuoteDisplays(quote, cents) {
+  function setQuoteDisplays(quote) {
     const market = marketRate(quote);
     setText('rate-display', market ? formatUsdWei(market) + ' / LITKEY' : '—');
     setText('discount-display', formatDiscountBps(quote ? quote.discount_basis_points : 0));
     setText('effective-rate-display', quote && quote.effective_usd_wei_per_litkey ? formatUsdWei(quote.effective_usd_wei_per_litkey) + ' credit / LITKEY' : '—');
-    if (!cents || !market || !quote || !quote.effective_usd_wei_per_litkey) {
-      setText('undiscounted-litkey-amount', '—');
-      return;
-    }
-    const undiscounted = amountWeiForCents(cents, market);
-    setText('undiscounted-litkey-amount', formatToken(undiscounted) + ' LITKEY');
   }
 
   async function fetchJson(url) {
@@ -131,7 +125,7 @@
     const quote = state.frozenQuote || state.quote;
     if (!quote || quote.crediting_paused || !quote.effective_usd_wei_per_litkey) {
       setText('quote-status', 'Crediting paused');
-      setQuoteDisplays(quote, null);
+      setQuoteDisplays(quote);
       setText('litkey-amount', '—');
       $('approve').disabled = true;
       $('pay').disabled = true;
@@ -140,7 +134,7 @@
 
     if (!state.config) {
       setText('quote-status', 'Payments unavailable');
-      setQuoteDisplays(quote, null);
+      setQuoteDisplays(quote);
       setText('litkey-amount', '—');
       $('approve').disabled = true;
       $('pay').disabled = true;
@@ -152,7 +146,7 @@
     if (state.frozenAmountWei !== null) {
       state.amountWei = state.frozenAmountWei;
       setText('litkey-amount', formatToken(state.frozenAmountWei) + ' LITKEY');
-      setQuoteDisplays(quote, cents);
+      setQuoteDisplays(quote);
       setText('quote-status', 'Frozen for approval');
       $('approve').disabled = true;
       $('pay').disabled = state.approvedAmountWei === null;
@@ -162,14 +156,14 @@
     if (!cents || cents < MIN_CENTS) {
       setText('quote-status', 'Enter at least $5.00');
       setText('litkey-amount', '—');
-      setQuoteDisplays(quote, null);
+      setQuoteDisplays(quote);
       $('approve').disabled = true;
       $('pay').disabled = true;
       return;
     }
     state.amountWei = amountWeiForCents(cents, quote.effective_usd_wei_per_litkey);
     setText('litkey-amount', formatToken(state.amountWei) + ' LITKEY');
-    setQuoteDisplays(quote, cents);
+    setQuoteDisplays(quote);
     setText('quote-status', 'Live');
     $('approve').disabled = !$('confirm-account').checked || !state.signer;
     $('pay').disabled = true;


### PR DESCRIPTION
## Summary
- Remove the confusing “Without discount” comparison row from `/payWithLitkey`
- Keep the market rate, discount percentage, discounted credit rate, and final LITKEY needed amount
- Update docs to match the simplified quote display

## Test Plan
- [x] `node --check static/pay-with-litkey.js`
- [x] `cargo +1.91 fmt --all -- --check`
- [x] `cargo +1.91 test --locked --all-targets -q`
- [x] `cargo +1.91 clippy --locked --all-features -- -D warnings`
- [x] `git diff --check`
