### PR TITLE
fix(ci): restore .git in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,3 @@
-# Keep Railway/Docker build context small.
-.git
-.gitignore
-
 # Build artifacts
 **/target/
 **/.cargo/


### PR DESCRIPTION
## Summary
- Revert the `.git` / `.gitignore` exclusions added to `.dockerignore` in #382, which broke the `lit-api-server` image build on `main`.
- `lit-api-server/src/version.rs` uses `git_version!()` and `git_submodule_versions!()`, which need `.git/` at compile time. With `.git` excluded from the build context the build fails with:

  ```
  error: git describe exited with status 128: fatal: not a git repository (or any of the parent directories): .git
   --> src/version.rs:4:38
  ```

- Failing run: https://github.com/LIT-Protocol/chipotle/actions/runs/26518513984/job/78107094243

The other entries from #382 (build artifacts, env files, IDE caches) are kept — only the `.git` / `.gitignore` lines are removed.

## Test plan
- [ ] `Deploy Staging` workflow's `build (lit-api-server, Dockerfile.lit-api-server)` job succeeds.
- [ ] Resulting image still starts (CMD `lit-api-server`).
- [ ] Confirm with lit-payments owners that Railway's lit-payments build is still acceptable without the `.git` exclusion (Dockerfile only `COPY`s `lit-billing-core/` and `lit-payments/`, so `.git` doesn't enter the image — only the context tarball is larger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)