### PR TITLE
fix(dashboard): use defined btn-outline for change-ownership Cancel button (NODE-4976)

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -995,7 +995,7 @@ async function promptForNewAdminAddress() {
          <input type="text" id="change-ownership-address-input" class="input" placeholder="0x…" autocomplete="off" spellcheck="false" autocapitalize="off" style="font-family:ui-monospace,'JetBrains Mono',monospace;" />
        </div>
        <div id="change-ownership-error" class="status error" style="display:none; margin-top:0.5rem;"></div>`,
-      `<button type="button" class="btn btn-secondary" id="change-ownership-cancel-btn">Cancel</button>
+      `<button type="button" class="btn btn-outline" id="change-ownership-cancel-btn">Cancel</button>
        <button type="button" class="btn btn-primary" id="change-ownership-accept-btn">Accept</button>`,
     );
     const input = document.getElementById('change-ownership-address-input');


### PR DESCRIPTION
## Summary

Follow-up to #417. The change-ownership modal's Cancel button used `class="btn btn-secondary"`, but `.btn-secondary` isn't defined in `styles.css` (only `.btn-primary`, `.btn-outline`, `.btn-danger` exist), so it rendered without secondary styling. Switched to `.btn-outline` to match every other dashboard modal's Cancel button. Caught by Copilot review on #417 after it merged.

## Test plan

- [ ] Open the change-ownership modal (account dropdown → Change Ownership, ChainSecured account)
- [ ] Confirm the Cancel button renders with the standard outline style, matching the Cancel buttons in other modals (add action, add key, billing, confirm-delete)

Linear: https://linear.app/litprotocol/issue/NODE-4976

🤖 Generated with [Claude Code](https://claude.com/claude-code)