### PR TITLE
fix(lit-actions): stop cross-execution js_params/bytecode leak via the eval-context code cache

### DIFF
--- a/lit-actions/ext/js/99_patches.js
+++ b/lit-actions/ext/js/99_patches.js
@@ -39,6 +39,10 @@ globalThis.LitTest = { op_panic };
 // parses per execution but its body is one string literal, so V8 only pays
 // for source-string scanning, not for compiling the bundled action body.
 //
+// The caller passes a content-derived `specifier` (the action's IPFS id) so
+// distinct actions occupy distinct code-cache keys; see the call site in
+// runtime.rs for why a shared specifier would let equal-length actions collide.
+//
 // The helper deletes itself from globalThis as its first action so user code
 // (which runs inside op_eval_context below) cannot reach it; this preserves
 // the `--disallow-code-generation-from-strings` posture by not handing actions

--- a/lit-actions/server/lib.rs
+++ b/lit-actions/server/lib.rs
@@ -7,7 +7,7 @@ pub mod worker_pool;
 
 pub mod server;
 
-pub use runtime::init_v8;
+pub use runtime::{get_lit_action_ipfs_id, init_v8};
 pub use server::*;
 
 // Re-exports

--- a/lit-actions/server/lib.rs
+++ b/lit-actions/server/lib.rs
@@ -2,7 +2,7 @@ mod bundler;
 pub mod cdn_module_loader;
 mod import_rewriter;
 mod runtime;
-mod v8_code_cache;
+pub mod v8_code_cache;
 pub mod worker_pool;
 
 pub mod server;

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -261,7 +261,12 @@ fn deno_isolate_init() -> Option<&'static [u8]> {
     Some(RUNTIME_SNAPSHOT)
 }
 
-fn get_lit_action_ipfs_id(code: &str) -> String {
+/// Compute the IPFS CID for a Lit Action's source. This is the action's
+/// canonical content identity: it keys the action-code cache and, via the
+/// op_eval_context specifier, the V8 code cache (so distinct actions can't
+/// collide on V8's length-based source hash). Exposed for tests that assert on
+/// the specifier (it appears in user-facing stack traces).
+pub fn get_lit_action_ipfs_id(code: &str) -> String {
     let ipfs_hasher = IpfsHasher::default();
     ipfs_hasher.compute(code.as_bytes())
 }
@@ -836,10 +841,22 @@ async fn execute_with_worker_inner(
     // execution, but its body is one string literal, so V8 only pays for
     // source-string scanning rather than compiling the bundled action body
     // (CPL-264).
+    //
+    // The specifier is content-derived (the action's IPFS id) rather than a
+    // constant. Deno's code-cache key is `(specifier, kind, source_hash)`, and
+    // `source_hash` degenerates to V8's length-based string identity hash for
+    // large sources — so two *different* actions of equal length would share a
+    // `source_hash` and collide under a shared specifier, handing one action
+    // the other's compiled bytecode. Keying the specifier on the action id puts
+    // each action in its own keyspace: same action -> same specifier -> still
+    // reuses bytecode (CPL-264); different action -> different specifier -> a
+    // clean miss, so V8 is never offered a mismatched cache entry to accept.
     let user_code_literal =
         serde_json::to_string(&user_code).context("Could not serialize user code for eval stub")?;
-    let stub =
-        format!("__litEvalCached({user_code_literal}, \"file:///user_provided_script.js\");");
+    let specifier = format!("file:///user_provided_script_{action_ipfs_id}.js");
+    let specifier_literal = serde_json::to_string(&specifier)
+        .context("Could not serialize eval specifier for eval stub")?;
+    let stub = format!("__litEvalCached({user_code_literal}, {specifier_literal});");
 
     if let Err(e) = worker
         .js_runtime

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -187,13 +187,18 @@ impl CachedActionCode {
                 .sum::<usize>()
     }
 
-    fn to_executable_code(&self, js_func_params: &str) -> String {
+    // NB: js_params are NOT baked in here — they are injected separately as the
+    // `globalThis.__litJsParams` global (see `inject_params_globals`). Keeping
+    // them out makes this source stable per bundled action, so the
+    // eval-context code cache keys/compiles correctly across requests instead
+    // of crossing one request's params into another's execution.
+    fn to_executable_code(&self) -> String {
         format!(
             "
         {code}
         ;
         (async () => {{
-        const params = {js_func_params} ;
+        const params = globalThis.__litJsParams;
         const data = await main(params);
         if (typeof data !== \"undefined\") {{
           LitActions.setResponse( {{ response: data }} );
@@ -537,8 +542,11 @@ fn execute_patch_deno(worker: &mut MainWorker) -> Result<()> {
     Ok(())
 }
 
-/// Inject caller-supplied globals via `Params.js`. Reserved for future use:
-/// `execute_js` always passes `None` today, so this is normally a no-op.
+/// Inject the caller-supplied js_params as a single global, `__litJsParams`,
+/// which the per-execution wrapper (see `to_executable_code`) reads and passes
+/// to `main(params)`. Injected via `execute_script` so it is NOT part of the
+/// source compiled through the eval-context code cache. No-op when params are
+/// absent.
 fn inject_params_globals(
     worker: &mut MainWorker,
     globals_to_inject: &Option<serde_json::Value>,
@@ -554,23 +562,22 @@ fn inject_params_globals(
         .get(&HEADER_KEY_X_PRIVACY_MODE.to_ascii_lowercase())
         .is_some_and(|v| v == "true")
     {
-        debug!("Injecting params as globals: **PRIVACY MODE**");
+        debug!("Injecting js_params global: **PRIVACY MODE**");
     } else {
-        debug!("Injecting params as globals: {params:?}");
+        debug!("Injecting js_params global: {params:?}");
     }
 
-    let _ = params
-        .as_object()
-        .context("Could not convert params to map")?;
-
+    // Bind the whole params object to a single internal global. JSON is a
+    // valid JS expression, so this is a literal assignment (no parsing of
+    // untrusted code — `params` came from serde_json, not the caller's source).
     let code = formatdoc! {r#"
         "use strict";
-        Object.assign(globalThis, {params});
+        globalThis.__litJsParams = {params};
     "#};
 
     worker
         .execute_script("Params.js", code.into())
-        .context("Error injecting params as globals")?;
+        .context("Error injecting js_params global")?;
 
     Ok(())
 }
@@ -733,10 +740,16 @@ async fn execute_with_worker_inner(
     // PatchDeno.js must run AFTER LitNamespace.js (which the caller already
     // injected) to preserve the original bootstrap order.
     execute_patch_deno(&mut worker)?;
-    // Reserved hook: today's call sites always pass globals=None; preserved
-    // here so re-enabling globals injection drops in at the historical spot
-    // (between PatchDeno.js and op-state wiring).
-    inject_params_globals(&mut worker, &None, &http_headers)?;
+    // Inject the caller's js_params as a single global (`__litJsParams`) here,
+    // via execute_script — which deliberately bypasses the eval-context code
+    // cache. This keeps js_params OUT of the source that flows through
+    // `op_eval_context`/`SharedV8CodeCache`, so the cached/compiled form is the
+    // stable, param-free bundled action code. Baking params into that source
+    // (the previous behavior) was unsafe: Deno's `op_eval_context` computes the
+    // same `source_hash` for different sources of equal length, so the code
+    // cache returned a *different* request's compiled bytecode — crossing
+    // js_params between executions (see CPL / the mpc-signing investigation).
+    inject_params_globals(&mut worker, &js_params, &http_headers)?;
 
     // Check the action code cache early so we can skip prepare_action_code
     // on cache hit (the real performance win). We always use CdnModuleLoader
@@ -792,13 +805,13 @@ async fn execute_with_worker_inner(
     )
     .await?;
 
-    let js_params = js_params.as_ref().unwrap_or_default();
-    let js_func_params = js_params.to_string();
+    // js_params were already injected as the `__litJsParams` global (see
+    // `inject_params_globals` above); they are intentionally NOT part of the
+    // cached/compiled source below.
 
-    // Params are injected per-execution and MUST NOT be part of the cached
-    // form: they change between invocations while the bundled JS stays the
-    // same. On cache hit we reuse the prepared form; on miss we prepare it
-    // (bundle CDN deps, snapshot loaded modules, cache the result).
+    // The bundled JS is cached and stable across invocations. On cache hit we
+    // reuse the prepared form; on miss we prepare it (bundle CDN deps, snapshot
+    // loaded modules, cache the result).
     let cached_code = if let Some(cached) = cached_code {
         cached
     } else {
@@ -813,7 +826,7 @@ async fn execute_with_worker_inner(
             .await?
     };
     record_loaded_modules(&loaded_modules, &cached_code);
-    let user_code = cached_code.to_executable_code(&js_func_params);
+    let user_code = cached_code.to_executable_code();
 
     // Route user code through op_eval_context (via the __litEvalCached helper
     // baked into 99_patches.js) so Deno's `eval_context_code_cache_cbs` —

--- a/lit-actions/server/runtime.rs
+++ b/lit-actions/server/runtime.rs
@@ -550,16 +550,21 @@ fn execute_patch_deno(worker: &mut MainWorker) -> Result<()> {
 /// Inject the caller-supplied js_params as a single global, `__litJsParams`,
 /// which the per-execution wrapper (see `to_executable_code`) reads and passes
 /// to `main(params)`. Injected via `execute_script` so it is NOT part of the
-/// source compiled through the eval-context code cache. No-op when params are
-/// absent.
+/// source compiled through the eval-context code cache.
+///
+/// When js_params is absent we still define the global as `null` (not leave it
+/// `undefined`): the previous code path serialized `Value::Null` into the
+/// wrapper, so actions that branch on `params === null` for the no-params case
+/// keep working.
 fn inject_params_globals(
     worker: &mut MainWorker,
     globals_to_inject: &Option<serde_json::Value>,
     http_headers: &BTreeMap<String, String>,
 ) -> Result<()> {
-    let Some(params) = globals_to_inject else {
-        return Ok(());
-    };
+    // Omitted js_params => inject `null`, matching the pre-change `main(null)`
+    // semantics rather than handing user code `undefined`.
+    let null = serde_json::Value::Null;
+    let params = globals_to_inject.as_ref().unwrap_or(&null);
 
     let _span = info_span!("Params.js").entered();
 
@@ -745,16 +750,6 @@ async fn execute_with_worker_inner(
     // PatchDeno.js must run AFTER LitNamespace.js (which the caller already
     // injected) to preserve the original bootstrap order.
     execute_patch_deno(&mut worker)?;
-    // Inject the caller's js_params as a single global (`__litJsParams`) here,
-    // via execute_script — which deliberately bypasses the eval-context code
-    // cache. This keeps js_params OUT of the source that flows through
-    // `op_eval_context`/`SharedV8CodeCache`, so the cached/compiled form is the
-    // stable, param-free bundled action code. Baking params into that source
-    // (the previous behavior) was unsafe: Deno's `op_eval_context` computes the
-    // same `source_hash` for different sources of equal length, so the code
-    // cache returned a *different* request's compiled bytecode — crossing
-    // js_params between executions (see CPL / the mpc-signing investigation).
-    inject_params_globals(&mut worker, &js_params, &http_headers)?;
 
     // Check the action code cache early so we can skip prepare_action_code
     // on cache hit (the real performance win). We always use CdnModuleLoader
@@ -798,6 +793,22 @@ async fn execute_with_worker_inner(
             let _ = memory_limit_tx.send(current_limit);
             current_limit * 2
         });
+
+    // Inject the caller's js_params as a single global (`__litJsParams`), via
+    // execute_script — which deliberately bypasses the eval-context code cache.
+    // This keeps js_params OUT of the source that flows through
+    // `op_eval_context`/`SharedV8CodeCache`, so the cached/compiled form is the
+    // stable, param-free bundled action code. Baking params into that source
+    // (the previous behavior) was unsafe: Deno's `op_eval_context` computes the
+    // same `source_hash` for different sources of equal length, so the code
+    // cache returned a *different* request's compiled bytecode — crossing
+    // js_params between executions (see CPL / the mpc-signing investigation).
+    //
+    // Must run AFTER the controller thread and near-heap-limit callback above:
+    // materializing a large params object into V8 is subject to the same
+    // timeout/OOM guards as user code, so an oversized params blob surfaces as
+    // a normal resource-exhausted/timeout error instead of a hard V8 abort.
+    inject_params_globals(&mut worker, &js_params, &http_headers)?;
 
     let mut interval = tokio::time::interval(Duration::from_millis(MEMORY_SAMPLE_INTERVAL_MS));
     let mut heap_stats = v8::HeapStatistics::default();

--- a/lit-actions/server/server.rs
+++ b/lit-actions/server/server.rs
@@ -511,6 +511,10 @@ pub struct TestServer {
     /// inside the running gRPC service.
     pub pool_health: Arc<crate::worker_pool::PoolHealth>,
     pub pool_target_size: usize,
+    /// Shared V8 code cache (same `Arc` the running server hands to its
+    /// workers). Cloned at construction so tests can assert on hit/miss
+    /// counters — e.g. that a repeated action reuses compiled bytecode.
+    pub v8_code_cache: SharedV8CodeCache,
 }
 
 impl TestServer {
@@ -524,6 +528,7 @@ impl TestServer {
         let pool = server.pool();
         let pool_health = pool.health();
         let pool_target_size = pool.target_size();
+        let v8_code_cache = server.v8_code_cache.clone();
 
         std::thread::spawn(move || {
             create_and_run_current_thread(async move {
@@ -550,6 +555,7 @@ impl TestServer {
             socket_file,
             pool_health,
             pool_target_size,
+            v8_code_cache,
         }
     }
 

--- a/lit-actions/server/v8_code_cache.rs
+++ b/lit-actions/server/v8_code_cache.rs
@@ -13,6 +13,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use deno_core::ModuleSpecifier;
@@ -29,6 +30,25 @@ pub fn new_v8_code_cache() -> SharedV8CodeCache {
 #[derive(Default)]
 pub struct V8CodeCache {
     inner: RwLock<V8CodeCacheState>,
+    /// `get_sync` lookups that returned cached bytecode / that missed.
+    /// Observability only — lets tests prove compiled bytecode was actually
+    /// reused across executions (vs. recompiled every run).
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl V8CodeCache {
+    /// Number of `get_sync` lookups served from cache (compiled bytecode
+    /// reused). See [`Self::misses`].
+    pub fn hits(&self) -> u64 {
+        self.hits.load(Ordering::Relaxed)
+    }
+
+    /// Number of `get_sync` lookups that found nothing (forcing a fresh
+    /// compile, whose result is then stored via `set_sync`).
+    pub fn misses(&self) -> u64 {
+        self.misses.load(Ordering::Relaxed)
+    }
 }
 
 #[derive(Default)]
@@ -136,10 +156,16 @@ impl CodeCache for V8CodeCache {
             kind: kind_to_u8(code_cache_type),
             source_hash,
         };
-        inner
+        let hit = inner
             .entries
             .get(&key_ref as &dyn V8CodeCacheKeyAccess)
-            .cloned()
+            .cloned();
+        if hit.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        hit
     }
 
     fn set_sync(
@@ -258,6 +284,22 @@ mod tests {
                 .as_deref(),
             Some(b"bytecode-b".as_ref())
         );
+    }
+
+    #[test]
+    fn hit_and_miss_counters_track_lookups() {
+        let cache = V8CodeCache::default();
+        let s = specifier();
+        assert_eq!((cache.hits(), cache.misses()), (0, 0));
+
+        // Miss: nothing stored yet.
+        assert!(cache.get_sync(&s, CodeCacheType::Script, 1).is_none());
+        assert_eq!((cache.hits(), cache.misses()), (0, 1));
+
+        // Store, then hit.
+        cache.set_sync(s.clone(), CodeCacheType::Script, 1, b"bytecode");
+        assert!(cache.get_sync(&s, CodeCacheType::Script, 1).is_some());
+        assert_eq!((cache.hits(), cache.misses()), (1, 1));
     }
 
     #[test]

--- a/lit-actions/server/v8_code_cache.rs
+++ b/lit-actions/server/v8_code_cache.rs
@@ -230,6 +230,36 @@ mod tests {
         assert!(cache.get_sync(&s, CodeCacheType::Script, 2).is_none());
     }
 
+    /// The specifier is part of the key. Two actions that collide on
+    /// `source_hash` (V8's length-based string identity hash degenerates to the
+    /// length for large sources, so equal-length actions share a hash) must
+    /// still occupy independent entries when given distinct, content-derived
+    /// specifiers — otherwise one action would be served the other's bytecode.
+    #[test]
+    fn specifier_is_part_of_key() {
+        let cache = V8CodeCache::default();
+        let action_a = specifier_n(1);
+        let action_b = specifier_n(2);
+
+        // Same kind, same colliding source_hash, different specifiers.
+        cache.set_sync(action_a.clone(), CodeCacheType::Script, 42, b"bytecode-a");
+        cache.set_sync(action_b.clone(), CodeCacheType::Script, 42, b"bytecode-b");
+
+        // Each specifier retrieves its own bytecode; no cross-contamination.
+        assert_eq!(
+            cache
+                .get_sync(&action_a, CodeCacheType::Script, 42)
+                .as_deref(),
+            Some(b"bytecode-a".as_ref())
+        );
+        assert_eq!(
+            cache
+                .get_sync(&action_b, CodeCacheType::Script, 42)
+                .as_deref(),
+            Some(b"bytecode-b".as_ref())
+        );
+    }
+
     #[test]
     fn set_replaces_existing_entry() {
         let cache = V8CodeCache::default();

--- a/lit-actions/tests/it.rs
+++ b/lit-actions/tests/it.rs
@@ -416,6 +416,95 @@ async fn js_params(mut client: TestClient) {
     // }
 }
 
+/// End-to-end proof of the code-cache fix on a *large* action — one whose
+/// bundled source is well past V8's `String::kMaxHashCalcLength` (16383), the
+/// regime where V8's string identity hash (and therefore Deno's code-cache
+/// key) degenerates to a length-only hash.
+///
+/// The same action is executed twice with *different but equal-length*
+/// `js_params`, asserting both halves of the fix:
+///   1. **caching worked** — the second run is served from the V8 code cache
+///      (compiled bytecode reused), so CPL-264 is genuinely active here;
+///   2. **params were NOT cached** — each run sees its own params, even though
+///      the two param payloads are byte-for-byte the same length. Before the
+///      fix baked params into the cached source, equal-length payloads produced
+///      equal-length sources that collided on the length-based hash, handing
+///      the second run the first run's params.
+#[tokio::test]
+async fn large_action_caches_code_but_not_params() {
+    let server = TestServer::start();
+    let v8_code_cache = server.v8_code_cache.clone();
+    let mut client = TestClient::new(server.socket_file);
+
+    // ~20 KB of payload, referenced from main() so a bundler/minifier can't
+    // drop it, pushes the bundled source comfortably past the 16383-char cutoff.
+    let padding = "x".repeat(20 * 1024);
+    let code = format!(
+        r#"
+        const PADDING = "{padding}";
+        async function main({{ token }}) {{
+            if (PADDING.length === 0) throw new Error("unreachable");
+            console.log(token);
+        }}
+        "#
+    );
+
+    // Equal-length, different-value tokens => equal-length JSON param payloads.
+    let token_a = "A".repeat(16);
+    let token_b = "B".repeat(16);
+    let params_a = format!(r#"{{"token":"{token_a}"}}"#);
+    let params_b = format!(r#"{{"token":"{token_b}"}}"#);
+    assert_eq!(
+        params_a.len(),
+        params_b.len(),
+        "the two param payloads must be equal length to exercise the collision"
+    );
+
+    // First run: misses the V8 code cache, compiles, and stores the bytecode.
+    client
+        .respond_with(PrintResponse {})
+        .execute_js(ExecutionRequest {
+            code: code.clone(),
+            js_params: Some(params_a.into_bytes()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        client.received::<PrintRequest>().message,
+        format!("{token_a}\n")
+    );
+    assert!(client.received::<ExecutionResult>().success);
+
+    // Second run: identical code => must HIT the V8 code cache; different
+    // params => must still observe ITS OWN params.
+    let hits_before = v8_code_cache.hits();
+    client
+        .respond_with(PrintResponse {})
+        .execute_js(ExecutionRequest {
+            code: code.clone(),
+            js_params: Some(params_b.into_bytes()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        client.received::<PrintRequest>().message,
+        format!("{token_b}\n"),
+        "second execution must see its own params, not the first run's"
+    );
+    assert!(client.received::<ExecutionResult>().success);
+
+    // Caching worked: the second run reused compiled bytecode.
+    assert!(
+        v8_code_cache.hits() > hits_before,
+        "second execution of the same action must reuse compiled bytecode \
+         (V8 code cache hit); hits before={}, after={}",
+        hits_before,
+        v8_code_cache.hits(),
+    );
+}
+
 #[rstest]
 #[tokio::test]
 async fn set_response(mut client: TestClient) {

--- a/lit-actions/tests/it.rs
+++ b/lit-actions/tests/it.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, bail};
 use indoc::{formatdoc, indoc};
 use lit_actions_server::proto::execute_js_request::AesEncryptResponse;
 use lit_actions_server::worker_pool::PoolHealth;
-use lit_actions_server::{TestServer, init_v8, proto::*, unix};
+use lit_actions_server::{TestServer, get_lit_action_ipfs_id, init_v8, proto::*, unix};
 use pretty_assertions::assert_eq;
 use rstest::*;
 use temp_file::TempFile;
@@ -576,24 +576,29 @@ async fn async_await(mut client: TestClient) {
 #[rstest]
 #[tokio::test]
 async fn reference_error(mut client: TestClient) {
-    let res = client
-        .execute_js("async function main() { nonexisting_function() }")
-        .await;
+    let code = "async function main() { nonexisting_function() }";
+    let res = client.execute_js(code).await;
 
     // User code now runs through `__litEvalCached` (op_eval_context) so V8's
     // script code cache is reachable for the bundled action (CPL-264). Side
     // effects on error output: the script name is the URL specifier used by
-    // op_eval_context, and two wrapper frames appear at the tail.
+    // op_eval_context, and two wrapper frames appear at the tail. The specifier
+    // is content-derived (the action's IPFS id) so distinct actions can't
+    // collide on V8's length-based code-cache hash.
+    let script = format!(
+        "file:///user_provided_script_{}.js",
+        get_lit_action_ipfs_id(code)
+    );
     assert_eq!(
         res.unwrap_err().to_string(),
-        indoc! {r#"
+        formatdoc! {r#"
             Uncaught (in promise) ReferenceError: nonexisting_function is not defined
-                at main (file:///user_provided_script.js:2:33)
-                at file:///user_provided_script.js:6:28
-                at file:///user_provided_script.js:10:11
-                at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:52:21)
+                at main ({script}:2:33)
+                at {script}:6:28
+                at {script}:10:11
+                at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:56:21)
                 at <user_provided_script>:1:1
-        "#}
+        "#, script = script}
         .trim()
     );
     assert_eq!(client.received::<ExecutionResult>().success, false);
@@ -611,17 +616,21 @@ async fn throw_error(mut client: TestClient) {
         let res = client.execute_js(code).await;
 
         // See `reference_error` for why the stack format differs from
-        // pre-CPL-264 output.
+        // pre-CPL-264 output and why the specifier is content-derived.
+        let script = format!(
+            "file:///user_provided_script_{}.js",
+            get_lit_action_ipfs_id(code)
+        );
         assert_eq!(
             res.unwrap_err().to_string(),
-            indoc! {r#"
+            formatdoc! {r#"
                 Uncaught (in promise) Error: boom
-                    at main (file:///user_provided_script.js:3:7)
-                    at file:///user_provided_script.js:9:28
-                    at file:///user_provided_script.js:13:11
-                    at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:52:21)
+                    at main ({script}:3:7)
+                    at {script}:9:28
+                    at {script}:13:11
+                    at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:56:21)
                     at <user_provided_script>:1:1
-            "#}
+            "#, script = script}
             .trim(),
         );
         assert_eq!(client.received::<ExecutionResult>().success, false);
@@ -635,16 +644,20 @@ async fn throw_error(mut client: TestClient) {
         "#};
         let res = client.execute_js(code).await;
 
+        let script = format!(
+            "file:///user_provided_script_{}.js",
+            get_lit_action_ipfs_id(code)
+        );
         assert_eq!(
             res.unwrap_err().to_string(),
-            indoc! {r#"
+            formatdoc! {r#"
                 Uncaught (in promise) Error: boom
-                    at main (file:///user_provided_script.js:3:11)
-                    at file:///user_provided_script.js:9:28
-                    at file:///user_provided_script.js:13:11
-                    at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:52:21)
+                    at main ({script}:3:11)
+                    at {script}:9:28
+                    at {script}:13:11
+                    at globalThis.__litEvalCached (ext:lit_actions/99_patches.js:56:21)
                     at <user_provided_script>:1:1
-            "#}
+            "#, script = script}
             .trim(),
         );
         assert_eq!(client.received::<ExecutionResult>().success, false);


### PR DESCRIPTION
## Summary

A Lit Action could run with **another request's `js_params`** — and, more
broadly, with **another action's compiled bytecode**. The eval-context V8 code
cache keys on a hash that collides for equal-length sources, so two unrelated
executions could be served each other's cached compilation. It caused
intermittent wrong-input execution (a cross-request data mix) and, secondarily,
fatal `V8_Fatal: stack_overflow()` aborts of the worker.

## Root cause

User code runs via `__litEvalCached(source, specifier)` → `op_eval_context` →
the `SharedV8CodeCache`, whose key is `(specifier, kind, source_hash)`.

Two things made that key collide across unrelated executions:

1. **`source_hash` degenerates to a length-based hash for large sources.** Deno's
   `op_eval_context` computes the *same* `source_hash` for different sources of
   equal length. V8's own `ConsumeCodeCache` validation is itself length-based,
   so it does not reject a mismatched entry either.
2. **The specifier was a constant** (`file:///user_provided_script.js`), so every
   action shared one keyspace.

On top of that, **per-request `js_params` were baked into the executed source**
by `CachedActionCode::to_executable_code`:

```js
{bundled action code}
;(async () => {
  const params = {js_func_params};   // <-- per-request params baked INTO the source
  const data = await main(params);
  ...
})();
```

So there were two distinct ways one execution could receive another's cached
compilation:

- **Params crossing:** the *same* action invoked with *different* params of equal
  serialized length → equal-length sources → `source_hash` collision → a cache
  **HIT** returns the first request's bytecode, with its baked-in params → the
  action runs **its own code but the first request's `js_params`.**
- **Action crossing:** *different* actions whose bundled sources happen to be
  equal length → `source_hash` collision under the shared constant specifier →
  one action is served the **other action's compiled bytecode.**

### Evidence (reproduced on a full local stack: anvil + dstack-sim + lit_actions + lit-api-server)

Instrumented client → lit-api-server boundary → action, matched by `sessionId`:
- client sends and lit-api-server forwards `sid=56634041 round=2` correctly,
- but the action executes with `sid=dc6e621d` — a *different* request's params.

Logging the cache directly: two requests with **different source content**
(`myhash` 86e200e7 vs 48f21109) but **equal length** (38164 bytes) produced the
**identical** Deno `source_hash=4decc2ac…` and both HIT.

Reproduced reliably with `examples/mpc-signing`'s 2-of-3 keygen (it relays large,
similar-sized session blobs round to round, so collisions are frequent). It
surfaced as `Invalid commitment hash` / `Missing message` (the MPC protocol
legitimately rejecting the wrong session) plus occasional V8 stack-overflow
aborts.

## Fix

Two complementary changes; both are required to close the bug.

**1. Stop baking params into the code-cached source.** Inject `js_params` as a
single global, `globalThis.__litJsParams`, via `execute_script` (which bypasses
the eval-context cache), and have the per-execution wrapper read it:
- `inject_params_globals` now sets `globalThis.__litJsParams = <params>` (was a
  no-op `Object.assign`, always called with `None`).
- `execute_with_worker` calls it with the actual `js_params` at the existing
  reserved hook.
- `to_executable_code` reads `const params = globalThis.__litJsParams` instead of
  inlining the params.

This makes the source compiled through `op_eval_context` the **stable, param-free
bundled action**, so the same action no longer crosses params on a `source_hash`
collision.

**2. Key the code cache on a content-derived specifier.** The eval stub now passes
`file:///user_provided_script_<ipfs_id>.js` (the action's IPFS CID — already the
canonical content id used for the action-code cache) instead of the constant
specifier:
- `runtime.rs`: content-derived specifier passed to `__litEvalCached`.
- `lib.rs`: expose `get_lit_action_ipfs_id` (the canonical content id).
- `v8_code_cache.rs`: `specifier_is_part_of_key` unit test (same hash + kind,
  different specifier → independent entries).
- `it.rs`: stack-trace assertions compute the specifier dynamically via
  `get_lit_action_ipfs_id`; bump `99_patches.js` call-site line for the new
  comment.

Each action now occupies its own keyspace: **same action → same specifier →
still reuses bytecode** (the CPL-264 optimization is preserved); **different
action → different specifier → a clean miss**, so V8 is never offered a
mismatched cache entry to accept.

### Why both

The two vectors are independent, so neither change alone is sufficient:
- Change 1 alone (param-free source, constant specifier) still lets two
  *different* actions of equal length collide and cross **bytecode**.
- Change 2 alone (content-derived specifier, params still baked in) still lets the
  *same* action with equal-length params collide and cross **params**.

Together there is no remaining path for one execution to receive another's
bytecode or params.

Individual param keys are not promoted to globals (passed to `main(params)`
exactly as before; `globalThis.Hello`-style access stays `undefined`). The whole
object is bound to a single internal global, `globalThis.__litJsParams`, for the
duration of the execution. Within one (single-tenant, fresh-per-request) isolate
that object is therefore readable by the action's own bundled code/imports — an
intra-execution defense-in-depth gap, not a cross-request path. Fully hiding it
would require emitting a statement before the action body in the per-execution
wrapper, which demotes a user action's own top-level `"use strict";` and silently
switches their code to sloppy mode; the alternatives (forcing whole-script strict,
or wrapping the body in a function) likewise change sloppy-mode and top-level
`var`/`this` semantics for existing actions. Since this is a same-trust-domain
hardening nicety, it is an accepted limitation rather than worth a semantics
regression.

### Behavior note

The specifier appears in user-facing error stack traces, so traces now carry the
action's IPFS id in the filename (`file:///user_provided_script_<id>.js`). A trace
only ever shows the executing action's own id, which its caller already knows.

## Verification

- 2-of-3 MPC keygen against the full local stack: **15/15, zero retries, no crash**
  (was ~25–50% per-attempt failure + intermittent worker aborts).
- `lit-actions` integration suite green (incl. `js_params` and the updated
  stack-trace assertions), plus the new `v8_code_cache` unit test.
- All PR CI checks green.

## Severity

Not MPC-specific: **any** two Lit Action executions that collide on the
length-based `source_hash` can receive each other's `js_params` or compiled
bytecode — worth treating as a potential cross-request/cross-tenant
data-exposure bug, not just flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
