### PR TITLE
fix(ci): avoid Foundry install flakes

### DIFF
--- a/.github/workflows/contract-bindings-check.yml
+++ b/.github/workflows/contract-bindings-check.yml
@@ -19,6 +19,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: contract-bindings
     runs-on: self-hosted
+    concurrency:
+      group: foundry-toolchain
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 
@@ -31,9 +34,22 @@ jobs:
         with:
           node-version: 22
 
-      - uses: foundry-rs/foundry-toolchain@v1
+      - name: Check Foundry toolchain
+        id: foundry-toolchain
+        run: |
+          if command -v forge >/dev/null 2>&1 && forge --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
+            forge --version
+            echo "installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "installed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Foundry
+        if: steps.foundry-toolchain.outputs.installed != 'true'
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          # Pinned for reproducibility. Bump intentionally when upgrading.
+          version: v1.5.1
 
       - name: Install contract dependencies
         working-directory: lit-api-server/blockchain/lit_node_express

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -19,6 +19,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: forge-test
     runs-on: self-hosted
+    concurrency:
+      group: foundry-toolchain
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +38,18 @@ jobs:
         working-directory: lit-api-server/blockchain/lit_node_express
         run: npm ci
 
+      - name: Check Foundry toolchain
+        id: foundry-toolchain
+        run: |
+          if command -v forge >/dev/null 2>&1 && forge --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
+            forge --version
+            echo "installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "installed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Foundry
+        if: steps.foundry-toolchain.outputs.installed != 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           # Pinned for reproducibility. Bump intentionally when upgrading.


### PR DESCRIPTION
## Summary
- serialize Foundry-using CI jobs through a shared `foundry-toolchain` concurrency group on self-hosted runners
- skip `foundry-rs/foundry-toolchain` when the pinned `forge` version is already present
- pin the contract bindings workflow to Foundry `v1.5.1` for reproducibility

## Why
`foundryup` fails on persistent self-hosted runners if a managed `forge` binary is running. Avoiding unnecessary installs and serializing Foundry CI prevents install-vs-test races across the affected workflows.

## Validation
- `python3` YAML parse for both changed workflow files
- `git diff --check`
- downloaded and ran `actionlint v1.7.7` against both changed workflow files
- shell regex sanity check for `1.5.1` vs `1.5.10`/`1.15.1`

Closes #409
