### PR TITLE
fix(ci): keep .env.example files in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 # Local env / temp files
 **/.env
 **/.env.*
+!**/.env.example
 **/.DS_Store
 **/tmp/
 **/coverage/


### PR DESCRIPTION
## Summary
- Add `!**/.env.example` negation to `.dockerignore` so the six tracked `.env.example` files reach the build context.
- After #396 restored `.git` in the lit-api-server build, `git_version!()` ran `git describe --dirty=-modified` and saw those files as missing, baking `-modified` into the binary's `commit_version` and breaking the `wait-for-api-restart` exact-SHA match (see run 26520924284).
- Real secrets (`.env`, `.env.local`, etc.) remain excluded.

## Test plan
- [ ] Confirm staging deploy reports `commit_version` without the `-modified` suffix and `wait-for-api-restart` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)