### PR TITLE
ci(deploy-static): add workflow_dispatch picker, drop deploy-preview

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -5,6 +5,16 @@ on:
     paths:
       - 'lit-static/**'
       - '.github/workflows/deploy-static.yml'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which deploy job to run'
+        required: true
+        default: 'deploy-next'
+        type: choice
+        options:
+          - deploy-next
+          - deploy-main
 
 permissions:
   contents: read
@@ -12,7 +22,9 @@ permissions:
 
 jobs:
   deploy-main:
-    if: github.ref == 'refs/heads/main'
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'deploy-main')
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +44,9 @@ jobs:
           command: pages deploy lit-static --project-name=lit-static-dev --branch=main
 
   deploy-next:
-    if: github.ref == 'refs/heads/next'
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/next') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'deploy-next')
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
@@ -50,25 +64,3 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy lit-static --project-name=lit-static-next --branch=main
-
-  deploy-preview:
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Inject API URL
-        run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
-
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy lit-static --project-name=lit-static-dev --branch=${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/deploy-static.yml` with a `target` choice input (`deploy-next` default, or `deploy-main`) so the workflow can be triggered manually against either job.
- Updates the `deploy-main` and `deploy-next` `if:` guards to fire on the matching branch push OR the matching manual selection.
- Removes the `deploy-preview` job — the workflow only triggers on `push`, so its `pull_request` condition was never reachable.

Closes NODE-4969.

## Test plan
- [ ] Verify the workflow appears under Actions with a "Run workflow" picker showing `deploy-next` (default) and `deploy-main`.
- [ ] Confirm pushes to `main` and `next` still trigger their respective jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)