### PR TITLE
feat(dashboard): refresh Stripe credit balance after every API call

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -267,6 +267,15 @@ let _clientInstance = null;
 let _clientBaseUrl = null;
 let _clientMode = null;
 
+// Fires after every successful client method call (Proxy below). Used by
+// billing.js to refresh the credit balance display after any API activity
+// (NODE-4971). Registered via setOnApiCallSuccess() from initBilling().
+let _onApiCallSuccess = null;
+
+export function setOnApiCallSuccess(cb) {
+  _onApiCallSuccess = cb;
+}
+
 export async function getClient() {
   const baseUrl = getBaseUrl();
   const mode = getMode();
@@ -323,7 +332,11 @@ export async function getClient() {
             const sovereignLifecycle = await buildSovereignLifecycle(target, prop);
             args = [{ ...args[0], sovereignLifecycle }];
           }
-          return val.apply(target, args);
+          const result = await val.apply(target, args);
+          if (_onApiCallSuccess) {
+            try { _onApiCallSuccess(prop); } catch (cbErr) { console.error('onApiCallSuccess', cbErr); }
+          }
+          return result;
         };
       },
     });

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -33,6 +33,7 @@ import {
   getClient,
   getMode,
   hasUsageKeyOverride,
+  setOnApiCallSuccess,
 } from './auth.js';
 import { formatError, logError } from './ui-utils.js';
 
@@ -99,6 +100,10 @@ export function clearBillingSession() {
     _abortController = null;
   }
   _walletAuthCache = null;
+  if (_balanceRefreshDebounceTimer) {
+    clearTimeout(_balanceRefreshDebounceTimer);
+    _balanceRefreshDebounceTimer = null;
+  }
 }
 
 /**
@@ -249,6 +254,48 @@ export function refreshBillingUI() {
       }, BILLING_RETRY_MS);
     }
   }).catch((e) => console.error('billing check failed', e));
+}
+
+// Billing endpoints we must NOT re-trigger from the post-call hook below —
+// refreshing the balance after `getBillingBalance` would recurse forever, and
+// firing during the Stripe payment dance (`createPaymentIntent` /
+// `confirmPayment`) would race the modal's own balance refresh on completion.
+const BILLING_METHODS = new Set([
+  'getBillingBalance',
+  'getStripeConfig',
+  'createPaymentIntent',
+  'confirmPayment',
+]);
+
+// Debounce timer so a burst of API calls (e.g. preloadAllTables fires 4 in
+// parallel on sign-in) coalesces into a single balance refresh.
+let _balanceRefreshDebounceTimer = null;
+const BALANCE_REFRESH_DEBOUNCE_MS = 200;
+
+/**
+ * Called after every successful client API call (NODE-4971). Refreshes the
+ * Stripe credit balance display so the topbar reflects the latest balance
+ * after any dashboard activity. No-op when:
+ *   - the method itself is a billing endpoint (would recurse),
+ *   - no auth key / billing not yet known to be available,
+ *   - a usage-key override is active (the topbar balance belongs to the
+ *     account key, not the override, and is hidden in this mode anyway),
+ *   - we're in sovereign mode without a cached wallet-auth header (we won't
+ *     trigger a wallet popup just to refresh the topbar — same rule as
+ *     refreshBillingUI()).
+ */
+function refreshBalanceFromApiCall(methodName) {
+  if (BILLING_METHODS.has(methodName)) return;
+  if (!billingAuthKey()) return;
+  if (hasUsageKeyOverride()) return;
+  if (_billingAvailable !== true) return;
+  if (getMode() === 'sovereign' && !hasValidWalletAuthCache()) return;
+
+  if (_balanceRefreshDebounceTimer) return;
+  _balanceRefreshDebounceTimer = setTimeout(() => {
+    _balanceRefreshDebounceTimer = null;
+    loadBillingBalance();
+  }, BALANCE_REFRESH_DEBOUNCE_MS);
 }
 
 async function loadBillingBalance() {
@@ -586,4 +633,6 @@ export function initBilling() {
   if (continueBtn) continueBtn.addEventListener('click', handleContinue);
   if (backBtn) backBtn.addEventListener('click', handleBack);
   if (payBtn) payBtn.addEventListener('click', handlePay);
+
+  setOnApiCallSuccess(refreshBalanceFromApiCall);
 }


### PR DESCRIPTION
## Summary
NODE-4971. The topbar credit balance now refreshes after any dashboard API activity, so it always reflects the latest Stripe balance.

- `auth.js`: the cached-client Proxy now invokes a registered `_onApiCallSuccess(prop)` callback after each successful method call.
- `billing.js`: `initBilling()` registers a debounced refresher that re-fetches `/billing/balance`. Skips billing endpoints (no recursion), usage-key overrides, and sovereign mode without a cached wallet-auth header (no surprise wallet popups). Bursts (e.g. the 4-call `preloadAllTables` on sign-in) coalesce via a 200ms debounce.

## Test plan
- [ ] Sign in (API mode); after sign-in, topbar balance shows once (debounced from preload).
- [ ] Trigger any dashboard action (create key, run action, etc.); balance refreshes once shortly after.
- [ ] Add funds; modal close shows updated balance, no duplicate refresh from the post-call hook.
- [ ] Sovereign mode without prior wallet-auth: navigating the dashboard does NOT trigger a wallet popup.
- [ ] Sovereign mode after Add Funds (cached auth): subsequent API calls refresh the balance silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)