### PR TITLE
test(lit-api-server): de-flake eip712 future-timestamp test

### DIFF
--- a/lit-api-server/src/core/eip712.rs
+++ b/lit-api-server/src/core/eip712.rs
@@ -767,7 +767,15 @@ mod tests {
     fn rejects_timestamp_too_far_future() {
         let chain_id = ensure_test_chain_id();
         let wallet = PrivateKeySigner::random();
-        let future = now_secs() + TIMESTAMP_SKEW_SECONDS + 1;
+        // Pick a timestamp comfortably past the skew window. A tight `+ 1`
+        // margin is flaky: the validator reads its own `now`, and if the wall
+        // clock advances even one second between here and that read (easy under
+        // CI load), `|now - issued_at|` lands exactly on TIMESTAMP_SKEW_SECONDS,
+        // which passes the strict `>` check and the timestamp is wrongly
+        // accepted. An hour of headroom can't be eroded by test-execution slop.
+        // (The mirror test `rejects_timestamp_too_old` is naturally robust —
+        // elapsed time only makes its timestamp staler.)
+        let future = now_secs() + TIMESTAMP_SKEW_SECONDS + 3600;
         let (typed, sig) = sign_canonical(&wallet, PRIMARY_TYPE_CREATE_WALLET, future, chain_id);
         let err = verify_eip712_signature(&typed, &sig, PRIMARY_TYPE_CREATE_WALLET)
             .expect_err("must reject — issued_at too far in future");


### PR DESCRIPTION
## Summary
`core::eip712::tests::rejects_timestamp_too_far_future` is flaky on CI (it failed a docs-only PR's `lit-api-server` job). Not a logic bug — a boundary race:

```rust
let future = now_secs() + TIMESTAMP_SKEW_SECONDS + 1;  // only 1s past the limit
```

`validate_timestamp` reads its **own** `now`. If the wall clock advances even one second between the test picking `future` and the validator reading `now` (easy under CI load), `|now - issued_at|` lands **exactly** on `TIMESTAMP_SKEW_SECONDS` (300), which passes the strict `> 300` check → the timestamp is accepted → `expect_err` panics.

This is why `rejects_timestamp_too_old` (uses `now - SKEW - 1`, only gets *more* stale with elapsed time) never flakes, but the future one does.

## Fix
Give the future timestamp an hour of headroom past the window (`now + SKEW + 3600`) so normal test-execution slop can't erode it back inside. Pure test change.

## Verification
Ran `cargo test --lib core::eip712::tests::rejects_timestamp` 3× locally — both timestamp tests pass every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)