### PR TITLE
fix(ci): drop buggy git_submodule_versions! macro

### DIFF
--- a/lit-api-server/src/version.rs
+++ b/lit-api-server/src/version.rs
@@ -1,7 +1,10 @@
-use git_version::git_submodule_versions;
 use git_version::git_version;
 
 pub(crate) const GIT_VERSION: &str = git_version!();
-pub(crate) const GIT_SUBMODULE_VERSIONS: &[(&str, &str)] = &git_submodule_versions!();
+// `git_submodule_versions!()` from git-version 0.3.9 mis-joins `$displaypath`
+// (relative to CARGO_MANIFEST_DIR) onto the repo root, breaking the build whenever
+// the crate lives in a subdirectory and the repo has submodules. The only submodule
+// here is the Foundry `forge-std` test dependency, which is irrelevant at runtime.
+pub(crate) const GIT_SUBMODULE_VERSIONS: &[(&str, &str)] = &[];
 pub(crate) const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 pub(crate) const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
## Summary
- The Deploy Staging build was failing in `cargo build --release --bin lit-api-server` with `git describe exited with status 128: fatal: cannot change to '/build/.git/../blockchain/lit_node_express/lib/forge-std'`.
- `git-version` 0.3.9's `git_submodule_versions!()` macro joins `\$displaypath` (relative to `CARGO_MANIFEST_DIR`) onto the repo root, so it looks for the submodule at the wrong path whenever the crate lives in a subdirectory. The bug was dormant until the `forge-std` submodule landed in #349.
- Replace the macro call in `lit-api-server/src/version.rs` with an empty slice. The only submodule is a Foundry test dependency unrelated to the runtime API server, so the `/version` endpoint's `submodule_versions` field stays in the response (just empty).

## Test plan
- [ ] Deploy Staging workflow's `build (lit-api-server, Dockerfile.lit-api-server)` job succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)