### PR TITLE
fix(ci): inject sandbox Stripe keys on every staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -297,8 +297,8 @@ jobs:
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
           PHALA_PRIVATE_KEY: ${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}
-          STRIPE_SECRET_KEY: ${{ github.ref != 'refs/heads/main' && secrets.STRIPE_SANDBOX_SECRET_KEY || '' }}
-          STRIPE_PUBLISHABLE_KEY: ${{ github.ref != 'refs/heads/main' && secrets.STRIPE_SANDBOX_PUBLISHABLE_KEY || '' }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SANDBOX_SECRET_KEY }}
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_SANDBOX_PUBLISHABLE_KEY }}
           GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
           BASE_CHAIN_RPC: ${{ secrets.BASE_CHAIN_RPC }}
           CERTBOT_AWS_ACCESS_KEY_ID: ${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- The `STRIPE_SECRET_KEY` / `STRIPE_PUBLISHABLE_KEY` env vars in `deploy-staging.yml` were gated on `github.ref != 'refs/heads/main'`, which evaluates to `false` on the main-branch staging deploy and resolves the expression to an empty string. The Phala CVM at `chipotle-dev` / `test.chipotle.litprotocol.com` has therefore been running with billing disabled.
- This caused the `k6-correctness` job ([run 26523171920](https://github.com/LIT-Protocol/chipotle/actions/runs/26523171920/job/78120797769)) to fail at `billing.spec.ts` because `GET /billing/stripe_config` returns HTTP 500 `"Billing not configured: Stripe billing is not configured on this node"`.
- Production deploys go through the separate `deploy-prod-*` workflows, so this workflow should unconditionally inject the sandbox keys (matching the `validate-secrets` step which already requires them).

## Test plan
- [ ] Merge to `main`, watch `Deploy Staging` redeploy `chipotle-dev`.
- [ ] After deploy, `curl https://test.chipotle.litprotocol.com/core/v1/billing/stripe_config` returns 200 with `{"publishable_key":"pk_test_…"}`.
- [ ] The next scheduled/triggered `k6-correctness` run passes `billing.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)