### PR TITLE
fix(dashboard): make change-ownership modal wallet input full-width (NODE-4976)

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -989,9 +989,11 @@ async function promptForNewAdminAddress() {
     };
     openModal(
       'Change account ownership',
-      `<p>Enter the Ethereum address of the wallet that should become the new admin for this ChainSecured account.</p>
-       <label class="form-label" for="change-ownership-address-input">New admin wallet address</label>
-       <input type="text" id="change-ownership-address-input" class="form-input" placeholder="0x…" autocomplete="off" spellcheck="false" />
+      `<p class="modal-action-desc" style="margin-bottom:1rem;">Enter the Ethereum address of the wallet that should become the new admin for this ChainSecured account.</p>
+       <div class="form-group">
+         <label for="change-ownership-address-input">New admin wallet address</label>
+         <input type="text" id="change-ownership-address-input" class="input" placeholder="0x…" autocomplete="off" spellcheck="false" autocapitalize="off" style="font-family:ui-monospace,'JetBrains Mono',monospace;" />
+       </div>
        <div id="change-ownership-error" class="status error" style="display:none; margin-top:0.5rem;"></div>`,
       `<button type="button" class="btn btn-secondary" id="change-ownership-cancel-btn">Cancel</button>
        <button type="button" class="btn btn-primary" id="change-ownership-accept-btn">Accept</button>`,


### PR DESCRIPTION
## Summary

The "Change account ownership" modal at `lit-static/dapps/dashboard/auth.js` used `.form-input` / `.form-label` class names that aren't defined anywhere in `styles.css`, so the wallet-address field fell back to default browser sizing — too narrow to show a full 42-char `0x…` address. Switched to the dashboard's standard `.form-group` + `.input` pattern (already used by every other modal) and added a monospace font for the address, matching the `usage-key-override-input` style.

No JS logic changed; the input id, error element, button ids, and Enter/Escape handlers are intact so `tryAccept()` and ethers validation still work.

## Test plan

- [ ] Sign in to the dashboard as a ChainSecured (sovereign) account
- [ ] Open the account dropdown → "Change Ownership"
- [ ] Confirm the address input fills the modal width and a full 42-char `0x…` address is fully visible in monospace
- [ ] Submit an invalid address — error message renders below the field
- [ ] Submit a valid address — proceeds to confirmation step

Linear: https://linear.app/litprotocol/issue/NODE-4976

🤖 Generated with [Claude Code](https://claude.com/claude-code)