### PR TITLE
ci: make Phala replica CVM name a manual-dispatch param

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -52,6 +52,12 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      phala_cvm_name:
+        description: "Target chipotle-prod CVM name or id (e.g. chipotle-prod-rep-xxxxx). Leave blank to use the current prod replica default. Set this to provision + propose against a freshly-added replica on a new Phala node during a zero-downtime upgrade."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   validate-secrets:
@@ -150,6 +156,7 @@ jobs:
       provision_hash: ${{ steps.prepare.outputs.provision_hash }}
       app_auth_address: ${{ steps.prepare.outputs.app_auth_address }}
       encrypted_env: ${{ steps.encrypt-env.outputs.encrypted_env }}
+      cvm_name: ${{ steps.prepare.outputs.cvm_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -189,6 +196,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Resolve the target CVM. A manual workflow_dispatch run may override
+          # it via the phala_cvm_name input (e.g. to provision + propose against
+          # a freshly-added replica on a new Phala node for a zero-downtime
+          # upgrade). Empty on tag pushes, so tagged prod releases keep using
+          # the current replica default below.
+          CVM_NAME="${{ inputs.phala_cvm_name }}"
+          if [ -z "$CVM_NAME" ]; then
+            CVM_NAME="chipotle-prod-rep-r68r6"
+          fi
+          echo "Target prod CVM: $CVM_NAME"
+          echo "cvm_name=$CVM_NAME" >> "$GITHUB_OUTPUT"
+
           # Build the API request payload with the docker-compose content and
           # the list of allowed environment variable keys. The actual secret
           # values are encrypted client-side in a separate step and sent
@@ -216,8 +235,8 @@ jobs:
             }' > "$PROVISION_FILE"
           echo "Request payload size: $(wc -c < "$PROVISION_FILE") bytes"
 
-          echo "Calling POST /cvms/chipotle-prod-rep-r68r6/compose_file/provision ..."
-          OUTPUT=$(phala api /cvms/chipotle-prod-rep-r68r6/compose_file/provision \
+          echo "Calling POST /cvms/$CVM_NAME/compose_file/provision ..."
+          OUTPUT=$(phala api "/cvms/$CVM_NAME/compose_file/provision" \
             -X POST \
             --input "$PROVISION_FILE" \
             2>&1) || {
@@ -247,7 +266,7 @@ jobs:
 
           # Extract the AppAuth (dstack_app) address from the CVM's KMS info.
           # This is the per-app contract that controls compose-hash whitelisting.
-          CVM_INFO=$(phala api /cvms/chipotle-prod-rep-r68r6 --json 2>&1) || true
+          CVM_INFO=$(phala api "/cvms/$CVM_NAME" --json 2>&1) || true
           echo "CVM info (kms): $(echo "$CVM_INFO" | jq '.kms_info // .detail' 2>/dev/null)"
           APP_AUTH=$(echo "$CVM_INFO" | jq -r '.kms_info.dstack_app_address // empty')
           if [ -z "$APP_AUTH" ]; then
@@ -415,7 +434,7 @@ jobs:
           jq -n \
             --arg compose_hash "${{ needs.prepare-deploy.outputs.compose_hash }}" \
             --arg safe_tx_hash "${{ needs.propose-compose-hash.outputs.safe_tx_hash }}" \
-            --arg phala_app_name "chipotle-prod-rep-r68r6" \
+            --arg phala_app_name "${{ needs.prepare-deploy.outputs.cvm_name }}" \
             --arg base_url "https://api.chipotle.litprotocol.com" \
             --arg api_root_url "https://api.chipotle.litprotocol.com/core/v1" \
             --arg safe_address "${{ vars.SAFE_ADDRESS_CHIPOTLE_PROD }}" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -58,6 +58,12 @@ on:
   push:
     branches: [main, next]
   workflow_dispatch:
+    inputs:
+      phala_cvm_name:
+        description: "Target Phala CVM name or id to deploy to (e.g. chipotle-next-rep-xxxxx). Leave blank to use the branch default. Use this to deploy onto a freshly-provisioned replica on a new Phala node during a zero-downtime migration."
+        required: false
+        type: string
+        default: ""
 
 jobs:
   validate-secrets:
@@ -101,17 +107,19 @@ jobs:
         id: set
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "phala_app_name=chipotle-dev" >> "$GITHUB_OUTPUT"
+            DEFAULT_APP_NAME="chipotle-dev"
             echo "instance_type=tdx.large" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-dev" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.main.toml" >> "$GITHUB_OUTPUT"
             DOMAIN="test.chipotle.litprotocol.com"
           elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
-            # Targets the prod2 instance provisioned via `phala instances add`
-            # during the prod6→prod2 migration. Shares the same app_id
-            # (0x969a8c14...) and derived keys as previous chipotle-next
-            # instances.
-            echo "phala_app_name=chipotle-next-rep-sa6xj" >> "$GITHUB_OUTPUT"
+            # Default targets the current prod replica provisioned via
+            # `phala instances add`. Shares the same app_id (0x969a8c14...)
+            # and derived keys as previous chipotle-next instances. To roll a
+            # new replica onto a different Phala node (zero-downtime upgrade),
+            # supply the `phala_cvm_name` input on a manual run instead of
+            # editing this default.
+            DEFAULT_APP_NAME="chipotle-next-rep-sa6xj"
             echo "instance_type=tdx.small" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-next" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.next.toml" >> "$GITHUB_OUTPUT"
@@ -120,6 +128,17 @@ jobs:
             echo "Unsupported branch for deployment"
             exit 1
           fi
+
+          # A manual workflow_dispatch run may override the target CVM via the
+          # phala_cvm_name input. This is empty on push events, so automated
+          # deploys keep using the branch default selected above.
+          PHALA_APP_NAME="${{ inputs.phala_cvm_name }}"
+          if [ -z "$PHALA_APP_NAME" ]; then
+            PHALA_APP_NAME="$DEFAULT_APP_NAME"
+          fi
+          echo "Deploying to Phala CVM: ${PHALA_APP_NAME}"
+          echo "phala_app_name=${PHALA_APP_NAME}" >> "$GITHUB_OUTPUT"
+
           echo "domain=${DOMAIN}" >> "$GITHUB_OUTPUT"
           echo "base_url=https://${DOMAIN}" >> "$GITHUB_OUTPUT"
           echo "api_root_url=https://${DOMAIN}/core/v1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual_phala-propose-add-device.yml
+++ b/.github/workflows/manual_phala-propose-add-device.yml
@@ -1,0 +1,88 @@
+# Propose an addDevice allowlisting to a Safe-owned DstackApp (AppAuth) contract.
+#
+# Use this for Safe-owned apps (e.g. chipotle-prod), where the simple
+# "Phala Add Device (manual)" workflow / `phala allow-devices add` fail with
+# "Sender ... is not the owner of contract ...": addDevice is onlyOwner and the
+# owner is a Safe multisig. This workflow proposes the addDevice call to the
+# Safe Transaction Service so signers can approve + execute it in the Safe UI.
+#
+# For single-key (EOA) DstackApp owners (chipotle-next / chipotle-dev), use
+# "Phala Add Device (manual)" instead — it signs the addDevice tx directly.
+#
+# After this workflow runs, open the printed Safe UI queue link, have signers
+# confirm, and Execute once the threshold is met. Then confirm with:
+#   phala allow-devices list <app_id>
+#
+# Required secrets:
+#   SAFE_PROPOSER_PRIVATE_KEY - EOA key registered as a Safe owner or delegate
+#   BASE_CHAIN_RPC            - Base mainnet RPC URL (optional; falls back to public)
+#
+# Required vars (defaults for chipotle-prod when the inputs are left blank):
+#   SAFE_ADDRESS_CHIPOTLE_PROD     - Safe multisig address (the AppAuth owner)
+#   APP_AUTH_ADDRESS_CHIPOTLE_PROD - AppAuth (DstackApp) contract address (= app_id)
+
+name: Phala Propose Add Device via Safe (manual)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      device_id:
+        description: "Device ID to allowlist (0x... bytes32), from `phala instances add --prepare-only`"
+        required: true
+        type: string
+      app_auth:
+        description: "AppAuth (DstackApp) contract address. Leave blank to use the chipotle-prod default (APP_AUTH_ADDRESS_CHIPOTLE_PROD)."
+        required: false
+        type: string
+        default: ""
+      safe:
+        description: "Safe multisig address that owns the AppAuth. Leave blank to use the chipotle-prod default (SAFE_ADDRESS_CHIPOTLE_PROD)."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  propose-add-device:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install contract dependencies
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: lit-api-server/blockchain/lit_node_express
+        run: npx hardhat compile
+
+      - name: Propose addDevice to Safe
+        working-directory: lit-api-server/blockchain/lit_node_express
+        env:
+          PROPOSER_PRIVATE_KEY: ${{ secrets.SAFE_PROPOSER_PRIVATE_KEY }}
+          BASE_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
+        run: |
+          APP_AUTH="${{ inputs.app_auth }}"
+          if [ -z "$APP_AUTH" ]; then
+            APP_AUTH="${{ vars.APP_AUTH_ADDRESS_CHIPOTLE_PROD }}"
+          fi
+          SAFE_ADDR="${{ inputs.safe }}"
+          if [ -z "$SAFE_ADDR" ]; then
+            SAFE_ADDR="${{ vars.SAFE_ADDRESS_CHIPOTLE_PROD }}"
+          fi
+          if [ -z "$APP_AUTH" ] || [ -z "$SAFE_ADDR" ]; then
+            echo "::error::app_auth and safe must be provided (no chipotle-prod default var is set)"
+            exit 1
+          fi
+          echo "Proposing addDevice(${{ inputs.device_id }}) on AppAuth $APP_AUTH via Safe $SAFE_ADDR"
+          npx hardhat propose-add-device \
+            --network base \
+            --safe "$SAFE_ADDR" \
+            --app-auth "$APP_AUTH" \
+            --device-id "${{ inputs.device_id }}"

--- a/lit-api-server/blockchain/lit_node_express/hardhat.config.ts
+++ b/lit-api-server/blockchain/lit_node_express/hardhat.config.ts
@@ -7,6 +7,7 @@ import "dotenv/config";
 import "./tasks/propose-diamond-cut";
 import "./tasks/execute-safe-tx";
 import "./tasks/propose-dstack-app";
+import "./tasks/propose-add-device";
 import "./tasks/transfer-ownership";
 import "./tasks/verify-compose-hash";
 import "./tasks/verify-diamond-facets";

--- a/lit-api-server/blockchain/lit_node_express/tasks/propose-add-device.ts
+++ b/lit-api-server/blockchain/lit_node_express/tasks/propose-add-device.ts
@@ -1,0 +1,121 @@
+import { task } from "hardhat/config";
+import SafeApiKit from "@safe-global/api-kit";
+import Safe from "@safe-global/protocol-kit";
+import { ethers } from "ethers";
+
+// AppAuth (DstackApp) contract ABI for device allowlisting. Each Phala CVM
+// with on-chain KMS has its own AppAuth contract; the KMS only releases keys
+// to allowlisted device IDs. addDevice is onlyOwner — for Safe-owned apps
+// (e.g. chipotle-prod) the call must go through the Safe, which is what this
+// task proposes. Mirrors propose-dstack-app.ts (addComposeHash).
+const APP_AUTH_ABI = [
+  "function addDevice(bytes32 deviceId)",
+  "function allowedDeviceIds(bytes32) view returns (bool)",
+  "function owner() view returns (address)",
+];
+
+task("propose-add-device", "Propose an AppAuth device allowlisting through Safe")
+  .addParam("safe", "Safe multisig address (the AppAuth owner)")
+  .addParam("appAuth", "AppAuth contract address (per-app dstack_app_address / app_id, NOT the KMS factory)")
+  .addParam("deviceId", "The Phala device ID to allowlist (hex, 32 bytes)")
+  .setAction(async (taskArgs, hre) => {
+    const proposerKey = process.env.PROPOSER_PRIVATE_KEY;
+    if (!proposerKey) {
+      throw new Error("PROPOSER_PRIVATE_KEY environment variable is required");
+    }
+
+    const { safe: safeAddress, appAuth: appAuthAddress, deviceId } = taskArgs;
+    const chainId = hre.network.config.chainId;
+
+    if (!chainId) {
+      throw new Error(`Chain ID not configured for network ${hre.network.name}`);
+    }
+
+    const proposerWallet = new ethers.Wallet(proposerKey);
+    const proposerAddress = proposerWallet.address;
+    console.log(`Network: ${hre.network.name} (chain ${chainId})`);
+    console.log(`Safe: ${safeAddress}`);
+    console.log(`AppAuth: ${appAuthAddress}`);
+    console.log(`Device ID: ${deviceId}`);
+    console.log(`Proposer address: ${proposerAddress}`);
+
+    // Encode the addDevice call
+    const iface = new ethers.Interface(APP_AUTH_ABI);
+    const deviceIdBytes = deviceId.startsWith("0x") ? deviceId : `0x${deviceId}`;
+    const calldata = iface.encodeFunctionData("addDevice", [deviceIdBytes]);
+
+    console.log(`\nEncoded calldata: ${calldata}`);
+    // Raw values for manual entry into the Safe UI (Transaction Builder) if needed:
+    console.log(`Manual entry — to: ${appAuthAddress}, value: 0, data: ${calldata}`);
+
+    // Initialize Protocol Kit (use any valid signer — we only need it to build the tx)
+    const rpcUrl =
+      (hre.network.config as { url?: string }).url || "https://mainnet.base.org";
+
+    const protocolKit = await Safe.init({
+      provider: rpcUrl,
+      signer: proposerKey,
+      safeAddress,
+    });
+
+    // Create Safe transaction and compute its hash
+    const safeTransaction = await protocolKit.createTransaction({
+      transactions: [
+        {
+          to: appAuthAddress,
+          data: calldata,
+          value: "0",
+          operation: 0, // Call
+        },
+      ],
+    });
+
+    const safeTxHash = await protocolKit.getTransactionHash(safeTransaction);
+    console.log(`\nSafe transaction hash: ${safeTxHash}`);
+
+    // Check if proposer is an owner. If not, sign as delegate using eth_sign
+    // (prepend "\x19Ethereum Signed Message:\n32" prefix).
+    const owners = await protocolKit.getOwners();
+    const isOwner = owners.some(
+      (o) => o.toLowerCase() === proposerAddress.toLowerCase()
+    );
+
+    let senderSignature: string;
+
+    if (isOwner) {
+      // Owner: use Protocol Kit's EIP-712 typed-data signature
+      const signed = await protocolKit.signTransaction(safeTransaction);
+      senderSignature = signed.encodedSignatures();
+    } else {
+      // Delegate: produce an eth_sign signature (pre-image hashed, v adjusted)
+      console.log(`\nProposer is not an owner — signing as delegate (eth_sign)`);
+      const messageBytes = ethers.getBytes(safeTxHash);
+      const rawSig = proposerWallet.signingKey.sign(
+        ethers.hashMessage(messageBytes)
+      );
+      // Safe expects v to be 31 or 32 for eth_sign signatures (v + 4)
+      const v = rawSig.v - 27 + 31;
+      senderSignature = ethers.solidityPacked(
+        ["bytes32", "bytes32", "uint8"],
+        [rawSig.r, rawSig.s, v]
+      );
+    }
+
+    const apiKit = new SafeApiKit({ chainId: BigInt(chainId) });
+
+    await apiKit.proposeTransaction({
+      safeAddress,
+      safeTransactionData: safeTransaction.data,
+      safeTxHash,
+      senderAddress: proposerAddress,
+      senderSignature,
+    });
+
+    console.log(`\nTransaction proposed to Safe Transaction Service.`);
+    console.log(
+      `\nSafe UI: https://app.safe.global/transactions/queue?safe=base:${safeAddress}`
+    );
+    console.log(`Safe TX Hash: ${safeTxHash}`);
+    // Machine-readable output for CI pipelines
+    console.log(`SAFE_TX_HASH=${safeTxHash}`);
+  });


### PR DESCRIPTION
## What

Replaces the hardcoded Phala replica CVM name in our manual deploy workflows with an optional `phala_cvm_name` `workflow_dispatch` input. This removes the per-migration "step 6" of editing a hardcoded CVM name by PR — for a zero-downtime node migration you now just enter the new replica's CVM name when you run the job.

## Why

We're adding a new **prod4** replica of **chipotle-prod** (`app_3f91deaf16ff7c823ee65081d6bafa1ceea05ffc`) and want to upgrade onto it while the existing replica stays up, so prod4 takes over the `api.chipotle.litprotocol.com` CNAME once it's online — a manual "zero-downtime" upgrade. That requires pointing the deploy at an arbitrary replica CVM without a code edit each time.

## Changes

- **`deploy-prod-1-propose.yml`** (chipotle-prod — the Safe two-phase flow): the prod CVM `chipotle-prod-rep-r68r6` was hardcoded in the provision API calls and in the deploy-context that Phase 2 reads. It's now resolved once from `phala_cvm_name` (default = current value) and surfaced as a `prepare-deploy` job output so the draft-release context carries it forward. **Phase 2 (`deploy-prod-2-execute-manual.yml`) needs no change** — it already reads the CVM name from that context artifact.
- **`deploy-staging.yml`** (chipotle-dev / chipotle-next): overrides the per-branch default CVM when the input is set.

Both inputs default to the existing hardcoded values and are **empty on tag/push events**, so automated (`v*` tag, push-to-`main`/`next`) deploys are unchanged.

## ⚠️ Operational notes for the prod4 cutover

- **chipotle-prod is Safe-owned**, so the prod upgrade is still the two-phase flow: Phase 1 propose → **2-of-N signers approve on-chain** → Phase 2 execute. This param does not (and can't) remove that approval step.
- **Allowlisting prod4's device uses the Safe `propose-add-device` → approve → execute flow**, *not* the simple `Phala Add Device (manual)` workflow (that signs with the EOA key, which isn't the prod Safe owner).
- The new prod4 replica CVM must already exist (`phala instances add` prepare + commit) **before** running Phase 1 against it, since Phase 1 provisions the compose against the named CVM.
- **Verification during overlap:** Phase 2's verify jobs hit `https://api.chipotle.litprotocol.com`, which the *old* replica still owns until prod4's ingress takes the CNAME — so a cutover run can deploy fine but fail/time out at the verify step until DNS settles. Follow-up: have the verify target the replica's direct `*-8000.*.phala.network` URL when an override is set (`wait-for-api-restart.yml` already supports this via its `phala_app_name` input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: `propose-add-device` Hardhat task

Allowlisting a new replica's device on **chipotle-prod** can't use `phala allow-devices add` / the `Phala Add Device (manual)` workflow — those sign `addDevice` with an EOA, which reverts because the AppAuth contract (`0x3F91Deaf…`) is owned by the Safe `0xF688411…`. Added `tasks/propose-add-device.ts` (mirrors `propose-dstack-app`): it encodes `addDevice(bytes32 deviceId)` and proposes it to the Safe Transaction Service so signers approve + execute via the Safe UI. Registered in `hardhat.config.ts`.

Run:
```
PROPOSER_PRIVATE_KEY=<safe proposer/delegate key> \
  npx hardhat propose-add-device --network base \
  --safe 0xF688411c0FFc300cAb33EB1dA651DBb3E6891098 \
  --app-auth 0x3F91Deaf16FF7C823eE65081d6bAFA1cEea05FfC \
  --device-id <0x… bytes32 device id>
```


### Plus a one-click wrapper: `Phala Propose Add Device via Safe (manual)`

`.github/workflows/manual_phala-propose-add-device.yml` wraps the task as a `workflow_dispatch` job (mirrors `Phala Add Device (manual)`, but Safe-based). Enter a `device_id` (app_auth/safe default to the chipotle-prod repo vars); it proposes `addDevice` to the Safe and prints the queue link + `SAFE_TX_HASH`. Uses `SAFE_PROPOSER_PRIVATE_KEY`.
