### PR TITLE
fix(phala): raise dstack-ingress nginx proxy timeouts to 900s

### DIFF
--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -128,6 +128,17 @@ services:
       # The IAM user (AWS_ACCESS_KEY_ID) assumes this role to modify DNS records.
       AWS_ROLE_ARN: "${CERTBOT_AWS_ROLE_ARN}"
       AWS_REGION: "${CERTBOT_AWS_REGION}"
+      # Raise the nginx proxy timeouts from their 60s default. dstack-ingress
+      # runs nginx internally for TLS termination; with these unset, a request
+      # whose response takes >60s gets a 504 from the ingress even though the
+      # action runtime (DEFAULT_TIMEOUT_MS) allows up to 15 minutes. We match
+      # that 15-minute runtime budget so the ingress is never the limiting
+      # factor for a long-running Lit Action (e.g. WASM zk-proving). Note:
+      # dstack-gateway's upstream TCP proxy still closes connections idle for
+      # >10 minutes, so a response that needs longer than that with no bytes
+      # flowing requires streaming/async rather than just a longer timeout.
+      PROXY_READ_TIMEOUT: "900s"
+      PROXY_SEND_TIMEOUT: "900s"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
       - cert-data:/etc/letsencrypt


### PR DESCRIPTION
## What

Adds `PROXY_READ_TIMEOUT: "900s"` and `PROXY_SEND_TIMEOUT: "900s"` to the `dstack-ingress` service in `docker-compose.phala.yml`.

## Why

`dstack-ingress` (the `dstacktee/dstack-ingress` image) terminates TLS with **nginx** inside the CVM and reverse-proxies `:443 → lit-api-server:8000`. With the proxy timeouts unset, nginx applies its **default `proxy_read_timeout` of 60s** — so any request whose response takes longer than 60s gets a **`504 Gateway Time-out` (Server: nginx/1.27.4)** from the ingress.

This is misleading because the limit is *not* coming from the platform or the runtime:

- **dstack-gateway** (Phala's ingress) is a custom Rust TCP/TLS proxy — it never parses HTTP and can't emit a 504 or a `Server: nginx` header. Its timeouts are `idle = 10m`, `total = 5h`.
- The **Lit Action runtime** (`lit-api-server`) allows up to **15 minutes** of execution (`DEFAULT_TIMEOUT_MS`).

So the only thing capping a long request at 60s is the nginx *inside dstack-ingress*, which is config we own. This surfaced while testing a long-running WASM action (zk-proving) that completes within the runtime's 15-minute budget but takes longer than 60s end-to-end, and was being cut off with a 504 at exactly 60s.

## How

The pinned image (`sha256:11c0481…`, nginx 1.27.4) already reads `PROXY_READ_TIMEOUT` / `PROXY_SEND_TIMEOUT` in its entrypoint and injects the matching nginx directives into `location /`. Verified by inspecting the running image:

```
$ docker run --rm --entrypoint sh dstacktee/dstack-ingress@sha256:11c0481... \
    -c 'grep -n PROXY_READ_TIMEOUT /scripts/entrypoint.sh'
22:if ! PROXY_READ_TIMEOUT=$(sanitize_proxy_timeout "$PROXY_READ_TIMEOUT"); then
118:    if [ -n "$PROXY_READ_TIMEOUT" ]; then
119:        proxy_read_timeout_conf="        ${PROXY_CMD}_read_timeout ${PROXY_READ_TIMEOUT};"
```

No custom image needed — just the env vars. The sanitizer accepts `^[0-9]+[smh]?$`.

### Why 900s

`900s` (15 min) matches the action runtime's **`DEFAULT_TIMEOUT_MS`**, so the ingress is never the limiting factor for any request the runtime itself would still allow to run.

**Caveat:** dstack-gateway's upstream TCP proxy has an `idle = 10m` (600s) timeout, so a connection that sits idle (no bytes in either direction) for >10 min will still be closed by the gateway before nginx's 900s is reached. For responses that take longer than ~10 min with nothing streaming, the right fix is streaming/async, not a longer proxy timeout. 900s is chosen to align the ingress with the runtime cap, not to enable >10-min idle holds.

## Deploy / risk

- Config-only change to the Phala compose; takes effect on the next ingress (re)deploy.
- No code changes, no new images, no behavioral change for sub-60s requests.
- Recommend rolling out on **dev** first.


## Proof (live test against prod)

Reproduced the 60s cutoff directly against prod (`https://api.chipotle.litprotocol.com/core/v1/lit_action`) with a Lit Action that just sleeps for a configurable duration and reports how long it actually slept:

```js
async function main({ sleepMs }) {
  const start = Date.now();
  await new Promise((r) => setTimeout(r, sleepMs));
  return { requestedMs: sleepMs, sleptMs: Date.now() - start };
}
```

| Requested sleep | Result | Wall time |
|------|--------|-----------|
| 3s   | ✅ `{ sleptMs: 3002 }` | 3.2s |
| 55s  | ✅ `{ requestedMs: 55000, sleptMs: 55002 }` | 55.3s |
| 65s  | ❌ **504 Gateway Time-out** (`Server: nginx/1.27.4`) | **60.18s** |
| 120s | ❌ **504 Gateway Time-out** (`Server: nginx/1.27.4`) | **60.16s** |

The cutoff is hard at **exactly 60s**, and the response is a raw nginx `504` — *not* the runtime's own `deadline_exceeded` error ("Your function exceeded the maximum runtime of {timeout_ms}ms…", `runtime.rs:890`). That's the tell: the action is still executing inside the TEE when nginx gives up. The engine itself would have allowed it to run for the full 15 minutes:

```rust
// lit-actions/server/runtime.rs:39
const DEFAULT_TIMEOUT_MS: u64 = 1000 * 60 * 15; // 15 minutes
```

This confirms the only thing capping requests at 60s is the nginx default `proxy_read_timeout` inside `dstack-ingress` — exactly what this PR fixes by setting it to `900s` to match `DEFAULT_TIMEOUT_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
