### PR TITLE
fix(dashboard): let Stripe collect postal_code so card AVS works (NODE-4974)

### DIFF
--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -460,13 +460,11 @@ async function handleContinue() {
     _paymentIntentId = intent.payment_intent_id;
 
     _elements = _stripe.elements({ clientSecret: intent.client_secret });
-    // Suppress billing-address collection — credits are scoped to the
-    // account/wallet, not to a postal address. `address: 'never'` hides the
-    // address fields entirely; Stripe still gathers any name/email that a
-    // specific payment method strictly needs.
-    _paymentElement = _elements.create('payment', {
-      fields: { billingDetails: { address: 'never' } },
-    });
+    // Let Stripe render the minimal address fields each payment method needs
+    // (country + postal for cards, nothing for most crypto). Card networks
+    // require postal_code for AVS, so we can't suppress it without breaking
+    // real charges.
+    _paymentElement = _elements.create('payment');
     _paymentElement.mount('#stripe-payment-element');
     setModalStep('payment');
   } catch (e) {
@@ -506,16 +504,7 @@ async function handlePay() {
   try {
     const result = await _stripe.confirmPayment({
       elements: _elements,
-      confirmParams: {
-        return_url: returnUrl,
-        // We tell the Payment Element not to render address fields
-        // (`fields.billingDetails.address: 'never'`), so Stripe requires us
-        // to pass a billing-address country here for methods that need one
-        // (e.g. card AVS). Default to 'US'; crypto methods ignore this.
-        payment_method_data: {
-          billing_details: { address: { country: 'US' } },
-        },
-      },
+      confirmParams: { return_url: returnUrl },
       redirect: 'if_required',
     });
 


### PR DESCRIPTION
## Summary
- The dashboard's Stripe Payment Element was configured with `fields.billingDetails.address: 'never'` while `confirmPayment` only supplied `country: 'US'`, so Stripe rejected every card charge: "did not pass confirmParams.payment_method_data.billing_details.address.postal_code".
- Drop the address suppression and the hardcoded country so Stripe renders the minimal address fields each payment method actually needs (country + postal for cards, nothing extra for most crypto), which also fixes card AVS.

## Test plan
- [ ] Open the dashboard billing modal, add credits with a real card, verify the postal-code field renders and the charge succeeds.
- [ ] Try a crypto payment method to confirm no extra fields are forced on flows that don't need them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)