### PR TITLE
fix(dashboard): standardize all modals to 480px width

### DIFF
--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -486,9 +486,9 @@
 
   <!-- Delete confirmation (reused) -->
   <div id="confirm-overlay" class="modal-overlay" aria-hidden="true">
-    <div class="modal-dialog" role="alertdialog" aria-modal="true">
+    <div class="modal-dialog" role="alertdialog" aria-modal="true" aria-labelledby="confirm-title">
       <div class="modal-header">
-        <h3 class="modal-title">Confirm delete</h3>
+        <h3 class="modal-title" id="confirm-title">Confirm delete</h3>
         <button type="button" class="modal-close" id="confirm-close-btn" aria-label="Close">&times;</button>
       </div>
       <div class="modal-body" id="confirm-message">Are you sure?</div>

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -486,7 +486,7 @@
 
   <!-- Delete confirmation (reused) -->
   <div id="confirm-overlay" class="modal-overlay" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-sm" role="alertdialog" aria-modal="true">
+    <div class="modal-dialog" role="alertdialog" aria-modal="true">
       <div class="modal-header">
         <h3 class="modal-title">Confirm delete</h3>
         <button type="button" class="modal-close" id="confirm-close-btn" aria-label="Close">&times;</button>
@@ -501,7 +501,7 @@
 
   <!-- Action progress (non-dismissible) -->
   <div id="action-overlay" class="modal-overlay" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-sm" role="dialog" aria-modal="true" aria-labelledby="action-title" tabindex="-1">
+    <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="action-title" tabindex="-1">
       <div class="modal-header">
         <h3 class="modal-title" id="action-title">Working…</h3>
       </div>

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -1783,10 +1783,6 @@ textarea.input.textarea-sm {
   flex-direction: column;
 }
 
-.modal-dialog-sm {
-  max-width: 360px;
-}
-
 .modal-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Resolves [NODE-4977](https://linear.app/litprotocol/issue/NODE-4977/dashboard-modal-width). The lit-static dashboard's delete confirmation and action progress modals used a `.modal-dialog-sm` override that capped them at 360px, while the rest used the 480px `.modal-dialog` base. This removes that override from both modals and deletes the now-unused CSS rule, so every dashboard modal renders at the largest (480px) width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)