### PR TITLE
fix(lit-triggers): call /core/v1/lit_action and document main() entrypoint

### DIFF
--- a/lit-triggers/SKILL.md
+++ b/lit-triggers/SKILL.md
@@ -152,9 +152,11 @@ AUTH = 'authorization: ' + 'Bearer ' + TOKEN
 BASE = 'https://triggers.litprotocol.com'
 USAGE_KEY = input('Paste scoped Chipotle usage key: ').strip()
 ACTION = r'''
-(async () => {
+const main = async () => {
   Lit.Actions.setResponse({ response: JSON.stringify({ ok: true, params }) });
-})();
+};
+
+main();
 '''.strip()
 body = {
     'name': 'Agent-created webhook',

--- a/lit-triggers/src/chipotle.rs
+++ b/lit-triggers/src/chipotle.rs
@@ -45,7 +45,7 @@ impl ChipotleClient {
     }
 
     pub fn lit_action_url(&self) -> String {
-        format!("{}/lit_action", self.base_url)
+        format!("{}/core/v1/lit_action", self.base_url)
     }
 
     pub fn build_lit_action_request(action_code: String, params: Value) -> LitActionRequest {
@@ -62,9 +62,11 @@ impl ChipotleClient {
         params: Value,
     ) -> Result<Value, ChipotleError> {
         let body = Self::build_lit_action_request(action_code, params);
+        let url = self.lit_action_url();
+        tracing::debug!(target: "chipotle", url = %url, "dispatching lit action");
         let response = self
             .http
-            .post(self.lit_action_url())
+            .post(&url)
             .bearer_auth(usage_api_key)
             .header("X-Api-Key", usage_api_key)
             .json(&body)
@@ -85,9 +87,17 @@ impl ChipotleClient {
         let parsed = parse_response_body(&text);
 
         if status.is_success() {
+            tracing::debug!(target: "chipotle", url = %url, status = %status, "lit action succeeded");
             return Ok(parsed.unwrap_or_else(|| json!({ "raw": text })));
         }
 
+        tracing::warn!(
+            target: "chipotle",
+            url = %url,
+            status = %status,
+            body_preview = %text.chars().take(256).collect::<String>(),
+            "lit action failed"
+        );
         Err(ChipotleError {
             message: format!("chipotle returned HTTP {status}"),
             transient: is_transient_status(status),
@@ -116,7 +126,7 @@ mod tests {
         let client = ChipotleClient::new("https://api.example.test/".to_string());
         assert_eq!(
             client.lit_action_url(),
-            "https://api.example.test/lit_action"
+            "https://api.example.test/core/v1/lit_action"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix Chipotle URL: client was POSTing to `/lit_action`, but `lit-api-server` mounts that route at `/core/v1/lit_action` — every dispatched run was failing with a Rocket 404.
- Add tracing for outbound Chipotle URL/status/body preview so the next failure leaves breadcrumbs in the logs (the existing logs only showed the webhook ingress).
- Fix the SKILL.md webhook example: the Lit Action runtime calls `main()` at the end of user code, so the prior IIFE example crashed with `ReferenceError: main is not defined` before any `setResponse`.

## Test plan
- [x] `cargo build` passes locally
- [x] Verified the fix path manually: `curl -X POST https://api.chipotle.litprotocol.com/core/v1/lit_action ...` returns 200 with a proper `{response, logs, has_error}` body
- [ ] After deploy, re-fire a webhook trigger and confirm `/api/triggers/<id>/runs` shows `status: completed` with the action response

🤖 Generated with [Claude Code](https://claude.com/claude-code)