### PR TITLE
fix(ci): whitelist provision_hash, not a client-side recompute (prod boot fix)

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -260,49 +260,28 @@ jobs:
           fi
           echo "app_auth_address=$APP_AUTH" >> "$GITHUB_OUTPUT"
 
-          # The provision API's compose_hash is a reference key for the
-          # PATCH/commit call — it does not match the hash the CVM computes
-          # at boot (SHA-256 of the full app-compose.json including server-
-          # managed fields like pre_launch_script, features, etc.).
-          # We fetch the full compose and compute the deploy hash client-side
-          # using the @phala/cloud SDK so the Safe proposal uses the correct
-          # value that the KMS will check via allowedComposeHashes.
-          echo "Fetching full app_compose from Phala API..."
-          FULL_COMPOSE=$(phala api /cvms/chipotle-prod-rep-r68r6/compose_file --json 2>&1) || {
-            echo "::error::Failed to fetch compose file: $FULL_COMPOSE"
-            exit 1
-          }
-
-          # Sanity check: the fetched compose's docker_compose_file should
-          # match what we just provisioned (if provision updated the server).
-          FETCHED_DC=$(echo "$FULL_COMPOSE" | jq -r '.docker_compose_file')
-          if [ "$FETCHED_DC" != "$COMPOSE_CONTENT" ]; then
-            echo "::warning::Fetched docker_compose_file does not match provisioned content. The provision may not have updated the compose file yet."
-            echo "Constructing full app_compose by merging server defaults with our compose..."
-            FULL_COMPOSE=$(echo "$FULL_COMPOSE" | jq --arg dc "$COMPOSE_CONTENT" '.docker_compose_file = $dc')
-          fi
-
-          # Compute the correct compose hash using the @phala/cloud SDK.
-          COMPOSE_HASH=$(echo "$FULL_COMPOSE" | node -e '
-            const path = require("path");
-            const prefix = require("child_process").execSync("npm prefix -g").toString().trim();
-            const { getComposeHash } = require(
-              require.resolve("@phala/cloud", { paths: [path.join(prefix, "lib/node_modules/phala")] })
-            );
-            let data = "";
-            process.stdin.on("data", chunk => data += chunk);
-            process.stdin.on("end", () => {
-              const appCompose = JSON.parse(data);
-              process.stdout.write(getComposeHash(appCompose));
-            });
-          ')
-          if [ -z "$COMPOSE_HASH" ]; then
-            echo "::error::Failed to compute compose hash client-side"
-            exit 1
-          fi
-          echo "Provision hash (API reference): $PROVISION_HASH"
-          echo "Compose hash (deploy/on-chain): $COMPOSE_HASH"
-          echo "compose_hash=$COMPOSE_HASH" >> "$GITHUB_OUTPUT"
+          # The on-chain whitelist hash MUST equal the hash the CVM commits
+          # and recomputes at boot — otherwise the KMS refuses to issue keys
+          # ("Compose hash not allowed") and the CVM cannot start.
+          #
+          # Phala's provision API already returns exactly that value: it is
+          # getComposeHash() over the full app_compose the server will store,
+          # and Phase 2 (commit-deploy) commits the deployment by referencing
+          # this same provision_hash. So the provision_hash IS the deploy and
+          # on-chain hash — we whitelist it directly.
+          #
+          # Do NOT recompute the hash client-side from a locally-assembled
+          # app_compose. The post-provision GET often hasn't caught up yet
+          # (the docker_compose_file won't byte-match what we sent), so any
+          # client-side reconstruction hashes a different object than the one
+          # that actually boots. That divergence is what whitelisted the wrong
+          # hash and broke the v1.1.4 prod boot: proposed
+          # c9b51bbf0a11bdff4f47aa2bbaf61b6bd5603d4775b1697d9b99afe1dd59427a
+          # but the CVM booted (and was committed with)
+          # c40639829920a7ab202492e182d6c5e9d439fd7fa742f50e9a2248226af5ee8b.
+          # See architectureDocs/deployment/vm-code-upgrade.md.
+          echo "Compose hash (provision = deploy = on-chain): $PROVISION_HASH"
+          echo "compose_hash=$PROVISION_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Fetch CVM encryption public key
         id: fetch-pubkey


### PR DESCRIPTION
## Problem

The `chipotle-prod-rep-r68r6` CVM failed to boot after the v1.1.4 upgrade with **"Compose hash not allowed."** The KMS only issues keys to a compose hash that's whitelisted on the AppAuth (DstackApp) contract on Base — and the hash we whitelisted was not the hash the CVM actually boots.

Confirmed across all three sources:

| Hash | Value | Role |
|---|---|---|
| `provision_hash` | `c40639…f5ee8b` | Phase 2 **committed** this → CVM **boots & checks** it |
| `compose_hash` (proposed) | `c9b51bbf…59427a` | Phase 1 **proposed & whitelisted** this |

On-chain at AppAuth `0x3F91Deaf…05FfC`:
- `allowedComposeHashes(c9b51bbf…)` → **true** (wrong hash whitelisted)
- `allowedComposeHashes(c40639…)` → **false** (the hash the CVM needs)

Fetching the CVM's currently-committed `app_compose` and running `getComposeHash` returns `c40639…` — identical to `provision_hash`. So the provision hash *is* the deploy/boot hash.

## Root cause

PR #229 ("compute compose hash client-side") split the deploy into two hashes: it kept `provision_hash` for the Phase 2 commit but introduced a **separate client-side `getComposeHash`** for the on-chain whitelist, plus a fallback that overwrites `docker_compose_file` with the local content when the post-provision GET hasn't caught up:

```bash
if [ "$FETCHED_DC" != "$COMPOSE_CONTENT" ]; then
  FULL_COMPOSE=$(... | jq '.docker_compose_file = $dc')   # ← reconstructs a different object
fi
COMPOSE_HASH=$(getComposeHash over FULL_COMPOSE)           # ← diverges from what boots
```

When that fallback fires (a ~3–5s race that fired in v1.1.4), the proposed hash is computed over a synthetic object that matches neither the committed compose nor the boot hash. Before #229 there was a single hash (the provision value) used for both propose and commit, so they could never disagree — which is why every earlier deploy worked.

## Fix

Whitelist the `provision_hash` directly and remove the client-side recompute + stale-fetch substitution fallback. `compose_hash` now always equals `provision_hash`, so **propose / verify-on-chain / commit are consistent by construction** — the value we whitelist is exactly the value Phase 2 commits and the CVM recomputes at boot.

Scope: Phase 1 (`deploy-prod-1-propose.yml`) only. `deploy-context.json` schema is unchanged; Phase 2 `verify-compose-hash-onchain` and `commit-deploy` now operate on the same value.

## Immediate prod unblock (separate from this PR)

The v1.1.4 compose is already committed correctly on the CVM; only the on-chain allowlist is wrong. To unblock now, whitelist `c40639…` via the Safe (`addComposeHash`), have signers execute, then `phala cvms start chipotle-prod-rep-r68r6` — no redeploy needed. This PR prevents recurrence on future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)