### PR TITLE
feat(auto-topup): phase 1 — schema + env vars + cache-invalidation endpoint

### DIFF
--- a/lit-api-server/Cargo.lock
+++ b/lit-api-server/Cargo.lock
@@ -4786,6 +4786,7 @@ dependencies = [
  "sqlx",
  "strum 0.28.0",
  "strum_macros 0.28.0",
+ "subtle",
  "tdx-quote",
  "tokio",
  "toml_edit 0.22.27",

--- a/lit-api-server/Cargo.toml
+++ b/lit-api-server/Cargo.toml
@@ -76,6 +76,7 @@ rand = { version = "0.8" }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 strum = "0.28.0"
 strum_macros = "0.28.0"
+subtle = "2.6"
 url = "2"
 
 rocket_okapi = { version = "=0.9.0", features = ["swagger"] }

--- a/lit-api-server/src/internal/config.rs
+++ b/lit-api-server/src/internal/config.rs
@@ -1,0 +1,38 @@
+//! Env-driven configuration for the inbound `lit-payments` → `lit-api-server`
+//! channel.
+//!
+//! Initialised once at boot and shoved into Rocket-managed state. Mirrors the
+//! `stripe::init()` pattern: returns `None` when the env var is missing so
+//! that local dev / TEE simulator runs without auto-top-up wiring keep
+//! working.
+//!
+//! Required env var:
+//!   • `LIT_INTERNAL_SHARED_SECRET` — shared with `lit-payments`. Compared in
+//!     constant time on inbound `X-Internal-Secret` headers from
+//!     `lit-payments`'s sync-credit handler. `lit-api-server` does NOT call
+//!     `lit-payments` in the new design (the trigger is the `customer.updated`
+//!     webhook), so no outbound URL is needed here.
+
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct InternalConfig {
+    /// Shared secret used by the [`super::guard::InternalSecret`] request
+    /// guard to authorize inbound calls from `lit-payments`
+    /// (`/internal/invalidate_balance_cache` after a successful sync credit).
+    pub lit_internal_shared_secret: String,
+}
+
+/// Initialise from env vars. Returns `None` when the secret is missing or
+/// empty — callers should mirror the existing `stripe::init()` pattern and
+/// route around the absence.
+pub fn init() -> Option<Arc<InternalConfig>> {
+    let secret = std::env::var("LIT_INTERNAL_SHARED_SECRET").ok()?;
+    if secret.trim().is_empty() {
+        return None;
+    }
+    tracing::info!("internal: lit-payments inbound channel enabled");
+    Some(Arc::new(InternalConfig {
+        lit_internal_shared_secret: secret,
+    }))
+}

--- a/lit-api-server/src/internal/guard.rs
+++ b/lit-api-server/src/internal/guard.rs
@@ -1,0 +1,52 @@
+//! Rocket request guard verifying the `X-Internal-Secret` header on inbound
+//! internal-only endpoints (Phase 5 adds `/internal/invalidate_balance_cache`,
+//! which is the first consumer).
+//!
+//! Mirrors `lit-payments::internal::guard::InternalSecret`: constant-time
+//! compare via `subtle::ConstantTimeEq` (§14 of the auto-top-up plan).
+//! Missing header, missing config, or mismatched value all yield 401.
+
+use std::sync::Arc;
+
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+use subtle::ConstantTimeEq;
+
+use super::config::InternalConfig;
+
+const HEADER: &str = "X-Internal-Secret";
+
+pub struct InternalSecret;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for InternalSecret {
+    type Error = ();
+
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let Some(presented) = req.headers().get_one(HEADER) else {
+            return Outcome::Error((Status::Unauthorized, ()));
+        };
+
+        // The Rocket-managed value is `Option<Arc<InternalConfig>>` so dev /
+        // simulator builds without the env vars set degrade to "no internal
+        // endpoints" rather than panicking at boot. A request hitting an
+        // internal endpoint in such a build is by definition unauthorized.
+        let cfg = match req.rocket().state::<Option<Arc<InternalConfig>>>() {
+            Some(Some(c)) => c,
+            Some(None) | None => return Outcome::Error((Status::Unauthorized, ())),
+        };
+
+        let expected = cfg.lit_internal_shared_secret.as_bytes();
+        let presented_bytes = presented.as_bytes();
+
+        if presented_bytes.len() != expected.len() {
+            return Outcome::Error((Status::Unauthorized, ()));
+        }
+
+        if bool::from(presented_bytes.ct_eq(expected)) {
+            Outcome::Success(InternalSecret)
+        } else {
+            Outcome::Error((Status::Unauthorized, ()))
+        }
+    }
+}

--- a/lit-api-server/src/internal/mod.rs
+++ b/lit-api-server/src/internal/mod.rs
@@ -1,0 +1,21 @@
+//! Internal service-to-service primitives for the auto-top-up feature.
+//!
+//! Holds:
+//!   • [`InternalConfig`] — env-driven config
+//!     (`LIT_INTERNAL_SHARED_SECRET`) initialised once at boot.
+//!   • [`InternalSecret`] — Rocket request guard verifying the
+//!     `X-Internal-Secret` header on inbound calls from `lit-payments`.
+//!   • [`routes::invalidate_balance_cache`] — the only internal endpoint.
+//!     Called by `lit-payments` after a successful sync credit so the
+//!     in-memory Stripe balance cache here drops the stale entry.
+//!
+//! `lit-api-server` never calls `lit-payments` in the new design (the
+//! trigger is the `customer.updated` webhook on the lit-payments side), so
+//! there is no outbound client helper.
+
+pub mod config;
+pub mod guard;
+pub mod routes;
+
+pub use config::InternalConfig;
+pub use guard::InternalSecret;

--- a/lit-api-server/src/internal/routes.rs
+++ b/lit-api-server/src/internal/routes.rs
@@ -1,0 +1,128 @@
+//! Internal Rocket routes mounted under `/internal/`.
+//!
+//! Only one endpoint in the new design:
+//!   `POST /internal/invalidate_balance_cache` — called by `lit-payments`
+//!   after a successful sync credit so `lit-api-server`'s in-memory Stripe
+//!   balance cache reflects the new balance immediately. Fire-and-forget on
+//!   the lit-payments side; an unreached endpoint is a degraded path (cache
+//!   self-heals via 10-minute TTL) but not a correctness problem.
+
+use std::sync::Arc;
+
+use rocket::http::Status;
+use rocket::serde::Deserialize;
+use rocket::serde::json::Json;
+use rocket::{State, post};
+
+use super::guard::InternalSecret;
+use crate::stripe::StripeState;
+
+#[derive(Debug, Deserialize)]
+#[serde(crate = "rocket::serde")]
+pub struct InvalidateBalanceCacheRequest {
+    pub customer_id: String,
+}
+
+#[post("/internal/invalidate_balance_cache", format = "json", data = "<body>")]
+pub async fn invalidate_balance_cache(
+    _auth: InternalSecret,
+    body: Json<InvalidateBalanceCacheRequest>,
+    stripe_state: &State<Option<Arc<StripeState>>>,
+) -> Status {
+    let Some(state) = stripe_state.inner() else {
+        // Stripe wiring disabled in this build — nothing to invalidate.
+        // Still return 200 so the caller doesn't log a spurious failure;
+        // there's no cache to be wrong about.
+        return Status::Ok;
+    };
+    state.invalidate_balance_cache(&body.customer_id).await;
+    Status::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    //! Phase 1 gate test: `/internal/invalidate_balance_cache` returns 200
+    //! with the correct `X-Internal-Secret` header and 401 with a missing or
+    //! mismatched one. The actual cache-invalidation side effect is covered
+    //! by Stripe-side tests; here we only verify the auth shape, since that
+    //! is the only thing Phase 1 ships.
+
+    use std::sync::Arc;
+
+    use rocket::http::{ContentType, Header, Status};
+    use rocket::local::asynchronous::Client;
+    use rocket::{Rocket, routes};
+
+    use super::super::config::InternalConfig;
+    use crate::stripe::StripeState;
+
+    const SECRET: &str = "test-secret-very-long-value-12345678";
+
+    async fn build() -> Client {
+        let cfg = Some(Arc::new(InternalConfig {
+            lit_internal_shared_secret: SECRET.to_string(),
+        }));
+        // The route signature takes `Option<Arc<StripeState>>`; ship `None`
+        // — the handler short-circuits to 200 in that case (no cache wired)
+        // and the auth guard runs first regardless, which is what we test.
+        let stripe: Option<Arc<StripeState>> = None;
+        let rocket = Rocket::build()
+            .manage(cfg)
+            .manage(stripe)
+            .mount("/", routes![super::invalidate_balance_cache]);
+        Client::tracked(rocket).await.expect("rocket client")
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_header() {
+        let client = build().await;
+        let resp = client
+            .post("/internal/invalidate_balance_cache")
+            .header(ContentType::JSON)
+            .body(r#"{"customer_id":"cus_test"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), Status::Unauthorized);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_secret() {
+        let client = build().await;
+        let resp = client
+            .post("/internal/invalidate_balance_cache")
+            .header(ContentType::JSON)
+            .header(Header::new("X-Internal-Secret", "definitely-wrong"))
+            .body(r#"{"customer_id":"cus_test"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), Status::Unauthorized);
+    }
+
+    #[tokio::test]
+    async fn accepts_correct_secret() {
+        let client = build().await;
+        let resp = client
+            .post("/internal/invalidate_balance_cache")
+            .header(ContentType::JSON)
+            .header(Header::new("X-Internal-Secret", SECRET))
+            .body(r#"{"customer_id":"cus_test"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), Status::Ok);
+    }
+
+    #[tokio::test]
+    async fn rejects_secret_of_different_length() {
+        // Length-mismatch path: the guard short-circuits before ct_eq.
+        // Verify the same 401 outcome.
+        let client = build().await;
+        let resp = client
+            .post("/internal/invalidate_balance_cache")
+            .header(ContentType::JSON)
+            .header(Header::new("X-Internal-Secret", "short"))
+            .body(r#"{"customer_id":"cus_test"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(resp.status(), Status::Unauthorized);
+    }
+}

--- a/lit-api-server/src/lib.rs
+++ b/lit-api-server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod core;
 pub mod dstack;
 pub mod error;
+pub mod internal;
 pub mod observability;
 pub mod restart;
 pub mod stripe;

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -6,6 +6,7 @@ use lit_api_server::config;
 use lit_api_server::core;
 use lit_api_server::core::v1::guards::cpu_overload::CpuOverloadMonitor;
 use lit_api_server::dstack;
+use lit_api_server::internal;
 use lit_api_server::observability;
 use lit_api_server::restart::{RestartHandle, start_server_trigger_listener};
 use lit_api_server::stripe;
@@ -151,6 +152,7 @@ async fn main() -> Result<(), rocket::Error> {
 
     let cpu_monitor = CpuOverloadMonitor::start();
     let stripe_state = stripe::init();
+    let internal_config = internal::config::init();
 
     // Initialize global singletons once, outside the restart loop, so they
     // aren't re-initialized (and don't re-log) on every Rocket rebuild.
@@ -190,6 +192,7 @@ async fn main() -> Result<(), rocket::Error> {
             chain_config.clone(),
             cpu_monitor.clone(),
             stripe_state.clone(),
+            internal_config.clone(),
             ipfs_cache.clone(),
         );
 
@@ -310,6 +313,7 @@ fn build_rocket(
     chain_config: Arc<lit_api_server::accounts::chain_config::ChainConfig>,
     cpu_monitor: CpuOverloadMonitor,
     stripe_state: Option<Arc<stripe::StripeState>>,
+    internal_config: Option<Arc<internal::InternalConfig>>,
     ipfs_cache: Cache<String, Arc<String>>,
 ) -> rocket::Rocket<rocket::Build> {
     let allowed_methods = HashSet::from([
@@ -349,6 +353,7 @@ fn build_rocket(
             routes![openapi_json, openapi_json_redirect, swagger_ui_redirect],
         )
         .mount("/", core::v1::health::routes())
+        .mount("/", routes![internal::routes::invalidate_balance_cache])
         .mount("/core/v1/", core_routes)
         .mount("/core/v1/", core::v1::health::routes())
         .mount(
@@ -366,6 +371,7 @@ fn build_rocket(
         .manage(chain_config)
         .manage(cpu_monitor)
         .manage(stripe_state)
+        .manage(internal_config)
         .manage(core::v1::health::LitActionsSocketPath(
             std::path::PathBuf::from(core::v1::health::LIT_ACTIONS_SOCKET),
         ));

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -193,6 +193,18 @@ pub async fn invalidate_wallet_cache(api_key: &str, state: &StripeState) {
     state.wallet_cache.invalidate(&cache_key(api_key)).await;
 }
 
+impl StripeState {
+    /// Drop the cached Stripe balance for a customer. Called by the internal
+    /// `/internal/invalidate_balance_cache` endpoint after `lit-payments`
+    /// applies a sync auto-top-up credit, so the next read goes back to
+    /// Stripe rather than serving the stale pre-credit balance from the
+    /// 10-minute TTL cache. Same primitive used internally by
+    /// `confirm_payment_intent` after a manual top-up.
+    pub async fn invalidate_balance_cache(&self, customer_id: &str) {
+        self.balance_cache.invalidate(customer_id).await;
+    }
+}
+
 /// Resolve any account identity to its billing wallet address.
 ///
 /// Accepts a raw API key (master or usage) or — for ChainSecured callers — a

--- a/lit-payments/migrations/20260605000001_auto_topup.sql
+++ b/lit-payments/migrations/20260605000001_auto_topup.sql
@@ -1,0 +1,76 @@
+-- Auto top-up: per-customer config + per-PI credit dedup ledger.
+--
+-- Scope: Stripe-paying users only. The Stripe customer is the source of truth
+-- for the saved PaymentMethod and the credit balance; these two tables hold
+-- the per-user *rule* (enable/threshold/amount/cap/card), the SCA recovery
+-- handoff (when an off-session charge returns authentication_required), and a
+-- dedup row for each successful auto top-up PaymentIntent we credit.
+
+CREATE TABLE auto_topup_config (
+    customer_id                TEXT        PRIMARY KEY,
+    wallet_address             TEXT        NOT NULL UNIQUE,
+    enabled                    BOOLEAN     NOT NULL DEFAULT false,
+    threshold_cents            BIGINT,
+    topup_amount_cents         BIGINT,
+    monthly_cap_cents          BIGINT,
+    payment_method_id          TEXT,
+    consent_version            TEXT,
+    consent_signed_at          TIMESTAMPTZ,
+    -- NULL | 'manual' | 'failures' | 'card_invalid' | 'requires_action'.
+    -- Set when the trigger handler auto-disables (3 consecutive failures) or
+    -- when off-session confirm returns authentication_required.
+    disabled_reason            TEXT,
+    -- SCA handoff: when paymentIntents.create returns authentication_required,
+    -- we stash the pending PI id here so the recovery page can resume it.
+    pending_action_pi_id       TEXT,
+    pending_action_at          TIMESTAMPTZ,
+    -- One-time, single-use token included in the SCA recovery email link.
+    -- 24h expiry; cleared on successful credit or expiry.
+    recovery_token             TEXT,
+    recovery_token_expires_at  TIMESTAMPTZ,
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- enabled=true ⇒ every field needed to actually charge a card must be set,
+    -- and the cap must cover at least one top-up. Min top-up $5 matches the
+    -- existing one-shot floor (MIN_TOPUP_CENTS in lit-api-server).
+    CONSTRAINT enabled_requires_config CHECK (
+        enabled = false OR (
+            threshold_cents IS NOT NULL AND threshold_cents > 0 AND
+            topup_amount_cents IS NOT NULL AND topup_amount_cents >= 500 AND
+            monthly_cap_cents IS NOT NULL AND monthly_cap_cents >= topup_amount_cents AND
+            payment_method_id IS NOT NULL AND
+            consent_version IS NOT NULL AND consent_signed_at IS NOT NULL
+        )
+    )
+);
+
+CREATE INDEX auto_topup_config_wallet_address_idx ON auto_topup_config (wallet_address);
+
+-- Partial index for the SCA recovery token lookup: GET /billing/auto_topup_resume?token=...
+-- resolves a presented token to a customer_id. Partial keeps the index small
+-- since recovery_token is non-NULL only while an SCA handoff is in flight.
+CREATE INDEX auto_topup_config_recovery_token_idx
+    ON auto_topup_config (recovery_token)
+    WHERE recovery_token IS NOT NULL;
+
+-- One row per successful auto top-up PaymentIntent we have credited.
+-- Primary key on payment_intent_id is the permanent dedup against the
+-- synchronous credit path (sync handler vs reconciler retry).
+CREATE TABLE auto_topup_credits (
+    payment_intent_id              TEXT        PRIMARY KEY,
+    customer_id                    TEXT        NOT NULL,
+    amount_cents                   BIGINT      NOT NULL CHECK (amount_cents > 0),
+    stripe_balance_transaction_id  TEXT,
+    credited_at                    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX auto_topup_credits_customer_credited_at_idx
+    ON auto_topup_credits (customer_id, credited_at DESC);
+
+-- Partial index used by the reconciler (§9) to find rows where the PI
+-- succeeded and we inserted the dedup row but the balance_transactions
+-- write didn't finish (NULL stripe_balance_transaction_id). Partial keeps
+-- this index trivially small under normal operation.
+CREATE INDEX auto_topup_credits_pending_balance_tx_idx
+    ON auto_topup_credits (stripe_balance_transaction_id)
+    WHERE stripe_balance_transaction_id IS NULL;

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -39,6 +39,27 @@ pub struct Config {
     /// admin portal and rate poller run but LITKEY browser payments stay
     /// disabled.
     pub litkey_chain: Option<chain::ChainConfig>,
+    /// Base URL of `lit-api-server`, used for the auto-top-up cache
+    /// invalidation callback after a successful credit. e.g.,
+    /// `https://api.litprotocol.com`.
+    pub lit_api_server_base_url: String,
+    /// High-entropy shared secret for the internal `lit-payments` ⇄
+    /// `lit-api-server` hop. Compared in constant time against the
+    /// `X-Internal-Secret` header on internal endpoints. Same value must be
+    /// configured on both services. Generate with `openssl rand -base64 32`.
+    pub lit_internal_shared_secret: String,
+    /// Stripe webhook signing secret. Used to verify the `Stripe-Signature`
+    /// header on `POST /stripe/webhook` (the single `customer.updated`
+    /// event that triggers the auto-top-up flow). Copy from the Stripe
+    /// Dashboard after registering the webhook endpoint, or from
+    /// `stripe listen` output in local dev.
+    pub stripe_webhook_secret: String,
+    /// Interval (seconds) between reconciler runs (Phase 6). The reconciler
+    /// walks recent auto-top-up PIs and credits any that the sync handler
+    /// missed (HTTP timeout on `paymentIntents.create` or the
+    /// `balance_transactions` write). Default 900 (15 minutes); set lower
+    /// (e.g. 60) for local testing.
+    pub reconciler_interval_secs: i64,
 }
 
 impl Config {
@@ -56,6 +77,12 @@ impl Config {
             max_daily_per_operator_cents: optional_i64("MAX_DAILY_PER_OPERATOR_CENTS", 10_000)?,
             litkey_discount_basis_points: parse_discount_basis_points()?,
             litkey_chain: parse_litkey_chain_config()?,
+            lit_api_server_base_url: required("LIT_API_SERVER_BASE_URL")?
+                .trim_end_matches('/')
+                .to_string(),
+            lit_internal_shared_secret: required("LIT_INTERNAL_SHARED_SECRET")?,
+            stripe_webhook_secret: required("STRIPE_WEBHOOK_SECRET")?,
+            reconciler_interval_secs: optional_i64("RECONCILER_INTERVAL_SECS", 900)?,
         })
     }
 }

--- a/lit-payments/src/internal/client.rs
+++ b/lit-payments/src/internal/client.rs
@@ -1,0 +1,60 @@
+//! Outbound internal-call helper.
+//!
+//! Phase 1 wiring for the future cache-invalidation callback to
+//! `lit-api-server`: `POST {LIT_API_SERVER_BASE_URL}/internal/...` with the
+//! `X-Internal-Secret` header set. The Phase 5 webhook handler will be the
+//! first real caller.
+//!
+//! Fire-and-forget at the call site — errors are surfaced via tracing and
+//! never propagated. A stale `lit-api-server` balance cache self-heals via
+//! the existing 10-minute TTL, so a missed callback is a degraded path, not
+//! a correctness problem.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::config::Config;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Build a `reqwest::Client` tuned for the internal hop:
+///   • 5-second total timeout (we never want to block a webhook handler
+///     waiting on the api-server)
+///   • TLS verification on (the default; the production hop is TLS only)
+pub fn build_client() -> Result<Client> {
+    Client::builder()
+        .timeout(TIMEOUT)
+        .build()
+        .context("building internal reqwest client")
+}
+
+/// POST a JSON body to a path on `lit-api-server` with the configured
+/// `X-Internal-Secret`. The path must begin with `/`.
+///
+/// Returns `Ok(())` on any 2xx response; otherwise an error including the
+/// status code (response body is intentionally not echoed — it may contain
+/// the internal secret in a misconfigured deployment).
+pub async fn post_internal<B: Serialize>(
+    client: &Client,
+    cfg: &Config,
+    path: &str,
+    body: &B,
+) -> Result<()> {
+    let url = format!("{}{}", cfg.lit_api_server_base_url, path);
+    let resp = client
+        .post(&url)
+        .header("X-Internal-Secret", &cfg.lit_internal_shared_secret)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("POST {path}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!("internal POST {path} returned {status}");
+    }
+    Ok(())
+}

--- a/lit-payments/src/internal/mod.rs
+++ b/lit-payments/src/internal/mod.rs
@@ -1,0 +1,10 @@
+//! Internal service-to-service primitives.
+//!
+//! `lit-payments` initiates calls to `lit-api-server` (cache invalidation
+//! after a successful sync credit — Phase 5). The reverse direction
+//! (`lit-api-server` → `lit-payments`) is intentionally absent in the new
+//! design: the auto-top-up trigger is the Stripe `customer.updated` webhook,
+//! not a fire-and-forget call from `lit-api-server`. So we only ship the
+//! outbound client helper here.
+
+pub mod client;

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod chain;
 pub mod config;
 pub mod db;
+pub mod internal;
 pub mod mail;
 pub mod portal;
 pub mod rate;


### PR DESCRIPTION
**Stack:** PR 1 of 8. Base: `DashKash54/stripe-metadata-vs-postgres`. Next: [#450](https://github.com/LIT-Protocol/chipotle/pull/450).

## What this PR does

Ships the foundation layer for the Stripe auto top-up feature. Three pieces, none of which contain auto-topup business logic yet — but every subsequent phase depends on them.

1. **Postgres schema** for the two new tables auto top-up needs.
2. **Env vars + shared-secret guard** so lit-payments can call lit-api-server (and vice versa) over an authenticated internal channel.
3. **`POST /internal/invalidate_balance_cache`** on lit-api-server — the only inbound internal call lit-api-server accepts from lit-payments. Phase 5 fires this after a successful sync credit so the api-server's balance cache drops the stale entry.

## How it's implemented

* `lit-payments/migrations/20260605000001_auto_topup.sql`:
  - `auto_topup_config` (per-user rule). Primary key `customer_id`, `UNIQUE(wallet_address)`, includes SCA-recovery columns (`pending_action_pi_id`, `pending_action_at`, `recovery_token`, `recovery_token_expires_at`) used by Phases 5 + 7. `CHECK enabled_requires_config` enforces "`enabled=true` ⇒ threshold/topup/cap/pm/consent all set".
  - `auto_topup_credits` (per-PI dedup ledger). PK on `payment_intent_id` so the Phase 5 webhook handler + Phase 6 reconciler converge on exactly one credit per PI.
  - Two partial indexes: `recovery_token IS NOT NULL` (Phase 7 token lookup) and `stripe_balance_transaction_id IS NULL` (Phase 6 reconciler's "partial credit" scan).
* `lit-payments/src/config.rs`: adds `LIT_API_SERVER_BASE_URL`, `LIT_INTERNAL_SHARED_SECRET`, `STRIPE_WEBHOOK_SECRET`, optional `RECONCILER_INTERVAL_SECS` (default 900) to `Config::from_env()`.
* `lit-payments/src/internal/client.rs`: reusable `reqwest::Client` builder + `post_internal()` helper for outbound calls to lit-api-server. Carries the `X-Internal-Secret` header.
* `lit-api-server/src/internal/{config,guard,routes}.rs`:
  - `InternalConfig::init()` reads `LIT_INTERNAL_SHARED_SECRET`, returns `None` when absent (mirrors `stripe::init()` pattern so dev/simulator builds don't crash without it).
  - `InternalSecret` Rocket request guard, constant-time compare via `subtle::ConstantTimeEq`. 401 on missing/wrong/length-mismatched header.
  - `POST /internal/invalidate_balance_cache` route, body `{customer_id}`, calls a new public method `StripeState::invalidate_balance_cache(&self, customer_id: &str)` that wraps the existing private `balance_cache.invalidate()` (mirrors precedent at `stripe.rs:613`).

## How it's been tested

* `cargo test --lib internal::` in `lit-api-server`: 4 Rocket integration tests using `rocket::local::asynchronous::Client` (same pattern as `health.rs`):
  - `accepts_correct_secret` → 200
  - `rejects_missing_header` → 401
  - `rejects_wrong_secret` → 401
  - `rejects_secret_of_different_length` → 401
* `cargo check` clean on both crates.
* `psql \d` against a freshly-migrated local Postgres confirms both tables, all columns, primary keys, the unique constraint, both partial indexes, and the `enabled_requires_config` CHECK.
* `INSERT … enabled=true` with null fields verified live to be rejected by the CHECK constraint.

## Key areas for review

* **Schema correctness** — `lit-payments/migrations/20260605000001_auto_topup.sql`. CHECK predicate, partial-index `WHERE` clauses, and SCA columns are load-bearing for later phases.
* **Constant-time compare** — `lit-api-server/src/internal/guard.rs:50–55`. Length-shortcircuit is intentional (length of expected secret isn't itself secret); the byte comparison uses `subtle::ConstantTimeEq`.
* **Cache-invalidation public surface** — `lit-api-server/src/stripe.rs` adds `impl StripeState { pub async fn invalidate_balance_cache(&self, ...) }`. Verify it's exactly what Phase 5's webhook handler will call.
* **Env-var failure mode** — `InternalConfig::init()` returns `None` when missing, which means routes that depend on it fail closed. Confirm that's the right shape for the TEE deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
