### PR TITLE
feat(auto-topup): phase 4 — GET/PUT /billing/auto_topup_config + validation

### DIFF
--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -2110,6 +2110,7 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sqlx",
  "time",
@@ -3326,6 +3327,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -42,3 +42,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 # Used by Phase 3+ integration tests to base64-encode mock X-Wallet-Auth
 # payloads. Production code in this crate doesn't need it.
 base64_light = "0.1"
+# Serializes integration tests that touch shared external state (Stripe
+# customers keyed by wallet metadata, real Postgres rows). Tagging tests
+# with `#[serial]` prevents the "search-lag duplicate creation" race the
+# Phase 4 development run hit.
+serial_test = "3"

--- a/lit-payments/src/auto_topup/db.rs
+++ b/lit-payments/src/auto_topup/db.rs
@@ -1,0 +1,172 @@
+//! Postgres queries against `auto_topup_config` and `auto_topup_credits`.
+//!
+//! The CHECK constraint on `auto_topup_config` (migration §4) is the source
+//! of truth for "enabled requires complete config" — we deliberately let
+//! the DB reject bad combinations rather than duplicating the logic in
+//! application code. The handler maps the `check_violation` SQLSTATE
+//! (`23514`) to a 400 with a clear message.
+
+use anyhow::Result;
+use sqlx::PgPool;
+use time::OffsetDateTime;
+
+use super::types::{AutoTopupConfigRow, AutoTopupConfigUpsert};
+
+type Row = (
+    String,                 // customer_id
+    String,                 // wallet_address
+    bool,                   // enabled
+    Option<i64>,            // threshold_cents
+    Option<i64>,            // topup_amount_cents
+    Option<i64>,            // monthly_cap_cents
+    Option<String>,         // payment_method_id
+    Option<String>,         // consent_version
+    Option<OffsetDateTime>, // consent_signed_at
+    Option<String>,         // disabled_reason
+    Option<String>,         // pending_action_pi_id
+    Option<OffsetDateTime>, // pending_action_at
+    Option<String>,         // recovery_token
+    Option<OffsetDateTime>, // recovery_token_expires_at
+    OffsetDateTime,         // updated_at
+);
+
+fn into_row(r: Row) -> AutoTopupConfigRow {
+    AutoTopupConfigRow {
+        customer_id: r.0,
+        wallet_address: r.1,
+        enabled: r.2,
+        threshold_cents: r.3,
+        topup_amount_cents: r.4,
+        monthly_cap_cents: r.5,
+        payment_method_id: r.6,
+        consent_version: r.7,
+        consent_signed_at: r.8,
+        disabled_reason: r.9,
+        pending_action_pi_id: r.10,
+        pending_action_at: r.11,
+        recovery_token: r.12,
+        recovery_token_expires_at: r.13,
+        updated_at: r.14,
+    }
+}
+
+const SELECT_COLUMNS: &str = "customer_id, wallet_address, enabled, \
+    threshold_cents, topup_amount_cents, monthly_cap_cents, payment_method_id, \
+    consent_version, consent_signed_at, disabled_reason, \
+    pending_action_pi_id, pending_action_at, recovery_token, \
+    recovery_token_expires_at, updated_at";
+
+pub async fn get_by_customer_id(
+    pool: &PgPool,
+    customer_id: &str,
+) -> Result<Option<AutoTopupConfigRow>> {
+    let row: Option<Row> = sqlx::query_as(&format!(
+        "SELECT {SELECT_COLUMNS} FROM auto_topup_config WHERE customer_id = $1"
+    ))
+    .bind(customer_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(into_row))
+}
+
+/// UPSERT the per-user config row.
+///
+/// Behavior on transition to `enabled = false`:
+///   * `disabled_reason` set to `'manual'`
+///   * `pending_action_pi_id`, `pending_action_at`, `recovery_token`,
+///     `recovery_token_expires_at` are all NULLed
+///
+/// The reset closes the gap codex flagged ("stale SCA/recovery state can
+/// trigger later charges"): once a user opts out, any pending off-session
+/// authentication handoff is moot, so the row should not carry the bait
+/// that would re-engage the flow when the user re-enables.
+///
+/// `wallet_address` is required so a brand-new row can be inserted; for
+/// existing rows the UPDATE branch keeps the existing wallet_address (the
+/// caller's resolved wallet always matches it anyway thanks to the UNIQUE
+/// constraint).
+pub async fn upsert(
+    pool: &PgPool,
+    customer_id: &str,
+    wallet_address: &str,
+    body: &AutoTopupConfigUpsert,
+) -> Result<AutoTopupConfigRow> {
+    // `consent_signed_at` is recorded now (server time) — never trusted
+    // from the client.
+    let now = OffsetDateTime::now_utc();
+    let consent_signed_at = if body.enabled { Some(now) } else { None };
+
+    let (disabled_reason, pending_pi, pending_at, token, token_exp) = if body.enabled {
+        // Re-enabling: don't carry forward an old disabled_reason; pending
+        // state, if any, stays — a webhook handler may still need it.
+        (
+            None::<String>,
+            None::<String>,
+            None::<OffsetDateTime>,
+            None::<String>,
+            None::<OffsetDateTime>,
+        )
+    } else {
+        // Disabling: 'manual' is the user-initiated reason. Pending state
+        // is cleared (see doc comment).
+        (Some("manual".to_string()), None, None, None, None)
+    };
+
+    let row: Row = sqlx::query_as(&format!(
+        "INSERT INTO auto_topup_config (\
+            customer_id, wallet_address, enabled, threshold_cents, \
+            topup_amount_cents, monthly_cap_cents, payment_method_id, \
+            consent_version, consent_signed_at, disabled_reason, \
+            pending_action_pi_id, pending_action_at, recovery_token, \
+            recovery_token_expires_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) \
+         ON CONFLICT (customer_id) DO UPDATE SET \
+            enabled = EXCLUDED.enabled, \
+            threshold_cents = EXCLUDED.threshold_cents, \
+            topup_amount_cents = EXCLUDED.topup_amount_cents, \
+            monthly_cap_cents = EXCLUDED.monthly_cap_cents, \
+            payment_method_id = EXCLUDED.payment_method_id, \
+            consent_version = EXCLUDED.consent_version, \
+            consent_signed_at = EXCLUDED.consent_signed_at, \
+            disabled_reason = EXCLUDED.disabled_reason, \
+            pending_action_pi_id = EXCLUDED.pending_action_pi_id, \
+            pending_action_at = EXCLUDED.pending_action_at, \
+            recovery_token = EXCLUDED.recovery_token, \
+            recovery_token_expires_at = EXCLUDED.recovery_token_expires_at, \
+            updated_at = EXCLUDED.updated_at \
+         RETURNING {SELECT_COLUMNS}"
+    ))
+    .bind(customer_id)
+    .bind(wallet_address)
+    .bind(body.enabled)
+    .bind(body.threshold_cents)
+    .bind(body.topup_amount_cents)
+    .bind(body.monthly_cap_cents)
+    .bind(body.payment_method_id.as_deref())
+    .bind(body.consent_version.as_deref())
+    .bind(consent_signed_at)
+    .bind(disabled_reason)
+    .bind(pending_pi)
+    .bind(pending_at)
+    .bind(token)
+    .bind(token_exp)
+    .bind(now)
+    .fetch_one(pool)
+    .await?;
+    Ok(into_row(row))
+}
+
+/// Returns true if the error is a Postgres CHECK constraint violation
+/// (SQLSTATE 23514) on the `enabled_requires_config` constraint. Lets
+/// handlers map "you said enabled=true but didn't set all required fields"
+/// to a 400 cleanly.
+pub fn is_check_constraint_violation(e: &anyhow::Error) -> bool {
+    e.downcast_ref::<sqlx::Error>()
+        .and_then(|e| match e {
+            sqlx::Error::Database(db) => Some(db),
+            _ => None,
+        })
+        .and_then(|db| db.code())
+        .map(|code| code == "23514")
+        .unwrap_or(false)
+}

--- a/lit-payments/src/auto_topup/db.rs
+++ b/lit-payments/src/auto_topup/db.rs
@@ -96,20 +96,20 @@ pub async fn upsert(
     let now = OffsetDateTime::now_utc();
     let consent_signed_at = if body.enabled { Some(now) } else { None };
 
-    let (disabled_reason, pending_pi, pending_at, token, token_exp) = if body.enabled {
-        // Re-enabling: don't carry forward an old disabled_reason; pending
-        // state, if any, stays — a webhook handler may still need it.
-        (
-            None::<String>,
-            None::<String>,
-            None::<OffsetDateTime>,
-            None::<String>,
-            None::<OffsetDateTime>,
-        )
+    // Codex P1 (Phase 4) fix: pending SCA recovery state belongs to the
+    // server, not the client. A normal enabled save during
+    // `requires_action` must NOT wipe `pending_action_pi_id` /
+    // `recovery_token` / etc. The SQL `ON CONFLICT DO UPDATE` below uses
+    // a CASE expression on each pending field to preserve the existing
+    // value when the upsert keeps the row enabled, and only clears them
+    // when the user explicitly disables. We also keep `disabled_reason`
+    // intact while it is `requires_action` so the dashboard's SCA banner
+    // logic stays correct; other disabled_reasons ('manual', 'failures')
+    // are cleared on re-enable as the user expects.
+    let new_disabled_reason: Option<String> = if body.enabled {
+        None
     } else {
-        // Disabling: 'manual' is the user-initiated reason. Pending state
-        // is cleared (see doc comment).
-        (Some("manual".to_string()), None, None, None, None)
+        Some("manual".to_string())
     };
 
     let row: Row = sqlx::query_as(&format!(
@@ -119,7 +119,7 @@ pub async fn upsert(
             consent_version, consent_signed_at, disabled_reason, \
             pending_action_pi_id, pending_action_at, recovery_token, \
             recovery_token_expires_at, updated_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULL, NULL, NULL, NULL, $11) \
          ON CONFLICT (customer_id) DO UPDATE SET \
             enabled = EXCLUDED.enabled, \
             threshold_cents = EXCLUDED.threshold_cents, \
@@ -128,11 +128,27 @@ pub async fn upsert(
             payment_method_id = EXCLUDED.payment_method_id, \
             consent_version = EXCLUDED.consent_version, \
             consent_signed_at = EXCLUDED.consent_signed_at, \
-            disabled_reason = EXCLUDED.disabled_reason, \
-            pending_action_pi_id = EXCLUDED.pending_action_pi_id, \
-            pending_action_at = EXCLUDED.pending_action_at, \
-            recovery_token = EXCLUDED.recovery_token, \
-            recovery_token_expires_at = EXCLUDED.recovery_token_expires_at, \
+            disabled_reason = CASE \
+                WHEN NOT EXCLUDED.enabled THEN EXCLUDED.disabled_reason \
+                WHEN auto_topup_config.disabled_reason = 'requires_action' THEN 'requires_action' \
+                ELSE NULL \
+            END, \
+            pending_action_pi_id = CASE \
+                WHEN EXCLUDED.enabled THEN auto_topup_config.pending_action_pi_id \
+                ELSE NULL \
+            END, \
+            pending_action_at = CASE \
+                WHEN EXCLUDED.enabled THEN auto_topup_config.pending_action_at \
+                ELSE NULL \
+            END, \
+            recovery_token = CASE \
+                WHEN EXCLUDED.enabled THEN auto_topup_config.recovery_token \
+                ELSE NULL \
+            END, \
+            recovery_token_expires_at = CASE \
+                WHEN EXCLUDED.enabled THEN auto_topup_config.recovery_token_expires_at \
+                ELSE NULL \
+            END, \
             updated_at = EXCLUDED.updated_at \
          RETURNING {SELECT_COLUMNS}"
     ))
@@ -145,11 +161,7 @@ pub async fn upsert(
     .bind(body.payment_method_id.as_deref())
     .bind(body.consent_version.as_deref())
     .bind(consent_signed_at)
-    .bind(disabled_reason)
-    .bind(pending_pi)
-    .bind(pending_at)
-    .bind(token)
-    .bind(token_exp)
+    .bind(new_disabled_reason)
     .bind(now)
     .fetch_one(pool)
     .await?;

--- a/lit-payments/src/auto_topup/mod.rs
+++ b/lit-payments/src/auto_topup/mod.rs
@@ -1,0 +1,11 @@
+//! Auto top-up feature: Postgres types + queries shared by the dashboard
+//! config endpoints (Phase 4) and the customer.updated webhook handler
+//! (Phase 5).
+//!
+//! Routes are mounted from `crate::billing::*`. Webhook + reconciler lands
+//! in later phases; everything that reads or writes
+//! `auto_topup_config` / `auto_topup_credits` flows through this module
+//! so the SQL surface stays in one place.
+
+pub mod db;
+pub mod types;

--- a/lit-payments/src/auto_topup/types.rs
+++ b/lit-payments/src/auto_topup/types.rs
@@ -1,0 +1,50 @@
+//! Strongly-typed view of an `auto_topup_config` row.
+//!
+//! `cents` everywhere — never dollars. The dashboard converts at the edge.
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// Full snapshot of an `auto_topup_config` row.
+///
+/// Optional fields reflect the schema: when `enabled = false`, all
+/// configuration fields may be NULL. The CHECK constraint on the table
+/// guarantees that `enabled = true` rows have every required field set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoTopupConfigRow {
+    pub customer_id: String,
+    pub wallet_address: String,
+    pub enabled: bool,
+    pub threshold_cents: Option<i64>,
+    pub topup_amount_cents: Option<i64>,
+    pub monthly_cap_cents: Option<i64>,
+    pub payment_method_id: Option<String>,
+    pub consent_version: Option<String>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub consent_signed_at: Option<OffsetDateTime>,
+    pub disabled_reason: Option<String>,
+    pub pending_action_pi_id: Option<String>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub pending_action_at: Option<OffsetDateTime>,
+    pub recovery_token: Option<String>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub recovery_token_expires_at: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub updated_at: OffsetDateTime,
+}
+
+/// Caller-supplied fields for the `PUT /billing/auto_topup_config` upsert.
+///
+/// Only the user-controllable fields appear here. Server-derived fields
+/// (`pending_action_pi_id`, `recovery_token`, `disabled_reason`,
+/// `updated_at`) are managed by the webhook handler and the disable
+/// transition — the dashboard never writes them directly.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AutoTopupConfigUpsert {
+    pub enabled: bool,
+    pub threshold_cents: Option<i64>,
+    pub topup_amount_cents: Option<i64>,
+    pub monthly_cap_cents: Option<i64>,
+    pub payment_method_id: Option<String>,
+    pub consent_version: Option<String>,
+}

--- a/lit-payments/src/billing/auto_topup_config.rs
+++ b/lit-payments/src/billing/auto_topup_config.rs
@@ -1,0 +1,230 @@
+//! `GET` / `PUT /billing/auto_topup_config` — dashboard CRUD for the
+//! per-user auto top-up rule.
+//!
+//! Behind the [`BillingAuth`] guard. Wallet-sig path is fully supported;
+//! API-key callers get 501 until the resolver hop is wired (Phase 5 needs
+//! the on-chain mapping anyway).
+//!
+//! The PUT path enforces:
+//!   - `cap >= topup_amount` (cap must cover at least one top-up)
+//!   - `topup_amount >= $5` (matches the existing manual-topup floor)
+//!   - `payment_method_id` belongs to the caller's Stripe customer
+//!     (prevents wallet A from setting a `pm_xxx` that belongs to wallet B)
+//!
+//! On the disable transition (`enabled = false`), the DB layer NULLs out
+//! pending SCA-recovery state — closing codex's gap #15 about stale
+//! pending_action_pi_id triggering charges after a user opts out.
+
+use lit_billing_auth::BillingAuth;
+use lit_billing_core::{StripeClient, customer};
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::{State, get, put};
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::auto_topup::db;
+use crate::auto_topup::types::{AutoTopupConfigRow, AutoTopupConfigUpsert};
+
+/// Hard floor on a single top-up amount: $5.00. Matches the existing
+/// one-shot manual top-up minimum so users don't get conflicting limits.
+const MIN_TOPUP_CENTS: i64 = 500;
+
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    pub error: &'static str,
+    pub message: String,
+}
+
+fn err(status: Status, code: &'static str, msg: impl Into<String>) -> (Status, Json<ErrorBody>) {
+    (
+        status,
+        Json(ErrorBody {
+            error: code,
+            message: msg.into(),
+        }),
+    )
+}
+
+/// Shared identity resolution: the dashboard endpoints all need the
+/// caller's wallet address + Stripe customer id. Wallet-sig auth gives us
+/// the wallet directly; API-key auth needs the on-chain resolver hop
+/// (Phase 5+). For now we 501 the API-key path so the dashboard's
+/// wallet-sig flow ships unblocked.
+async fn resolve_caller(
+    auth: &BillingAuth,
+    stripe: &StripeClient,
+) -> Result<(String, String), (Status, Json<ErrorBody>)> {
+    let wallet_address = match auth {
+        BillingAuth::WalletSigned {
+            wallet_address_hex, ..
+        } => wallet_address_hex.clone(),
+        BillingAuth::ApiKey(_) => {
+            return Err(err(
+                Status::NotImplemented,
+                "api_key_config_unsupported",
+                "API-key callers must use the dashboard wallet-sign flow to manage auto top-up config.",
+            ));
+        }
+    };
+    let customer_id = customer::find_by_wallet(stripe, &wallet_address)
+        .await
+        .map_err(|e| {
+            tracing::error!("auto_topup_config: customer lookup failed: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "stripe_lookup_failed",
+                "Could not contact Stripe to look up your customer record; try again.",
+            )
+        })?
+        .ok_or_else(|| {
+            err(
+                Status::BadRequest,
+                "no_stripe_customer",
+                "Make a one-time top-up first to set up billing, then come back to configure auto top-up.",
+            )
+        })?;
+    Ok((wallet_address, customer_id))
+}
+
+#[get("/billing/auto_topup_config")]
+pub async fn get_auto_topup_config(
+    auth: BillingAuth,
+    stripe: &State<StripeClient>,
+    pool: &State<PgPool>,
+) -> Result<Json<Option<AutoTopupConfigRow>>, (Status, Json<ErrorBody>)> {
+    let (_wallet, customer_id) = resolve_caller(&auth, stripe.inner()).await?;
+    let row = db::get_by_customer_id(pool.inner(), &customer_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("auto_topup_config GET: db read failed: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "db_unavailable",
+                "Could not read your auto top-up config; try again.",
+            )
+        })?;
+    Ok(Json(row))
+}
+
+/// Verify `payment_method_id` is attached to the caller's Stripe customer.
+///
+/// We list the customer's payment methods (paginated; 100/page) and require
+/// the requested `pm_xxx` to appear. This is the cheapest cross-tenant
+/// guard: even with 100s of cards, the API call cost is bounded, and a
+/// caller can only attach a pm_xxx they actually own (Stripe enforces that
+/// at the SetupIntent confirm step).
+async fn verify_payment_method_owned(
+    stripe: &StripeClient,
+    customer_id: &str,
+    payment_method_id: &str,
+) -> Result<bool, anyhow::Error> {
+    let resp = stripe
+        .get(
+            "payment_methods",
+            &[
+                ("customer", customer_id),
+                ("type", "card"),
+                ("limit", "100"),
+            ],
+        )
+        .await?;
+    let owned = resp
+        .body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| m.get("id").and_then(|v| v.as_str()))
+                .any(|id| id == payment_method_id)
+        })
+        .unwrap_or(false);
+    Ok(owned)
+}
+
+#[put("/billing/auto_topup_config", format = "json", data = "<body>")]
+pub async fn put_auto_topup_config(
+    auth: BillingAuth,
+    body: Json<AutoTopupConfigUpsert>,
+    stripe: &State<StripeClient>,
+    pool: &State<PgPool>,
+) -> Result<Json<AutoTopupConfigRow>, (Status, Json<ErrorBody>)> {
+    let (wallet_address, customer_id) = resolve_caller(&auth, stripe.inner()).await?;
+    let body = body.into_inner();
+
+    // Server-side invariants. The DB CHECK constraint also enforces these,
+    // but giving a structured error message is friendlier than surfacing a
+    // raw constraint violation.
+    if body.enabled {
+        let threshold = body.threshold_cents.unwrap_or(0);
+        let topup = body.topup_amount_cents.unwrap_or(0);
+        let cap = body.monthly_cap_cents.unwrap_or(0);
+        if threshold <= 0 || topup < MIN_TOPUP_CENTS || cap < topup {
+            return Err(err(
+                Status::BadRequest,
+                "invalid_config",
+                format!(
+                    "Auto top-up requires threshold > 0, top-up amount >= {MIN_TOPUP_CENTS} cents, \
+                     and monthly cap >= top-up amount."
+                ),
+            ));
+        }
+        if body.payment_method_id.is_none() {
+            return Err(err(
+                Status::BadRequest,
+                "invalid_config",
+                "Auto top-up requires a saved card. Save one first via /billing/setup_intent.",
+            ));
+        }
+        if body.consent_version.is_none() {
+            return Err(err(
+                Status::BadRequest,
+                "invalid_config",
+                "Auto top-up requires consent acknowledgement.",
+            ));
+        }
+    }
+
+    // Cross-tenant guard: a wallet must not be able to set a pm_xxx that
+    // belongs to a different Stripe customer.
+    if let Some(pm) = body.payment_method_id.as_deref() {
+        let owned = verify_payment_method_owned(stripe.inner(), &customer_id, pm)
+            .await
+            .map_err(|e| {
+                tracing::error!("auto_topup_config PUT: pm ownership check failed: {e}");
+                err(
+                    Status::ServiceUnavailable,
+                    "stripe_lookup_failed",
+                    "Could not verify the payment method; try again.",
+                )
+            })?;
+        if !owned {
+            return Err(err(
+                Status::BadRequest,
+                "payment_method_not_owned",
+                "That payment method does not belong to your account.",
+            ));
+        }
+    }
+
+    let row = db::upsert(pool.inner(), &customer_id, &wallet_address, &body)
+        .await
+        .map_err(|e| {
+            if db::is_check_constraint_violation(&e) {
+                err(
+                    Status::BadRequest,
+                    "invalid_config",
+                    "Auto top-up requires all of threshold, top-up amount, monthly cap, \
+                     a saved card, and consent when enabled.",
+                )
+            } else {
+                tracing::error!("auto_topup_config PUT: upsert failed: {e}");
+                err(
+                    Status::ServiceUnavailable,
+                    "db_unavailable",
+                    "Could not save your auto top-up config; try again.",
+                )
+            }
+        })?;
+    Ok(Json(row))
+}

--- a/lit-payments/src/billing/auto_topup_config_tests.rs
+++ b/lit-payments/src/billing/auto_topup_config_tests.rs
@@ -1,0 +1,461 @@
+//! Phase 4 integration tests for `GET` / `PUT /billing/auto_topup_config`.
+//!
+//! Requires `STRIPE_SECRET_KEY` (skip silently if absent) AND
+//! `DATABASE_URL` pointed at the local dev Postgres with migrations
+//! applied. The skip-on-missing-key pattern keeps the suite green on
+//! machines without billing credentials configured.
+//!
+//! Each test uses a deterministic wallet address; the
+//! [`super::setup_intent_tests::ensure_unique_customer`] helper handles
+//! Stripe search-lag duplicate creation across reruns.
+//!
+//! Scenarios:
+//!   - GET on a wallet with no DB row → 200 + `null`.
+//!   - PUT enabled=false → 200, `disabled_reason = 'manual'`, GET roundtrip.
+//!   - PUT enabled=true with all fields → 200, row persisted.
+//!   - PUT enabled=true with `cap < topup_amount` → 400 (server validation).
+//!   - PUT enabled=true with `topup < $5` → 400.
+//!   - PUT enabled=true with null threshold → 400.
+//!   - PUT with pm_xxx belonging to a DIFFERENT customer → 400
+//!     (cross-tenant guard — codex gap #14).
+//!   - Disable transition clears `pending_action_pi_id` + `recovery_token`
+//!     (codex gap #15).
+//!   - API-key caller → 501.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lit_billing_auth::{AuthError, AuthResolver, ResolvedIdentity, WalletAuthPayload};
+use lit_billing_core::StripeClient;
+use rocket::http::{Header, Status};
+use rocket::local::asynchronous::Client;
+use rocket::{Rocket, routes};
+use serde_json::Value;
+use sqlx::PgPool;
+
+use crate::auto_topup::types::AutoTopupConfigUpsert;
+use crate::config::Config;
+
+const TEST_WALLET_CRUD_BASIC: &str = "0xcccc0000cccc0000cccc0000cccc0000cccc0003";
+const TEST_WALLET_CRUD_PM_OWNERSHIP: &str = "0xeeee0000eeee0000eeee0000eeee0000eeee0005";
+const TEST_WALLET_CRUD_DISABLE: &str = "0xdddd0000dddd0000dddd0000dddd0000dddd0006";
+
+fn stripe_key() -> Option<String> {
+    std::env::var("STRIPE_SECRET_KEY").ok().filter(|k| {
+        !k.trim().is_empty() && (k.starts_with("rk_test_") || k.starts_with("sk_test_"))
+    })
+}
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+fn test_config(stripe_secret_key: String, db_url: String) -> Config {
+    Config {
+        database_url: db_url,
+        magic_link_signing_key: vec![0u8; 32],
+        resend_api_key: "unused".into(),
+        mail_from: "unused".into(),
+        public_base_url: "http://unused".into(),
+        stripe_secret_key,
+        stripe_publishable_key: "pk_test_phase4_test".into(),
+        max_grant_cents: 0,
+        max_daily_per_operator_cents: 0,
+        litkey_discount_basis_points: 0,
+        litkey_chain: None,
+        lit_api_server_base_url: "http://unused".into(),
+        lit_internal_shared_secret: "unused".into(),
+        stripe_webhook_secret: "unused".into(),
+        reconciler_interval_secs: 900,
+    }
+}
+
+struct FixedWalletResolver {
+    wallet: String,
+}
+
+#[async_trait]
+impl AuthResolver for FixedWalletResolver {
+    async fn verify_wallet_auth(
+        &self,
+        _payload: &WalletAuthPayload,
+    ) -> Result<ResolvedIdentity, AuthError> {
+        Ok(ResolvedIdentity {
+            wallet_address_hex: self.wallet.clone(),
+            api_key_hash_hex: format!("0x{}", "0".repeat(64)),
+        })
+    }
+    async fn resolve_api_key(&self, _api_key: &str) -> Result<ResolvedIdentity, AuthError> {
+        Err(AuthError::BadCredentials("unused".into()))
+    }
+}
+
+async fn build_client(key: String, db_url: String, wallet: &str) -> Client {
+    let cfg = test_config(key.clone(), db_url.clone());
+    let stripe = StripeClient::new(key).expect("stripe client");
+    let pool = PgPool::connect(&db_url).await.expect("connect db");
+    let resolver: Arc<dyn AuthResolver> = Arc::new(FixedWalletResolver {
+        wallet: wallet.to_string(),
+    });
+    let rocket = Rocket::build()
+        .manage(cfg)
+        .manage(stripe)
+        .manage(pool)
+        .manage(resolver)
+        .mount(
+            "/",
+            routes![
+                super::auto_topup_config::get_auto_topup_config,
+                super::auto_topup_config::put_auto_topup_config,
+            ],
+        );
+    Client::tracked(rocket).await.expect("rocket client")
+}
+
+fn wallet_header() -> String {
+    let json = serde_json::json!({"typed_data":{"primaryType":"BillingAuth"},"signature":"0xdead"});
+    base64_light::base64_encode(&serde_json::to_string(&json).unwrap())
+}
+
+/// Attach a `pm_card_visa` PaymentMethod to the customer and return its id.
+/// Idempotent enough for tests — Stripe lets a single PaymentMethod attach
+/// to many customers (different ids per attach); on rerun we get a fresh
+/// pm_xxx but the previous one stays attached. That doesn't affect the
+/// ownership-check tests since we always use the freshly-returned id.
+async fn attach_test_card(stripe: &StripeClient, customer_id: &str) -> String {
+    let pm = stripe
+        .post(
+            "payment_methods",
+            &[("type", "card"), ("card[token]", "tok_visa")],
+        )
+        .await
+        .expect("create pm");
+    let pm_id = pm.body["id"].as_str().expect("pm id").to_string();
+    stripe
+        .post(
+            &format!("payment_methods/{pm_id}/attach"),
+            &[("customer", customer_id)],
+        )
+        .await
+        .expect("attach pm");
+    pm_id
+}
+
+/// Delete the `auto_topup_config` rows for this wallet so each test starts
+/// from a clean slate. We delete by wallet_address (not customer_id) because
+/// the schema enforces `UNIQUE(wallet_address)` — if test dedup churned the
+/// Stripe customer id, the old row still holds the wallet lock and would
+/// block a fresh UPSERT. Idempotent.
+async fn reset_config_row_for_wallet(pool: &PgPool, wallet_address: &str) {
+    let _ = sqlx::query("DELETE FROM auto_topup_config WHERE wallet_address = $1")
+        .bind(wallet_address)
+        .execute(pool)
+        .await;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn get_returns_null_when_no_row_exists() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_BASIC).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_BASIC).await;
+
+    let client = build_client(key, url, TEST_WALLET_CRUD_BASIC).await;
+    let resp = client
+        .get("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    let body: Value = resp.into_json().await.unwrap();
+    assert!(body.is_null(), "expected null, got {body}");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_then_get_roundtrips_disabled_config() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_BASIC).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_BASIC).await;
+
+    let client = build_client(key.clone(), url.clone(), TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: false,
+        threshold_cents: None,
+        topup_amount_cents: None,
+        monthly_cap_cents: None,
+        payment_method_id: None,
+        consent_version: None,
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    let written: Value = resp.into_json().await.unwrap();
+    assert_eq!(written["enabled"], false);
+    assert_eq!(written["disabled_reason"], "manual");
+
+    let resp = client
+        .get("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    let got: Value = resp.into_json().await.unwrap();
+    assert_eq!(got["enabled"], false);
+    assert_eq!(got["customer_id"], cust.as_str());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_enabled_with_all_fields_persists() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_BASIC).await;
+    let pm_id = attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_BASIC).await;
+
+    let client = build_client(key.clone(), url.clone(), TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(200),      // $2 threshold
+        topup_amount_cents: Some(2_000), // $20 top-up
+        monthly_cap_cents: Some(10_000), // $100/mo cap
+        payment_method_id: Some(pm_id.clone()),
+        consent_version: Some("v1".into()),
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(
+        resp.status(),
+        Status::Ok,
+        "PUT failed: {}",
+        resp.into_string().await.unwrap_or_default()
+    );
+    let got: Value = resp.into_json().await.unwrap();
+    assert_eq!(got["enabled"], true);
+    assert_eq!(got["threshold_cents"], 200);
+    assert_eq!(got["topup_amount_cents"], 2_000);
+    assert_eq!(got["monthly_cap_cents"], 10_000);
+    assert_eq!(got["payment_method_id"], pm_id.as_str());
+    assert!(got["disabled_reason"].is_null());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_enabled_with_cap_below_topup_rejected() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_BASIC).await;
+    let pm_id = attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_BASIC).await;
+
+    let client = build_client(key.clone(), url.clone(), TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(200),
+        topup_amount_cents: Some(2_000),
+        monthly_cap_cents: Some(1_000), // < topup
+        payment_method_id: Some(pm_id),
+        consent_version: Some("v1".into()),
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::BadRequest);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["error"], "invalid_config");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_enabled_with_topup_below_floor_rejected() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url, TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(200),
+        topup_amount_cents: Some(100), // $1 < $5 floor
+        monthly_cap_cents: Some(1_000),
+        payment_method_id: Some("pm_unused".into()),
+        consent_version: Some("v1".into()),
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::BadRequest);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["error"], "invalid_config");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_enabled_with_null_threshold_rejected() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url, TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: None,
+        topup_amount_cents: Some(2_000),
+        monthly_cap_cents: Some(10_000),
+        payment_method_id: Some("pm_unused".into()),
+        consent_version: Some("v1".into()),
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::BadRequest);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["error"], "invalid_config");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_with_pm_owned_by_different_customer_rejected() {
+    // Codex gap #14: cross-tenant pm_xxx. Caller A must not be able to
+    // configure auto-topup against a card attached to caller B.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust_owner =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_PM_OWNERSHIP)
+            .await;
+    let other_cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_BASIC).await;
+    // Attach the card to cust_owner.
+    let pm_id = attach_test_card(&stripe, &cust_owner).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_BASIC).await;
+
+    // Now wallet TEST_WALLET_CRUD_BASIC (other_cust) tries to claim that pm.
+    let client = build_client(key.clone(), url.clone(), TEST_WALLET_CRUD_BASIC).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(200),
+        topup_amount_cents: Some(2_000),
+        monthly_cap_cents: Some(10_000),
+        payment_method_id: Some(pm_id),
+        consent_version: Some("v1".into()),
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::BadRequest);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["error"], "payment_method_not_owned");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn put_disable_clears_pending_action_state() {
+    // Codex gap #15: when a user opts out, pending SCA-recovery state must
+    // be cleared so a re-enable can't re-trigger an old charge.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_CRUD_DISABLE).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_config_row_for_wallet(&pool, TEST_WALLET_CRUD_DISABLE).await;
+
+    // Seed a row simulating "SCA pending": enabled=true with a saved card
+    // PLUS pending_action_pi_id + recovery_token set. The webhook handler
+    // would have written this in production (Phase 5).
+    let pm_id = attach_test_card(&stripe, &cust).await;
+    let now = time::OffsetDateTime::now_utc();
+    sqlx::query(
+        "INSERT INTO auto_topup_config (\
+            customer_id, wallet_address, enabled, threshold_cents, \
+            topup_amount_cents, monthly_cap_cents, payment_method_id, \
+            consent_version, consent_signed_at, disabled_reason, \
+            pending_action_pi_id, pending_action_at, recovery_token, \
+            recovery_token_expires_at, updated_at) \
+         VALUES ($1, $2, true, 200, 2000, 10000, $3, 'v1', $4, 'requires_action', \
+            'pi_test_pending_xxx', $4, 'recovery_tok_xyz', $5, $4)",
+    )
+    .bind(&cust)
+    .bind(TEST_WALLET_CRUD_DISABLE)
+    .bind(&pm_id)
+    .bind(now)
+    .bind(now + time::Duration::hours(24))
+    .execute(&pool)
+    .await
+    .expect("seed pending row");
+
+    let client = build_client(key.clone(), url.clone(), TEST_WALLET_CRUD_DISABLE).await;
+    let body = AutoTopupConfigUpsert {
+        enabled: false,
+        threshold_cents: None,
+        topup_amount_cents: None,
+        monthly_cap_cents: None,
+        payment_method_id: None,
+        consent_version: None,
+    };
+    let resp = client
+        .put("/billing/auto_topup_config")
+        .header(Header::new("X-Wallet-Auth", wallet_header()))
+        .json(&body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    let got: Value = resp.into_json().await.unwrap();
+    assert_eq!(got["enabled"], false);
+    assert_eq!(got["disabled_reason"], "manual");
+    assert!(got["pending_action_pi_id"].is_null());
+    assert!(got["pending_action_at"].is_null());
+    assert!(got["recovery_token"].is_null());
+    assert!(got["recovery_token_expires_at"].is_null());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn api_key_caller_returns_501() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url, TEST_WALLET_CRUD_BASIC).await;
+    let resp = client
+        .get("/billing/auto_topup_config")
+        .header(Header::new("X-Api-Key", "raw-api-key-abc"))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::NotImplemented);
+}

--- a/lit-payments/src/billing/mod.rs
+++ b/lit-payments/src/billing/mod.rs
@@ -6,7 +6,10 @@
 //! lit-api-server's internal endpoints over the existing
 //! `X-Internal-Secret` channel (see `auth_resolver::HttpAuthResolver`).
 
+pub mod auto_topup_config;
 pub mod setup_intent;
 
 #[cfg(test)]
-mod setup_intent_tests;
+mod auto_topup_config_tests;
+#[cfg(test)]
+pub(crate) mod setup_intent_tests;

--- a/lit-payments/src/billing/setup_intent_tests.rs
+++ b/lit-payments/src/billing/setup_intent_tests.rs
@@ -118,7 +118,7 @@ fn wallet_header() -> String {
 ///   4. Waits for Stripe's search index to consistently return that id.
 ///
 /// Per-test calls are cheap on a clean account (one search hit, no delete).
-async fn ensure_unique_customer(stripe: &StripeClient, wallet: &str) -> String {
+pub(crate) async fn ensure_unique_customer(stripe: &StripeClient, wallet: &str) -> String {
     let query = format!("metadata['wallet_address']:'{wallet}'");
     let resp = stripe
         .get(
@@ -138,26 +138,16 @@ async fn ensure_unique_customer(stripe: &StripeClient, wallet: &str) -> String {
         })
         .unwrap_or_default();
 
-    let surviving = match ids.split_first() {
-        Some((first, rest)) => {
-            for dupe in rest {
-                tracing::warn!("deleting duplicate customer {dupe} for wallet {wallet}");
-                let _ = stripe.post(&format!("customers/{dupe}"), &[]).await;
-                // Stripe customer DELETE requires the customers/{id} DELETE
-                // HTTP verb, not POST. Use a raw reqwest call so we don't
-                // bloat the shared client surface.
-                let _ = reqwest::Client::new()
-                    .delete(format!("https://api.stripe.com/v1/customers/{dupe}"))
-                    .basic_auth(
-                        std::env::var("STRIPE_SECRET_KEY").unwrap_or_default(),
-                        Some(""),
-                    )
-                    .header("Stripe-Version", "2020-08-27")
-                    .send()
-                    .await;
-            }
-            first.clone()
-        }
+    // No dedup-by-deletion: deleting Stripe customers under tests has
+    // produced orphan rows in `auto_topup_config` (which holds
+    // `UNIQUE(wallet_address)`). Instead, take whichever id Stripe search
+    // returns first and accept extras as benign test-only fixtures. The
+    // handler's `find_by_wallet` will consistently return the same first id
+    // on subsequent calls because Stripe search ordering is stable within
+    // a short window. If a fully-fresh wallet has zero matches, create one
+    // and poll search until indexing settles.
+    let surviving = match ids.first() {
+        Some(first) => first.clone(),
         None => lit_billing_core::customer::find_or_create_by_wallet(stripe, wallet)
             .await
             .expect("create customer"),
@@ -176,6 +166,7 @@ async fn ensure_unique_customer(stripe: &StripeClient, wallet: &str) -> String {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn setup_intent_returns_client_secret_when_customer_exists() {
     let Some(key) = stripe_key() else {
         eprintln!("STRIPE_SECRET_KEY not set — skipping Stripe-backed test");
@@ -215,6 +206,7 @@ async fn setup_intent_returns_client_secret_when_customer_exists() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn setup_intent_returns_400_when_no_customer() {
     let Some(key) = stripe_key() else {
         eprintln!("STRIPE_SECRET_KEY not set — skipping Stripe-backed test");
@@ -239,6 +231,7 @@ async fn setup_intent_returns_400_when_no_customer() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn setup_intent_returns_501_for_api_key_caller() {
     // Stripe key NOT required for this path — the handler short-circuits
     // before calling Stripe. Skip only if the build can't even construct

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod auth;
 pub mod auth_resolver;
+pub mod auto_topup;
 pub mod billing;
 pub mod chain;
 pub mod config;

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -72,6 +72,8 @@ async fn rocket() -> _ {
                 chain::claim_payment,
                 rate::override_rate,
                 billing_routes::setup_intent::setup_intent,
+                billing_routes::auto_topup_config::get_auto_topup_config,
+                billing_routes::auto_topup_config::put_auto_topup_config,
             ],
         )
         .mount("/static", FileServer::from("static"))


### PR DESCRIPTION
**Stack:** PR 4 of 8. Base: `auto-topup-phase-3`. Diff shows only Phase 4.

## What
Dashboard CRUD for the per-user auto top-up rule.

* **lit-payments/src/auto_topup/{mod,types,db}.rs** — Postgres model + queries for `auto_topup_config`. UPSERT respects the CHECK constraint; disable transition NULLs `pending_action_pi_id`, `pending_action_at`, `recovery_token`, `recovery_token_expires_at` so re-enable can't re-trigger a charge against stale SCA state (codex gap #15).
* **lit-payments/src/billing/auto_topup_config.rs** — GET + PUT handlers behind BillingAuth (wallet-sig only). Server-side validation: cap ≥ topup, topup ≥ $5, threshold > 0, pm + consent required when enabled. Cross-tenant guard: `GET /v1/payment_methods?customer=cus_xxx` confirms the requested `pm_xxx` belongs to the caller (codex gap #14). DB CHECK violation (SQLSTATE 23514) → 400 invalid_config.

## Tests
9 integration tests covering: GET-when-no-row, PUT enabled=false roundtrip, PUT enabled=true full happy path, cap<topup → 400, topup<$5 → 400, null threshold → 400, cross-tenant pm rejection, disable-clears-pending, API-key → 501.

Test infrastructure: `serial_test::serial` added; all Stripe/DB-touching tests use `#[serial]` to prevent search-lag-duplicate-creation races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)