### PR TITLE
feat(dashboard): add About modal with dashboard + API versions (NODE-4975)

### DIFF
--- a/.github/workflows/deploy-prod-3-static.yml
+++ b/.github/workflows/deploy-prod-3-static.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://api.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
 
+      - name: Resolve dashboard git commit
+        id: resolve_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Inject dashboard git commit
+        run: sed -i "s|__LIT_DASHBOARD_GIT_COMMIT__|${{ steps.resolve_sha.outputs.sha }}|g" lit-static/dapps/dashboard/about.js
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
 
+      - name: Inject dashboard git commit
+        run: sed -i "s|__LIT_DASHBOARD_GIT_COMMIT__|${GITHUB_SHA}|g" lit-static/dapps/dashboard/about.js
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
@@ -57,6 +60,9 @@ jobs:
 
       - name: Inject API URL
         run: sed -i "s|__LIT_API_BASE_URL__|https://test.chipotle.litprotocol.com|g" lit-static/dapps/dashboard/auth.js
+
+      - name: Inject dashboard git commit
+        run: sed -i "s|__LIT_DASHBOARD_GIT_COMMIT__|${GITHUB_SHA}|g" lit-static/dapps/dashboard/about.js
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/lit-static/dapps/dashboard/about.js
+++ b/lit-static/dapps/dashboard/about.js
@@ -10,7 +10,7 @@
  */
 
 import { getBaseUrl } from './auth.js';
-import { openModal, escapeHtml, logError } from './ui-utils.js';
+import { openModal, closeModal, escapeHtml, logError } from './ui-utils.js';
 
 const GITHUB_REPO_URL = 'https://github.com/LIT-Protocol/chipotle';
 const DASHBOARD_COMMIT_RAW = '__LIT_DASHBOARD_GIT_COMMIT__';
@@ -34,10 +34,17 @@ function extractSha(s) {
   return '';
 }
 
-function commitLinkHtml(commit) {
-  if (!commit) return '<span class="mono">local</span>';
+// Render a commit value as a (possibly-linked) short label.
+// `emptyLabel` controls the fallback when `commit` is empty — "local" for the
+// dashboard build placeholder, "unknown" for an API response missing the field.
+function commitLinkHtml(commit, emptyLabel) {
+  if (!commit) return `<span class="mono">${escapeHtml(emptyLabel)}</span>`;
   const sha = extractSha(commit);
-  const label = commit.length > 16 ? commit.slice(0, 12) : commit;
+  // When a SHA is present, the label is the short SHA so it matches the link
+  // target. Otherwise fall back to truncating the raw string.
+  const label = sha
+    ? sha.slice(0, 12)
+    : (commit.length > 16 ? commit.slice(0, 12) : commit);
   if (!sha) return `<span class="mono">${escapeHtml(label)}</span>`;
   const href = `${GITHUB_REPO_URL}/commit/${encodeURIComponent(sha)}`;
   return `<a class="mono" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
@@ -51,7 +58,7 @@ async function fetchApiVersion() {
 }
 
 function bodyHtml(apiVersionHtml) {
-  const dashHtml = commitLinkHtml(dashboardCommit());
+  const dashHtml = commitLinkHtml(dashboardCommit(), 'local');
   return `
     <p style="margin:0 0 0.75rem;">
       The Chipotle Dashboard is a web interface for managing your Lit accounts, wallets, groups, IPFS actions, and usage API keys.
@@ -73,20 +80,16 @@ const FOOTER_HTML = `<button type="button" class="btn btn-primary" id="about-clo
 
 function openAboutModal() {
   openModal('About Dashboard', bodyHtml('<span class="mono">Loading…</span>'), FOOTER_HTML);
-  document.getElementById('about-close-btn')?.addEventListener('click', () => {
-    const overlay = document.getElementById('modal-overlay');
-    if (overlay) {
-      overlay.classList.remove('is-open');
-      overlay.setAttribute('aria-hidden', 'true');
-    }
-  });
+  // The shared modal X and overlay-click are wired by initModalClose();
+  // we only need to wire our explicit footer Close button.
+  document.getElementById('about-close-btn')?.addEventListener('click', closeModal);
 
   fetchApiVersion().then((v) => {
     const el = document.getElementById('about-api-version');
     if (!el) return;
     const commit = (v && v.commit_version) ? String(v.commit_version) : '';
     const pkgVersion = (v && v.version) ? String(v.version) : '';
-    const link = commitLinkHtml(commit);
+    const link = commitLinkHtml(commit, 'unknown');
     el.innerHTML = pkgVersion
       ? `${link} <span class="muted">(v${escapeHtml(pkgVersion)})</span>`
       : link;

--- a/lit-static/dapps/dashboard/about.js
+++ b/lit-static/dapps/dashboard/about.js
@@ -1,0 +1,113 @@
+/**
+ * About Dashboard modal — shows dashboard + API versions and a GitHub link.
+ *
+ * The dashboard commit is baked in at deploy time by replacing the
+ * `__LIT_DASHBOARD_GIT_COMMIT__` placeholder below (see
+ * .github/workflows/deploy-static.yml and deploy-prod-3-static.yml). When
+ * the placeholder is left unreplaced (local dev), we display "local".
+ *
+ * The API version is fetched from `GET /core/v1/version`.
+ */
+
+import { getBaseUrl } from './auth.js';
+import { openModal, escapeHtml, logError } from './ui-utils.js';
+
+const GITHUB_REPO_URL = 'https://github.com/LIT-Protocol/chipotle';
+const DASHBOARD_COMMIT_RAW = '__LIT_DASHBOARD_GIT_COMMIT__';
+// Reassembled at runtime so the deploy-time `sed` replacement does not also
+// rewrite this sentinel (it only matches the exact contiguous placeholder).
+const PLACEHOLDER = '__LIT_' + 'DASHBOARD_GIT_COMMIT__';
+
+function dashboardCommit() {
+  return DASHBOARD_COMMIT_RAW === PLACEHOLDER ? '' : DASHBOARD_COMMIT_RAW;
+}
+
+// Extract a hex SHA from a `git describe` style string. Returns '' if none.
+// Accepts a full 40-char hash, a 7-12 char short hash, or the `g<sha>` suffix
+// produced by `git describe` after a tag (e.g. "v1.2.3-4-gabcdef0").
+function extractSha(s) {
+  if (!s) return '';
+  const describeMatch = s.match(/-g([0-9a-f]{7,40})(?:-[^ ]*)?$/i);
+  if (describeMatch) return describeMatch[1];
+  const bareMatch = s.match(/^[0-9a-f]{7,40}$/i);
+  if (bareMatch) return bareMatch[0];
+  return '';
+}
+
+function commitLinkHtml(commit) {
+  if (!commit) return '<span class="mono">local</span>';
+  const sha = extractSha(commit);
+  const label = commit.length > 16 ? commit.slice(0, 12) : commit;
+  if (!sha) return `<span class="mono">${escapeHtml(label)}</span>`;
+  const href = `${GITHUB_REPO_URL}/commit/${encodeURIComponent(sha)}`;
+  return `<a class="mono" href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a>`;
+}
+
+async function fetchApiVersion() {
+  const baseUrl = getBaseUrl().replace(/\/$/, '');
+  const res = await fetch(`${baseUrl}/core/v1/version`, { method: 'GET' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return await res.json();
+}
+
+function bodyHtml(apiVersionHtml) {
+  const dashHtml = commitLinkHtml(dashboardCommit());
+  return `
+    <p style="margin:0 0 0.75rem;">
+      The Chipotle Dashboard is a web interface for managing your Lit accounts, wallets, groups, IPFS actions, and usage API keys.
+    </p>
+    <p style="margin:0 0 1rem;">
+      Built by <a href="https://litprotocol.com" target="_blank" rel="noopener">Lit Protocol</a>. Source available on
+      <a href="${escapeHtml(GITHUB_REPO_URL)}" target="_blank" rel="noopener">GitHub</a>.
+    </p>
+    <dl class="about-versions">
+      <dt>Dashboard version</dt>
+      <dd>${dashHtml}</dd>
+      <dt>API version</dt>
+      <dd id="about-api-version">${apiVersionHtml}</dd>
+    </dl>
+  `;
+}
+
+const FOOTER_HTML = `<button type="button" class="btn btn-primary" id="about-close-btn">Close</button>`;
+
+function openAboutModal() {
+  openModal('About Dashboard', bodyHtml('<span class="mono">Loading…</span>'), FOOTER_HTML);
+  document.getElementById('about-close-btn')?.addEventListener('click', () => {
+    const overlay = document.getElementById('modal-overlay');
+    if (overlay) {
+      overlay.classList.remove('is-open');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+  });
+
+  fetchApiVersion().then((v) => {
+    const el = document.getElementById('about-api-version');
+    if (!el) return;
+    const commit = (v && v.commit_version) ? String(v.commit_version) : '';
+    const pkgVersion = (v && v.version) ? String(v.version) : '';
+    const link = commitLinkHtml(commit);
+    el.innerHTML = pkgVersion
+      ? `${link} <span class="muted">(v${escapeHtml(pkgVersion)})</span>`
+      : link;
+  }).catch((e) => {
+    logError('about:fetchApiVersion', e);
+    const el = document.getElementById('about-api-version');
+    if (el) el.innerHTML = '<span class="mono">unavailable</span>';
+  });
+}
+
+export function initAbout() {
+  const btn = document.getElementById('about-dashboard-btn');
+  if (!btn) return;
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const wrap = document.getElementById('account-dropdown');
+    const trigger = document.getElementById('account-dropdown-trigger');
+    const panel = document.getElementById('account-dropdown-panel');
+    if (wrap) wrap.classList.remove('is-open');
+    if (trigger) trigger.setAttribute('aria-expanded', 'false');
+    if (panel) panel.setAttribute('aria-hidden', 'true');
+    openAboutModal();
+  });
+}

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -11,6 +11,7 @@ import { initKeys, loadUsageKeys } from './keys.js';
 import { initActions, loadActions } from './actions.js';
 import { initWallets, loadWallets } from './wallets.js';
 import { initActionRunner } from './runner.js';
+import { initAbout } from './about.js';
 
 // ----- Preload all tables (with error visibility) -----
 
@@ -314,6 +315,7 @@ function init() {
   initBilling();
   initUsageKeyOverride();
   initChainSecuredRpc();
+  initAbout();
 }
 
 init();

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -168,6 +168,8 @@
                 <button type="button" class="account-dropdown-item is-chainsecured-only" id="toggle-chainsecured-rpc-btn" role="menuitem">RPC URL</button>
                 <button type="button" class="account-dropdown-item account-dropdown-convert" id="convert-to-chainsecured-btn" role="menuitem" hidden>Convert to ChainSecured</button>
                 <button type="button" class="account-dropdown-item" id="change-ownership-btn" role="menuitem" hidden>Change Ownership</button>
+                <div class="account-dropdown-divider" role="separator"></div>
+                <button type="button" class="account-dropdown-item" id="about-dashboard-btn" role="menuitem">About Dashboard</button>
                 <button type="button" class="account-dropdown-item account-dropdown-signout" id="account-signout-btn" role="menuitem">Sign out</button>
               </div>
             </div>

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -1805,6 +1805,30 @@ textarea.input.textarea-sm {
   line-height: 1.5;
 }
 
+.about-versions {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 1rem;
+  row-gap: 0.375rem;
+  margin: 0;
+  padding: 0.75rem 0 0;
+  border-top: 1px solid var(--border);
+}
+
+.about-versions dt {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.about-versions dd {
+  margin: 0;
+  color: var(--text);
+}
+
+.about-versions .muted {
+  color: var(--text-muted);
+}
+
 .modal-progress-text {
   color: var(--text);
   font-weight: 500;


### PR DESCRIPTION
## Summary
- Adds an **About Dashboard** item to the account menu dropdown that opens a modal with a one-sentence description, a GitHub link, and the build commits for both the dashboard and the API.
- Dashboard commit is baked in at deploy time via a sed-injected `__LIT_DASHBOARD_GIT_COMMIT__` placeholder (mirroring the existing `__LIT_API_BASE_URL__` pattern in `deploy-static.yml` and `deploy-prod-3-static.yml`); API commit is fetched live from `GET /core/v1/version`.
- Falls back to "local" when the placeholder is unreplaced (local dev) and gracefully handles both raw SHAs and `git describe` style versions (e.g. `v1.2.3-4-gabcdef`) when building the GitHub commit link.

## Test plan
- [ ] Local: open the dashboard, click Account → About Dashboard; modal shows description, GitHub link, "local" dashboard version, and the API commit fetched from `/core/v1/version`.
- [ ] After deploy: dashboard version shows a short SHA linking to the corresponding GitHub commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)