### PR TITLE
docs: add LITKEY payment section

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,6 +22,7 @@
               "management/account_modes",
               "management/pricing",
               "management/crypto",
+              "management/litkey",
               "management/api_keys"
             ]
           },

--- a/docs/management/litkey.mdx
+++ b/docs/management/litkey.mdx
@@ -1,0 +1,59 @@
+---
+title: "LITKEY"
+description: "The LITKEY token — pay for Lit Protocol services on-chain and get a 25% discount over credit card."
+---
+
+## Overview
+
+**LITKEY** is the native payment token for Lit Protocol services. You can use it to buy API credits directly from your wallet — no Stripe, no card, no fiat conversion.
+
+Paying with LITKEY gets you a **25% discount** on API credits compared to paying with a credit card.
+
+<Card
+  title="Get LITKEY"
+  icon="arrow-up-right-from-square"
+  href="https://www.aerodrome.finance/swap?from=0x4200000000000000000000000000000000000006&to=0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49&chain0=8453&chain1=8453"
+  horizontal
+>
+  Swap ETH for LITKEY on Aerodrome (Base mainnet).
+</Card>
+
+---
+
+## Why pay with LITKEY?
+
+- **25% discount** vs. credit card pricing. Every dollar of LITKEY credits 1.33× the dashboard rate.
+- **No card required.** Pay from any wallet that holds LITKEY.
+- **On-chain settlement.** Payments are verifiable on Base.
+
+---
+
+## Where LITKEY lives
+
+LITKEY is live on a number of chains, but **Base** is the primary payment chain and where most liquidity sits. The canonical token on Base is:
+
+```
+0xf732a566121fa6362e9e0fbdd6d66e5c8c925e49
+```
+
+If you hold LITKEY on another chain, bridge it to Base before paying:
+
+<Card
+  title="Bridge LITKEY cross-chain"
+  icon="bridge"
+  href="https://nexus.hyperlane.xyz/"
+  horizontal
+>
+  Move LITKEY between supported chains via Hyperlane Nexus.
+</Card>
+
+---
+
+## How to pay with LITKEY
+
+1. Acquire LITKEY on Base (see **Get LITKEY** above), or bridge from another chain via Hyperlane Nexus.
+2. From the [Dashboard](https://dashboard.chipotle.litprotocol.com/dapps/dashboard/), choose **Pay with LITKEY** when adding funds.
+3. Confirm the account to credit, approve the exact LITKEY amount, and submit the payment transaction.
+4. Credits are applied to your account once the on-chain payment is confirmed.
+
+For credit-card and Stripe-crypto flows, see [Pricing](/management/pricing) and [Crypto Payments](/management/crypto).

--- a/docs/management/pricing.mdx
+++ b/docs/management/pricing.mdx
@@ -67,6 +67,10 @@ The minimum top-up is **$5.00**. All packages are one-time purchases with no exp
 
 You can pay with cryptocurrency (ETH, USDC, SOL, and other tokens) via Stripe's crypto payment integration. See the [Crypto Payments](/management/crypto) guide for full instructions on paying from the dashboard or via the API.
 
+### Paying with LITKEY (25% discount)
+
+Paying with the **LITKEY** token gets you a **25% discount** vs. credit card pricing. LITKEY is paid directly on-chain (Base mainnet) — no Stripe involved. See the [LITKEY](/management/litkey) guide for where to acquire it and how to pay.
+
 ---
 
 ## Credit Balance


### PR DESCRIPTION
## Summary
- New `docs/management/litkey.mdx` page covering LITKEY: a "Get LITKEY" link to Aerodrome on Base, the 25% discount vs. credit card, the Base token address, and a Hyperlane Nexus bridge link for cross-chain holders.
- Registered under Management in `docs/docs.json` and cross-linked from `docs/management/pricing.mdx`.

## Test plan
- [ ] Verify Mintailify renders the new page and nav entry locally
- [ ] Confirm both external links (Aerodrome swap, Hyperlane Nexus) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)