### PR TITLE
fix(lit-payments): fix white-on-white text on pay-with-litkey in dark mode

### DIFF
--- a/lit-payments/static/pay-with-litkey.css
+++ b/lit-payments/static/pay-with-litkey.css
@@ -1,5 +1,8 @@
-.litkey-pay-page { min-height: 100vh; display: grid; place-items: center; padding: 2rem; background: #f6f8fb; }
-.pay-card { width: min(760px, 100%); background: #fff; border: 1px solid #dfe6ef; border-radius: 18px; box-shadow: 0 20px 60px rgba(15, 23, 42, .12); padding: 2rem; }
+/* The pay card is always light, so pin a light scheme and dark text rather than
+   inheriting --fg from style.css, which flips to near-white in dark mode. */
+.litkey-pay-page { color-scheme: light; min-height: 100vh; display: grid; place-items: center; padding: 2rem; background: #f6f8fb; color: #0f172a; }
+.pay-card { width: min(760px, 100%); background: #fff; border: 1px solid #dfe6ef; border-radius: 18px; box-shadow: 0 20px 60px rgba(15, 23, 42, .12); padding: 2rem; color: #0f172a; }
+.pay-card h1, .pay-card h2 { color: #0f172a; }
 .pay-card h1 { margin: .25rem 0 .5rem; }
 .pay-card h2 { font-size: 1rem; margin: 0 0 1rem; }
 .eyebrow { color: #5b6ee1; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; font-size: .75rem; }


### PR DESCRIPTION
The `pay-with-litkey` page hardcodes light backgrounds (`#fff` card on `#f6f8fb`) but never set its own text color, so it inherited `--fg` from the shared `style.css`. That stylesheet's `prefers-color-scheme: dark` block flips `--fg` to near-white, making the headings, account values, and quote values render white-on-white for any dark-mode visitor. This fix pins `.litkey-pay-page` / `.pay-card` to `color-scheme: light` with explicit dark text (`#0f172a`). It's a static-asset CSS change, so it takes effect on the next deploy of the lit-payments static files.