### PR TITLE
feat(lit-triggers): expose raw webhook body and verification headers

### DIFF
--- a/lit-triggers/SKILL.md
+++ b/lit-triggers/SKILL.md
@@ -187,10 +187,30 @@ print('Webhook URL:', BASE + '/webhook/' + trigger['id'])
 PY
 ```
 
-The webhook receives JSON bodies as `params.event`, and selected safe headers as `params.headers`. Fire it with:
+The webhook receives JSON bodies as `params.event`, the exact raw request body
+as `params.event_raw` (a string), and selected safe headers as `params.headers`.
+Fire it with:
 
 ```bash
 curl -fsS -X POST 'https://triggers.litprotocol.com/webhook/<trigger-id>'   -H 'content-type: application/json'   -d '{"hello":"world"}'
+```
+
+To authenticate the sender, verify a signature over `params.event_raw`. Most
+verification headers are passed through (e.g. `x-hub-signature-256`,
+`x-github-event`, `stripe-signature`, `x-slack-signature`); secret-bearing
+headers like `authorization`, `cookie`, and `x-api-key` are stripped. Example
+GitHub HMAC check inside an action:
+
+```js
+const sigHeader = (params.headers["x-hub-signature-256"] || [])[0] || "";
+const expected =
+  "sha256=" +
+  ethers.utils.computeHmac(
+    ethers.utils.SupportedAlgorithm.sha256,
+    ethers.utils.toUtf8Bytes(SECRET),
+    ethers.utils.toUtf8Bytes(params.event_raw)
+  ).slice(2);
+// constant-time compare expected vs sigHeader before trusting params.event
 ```
 
 ## 5. Create a Schedule Trigger

--- a/lit-triggers/src/webhook.rs
+++ b/lit-triggers/src/webhook.rs
@@ -26,6 +26,23 @@ const SENSITIVE_HEADERS: &[&str] = &[
     "proxy-authorization",
 ];
 
+/// Non-secret verification headers that webhook senders attach so the receiver
+/// can authenticate the request (HMAC signatures, event type/delivery ids).
+/// These are safe to expose to the action — they are the receiver's to verify,
+/// and require a shared secret (not present in the header) to forge.
+const VERIFICATION_HEADERS: &[&str] = &[
+    "x-hub-signature-256",
+    "x-hub-signature",
+    "x-github-event",
+    "x-github-delivery",
+    "x-github-hook-id",
+    "stripe-signature",
+    "x-slack-signature",
+    "x-slack-request-timestamp",
+    "x-webhook-signature",
+    "x-signature",
+];
+
 #[derive(Debug, Serialize)]
 pub struct WebhookAcceptedResponse {
     pub run_id: Uuid,
@@ -250,10 +267,16 @@ async fn build_run_input(
         return Err(err(Status::PayloadTooLarge, "body_too_large"));
     }
 
+    // Preserve the exact raw body so actions can verify signatures (GitHub
+    // X-Hub-Signature-256, Stripe Stripe-Signature, etc.) that are computed as
+    // an HMAC over the original bytes. parse_event borrows the bytes, so this
+    // lossy copy is independent of the parsed `event`.
+    let event_raw = String::from_utf8_lossy(bytes.value.as_ref()).into_owned();
     let event = parse_event(bytes.value.as_ref(), content_type)?;
     Ok(json!({
         "source": "webhook",
         "event": event,
+        "event_raw": event_raw,
         "headers": safe_headers(headers),
     }))
 }
@@ -287,6 +310,7 @@ fn safe_headers(headers: &[(String, String)]) -> Value {
             || name == "content-type"
             || name == "user-agent"
             || name == "x-request-id"
+            || VERIFICATION_HEADERS.contains(&name.as_str())
         {
             grouped
                 .entry(name.to_string())
@@ -338,6 +362,27 @@ mod tests {
             json!({
                 "content-type": ["application/json"],
                 "user-agent": ["test"]
+            })
+        );
+    }
+
+    #[test]
+    fn safe_headers_passes_verification_headers() {
+        let headers = vec![
+            (
+                "x-hub-signature-256".to_string(),
+                "sha256=abc123".to_string(),
+            ),
+            ("x-github-event".to_string(), "release".to_string()),
+            ("authorization".to_string(), "Bearer secret".to_string()),
+        ];
+
+        let safe = safe_headers(&headers);
+        assert_eq!(
+            safe,
+            json!({
+                "x-hub-signature-256": ["sha256=abc123"],
+                "x-github-event": ["release"]
             })
         );
     }


### PR DESCRIPTION
## Summary
Webhook actions currently can't authenticate the sender — the raw request body is discarded after JSON parsing, and `safe_headers` strips every header except a tiny allowlist. So HMAC signatures (GitHub `X-Hub-Signature-256`, Stripe `Stripe-Signature`) and the raw bytes they're computed over never reach the action.

This adds:
- **`params.event_raw`** — the exact raw request body (capped by the existing `WEBHOOK_MAX_BODY_BYTES` limit), so actions can recompute an HMAC over the signed bytes.
- **Curated verification-header passthrough** — `x-hub-signature-256`, `x-hub-signature`, `x-github-event`, `x-github-delivery`, `x-github-hook-id`, `stripe-signature`, `x-slack-signature`, `x-slack-request-timestamp`, `x-webhook-signature`, `x-signature`. Secret-bearing headers (`authorization`, `cookie`, `x-api-key`) remain stripped.

Unblocks the `webhook → on-chain` examples (GitHub release attestation, Stripe → subscriber), where a *verified* off-chain event must drive the keyless signer.

## Test plan
- [x] `cargo test webhook` — 9 pass, incl. new `safe_headers_passes_verification_headers`
- [ ] After deploy: fire a webhook with `X-Hub-Signature-256` and confirm the action sees `params.event_raw` + the header, and HMAC verification matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)