### PR TITLE
feat(auto-topup): phase 5 — customer.updated webhook + sync charge + sync credit

### DIFF
--- a/lit-billing-core/src/http.rs
+++ b/lit-billing-core/src/http.rs
@@ -1,5 +1,7 @@
 //! Pure HTTP response parsing for the Stripe API.
 
+use std::fmt;
+
 use anyhow::Result;
 use reqwest::StatusCode;
 
@@ -10,38 +12,81 @@ pub struct StripeResponse {
     pub body: serde_json::Value,
 }
 
+/// Structured Stripe API error.
+///
+/// Keeps the full response body alongside the status code so callers can
+/// reach for nested fields Stripe puts on `error`, e.g.
+/// `error.payment_intent.id` — which the webhook handler needs to stage
+/// the SCA recovery handoff (see lit-payments handler.rs).
+///
+/// Wrap in `anyhow::Error::new(...)` for propagation; downcast via
+/// `e.downcast_ref::<StripeError>()` at the consumer side.
+#[derive(Debug, Clone)]
+pub struct StripeError {
+    pub status: StatusCode,
+    pub body: serde_json::Value,
+}
+
+impl StripeError {
+    pub fn error_type(&self) -> Option<&str> {
+        self.body.pointer("/error/type").and_then(|v| v.as_str())
+    }
+    pub fn code(&self) -> Option<&str> {
+        self.body.pointer("/error/code").and_then(|v| v.as_str())
+    }
+    pub fn param(&self) -> Option<&str> {
+        self.body.pointer("/error/param").and_then(|v| v.as_str())
+    }
+    pub fn message(&self) -> Option<&str> {
+        self.body.pointer("/error/message").and_then(|v| v.as_str())
+    }
+    /// `error.payment_intent.id` — Stripe sets this on confirm-time
+    /// failures (incl. `authentication_required`) so the SCA recovery
+    /// flow can retrieve the same PI by id.
+    pub fn payment_intent_id(&self) -> Option<&str> {
+        self.body
+            .pointer("/error/payment_intent/id")
+            .and_then(|v| v.as_str())
+    }
+}
+
+impl fmt::Display for StripeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Stripe error (HTTP {}, type={}, code={}, param={}, permission={}): {}",
+            self.status,
+            self.error_type().unwrap_or("unknown_type"),
+            self.code().unwrap_or("unknown_code"),
+            self.param().unwrap_or("unknown_param"),
+            self.body
+                .pointer("/error/permission")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown_permission"),
+            self.message().unwrap_or("unknown error"),
+        )
+    }
+}
+
+impl std::error::Error for StripeError {}
+
 /// Parse a Stripe API response from raw status + body text.
 ///
 /// Accepts `(StatusCode, &str)` rather than `reqwest::Response` so this logic
 /// is trivially unit-testable without mocking HTTP.
+///
+/// On Stripe-side errors (response body contains `"error": {...}`), this
+/// returns `Err(anyhow::Error::new(StripeError { ... }))`. Callers that
+/// need the structured error (e.g. to extract `error.payment_intent.id`)
+/// downcast via `err.downcast_ref::<StripeError>()`. The `Display` impl
+/// preserves the previous "HTTP X, type=, code=, ..." format so existing
+/// log lines and tests that assert on the message stay valid.
 pub fn parse_stripe_response(status: StatusCode, body_text: &str) -> Result<StripeResponse> {
     let body: serde_json::Value = serde_json::from_str(body_text)
         .map_err(|e| anyhow::anyhow!("Stripe: invalid JSON (HTTP {status}): {e}"))?;
 
-    if let Some(e) = body.get("error") {
-        let msg = e
-            .get("message")
-            .and_then(|m| m.as_str())
-            .unwrap_or("unknown error");
-        let error_type = e
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown_type");
-        let code = e
-            .get("code")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown_code");
-        let param = e
-            .get("param")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown_param");
-        let permission = e
-            .get("permission")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown_permission");
-        anyhow::bail!(
-            "Stripe error (HTTP {status}, type={error_type}, code={code}, param={param}, permission={permission}): {msg}"
-        );
+    if body.get("error").is_some() {
+        return Err(anyhow::Error::new(StripeError { status, body }));
     }
 
     Ok(StripeResponse { status, body })
@@ -67,6 +112,8 @@ mod tests {
     fn parse_stripe_response_4xx_with_error() {
         let body = r#"{"error": {"message": "Invalid API Key provided", "type": "authentication_error", "code": "api_key_invalid", "param": "api_key", "permission": "customers_read"}}"#;
         let err = parse_stripe_response(StatusCode::UNAUTHORIZED, body).unwrap_err();
+        // Backwards-compat: the Display string still carries the legacy
+        // diagnostic fields so existing logs and tests keep working.
         let msg = err.to_string();
         assert!(msg.contains("HTTP 401"), "expected HTTP 401 in: {msg}");
         assert!(
@@ -89,6 +136,12 @@ mod tests {
             msg.contains("Invalid API Key provided"),
             "expected error message in: {msg}"
         );
+        // New: structured access through downcast.
+        let se = err
+            .downcast_ref::<StripeError>()
+            .expect("error is StripeError");
+        assert_eq!(se.error_type(), Some("authentication_error"));
+        assert_eq!(se.code(), Some("api_key_invalid"));
     }
 
     #[test]
@@ -127,5 +180,29 @@ mod tests {
         let body = r#"{"balance": -500, "currency": "usd"}"#;
         let resp = parse_stripe_response(StatusCode::OK, body).unwrap();
         assert_eq!(resp.body["balance"], -500);
+    }
+
+    #[test]
+    fn stripe_error_surfaces_payment_intent_id() {
+        // Stripe's `authentication_required` shape: error.payment_intent.id
+        // carries the PI to retry. Codex P1 #1 — handler must read this
+        // structured field instead of regexing the formatted message.
+        let body = r#"{
+            "error": {
+                "type": "card_error",
+                "code": "authentication_required",
+                "message": "Your card was declined. This transaction requires authentication.",
+                "payment_intent": {
+                    "id": "pi_3NopeYrGhjEGDNSRy42abc",
+                    "status": "requires_action"
+                }
+            }
+        }"#;
+        let err = parse_stripe_response(StatusCode::PAYMENT_REQUIRED, body).unwrap_err();
+        let se = err
+            .downcast_ref::<StripeError>()
+            .expect("error is StripeError");
+        assert_eq!(se.code(), Some("authentication_required"));
+        assert_eq!(se.payment_intent_id(), Some("pi_3NopeYrGhjEGDNSRy42abc"));
     }
 }

--- a/lit-billing-core/src/lib.rs
+++ b/lit-billing-core/src/lib.rs
@@ -25,4 +25,4 @@ pub mod http;
 pub mod reporting;
 
 pub use client::StripeClient;
-pub use http::StripeResponse;
+pub use http::{StripeError, StripeResponse};

--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -2113,6 +2113,8 @@ dependencies = [
  "serial_test",
  "sha2",
  "sqlx",
+ "subtle",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4"
 hmac = "0.12"
 lit-billing-auth = { path = "../lit-billing-auth" }
 lit-billing-core = { path = "../lit-billing-core" }
-moka = { version = "0.12", features = ["future"] }
+moka = { version = "0.12", features = ["future", "sync"] }
 num-bigint = "0.4"
 num-traits = "0.2"
 rand = "0.8"
@@ -25,6 +25,8 @@ rocket = { version = "0.5.1", features = ["json", "secrets"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 sha2 = "0.10"
+subtle = "2.6"
+thiserror = "1.0"
 sqlx = { version = "0.8", features = [
     "postgres",
     "runtime-tokio",

--- a/lit-payments/src/auto_topup/db.rs
+++ b/lit-payments/src/auto_topup/db.rs
@@ -168,6 +168,133 @@ pub async fn upsert(
     Ok(into_row(row))
 }
 
+/// Mark the config as auto-disabled after the consecutive-failure
+/// threshold is crossed. Idempotent — the WHERE clause means a second call
+/// is a no-op even if the row was already disabled.
+pub async fn disable_after_failures(pool: &PgPool, customer_id: &str) -> Result<()> {
+    let now = OffsetDateTime::now_utc();
+    sqlx::query(
+        "UPDATE auto_topup_config \
+            SET enabled = false, \
+                disabled_reason = 'failures', \
+                pending_action_pi_id = NULL, \
+                pending_action_at = NULL, \
+                recovery_token = NULL, \
+                recovery_token_expires_at = NULL, \
+                updated_at = $1 \
+            WHERE customer_id = $2",
+    )
+    .bind(now)
+    .bind(customer_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Record an off-session `authentication_required` handoff: store the
+/// pending PI id + a fresh recovery token (24h TTL). The auto top-up rule
+/// stays in the DB but is functionally paused — `disabled_reason` is
+/// `'requires_action'`, the dashboard shows the "action required" banner,
+/// and any new `customer.updated` will short-circuit on the
+/// disabled_reason check.
+pub async fn set_pending_action(
+    pool: &PgPool,
+    customer_id: &str,
+    pi_id: &str,
+    recovery_token: &str,
+) -> Result<()> {
+    let now = OffsetDateTime::now_utc();
+    let expires = now + time::Duration::hours(24);
+    sqlx::query(
+        "UPDATE auto_topup_config \
+            SET pending_action_pi_id = $1, \
+                pending_action_at = $2, \
+                recovery_token = $3, \
+                recovery_token_expires_at = $4, \
+                disabled_reason = 'requires_action', \
+                updated_at = $2 \
+            WHERE customer_id = $5",
+    )
+    .bind(pi_id)
+    .bind(now)
+    .bind(recovery_token)
+    .bind(expires)
+    .bind(customer_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Atomically clear the pending-action state after the SCA recovery flow
+/// credits a previously-pending PI. The `pending_action_pi_id` WHERE
+/// predicate makes the write a no-op if some other concurrent path
+/// already cleared it.
+pub async fn clear_pending_action(pool: &PgPool, customer_id: &str, pi_id: &str) -> Result<()> {
+    let now = OffsetDateTime::now_utc();
+    sqlx::query(
+        "UPDATE auto_topup_config \
+            SET pending_action_pi_id = NULL, \
+                pending_action_at = NULL, \
+                recovery_token = NULL, \
+                recovery_token_expires_at = NULL, \
+                disabled_reason = NULL, \
+                updated_at = $1 \
+            WHERE customer_id = $2 AND pending_action_pi_id = $3",
+    )
+    .bind(now)
+    .bind(customer_id)
+    .bind(pi_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// INSERT a row into `auto_topup_credits` (PK on `payment_intent_id`) to
+/// claim the credit slot. Returns `Ok(true)` if the row was inserted,
+/// `Ok(false)` if a row already existed (dedup hit — concurrent webhook
+/// + reconciler, or a webhook replay). Atomic — the unique constraint is
+/// the durable correctness primitive (see plan §11).
+pub async fn try_insert_credit(
+    pool: &PgPool,
+    payment_intent_id: &str,
+    customer_id: &str,
+    amount_cents: i64,
+) -> Result<bool> {
+    let inserted: Option<(String,)> = sqlx::query_as(
+        "INSERT INTO auto_topup_credits (payment_intent_id, customer_id, amount_cents) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (payment_intent_id) DO NOTHING \
+         RETURNING payment_intent_id",
+    )
+    .bind(payment_intent_id)
+    .bind(customer_id)
+    .bind(amount_cents)
+    .fetch_optional(pool)
+    .await?;
+    Ok(inserted.is_some())
+}
+
+/// Mark a previously-inserted credit row as fully credited (the
+/// `balance_transactions` write succeeded). The reconciler distinguishes
+/// "credit row exists, balance_tx_id NULL" (partial — retry) from
+/// "credit row exists with balance_tx_id" (done — skip).
+pub async fn mark_credit_completed(
+    pool: &PgPool,
+    payment_intent_id: &str,
+    stripe_balance_transaction_id: &str,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE auto_topup_credits \
+            SET stripe_balance_transaction_id = $1 \
+            WHERE payment_intent_id = $2",
+    )
+    .bind(stripe_balance_transaction_id)
+    .bind(payment_intent_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Returns true if the error is a Postgres CHECK constraint violation
 /// (SQLSTATE 23514) on the `enabled_requires_config` constraint. Lets
 /// handlers map "you said enabled=true but didn't set all required fields"

--- a/lit-payments/src/auto_topup/mod.rs
+++ b/lit-payments/src/auto_topup/mod.rs
@@ -9,3 +9,4 @@
 
 pub mod db;
 pub mod types;
+pub mod webhook;

--- a/lit-payments/src/auto_topup/webhook/handler.rs
+++ b/lit-payments/src/auto_topup/webhook/handler.rs
@@ -117,6 +117,16 @@ pub async fn stripe_webhook(
         None => return Status::Ok,
     };
     let new_balance = obj.get("balance").and_then(|v| v.as_i64()).unwrap_or(0);
+    // Codex P1 (Phase 5): use the Stripe webhook event.id as the
+    // idempotency-key seed for `paymentIntents.create`. Stripe redelivers
+    // the same event with the same id on 5xx replies, so a stable key
+    // means Stripe dedupes the retry on its side instead of letting us
+    // create a second PI per retry.
+    let event_id = event
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
     match process_event(
         cfg.inner(),
@@ -125,6 +135,7 @@ pub async fn stripe_webhook(
         mutex_cache.inner(),
         &customer_id,
         new_balance,
+        &event_id,
     )
     .await
     {
@@ -154,20 +165,42 @@ async fn process_event(
     mutex_cache: &PerCustomerMutex,
     customer_id: &str,
     payload_balance: i64,
+    event_id: &str,
 ) -> Result<(), ProcessError> {
-    // Step 3a: Load config. Short-circuit unless the row is enabled AND
-    // not already in an SCA-pending state. Skipping the
-    // pending_action_pi_id check would let a fresh customer.updated event
-    // fire a second off-session PI while the first is still waiting on
-    // the user's 3DS confirmation — which overwrites the recovery_token
-    // (single-use!) and leaves us stuck with two pending PIs the
-    // dashboard can't distinguish. The webhook handler that staged the
-    // pending state already set `disabled_reason = 'requires_action'`;
-    // we treat that as a soft pause that the SCA resume / clear-pending
-    // path is responsible for lifting.
+    // Step 3a (pre-mutex): cheap payload-only quick exit. We re-read the
+    // config under the mutex below; this lookup is just to avoid taking
+    // the mutex when the row is plainly disabled or the payload balance
+    // already exceeds the threshold. Codex P1 (Phase 5): the
+    // load-bearing config read must happen INSIDE the mutex so that a
+    // concurrent SCA-staging path that sets pending_action_pi_id is
+    // observed by the next webhook tick. Without that ordering, two
+    // overlapping customer.updated deliveries can both see
+    // pending_action_pi_id=None and each fire an off-session PI.
+    let pre_check = db::get_by_customer_id(pool, customer_id)
+        .await
+        .context("db read auto_topup_config (pre-mutex)")?;
+    let pre_threshold = match &pre_check {
+        Some(c) if c.enabled && c.pending_action_pi_id.is_none() => c.threshold_cents,
+        _ => return Ok(()),
+    };
+    if let Some(t) = pre_threshold {
+        if -payload_balance >= t {
+            return Ok(());
+        }
+    }
+
+    // Step 4: Acquire per-customer mutex. Serializes concurrent
+    // customer.updated deliveries for the same customer.
+    let mutex = mutex_cache.get(customer_id);
+    let _guard = mutex.lock().await;
+
+    // Step 4b: Re-load config under the mutex. Required for correctness
+    // when another delivery (or the SCA-staging path) raced ahead of us
+    // and changed enabled / pending_action_pi_id between our pre-check
+    // and the lock acquisition.
     let config = match db::get_by_customer_id(pool, customer_id)
         .await
-        .context("db read auto_topup_config")?
+        .context("db read auto_topup_config (post-mutex)")?
     {
         Some(c) if c.enabled && c.pending_action_pi_id.is_none() => c,
         _ => return Ok(()),
@@ -177,18 +210,6 @@ async fn process_event(
             "enabled config missing threshold for {customer_id} — CHECK constraint should have caught this"
         ))
     })?;
-
-    // Step 3b: Quick exit on payload balance. Available credit = -balance
-    // (Stripe stores customer.balance as negative when the customer has
-    // credit available). If they're already above threshold, skip.
-    if -payload_balance >= threshold {
-        return Ok(());
-    }
-
-    // Step 4: Acquire per-customer mutex. Serializes concurrent
-    // customer.updated deliveries for the same customer.
-    let mutex = mutex_cache.get(customer_id);
-    let _guard = mutex.lock().await;
 
     // Step 5: Fresh balance fetch — don't trust the webhook payload after
     // the mutex wait; the balance may have moved.
@@ -241,18 +262,26 @@ async fn process_event(
         return Ok(());
     }
 
-    // Step 9: Create off-session PaymentIntent. Idempotency key is a fresh
-    // UUID — webhook replays for the same customer.updated event happen
-    // rarely enough that we don't need to derive a stable key here; the
-    // unique constraint on auto_topup_credits.payment_intent_id catches
-    // duplicate credit attempts even if Stripe creates two PIs.
+    // Step 9: Create off-session PaymentIntent. Codex P1 (Phase 5): the
+    // idempotency-key MUST derive from the Stripe event.id so that when
+    // Stripe redelivers the same customer.updated event (which it does
+    // on every 5xx we return), `paymentIntents.create` gets deduped on
+    // Stripe's side instead of creating a second PI per retry. The 24h
+    // idempotency-key TTL is the right scope — well past Stripe's 3-day
+    // retry window for an individual event would risk false hits, but
+    // within a redelivery burst it's exactly what we want. Falls back
+    // to a UUID if event_id is missing (only the unit-test paths).
     let payment_method_id = config
         .payment_method_id
         .as_deref()
         .expect("CHECK constraint enforces non-null when enabled");
     let wallet_address = config.wallet_address.as_str();
     let amount_str = topup_amount.to_string();
-    let idempotency_key = Uuid::new_v4().to_string();
+    let idempotency_key = if event_id.is_empty() {
+        Uuid::new_v4().to_string()
+    } else {
+        format!("auto_topup_pi:{event_id}")
+    };
     let pi_resp = stripe
         .post_with_idempotency(
             "payment_intents",
@@ -284,6 +313,19 @@ async fn process_event(
             // recovery page later calls Stripe with a non-PI id.
             if let Some(stripe_err) = e.downcast_ref::<lit_billing_core::StripeError>() {
                 let code = stripe_err.code().unwrap_or("");
+                // Codex P1 (Phase 5): structured Stripe 5xx (HTTP 5xx
+                // with a JSON `error` body, typically error.type=api_error)
+                // is a transient failure — Stripe's side is degraded, not
+                // a permanent decline. Pre-fix this collapsed to Ok(()),
+                // which acked the webhook and lost the retry. Returning
+                // Transient surfaces the 503 to Stripe; their 3-day
+                // redelivery loop is exactly the right retry primitive.
+                if stripe_err.status.is_server_error() {
+                    return Err(ProcessError::Transient(anyhow::anyhow!(
+                        "Stripe {} on paymentIntents.create: {stripe_err}",
+                        stripe_err.status
+                    )));
+                }
                 if code == "authentication_required" {
                     let pi_id = stripe_err
                         .payment_intent_id()

--- a/lit-payments/src/auto_topup/webhook/handler.rs
+++ b/lit-payments/src/auto_topup/webhook/handler.rs
@@ -1,0 +1,644 @@
+//! `POST /stripe/webhook` — `customer.updated` handler.
+//!
+//! Implements the full §6 flow synchronously inside the webhook request:
+//! verify signature → quick exits → mutex → fresh balance → list PIs →
+//! failure/cap check → off-session PaymentIntent create → sync credit →
+//! cache invalidation. Returns 5xx on transient backend failures so
+//! Stripe retries (3-day window); 200 only after credit work commits.
+//!
+//! The handler is generously instrumented because Phase 5 is the
+//! load-bearing trigger — when it misbehaves in production, observability
+//! is the difference between a 1-hour incident and a 1-day one.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use lit_billing_core::StripeClient;
+use rocket::data::{Data, ToByteUnit};
+use rocket::http::{Header, Status};
+use rocket::request::{FromRequest, Outcome, Request};
+use rocket::{State, post};
+use serde_json::Value;
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::auto_topup::db;
+use crate::auto_topup::webhook::mutex::PerCustomerMutex;
+use crate::auto_topup::webhook::sca::generate_recovery_token;
+use crate::auto_topup::webhook::signature::verify as verify_signature;
+use crate::config::Config;
+use crate::internal::client as internal_client;
+
+const MAX_BODY_BYTES: u64 = 1 * 1024 * 1024;
+
+/// Minimum top-up floor — same value the dashboard validation enforces in
+/// `billing::auto_topup_config`. Kept here as a documented constant for the
+/// failure-threshold test and for future use by spec-derived assertions.
+#[allow(dead_code)]
+const MIN_TOPUP_CENTS: i64 = 500;
+
+const FAILURE_DISABLE_THRESHOLD: usize = 3;
+
+/// Webhook-specific request guard that extracts the Stripe-Signature
+/// header. Returning here as `Option<String>` lets the handler decide
+/// whether absence is a hard 401 or some other shape.
+pub struct StripeSignatureHeader(pub Option<String>);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for StripeSignatureHeader {
+    type Error = ();
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let value = req
+            .headers()
+            .get_one("Stripe-Signature")
+            .map(|s| s.to_string());
+        Outcome::Success(StripeSignatureHeader(value))
+    }
+}
+
+#[post("/stripe/webhook", data = "<body>")]
+pub async fn stripe_webhook(
+    sig: StripeSignatureHeader,
+    body: Data<'_>,
+    cfg: &State<Config>,
+    stripe: &State<StripeClient>,
+    pool: &State<PgPool>,
+    mutex_cache: &State<PerCustomerMutex>,
+) -> Status {
+    let raw = match body.open(MAX_BODY_BYTES.bytes()).into_bytes().await {
+        Ok(v) if v.is_complete() => v.into_inner(),
+        Ok(_) => {
+            tracing::warn!("stripe webhook: body exceeded {MAX_BODY_BYTES} bytes");
+            return Status::PayloadTooLarge;
+        }
+        Err(e) => {
+            tracing::warn!("stripe webhook: read body failed: {e}");
+            return Status::BadRequest;
+        }
+    };
+
+    let Some(header_value) = sig.0 else {
+        return Status::Unauthorized;
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    if let Err(e) = verify_signature(&header_value, &raw, &cfg.stripe_webhook_secret, now) {
+        tracing::warn!("stripe webhook: signature rejected: {e}");
+        return Status::Unauthorized;
+    }
+
+    let event: Value = match serde_json::from_slice(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("stripe webhook: body not JSON: {e}");
+            return Status::BadRequest;
+        }
+    };
+
+    // Step 2: Filter event type AND require a balance change. The latter
+    // is the cheap "not for us" reject for customer.updated events that
+    // change email / metadata / etc. without touching balance.
+    if event.get("type").and_then(|v| v.as_str()) != Some("customer.updated") {
+        return Status::Ok;
+    }
+    if event.pointer("/data/previous_attributes/balance").is_none() {
+        return Status::Ok;
+    }
+
+    let obj = match event.pointer("/data/object") {
+        Some(o) => o,
+        None => return Status::Ok,
+    };
+    let customer_id = match obj.get("id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => return Status::Ok,
+    };
+    let new_balance = obj.get("balance").and_then(|v| v.as_i64()).unwrap_or(0);
+
+    match process_event(
+        cfg.inner(),
+        stripe.inner(),
+        pool.inner(),
+        mutex_cache.inner(),
+        &customer_id,
+        new_balance,
+    )
+    .await
+    {
+        Ok(()) => Status::Ok,
+        Err(ProcessError::Transient(e)) => {
+            tracing::error!("stripe webhook: transient error: {e:?}");
+            Status::ServiceUnavailable
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ProcessError {
+    Transient(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ProcessError {
+    fn from(e: anyhow::Error) -> Self {
+        ProcessError::Transient(e)
+    }
+}
+
+async fn process_event(
+    cfg: &Config,
+    stripe: &StripeClient,
+    pool: &PgPool,
+    mutex_cache: &PerCustomerMutex,
+    customer_id: &str,
+    payload_balance: i64,
+) -> Result<(), ProcessError> {
+    // Step 3a: Load config. Short-circuit unless the row is enabled AND
+    // not already in an SCA-pending state. Skipping the
+    // pending_action_pi_id check would let a fresh customer.updated event
+    // fire a second off-session PI while the first is still waiting on
+    // the user's 3DS confirmation — which overwrites the recovery_token
+    // (single-use!) and leaves us stuck with two pending PIs the
+    // dashboard can't distinguish. The webhook handler that staged the
+    // pending state already set `disabled_reason = 'requires_action'`;
+    // we treat that as a soft pause that the SCA resume / clear-pending
+    // path is responsible for lifting.
+    let config = match db::get_by_customer_id(pool, customer_id)
+        .await
+        .context("db read auto_topup_config")?
+    {
+        Some(c) if c.enabled && c.pending_action_pi_id.is_none() => c,
+        _ => return Ok(()),
+    };
+    let threshold = config.threshold_cents.ok_or_else(|| {
+        ProcessError::Transient(anyhow::anyhow!(
+            "enabled config missing threshold for {customer_id} — CHECK constraint should have caught this"
+        ))
+    })?;
+
+    // Step 3b: Quick exit on payload balance. Available credit = -balance
+    // (Stripe stores customer.balance as negative when the customer has
+    // credit available). If they're already above threshold, skip.
+    if -payload_balance >= threshold {
+        return Ok(());
+    }
+
+    // Step 4: Acquire per-customer mutex. Serializes concurrent
+    // customer.updated deliveries for the same customer.
+    let mutex = mutex_cache.get(customer_id);
+    let _guard = mutex.lock().await;
+
+    // Step 5: Fresh balance fetch — don't trust the webhook payload after
+    // the mutex wait; the balance may have moved.
+    let fresh_balance = lit_billing_core::balance::fetch(stripe, customer_id)
+        .await
+        .context("fetch fresh balance")?;
+    if -fresh_balance >= threshold {
+        return Ok(());
+    }
+
+    // Step 6: List PIs this month. Stripe doesn't filter by metadata
+    // server-side on list, so we filter client-side.
+    let month_start = month_start_unix(OffsetDateTime::now_utc());
+    let pis = list_pis_since(stripe, customer_id, month_start)
+        .await
+        .context("list PIs")?;
+
+    // Step 7: Derive consecutive failure count from most recent PIs.
+    // Disabling at >=3 matches plan §6 + the spec the team agreed on.
+    let consecutive_failures = count_consecutive_failures(&pis);
+    if consecutive_failures >= FAILURE_DISABLE_THRESHOLD {
+        db::disable_after_failures(pool, customer_id)
+            .await
+            .context("disable after failures")?;
+        // TODO Phase 8: dispatch "card needs updating" email via Resend.
+        tracing::warn!(
+            customer_id,
+            consecutive_failures,
+            "auto top-up disabled after consecutive failures"
+        );
+        return Ok(());
+    }
+
+    // Step 8: Cap check. Sum amounts of all non-failed PIs this month.
+    let topup_amount = config
+        .topup_amount_cents
+        .expect("CHECK constraint enforces non-null when enabled");
+    let monthly_cap = config
+        .monthly_cap_cents
+        .expect("CHECK constraint enforces non-null when enabled");
+    let spend_so_far = month_spend_cents(&pis);
+    if spend_so_far + topup_amount > monthly_cap {
+        tracing::info!(
+            customer_id,
+            spend_so_far,
+            topup_amount,
+            monthly_cap,
+            "auto top-up cap reached; skipping charge"
+        );
+        return Ok(());
+    }
+
+    // Step 9: Create off-session PaymentIntent. Idempotency key is a fresh
+    // UUID — webhook replays for the same customer.updated event happen
+    // rarely enough that we don't need to derive a stable key here; the
+    // unique constraint on auto_topup_credits.payment_intent_id catches
+    // duplicate credit attempts even if Stripe creates two PIs.
+    let payment_method_id = config
+        .payment_method_id
+        .as_deref()
+        .expect("CHECK constraint enforces non-null when enabled");
+    let wallet_address = config.wallet_address.as_str();
+    let amount_str = topup_amount.to_string();
+    let idempotency_key = Uuid::new_v4().to_string();
+    let pi_resp = stripe
+        .post_with_idempotency(
+            "payment_intents",
+            &[
+                ("amount", amount_str.as_str()),
+                ("currency", "usd"),
+                ("customer", customer_id),
+                ("payment_method", payment_method_id),
+                ("off_session", "true"),
+                ("confirm", "true"),
+                ("metadata[source]", "auto_topup"),
+                ("metadata[wallet_address]", wallet_address),
+            ],
+            &idempotency_key,
+        )
+        .await;
+
+    let pi_body = match pi_resp {
+        Ok(r) => r.body,
+        Err(e) => {
+            // Distinguish "Stripe returned a structured error with
+            // error.code" (decline / sca / etc.) from "HTTP timed out
+            // before any response" (transient — reconciler handles).
+            //
+            // Codex P1 #1: read `error.payment_intent.id` from the
+            // structured StripeError body instead of regexing the Display
+            // string. Without this, SCA recovery stages whatever string
+            // we happened to format as `pending_action_pi_id`, and the
+            // recovery page later calls Stripe with a non-PI id.
+            if let Some(stripe_err) = e.downcast_ref::<lit_billing_core::StripeError>() {
+                let code = stripe_err.code().unwrap_or("");
+                if code == "authentication_required" {
+                    let pi_id = stripe_err
+                        .payment_intent_id()
+                        .ok_or_else(|| {
+                            ProcessError::Transient(anyhow::anyhow!(
+                                "Stripe returned authentication_required without error.payment_intent.id; \
+                                 cannot stage SCA recovery"
+                            ))
+                        })?;
+                    handle_sca_required(pool, customer_id, pi_id).await?;
+                    return Ok(());
+                }
+                if matches!(
+                    code,
+                    "card_declined"
+                        | "expired_card"
+                        | "insufficient_funds"
+                        | "incorrect_cvc"
+                        | "processing_error"
+                ) {
+                    // TODO Phase 8: dispatch decline email. Failure
+                    // counter derivation in step 7 handles auto-disable.
+                    tracing::warn!(customer_id, code, "auto top-up charge declined");
+                    return Ok(());
+                }
+                // Other Stripe-side errors: not retriable here, but log
+                // and let the reconciler / next webhook tick figure it
+                // out. Return Ok(200) so Stripe doesn't pile on retries.
+                tracing::warn!(
+                    customer_id,
+                    code,
+                    "auto top-up: unexpected Stripe error code"
+                );
+                return Ok(());
+            }
+            // Non-Stripe error (network timeout, JSON parse, 5xx with no
+            // structured body). Treat as transient — Stripe retries the
+            // webhook; the reconciler catches any orphaned succeeded PI.
+            return Err(ProcessError::Transient(anyhow::anyhow!(
+                "paymentIntents.create transient error: {e:?}"
+            )));
+        }
+    };
+
+    let pi_id = pi_body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe PI response missing id"))?
+        .to_string();
+    let pi_status = pi_body.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if pi_status != "succeeded" {
+        // Stripe occasionally returns `requires_action` with status code 200
+        // (not as an error). Treat it the same way.
+        if pi_status == "requires_action" {
+            handle_sca_required(pool, customer_id, &pi_id).await?;
+            return Ok(());
+        }
+        tracing::warn!(
+            customer_id,
+            pi_id,
+            pi_status,
+            "PI not succeeded; skip credit"
+        );
+        return Ok(());
+    }
+
+    // Step 10: Try to claim the credit slot. ON CONFLICT DO NOTHING means
+    // a concurrent webhook + reconciler attempting the same PI converge
+    // on exactly one credit row.
+    let claimed = db::try_insert_credit(pool, &pi_id, customer_id, topup_amount)
+        .await
+        .context("claim credit row")?;
+    if !claimed {
+        // Someone else (other replica, reconciler) is/has credited this PI.
+        // Safe to return — the credit lands either way.
+        return Ok(());
+    }
+
+    // Step 11: Write the balance transaction. Idempotency-Key locks the
+    // logical "credit for PI X" operation at Stripe's side too.
+    let credit_idem = format!("credit:{pi_id}");
+    let neg_amount = (-topup_amount).to_string();
+    let bt_resp = stripe
+        .post_with_idempotency(
+            &format!("customers/{customer_id}/balance_transactions"),
+            &[
+                ("amount", neg_amount.as_str()),
+                ("currency", "usd"),
+                ("description", &format!("Auto top-up via {pi_id}")),
+            ],
+            &credit_idem,
+        )
+        .await
+        .context("balance_transactions write")?;
+    let bt_id = bt_resp
+        .body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe balance_tx response missing id"))?
+        .to_string();
+
+    // Step 12: Mark the credit complete in our ledger.
+    db::mark_credit_completed(pool, &pi_id, &bt_id)
+        .await
+        .context("mark credit completed")?;
+
+    // Step 12b: If this PI was the SCA recovery target, clear pending state.
+    if config.pending_action_pi_id.as_deref() == Some(pi_id.as_str()) {
+        let _ = db::clear_pending_action(pool, customer_id, &pi_id).await;
+    }
+
+    // Step 13: Invalidate lit-api-server's balance cache. Fire-and-forget;
+    // a failure here means the api-server serves the stale balance for up
+    // to 10 minutes (TTL). Not a correctness problem; just freshness.
+    let _ = invalidate_cache(cfg, customer_id).await;
+
+    Ok(())
+}
+
+fn month_start_unix(now: OffsetDateTime) -> i64 {
+    let first = OffsetDateTime::new_utc(
+        time::Date::from_calendar_date(now.year(), now.month(), 1)
+            .expect("first-of-month is always valid"),
+        time::Time::MIDNIGHT,
+    );
+    first.unix_timestamp()
+}
+
+async fn list_pis_since(
+    stripe: &StripeClient,
+    customer_id: &str,
+    since_unix: i64,
+) -> anyhow::Result<Vec<Value>> {
+    let mut out = Vec::new();
+    let mut starting_after: Option<String> = None;
+    let since_str = since_unix.to_string();
+    loop {
+        let mut params: Vec<(&str, &str)> = vec![
+            ("customer", customer_id),
+            ("limit", "100"),
+            ("created[gte]", since_str.as_str()),
+        ];
+        if let Some(ref s) = starting_after {
+            params.push(("starting_after", s.as_str()));
+        }
+        let resp = stripe
+            .get("payment_intents", &params)
+            .await
+            .context("payment_intents.list")?;
+        let data = resp.body.get("data").and_then(|d| d.as_array()).cloned();
+        let Some(arr) = data else { break };
+        let has_more = resp
+            .body
+            .get("has_more")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut last_id: Option<String> = None;
+        for pi in arr.iter() {
+            if pi.pointer("/metadata/source").and_then(|v| v.as_str()) == Some("auto_topup") {
+                out.push(pi.clone());
+            }
+            last_id = pi.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+        }
+        if !has_more {
+            break;
+        }
+        match last_id {
+            Some(id) => starting_after = Some(id),
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+fn count_consecutive_failures(pis: &[Value]) -> usize {
+    // The PI list endpoint returns newest first by default; we iterate in
+    // that order and stop counting at the first non-failed PI.
+    let mut count = 0;
+    for pi in pis {
+        if is_failed(pi) {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+    count
+}
+
+fn is_failed(pi: &Value) -> bool {
+    let status = pi.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status == "requires_payment_method" {
+        return true;
+    }
+    let last_err_code = pi
+        .pointer("/last_payment_error/code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    matches!(
+        last_err_code,
+        "card_declined"
+            | "expired_card"
+            | "insufficient_funds"
+            | "incorrect_cvc"
+            | "processing_error"
+    )
+}
+
+/// Sum `amount` over all non-failed PIs in the window. Mirrors the cap
+/// definition: "total non-failed spend this month".
+fn month_spend_cents(pis: &[Value]) -> i64 {
+    pis.iter()
+        .filter(|pi| !is_failed(pi))
+        .filter_map(|pi| pi.get("amount").and_then(|v| v.as_i64()))
+        .sum()
+}
+
+async fn handle_sca_required(
+    pool: &PgPool,
+    customer_id: &str,
+    pi_id: &str,
+) -> Result<(), ProcessError> {
+    let token = generate_recovery_token();
+    db::set_pending_action(pool, customer_id, pi_id, &token)
+        .await
+        .context("set pending_action")?;
+    // TODO Phase 8: dispatch the tokenized recovery email via Resend.
+    tracing::info!(
+        customer_id,
+        pi_id,
+        "auto top-up: SCA recovery handoff staged"
+    );
+    Ok(())
+}
+
+/// Best-effort fallback extractor — only used by unit tests now.
+/// Production code reads `error.payment_intent.id` directly via the
+/// `StripeError` downcast (Codex P1 #1 fix).
+#[cfg(test)]
+fn extract_pi_id(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let needle = b"pi_";
+    bytes.windows(3).enumerate().find_map(|(i, w)| {
+        if w != needle {
+            return None;
+        }
+        let mut end = i + 3;
+        while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+            end += 1;
+        }
+        if end - i >= 6 {
+            Some(String::from_utf8_lossy(&bytes[i..end]).into_owned())
+        } else {
+            None
+        }
+    })
+}
+
+async fn invalidate_cache(cfg: &Config, customer_id: &str) -> anyhow::Result<()> {
+    let client = internal_client::build_client()?;
+    let body = serde_json::json!({ "customer_id": customer_id });
+    internal_client::post_internal(&client, cfg, "/internal/invalidate_balance_cache", &body).await
+}
+
+/// Used by `Rocket::custom` configurations that need to expose the
+/// signature header on outbound responses for ergonomic debugging in
+/// development; not used in production. Kept here so it lives next to
+/// the verifier.
+#[allow(dead_code)]
+fn debug_header(name: &str, value: &str) -> Header<'static> {
+    Header::new(name.to_string(), value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn month_start_unix_is_first_of_month_midnight() {
+        let mid_month = OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(2026, time::Month::June, 15).unwrap(),
+            time::Time::from_hms(12, 34, 56).unwrap(),
+        );
+        let start = month_start_unix(mid_month);
+        let parsed = OffsetDateTime::from_unix_timestamp(start).unwrap();
+        assert_eq!(parsed.year(), 2026);
+        assert_eq!(parsed.month(), time::Month::June);
+        assert_eq!(parsed.day(), 1);
+        assert_eq!(parsed.hour(), 0);
+        assert_eq!(parsed.minute(), 0);
+    }
+
+    #[test]
+    fn count_consecutive_failures_stops_at_first_success() {
+        let pi = |status: &str, code: Option<&str>| {
+            let mut m = serde_json::Map::new();
+            m.insert("status".into(), serde_json::Value::String(status.into()));
+            if let Some(c) = code {
+                m.insert("last_payment_error".into(), serde_json::json!({"code": c}));
+            }
+            Value::Object(m)
+        };
+        let list = vec![
+            pi("requires_payment_method", None),
+            pi("succeeded", None),
+            pi("requires_payment_method", None),
+            pi("requires_payment_method", None),
+        ];
+        // Only the first one counts; chain stops at the succeeded.
+        assert_eq!(count_consecutive_failures(&list), 1);
+    }
+
+    #[test]
+    fn count_consecutive_failures_recognizes_error_codes() {
+        let pi = |code: &str| serde_json::json!({"status":"processing","last_payment_error":{"code":code}});
+        let list = vec![
+            pi("card_declined"),
+            pi("insufficient_funds"),
+            pi("expired_card"),
+        ];
+        assert_eq!(count_consecutive_failures(&list), 3);
+    }
+
+    #[test]
+    fn month_spend_sums_non_failed_only() {
+        let succeeded = serde_json::json!({"status":"succeeded","amount":2000});
+        let failed = serde_json::json!({"status":"requires_payment_method","amount":500});
+        let pending = serde_json::json!({"status":"processing","amount":1500});
+        let list = vec![succeeded, failed, pending];
+        assert_eq!(month_spend_cents(&list), 3500);
+    }
+
+    #[test]
+    fn extract_pi_id_pulls_from_error_strings() {
+        let s = "Stripe error: authentication_required pi_3TfxzqGhjEGDNSRy0VYfHVf6 details";
+        assert_eq!(
+            extract_pi_id(s),
+            Some("pi_3TfxzqGhjEGDNSRy0VYfHVf6".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_pi_id_returns_none_when_absent() {
+        assert!(extract_pi_id("nothing here").is_none());
+    }
+
+    /// Plan §6 step 7: at exactly 3 consecutive failures we auto-disable.
+    /// One less should NOT trigger.
+    #[test]
+    fn failure_threshold_is_three() {
+        assert_eq!(FAILURE_DISABLE_THRESHOLD, 3);
+    }
+
+    /// Plan §6 step 8 / dashboard: floor matches the manual-topup floor.
+    #[test]
+    fn min_topup_matches_manual_floor() {
+        assert_eq!(MIN_TOPUP_CENTS, 500);
+    }
+}

--- a/lit-payments/src/auto_topup/webhook/handler_tests.rs
+++ b/lit-payments/src/auto_topup/webhook/handler_tests.rs
@@ -1,0 +1,712 @@
+//! Phase 5 integration tests — `POST /stripe/webhook`.
+//!
+//! These hit **real Stripe test mode** and the local Postgres DB.
+//! Silent-skipped when `STRIPE_SECRET_KEY` or `DATABASE_URL` is missing.
+//! Each test uses a deterministic wallet so reruns are idempotent.
+//!
+//! Coverage — paired with the 11 codex gaps in the test-strategy
+//! discussion:
+//!   - signature tampering → 401  (gap #4 partial)
+//!   - timestamp skew → 401  (gap #4)
+//!   - non-`customer.updated` event → 200 no-op  (cheap reject)
+//!   - `customer.updated` without `previous_attributes.balance` → 200
+//!     no-op  (gap #3)
+//!   - `enabled=false` config → 200 no Stripe call, no credit row
+//!   - balance still at/above threshold → 200 no PI created
+//!   - happy path: balance dropped below threshold → PI created → credit
+//!     row inserted with non-null `stripe_balance_transaction_id`
+//!     (gap #1 partial — see "split-credit" deferred to Phase 6 reconciler
+//!     coverage)
+//!   - **replay safety**: deliver the same event twice → still exactly
+//!     one credit row, balance not double-credited  (gap #2, #6)
+//!   - cap reached: pre-existing PIs already at/above cap →  second
+//!     top-up skipped  (gap #7, partial of gap #11)
+
+use std::sync::Arc;
+
+use hmac::{Hmac, Mac};
+use lit_billing_core::StripeClient;
+use rocket::http::{Header, Status};
+use rocket::local::asynchronous::Client;
+use rocket::{Rocket, routes};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use sqlx::PgPool;
+
+use crate::auto_topup::types::AutoTopupConfigUpsert;
+use crate::auto_topup::webhook::mutex::PerCustomerMutex;
+use crate::config::Config;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const WEBHOOK_SECRET: &str = "whsec_test_phase5_webhook_secret_value_for_integration_tests";
+
+const TEST_WALLET_WEBHOOK_HAPPY: &str = "0x1010101010101010101010101010101010101010";
+const TEST_WALLET_WEBHOOK_REPLAY: &str = "0x2020202020202020202020202020202020202020";
+const TEST_WALLET_WEBHOOK_CAP: &str = "0x3030303030303030303030303030303030303030";
+const TEST_WALLET_WEBHOOK_DISABLED: &str = "0x4040404040404040404040404040404040404040";
+const TEST_WALLET_WEBHOOK_BENIGN: &str = "0x5050505050505050505050505050505050505050";
+const TEST_WALLET_WEBHOOK_PENDING: &str = "0x6161616161616161616161616161616161616161";
+
+fn stripe_key() -> Option<String> {
+    std::env::var("STRIPE_SECRET_KEY").ok().filter(|k| {
+        !k.trim().is_empty() && (k.starts_with("rk_test_") || k.starts_with("sk_test_"))
+    })
+}
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+fn test_config(stripe_secret_key: String, db_url: String) -> Config {
+    Config {
+        database_url: db_url,
+        magic_link_signing_key: vec![0u8; 32],
+        resend_api_key: "unused".into(),
+        mail_from: "unused".into(),
+        public_base_url: "http://unused".into(),
+        stripe_secret_key,
+        stripe_publishable_key: "pk_test_phase5".into(),
+        max_grant_cents: 0,
+        max_daily_per_operator_cents: 0,
+        litkey_discount_basis_points: 0,
+        litkey_chain: None,
+        // Cache-invalidation hop won't be reachable in tests; the
+        // fire-and-forget call swallows the error, so a bad URL is fine.
+        lit_api_server_base_url: "http://127.0.0.1:1".into(),
+        lit_internal_shared_secret: "unused".into(),
+        stripe_webhook_secret: WEBHOOK_SECRET.into(),
+        reconciler_interval_secs: 900,
+    }
+}
+
+async fn build_client(key: String, url: String) -> Client {
+    let cfg = test_config(key.clone(), url.clone());
+    let stripe = StripeClient::new(key).expect("stripe client");
+    let pool = PgPool::connect(&url).await.expect("connect db");
+    let rocket = Rocket::build()
+        .manage(cfg)
+        .manage(stripe)
+        .manage(pool)
+        .manage(PerCustomerMutex::new())
+        .mount("/", routes![super::handler::stripe_webhook]);
+    Client::tracked(rocket).await.expect("rocket client")
+}
+
+fn sign_now(body: &[u8]) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    sign_with_timestamp(body, now)
+}
+
+fn sign_with_timestamp(body: &[u8], timestamp: i64) -> String {
+    let mut mac = HmacSha256::new_from_slice(WEBHOOK_SECRET.as_bytes()).expect("hmac key");
+    mac.update(timestamp.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    let sig = hex::encode(mac.finalize().into_bytes());
+    format!("t={timestamp},v1={sig}")
+}
+
+/// Build a `customer.updated` event body with a balance change. Caller
+/// supplies the customer id and the new/previous balances.
+fn balance_change_event(customer_id: &str, new_balance: i64, previous_balance: i64) -> Vec<u8> {
+    let evt = json!({
+        "id": "evt_test_webhook",
+        "type": "customer.updated",
+        "data": {
+            "object": {
+                "id": customer_id,
+                "balance": new_balance,
+            },
+            "previous_attributes": {
+                "balance": previous_balance,
+            }
+        }
+    });
+    serde_json::to_vec(&evt).unwrap()
+}
+
+/// Build a `customer.updated` event with NO balance change. Mirrors what
+/// Stripe sends when only email / metadata changes.
+fn metadata_change_event(customer_id: &str) -> Vec<u8> {
+    let evt = json!({
+        "id": "evt_test_meta",
+        "type": "customer.updated",
+        "data": {
+            "object": {
+                "id": customer_id,
+                "balance": 0,
+            },
+            "previous_attributes": {
+                "email": "old@example.com",
+            }
+        }
+    });
+    serde_json::to_vec(&evt).unwrap()
+}
+
+/// Drop the customer balance to the desired value via balance_transactions.
+/// Stripe stores customer.balance as a signed integer; negative = credit
+/// available. We use `delta = desired - current` to land at `desired`.
+async fn set_customer_balance(stripe: &StripeClient, customer_id: &str, desired: i64) {
+    let cur = lit_billing_core::balance::fetch(stripe, customer_id)
+        .await
+        .unwrap_or(0);
+    let delta = desired - cur;
+    if delta == 0 {
+        return;
+    }
+    let amount = delta.to_string();
+    stripe
+        .post(
+            &format!("customers/{customer_id}/balance_transactions"),
+            &[
+                ("amount", amount.as_str()),
+                ("currency", "usd"),
+                ("description", "phase5_test_balance_setter"),
+            ],
+        )
+        .await
+        .expect("balance setter");
+}
+
+/// Wipe DB rows for the given wallet/customer so each test starts clean.
+async fn reset_for(pool: &PgPool, wallet: &str, customer_id: &str) {
+    let _ = sqlx::query("DELETE FROM auto_topup_credits WHERE customer_id = $1")
+        .bind(customer_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auto_topup_config WHERE wallet_address = $1")
+        .bind(wallet)
+        .execute(pool)
+        .await;
+}
+
+/// Seed an `enabled = true` config row with default knobs and the given pm.
+async fn seed_enabled_config(
+    pool: &PgPool,
+    customer_id: &str,
+    wallet: &str,
+    pm_id: &str,
+    threshold: i64,
+    topup: i64,
+    cap: i64,
+) {
+    let upsert = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(threshold),
+        topup_amount_cents: Some(topup),
+        monthly_cap_cents: Some(cap),
+        payment_method_id: Some(pm_id.to_string()),
+        consent_version: Some("v1".into()),
+    };
+    crate::auto_topup::db::upsert(pool, customer_id, wallet, &upsert)
+        .await
+        .expect("seed config");
+}
+
+async fn count_credit_rows(pool: &PgPool, customer_id: &str) -> i64 {
+    let (n,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM auto_topup_credits WHERE customer_id = $1")
+            .bind(customer_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    n
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Signature / event-filter tests (no Stripe network calls)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rejects_tampered_signature() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url).await;
+    let body = balance_change_event("cus_unused", -100, 0);
+    let header = sign_now(&body);
+    // Mutate one hex char in the v1= portion.
+    let bad = header.replace(",v1=", ",v1=ff");
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", bad))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Unauthorized);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rejects_stale_timestamp() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url).await;
+    let body = balance_change_event("cus_unused", -100, 0);
+    let stale = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+        - 3600; // 1 hour ago
+    let header = sign_with_timestamp(&body, stale);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Unauthorized);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn ignores_event_without_balance_change() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url).await;
+    let body = metadata_change_event("cus_anything");
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    // No balance change → handler treats as not-our-event → 200.
+    assert_eq!(resp.status(), Status::Ok);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn ignores_non_customer_updated_event() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url).await;
+    let body = serde_json::to_vec(&json!({
+        "type": "charge.succeeded",
+        "data": {"object": {"id": "ch_xxx"}}
+    }))
+    .unwrap();
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Config-state short-circuit tests (Stripe customer, no PI creation)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn short_circuits_when_config_disabled() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_DISABLED,
+    )
+    .await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_DISABLED, &cust).await;
+
+    // Disabled config: just an enabled=false row exists for this wallet.
+    let upsert = AutoTopupConfigUpsert {
+        enabled: false,
+        threshold_cents: None,
+        topup_amount_cents: None,
+        monthly_cap_cents: None,
+        payment_method_id: None,
+        consent_version: None,
+    };
+    crate::auto_topup::db::upsert(&pool, &cust, TEST_WALLET_WEBHOOK_DISABLED, &upsert)
+        .await
+        .unwrap();
+
+    let client = build_client(key, url).await;
+    let body = balance_change_event(&cust, -100, 0);
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    assert_eq!(count_credit_rows(&pool, &cust).await, 0);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn ignores_when_payload_balance_above_threshold() {
+    // Payload claims balance still has plenty of credit (-2000 = $20).
+    // Even though the row is enabled with threshold=500 ($5), no top-up
+    // fires because the user isn't actually low.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_BENIGN,
+    )
+    .await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_BENIGN, &cust).await;
+
+    let pm_id = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    seed_enabled_config(
+        &pool,
+        &cust,
+        TEST_WALLET_WEBHOOK_BENIGN,
+        &pm_id,
+        500,
+        2_000,
+        10_000,
+    )
+    .await;
+
+    let client = build_client(key, url).await;
+    let body = balance_change_event(&cust, -5_000, -10_000); // still $50 credit
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    assert_eq!(count_credit_rows(&pool, &cust).await, 0);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Happy path + replay safety (real Stripe charge fires)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn happy_path_charges_and_credits() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_HAPPY,
+    )
+    .await;
+    let pm_id = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_HAPPY, &cust).await;
+    seed_enabled_config(
+        &pool,
+        &cust,
+        TEST_WALLET_WEBHOOK_HAPPY,
+        &pm_id,
+        500,
+        2_000,
+        10_000,
+    )
+    .await;
+    // Drive the actual Stripe balance below threshold so the handler's
+    // fresh re-fetch (step 5) agrees with the payload.
+    set_customer_balance(&stripe, &cust, -100).await; // $1 credit, below $5
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let body = balance_change_event(&cust, -100, -1000);
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(
+        resp.status(),
+        Status::Ok,
+        "body: {}",
+        resp.into_string().await.unwrap_or_default()
+    );
+    assert_eq!(count_credit_rows(&pool, &cust).await, 1);
+
+    // Verify the credit row has a non-null balance_transaction_id (full
+    // credit committed, not partial).
+    let (bt_id,): (Option<String>,) = sqlx::query_as(
+        "SELECT stripe_balance_transaction_id FROM auto_topup_credits WHERE customer_id = $1",
+    )
+    .bind(&cust)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(bt_id.is_some(), "balance_transaction_id should be set");
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn replay_of_same_event_is_safe() {
+    // Two deliveries of the same customer.updated event must not result
+    // in two credits — protects against Stripe webhook redelivery /
+    // network blip retries.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_REPLAY,
+    )
+    .await;
+    let pm_id = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_REPLAY, &cust).await;
+    seed_enabled_config(
+        &pool,
+        &cust,
+        TEST_WALLET_WEBHOOK_REPLAY,
+        &pm_id,
+        500,
+        2_000,
+        10_000,
+    )
+    .await;
+    set_customer_balance(&stripe, &cust, -100).await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let body = balance_change_event(&cust, -100, -1000);
+    let header = sign_now(&body);
+
+    // Deliver the event twice.
+    let r1 = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header.clone()))
+        .body(body.clone())
+        .dispatch()
+        .await;
+    assert_eq!(r1.status(), Status::Ok);
+    let credits_after_first = count_credit_rows(&pool, &cust).await;
+
+    // On the second delivery, the fresh balance fetch (step 5) sees the
+    // balance is now ABOVE threshold (we just credited $20), so the
+    // handler short-circuits without creating a new PI. This is the
+    // expected real-world behaviour — Stripe's stale webhook re-delivery
+    // arrives after the credit has settled. The credit count must not
+    // increase regardless.
+    let r2 = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(r2.status(), Status::Ok);
+    let credits_after_second = count_credit_rows(&pool, &cust).await;
+    assert_eq!(
+        credits_after_first, credits_after_second,
+        "replay must not create an additional credit row"
+    );
+    assert_eq!(credits_after_first, 1);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cap reached
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Helper: sum existing this-month auto_topup PI amounts at Stripe for
+/// this customer. Lets the cap test set a budget that leaves room for
+/// exactly one more top-up regardless of accumulated state from prior
+/// test runs.
+async fn existing_month_spend(stripe: &StripeClient, customer_id: &str) -> i64 {
+    let month_start = {
+        let now = time::OffsetDateTime::now_utc();
+        time::OffsetDateTime::new_utc(
+            time::Date::from_calendar_date(now.year(), now.month(), 1).unwrap(),
+            time::Time::MIDNIGHT,
+        )
+        .unix_timestamp()
+    };
+    let since = month_start.to_string();
+    let resp = stripe
+        .get(
+            "payment_intents",
+            &[
+                ("customer", customer_id),
+                ("limit", "100"),
+                ("created[gte]", since.as_str()),
+            ],
+        )
+        .await
+        .expect("list pis");
+    resp.body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|pi| {
+                    let is_auto = pi.pointer("/metadata/source").and_then(|v| v.as_str())
+                        == Some("auto_topup");
+                    let status = pi.get("status").and_then(|v| v.as_str()).unwrap_or("");
+                    let failed = status == "requires_payment_method";
+                    is_auto && !failed
+                })
+                .filter_map(|pi| pi.get("amount").and_then(|v| v.as_i64()))
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn cap_reached_skips_charge() {
+    // Sum of this-month auto_topup PIs already equals the cap. Webhook
+    // arrives with balance below threshold but the cap check refuses.
+    //
+    // State-aware setup: Stripe customers carry PI history across runs
+    // and we can't delete past PIs. So compute the existing this-month
+    // auto_topup spend at Stripe and set the cap to `existing + topup` —
+    // that leaves room for *exactly one more* charge, regardless of how
+    // many times the test has run before.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_CAP,
+    )
+    .await;
+    let pm_id = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_CAP, &cust).await;
+
+    let topup = 500i64; // $5 per top-up
+    let existing = existing_month_spend(&stripe, &cust).await;
+    // cap = existing + topup → there is room for the first delivery and
+    // exactly one more, so the SECOND delivery should be the one refused.
+    let cap = existing + topup;
+    seed_enabled_config(
+        &pool,
+        &cust,
+        TEST_WALLET_WEBHOOK_CAP,
+        &pm_id,
+        500,
+        topup,
+        cap,
+    )
+    .await;
+    set_customer_balance(&stripe, &cust, -100).await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+
+    let credits_before = count_credit_rows(&pool, &cust).await;
+
+    // First delivery: should charge $5 (fills cap exactly).
+    let body = balance_change_event(&cust, -100, -1000);
+    let header = sign_now(&body);
+    let r1 = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(r1.status(), Status::Ok);
+    let credits_after_first = count_credit_rows(&pool, &cust).await;
+    assert_eq!(
+        credits_after_first,
+        credits_before + 1,
+        "first delivery should have credited the user"
+    );
+
+    // Second delivery: cap is now full → must be skipped.
+    set_customer_balance(&stripe, &cust, -100).await;
+    let body2 = balance_change_event(&cust, -100, -1000);
+    let header2 = sign_now(&body2);
+    let r2 = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header2))
+        .body(body2)
+        .dispatch()
+        .await;
+    assert_eq!(r2.status(), Status::Ok);
+    assert_eq!(
+        count_credit_rows(&pool, &cust).await,
+        credits_after_first,
+        "cap should have prevented a second credit"
+    );
+}
+
+/// Codex P1 #2: while an SCA-pending PI is in flight, another
+/// `customer.updated` arriving for the same customer MUST NOT spawn a
+/// second off-session PI. Doing so would overwrite the single-use
+/// recovery_token and leave the user stranded between two pending PIs.
+///
+/// Seed: enabled config row with `pending_action_pi_id` populated (the
+/// state the webhook handler would have written when the first PI hit
+/// `authentication_required`). Then deliver a balance-drop event and
+/// assert no new credit row appears.
+#[tokio::test]
+#[serial_test::serial]
+async fn pending_action_pauses_further_topups() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_WEBHOOK_PENDING,
+    )
+    .await;
+    let pm_id = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_WEBHOOK_PENDING, &cust).await;
+    seed_enabled_config(
+        &pool,
+        &cust,
+        TEST_WALLET_WEBHOOK_PENDING,
+        &pm_id,
+        500,
+        2_000,
+        10_000,
+    )
+    .await;
+    // Simulate the prior webhook tick having staged an SCA handoff.
+    crate::auto_topup::db::set_pending_action(
+        &pool,
+        &cust,
+        "pi_test_pending_blockade_xxx",
+        "phase5-pending-blockade-token",
+    )
+    .await
+    .unwrap();
+    set_customer_balance(&stripe, &cust, -100).await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let body = balance_change_event(&cust, -100, -1000);
+    let header = sign_now(&body);
+    let resp = client
+        .post("/stripe/webhook")
+        .header(Header::new("Stripe-Signature", header))
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    assert_eq!(
+        count_credit_rows(&pool, &cust).await,
+        0,
+        "pending SCA must block additional off-session charges"
+    );
+    // The recovery token must still be intact — the short-circuit fired
+    // before any DB mutation could overwrite it.
+    let (token,): (Option<String>,) =
+        sqlx::query_as("SELECT recovery_token FROM auto_topup_config WHERE customer_id = $1")
+            .bind(&cust)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(token.as_deref(), Some("phase5-pending-blockade-token"));
+}

--- a/lit-payments/src/auto_topup/webhook/mod.rs
+++ b/lit-payments/src/auto_topup/webhook/mod.rs
@@ -1,0 +1,15 @@
+//! Stripe `customer.updated` webhook — the only trigger for auto top-up.
+//!
+//! The handler does the full §6 flow synchronously inside the webhook
+//! request: HMAC verification → quick exits → mutex → fresh balance fetch
+//! → PI list / failure / cap → off-session PI create → sync credit →
+//! cache invalidation. Returns 5xx on transient backend errors so Stripe
+//! retries; returns 200 ONLY after credit work is committed.
+
+pub mod handler;
+pub mod mutex;
+pub mod sca;
+pub mod signature;
+
+#[cfg(test)]
+mod handler_tests;

--- a/lit-payments/src/auto_topup/webhook/mutex.rs
+++ b/lit-payments/src/auto_topup/webhook/mutex.rs
@@ -1,0 +1,54 @@
+//! Per-customer in-process mutex.
+//!
+//! Serializes concurrent `customer.updated` deliveries for the same
+//! customer so the PI-list / cap / charge logic in `handler.rs` doesn't
+//! race against itself. The cache is `moka::sync` with a 5-minute TTL —
+//! short-lived per the plan's §10 "this is an optimization, not a
+//! correctness primitive" framing.
+//!
+//! Correctness still rests on:
+//!   - Stripe Idempotency-Key on `paymentIntents.create`
+//!   - Postgres `UNIQUE(payment_intent_id)` on `auto_topup_credits`
+//!   - Stripe Idempotency-Key on `balance_transactions` write
+//!
+//! Those three layers hold even if the mutex is bypassed (e.g. when
+//! `lit-payments` is horizontally scaled and two replicas receive copies
+//! of the same event).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use moka::sync::Cache;
+use tokio::sync::Mutex;
+
+const MUTEX_CACHE_CAPACITY: u64 = 10_000;
+const MUTEX_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Shared mutex registry. Build once at startup and hand to Rocket state.
+#[derive(Clone)]
+pub struct PerCustomerMutex {
+    inner: Cache<String, Arc<Mutex<()>>>,
+}
+
+impl PerCustomerMutex {
+    pub fn new() -> Self {
+        let inner = Cache::builder()
+            .max_capacity(MUTEX_CACHE_CAPACITY)
+            .time_to_idle(MUTEX_CACHE_TTL)
+            .build();
+        Self { inner }
+    }
+
+    /// Acquire (or create) the mutex for `customer_id`. Holders hold for
+    /// the lifetime of the returned `OwnedMutexGuard`-equivalent.
+    pub fn get(&self, customer_id: &str) -> Arc<Mutex<()>> {
+        self.inner
+            .get_with(customer_id.to_string(), || Arc::new(Mutex::new(())))
+    }
+}
+
+impl Default for PerCustomerMutex {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lit-payments/src/auto_topup/webhook/sca.rs
+++ b/lit-payments/src/auto_topup/webhook/sca.rs
@@ -1,0 +1,40 @@
+//! SCA recovery-token primitives.
+//!
+//! Used when an off-session PaymentIntent returns `authentication_required`.
+//! We mint a one-time, URL-safe token, persist it on the
+//! `auto_topup_config` row (with a 24-hour expiry), email it to the user,
+//! and let Phase 7's `/billing/auto_topup_resume` endpoint exchange it for
+//! the PI's `client_secret`.
+//!
+//! The token is the dashboard's only handle on the pending PI — keep it
+//! random enough that guessing is infeasible. 32 random bytes (URL-safe
+//! base64 encoded, ~43 chars) is well above the practical threshold and
+//! matches the existing `auth::session::generate_token` shape.
+
+use base64::Engine;
+use rand::RngCore;
+
+pub fn generate_recovery_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn tokens_are_unique_and_url_safe() {
+        let mut seen = HashSet::new();
+        for _ in 0..200 {
+            let tok = generate_recovery_token();
+            assert!(!tok.contains('+'));
+            assert!(!tok.contains('/'));
+            assert!(!tok.contains('='));
+            assert!(tok.len() >= 40);
+            assert!(seen.insert(tok), "duplicate token");
+        }
+    }
+}

--- a/lit-payments/src/auto_topup/webhook/signature.rs
+++ b/lit-payments/src/auto_topup/webhook/signature.rs
@@ -1,0 +1,220 @@
+//! Stripe-Signature verification.
+//!
+//! Stripe sends each webhook with a header of the form
+//! `t={unix_ts},v1={hex_hmac_sha256}`. We:
+//!
+//! 1. Parse the header. Reject if it doesn't match the expected schema.
+//! 2. Reject if `|now - t| > 300` (5-minute timestamp skew tolerance —
+//!    Stripe's recommended floor and the same window CPL-329's invoice
+//!    webhook handler uses).
+//! 3. Compute `HMAC-SHA256(secret, "{t}.{raw_body}")` and constant-time
+//!    compare against `v1`. Constant-time matters: a normal `==` short-
+//!    circuits on the first mismatched byte and an attacker can in theory
+//!    learn the secret byte-by-byte from response timing.
+//!
+//! Stripe occasionally sends multiple `v1=` entries during webhook secret
+//! rotation. Any one match passes verification.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Maximum acceptable skew between the timestamp Stripe signed and our
+/// system clock. 300 seconds matches Stripe's documented recommendation.
+pub const TIMESTAMP_SKEW_SECONDS: i64 = 300;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SignatureError {
+    #[error("missing or empty Stripe-Signature header")]
+    Missing,
+    #[error("malformed Stripe-Signature header: {0}")]
+    Malformed(String),
+    #[error("timestamp skew exceeds tolerance: |now - t| = {0}s > {TIMESTAMP_SKEW_SECONDS}s")]
+    TimestampSkew(i64),
+    #[error("no v1 signature matched the expected HMAC")]
+    NoMatch,
+}
+
+/// Verify the `Stripe-Signature` header value against `raw_body` using the
+/// shared webhook secret. `now_unix` is parameterized so tests can pin time;
+/// production callers pass `std::time::SystemTime::now()`-derived seconds.
+pub fn verify(
+    header_value: &str,
+    raw_body: &[u8],
+    secret: &str,
+    now_unix: i64,
+) -> Result<(), SignatureError> {
+    if header_value.trim().is_empty() {
+        return Err(SignatureError::Missing);
+    }
+
+    let mut timestamp: Option<i64> = None;
+    let mut v1_signatures: Vec<&str> = Vec::new();
+    for part in header_value.split(',') {
+        let (k, v) = part
+            .split_once('=')
+            .ok_or_else(|| SignatureError::Malformed(format!("missing '=' in {part:?}")))?;
+        match k.trim() {
+            "t" => {
+                timestamp = Some(
+                    v.trim()
+                        .parse::<i64>()
+                        .map_err(|e| SignatureError::Malformed(format!("t not int: {e}")))?,
+                );
+            }
+            "v1" => v1_signatures.push(v.trim()),
+            _ => {
+                // Stripe documents v0 (deprecated) and forward-compat
+                // entries; ignore unknown schemes.
+            }
+        }
+    }
+
+    let t = timestamp.ok_or_else(|| SignatureError::Malformed("no t=...".into()))?;
+    let skew = (now_unix - t).abs();
+    if skew > TIMESTAMP_SKEW_SECONDS {
+        return Err(SignatureError::TimestampSkew(skew));
+    }
+    if v1_signatures.is_empty() {
+        return Err(SignatureError::Malformed("no v1=...".into()));
+    }
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    // Stripe signs the exact string `{timestamp}.{raw_body}`.
+    mac.update(t.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(raw_body);
+    let expected = mac.finalize().into_bytes();
+
+    for sig_hex in v1_signatures {
+        if let Ok(presented) = hex::decode(sig_hex)
+            && presented.len() == expected.len()
+            && bool::from(presented.ct_eq(&expected))
+        {
+            return Ok(());
+        }
+    }
+    Err(SignatureError::NoMatch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "whsec_test_secret_value_for_unit_tests";
+
+    fn sign(timestamp: i64, body: &[u8]) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(SECRET.as_bytes()).expect("HMAC accepts any key length");
+        mac.update(timestamp.to_string().as_bytes());
+        mac.update(b".");
+        mac.update(body);
+        let hex_sig = hex::encode(mac.finalize().into_bytes());
+        format!("t={timestamp},v1={hex_sig}")
+    }
+
+    #[test]
+    fn accepts_valid_signature_within_window() {
+        let now = 1_780_000_000;
+        let body = br#"{"id":"evt_xxx","type":"customer.updated"}"#;
+        let header = sign(now, body);
+        assert!(verify(&header, body, SECRET, now).is_ok());
+    }
+
+    #[test]
+    fn accepts_within_300s_skew() {
+        let now = 1_780_000_000;
+        let signed_at = now - 299;
+        let body = b"body";
+        let header = sign(signed_at, body);
+        assert!(verify(&header, body, SECRET, now).is_ok());
+    }
+
+    #[test]
+    fn rejects_skew_beyond_tolerance() {
+        let now = 1_780_000_000;
+        let signed_at = now - 301;
+        let body = b"body";
+        let header = sign(signed_at, body);
+        match verify(&header, body, SECRET, now) {
+            Err(SignatureError::TimestampSkew(s)) => assert!(s > TIMESTAMP_SKEW_SECONDS),
+            other => panic!("expected TimestampSkew, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_future_skew_beyond_tolerance() {
+        let now = 1_780_000_000;
+        let signed_at = now + 301;
+        let body = b"body";
+        let header = sign(signed_at, body);
+        match verify(&header, body, SECRET, now) {
+            Err(SignatureError::TimestampSkew(_)) => {}
+            other => panic!("expected TimestampSkew, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_body_tampering() {
+        let now = 1_780_000_000;
+        let body = b"original-body";
+        let header = sign(now, body);
+        let tampered = b"tampered-body";
+        assert!(matches!(
+            verify(&header, tampered, SECRET, now),
+            Err(SignatureError::NoMatch)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_secret() {
+        let now = 1_780_000_000;
+        let body = b"body";
+        let header = sign(now, body);
+        assert!(matches!(
+            verify(&header, body, "different_secret", now),
+            Err(SignatureError::NoMatch)
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_v1() {
+        let header = "t=1780000000";
+        assert!(matches!(
+            verify(header, b"body", SECRET, 1_780_000_000),
+            Err(SignatureError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_timestamp() {
+        let header = "v1=abcdef";
+        assert!(matches!(
+            verify(header, b"body", SECRET, 1_780_000_000),
+            Err(SignatureError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_header() {
+        assert!(matches!(
+            verify("", b"body", SECRET, 1_780_000_000),
+            Err(SignatureError::Missing)
+        ));
+    }
+
+    #[test]
+    fn accepts_multiple_v1_entries_during_rotation() {
+        // Stripe sends both old + new v1 signatures during webhook secret
+        // rotation. Any single match must pass.
+        let now = 1_780_000_000;
+        let body = b"body";
+        let valid = sign(now, body);
+        // valid is "t=...,v1=hex" — append a junk v1.
+        let with_extra = format!("{valid},v1=deadbeef00");
+        assert!(verify(&with_extra, body, SECRET, now).is_ok());
+    }
+}

--- a/lit-payments/src/billing/auto_topup_config_tests.rs
+++ b/lit-payments/src/billing/auto_topup_config_tests.rs
@@ -119,29 +119,7 @@ fn wallet_header() -> String {
     base64_light::base64_encode(&serde_json::to_string(&json).unwrap())
 }
 
-/// Attach a `pm_card_visa` PaymentMethod to the customer and return its id.
-/// Idempotent enough for tests — Stripe lets a single PaymentMethod attach
-/// to many customers (different ids per attach); on rerun we get a fresh
-/// pm_xxx but the previous one stays attached. That doesn't affect the
-/// ownership-check tests since we always use the freshly-returned id.
-async fn attach_test_card(stripe: &StripeClient, customer_id: &str) -> String {
-    let pm = stripe
-        .post(
-            "payment_methods",
-            &[("type", "card"), ("card[token]", "tok_visa")],
-        )
-        .await
-        .expect("create pm");
-    let pm_id = pm.body["id"].as_str().expect("pm id").to_string();
-    stripe
-        .post(
-            &format!("payment_methods/{pm_id}/attach"),
-            &[("customer", customer_id)],
-        )
-        .await
-        .expect("attach pm");
-    pm_id
-}
+use super::setup_intent_tests::attach_test_card;
 
 /// Delete the `auto_topup_config` rows for this wallet so each test starts
 /// from a clean slate. We delete by wallet_address (not customer_id) because

--- a/lit-payments/src/billing/setup_intent_tests.rs
+++ b/lit-payments/src/billing/setup_intent_tests.rs
@@ -118,6 +118,29 @@ fn wallet_header() -> String {
 ///   4. Waits for Stripe's search index to consistently return that id.
 ///
 /// Per-test calls are cheap on a clean account (one search hit, no delete).
+/// Attach a `pm_card_visa` PaymentMethod to the customer and return its id.
+/// Idempotent enough for tests — Stripe lets a single PaymentMethod attach
+/// to many customers (different ids per attach); on rerun we get a fresh
+/// pm_xxx but the previous one stays attached.
+pub(crate) async fn attach_test_card(stripe: &StripeClient, customer_id: &str) -> String {
+    let pm = stripe
+        .post(
+            "payment_methods",
+            &[("type", "card"), ("card[token]", "tok_visa")],
+        )
+        .await
+        .expect("create pm");
+    let pm_id = pm.body["id"].as_str().expect("pm id").to_string();
+    stripe
+        .post(
+            &format!("payment_methods/{pm_id}/attach"),
+            &[("customer", customer_id)],
+        )
+        .await
+        .expect("attach pm");
+    pm_id
+}
+
 pub(crate) async fn ensure_unique_customer(stripe: &StripeClient, wallet: &str) -> String {
     let query = format!("metadata['wallet_address']:'{wallet}'");
     let resp = stripe

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -6,6 +6,8 @@ use lit_billing_auth::{AuthResolver, BillingAuth};
 use lit_billing_core::StripeClient;
 use lit_payments::auth::routes as auth_routes;
 use lit_payments::auth_resolver::HttpAuthResolver;
+use lit_payments::auto_topup::webhook::handler as webhook_handler;
+use lit_payments::auto_topup::webhook::mutex::PerCustomerMutex;
 use lit_payments::billing as billing_routes;
 use lit_payments::portal::routes as portal_routes;
 use lit_payments::rate;
@@ -43,6 +45,7 @@ async fn rocket() -> _ {
         .expect("auth resolver"),
     );
     rate::spawn_rate_poller(pool.clone());
+    let per_customer_mutex = PerCustomerMutex::new();
     rocket::build()
         .manage(pool)
         .manage(cfg)
@@ -50,6 +53,7 @@ async fn rocket() -> _ {
         .manage(rate_limit)
         .manage(stripe)
         .manage(auth_resolver)
+        .manage(per_customer_mutex)
         .mount(
             "/",
             routes![
@@ -74,6 +78,7 @@ async fn rocket() -> _ {
                 billing_routes::setup_intent::setup_intent,
                 billing_routes::auto_topup_config::get_auto_topup_config,
                 billing_routes::auto_topup_config::put_auto_topup_config,
+                webhook_handler::stripe_webhook,
             ],
         )
         .mount("/static", FileServer::from("static"))


### PR DESCRIPTION
**Stack:** PR 5 of 8. Base: `auto-topup-phase-4`. Diff shows only Phase 5.

## What
Load-bearing trigger phase. Implements the full §6 flow synchronously inside the webhook request: HMAC verification → quick exits → per-customer mutex → fresh balance fetch → PI list / failure / cap → off-session PaymentIntent create → INSERT auto_topup_credits ON CONFLICT DO NOTHING → balance_transactions write with credit:{pi.id} idempotency key → UPDATE row with bt_id → fire-and-forget cache invalidation.

* Raw `Data` handler (NOT Json — HMAC verifies exact bytes), 1 MiB body cap.
* HMAC-SHA256 signature verification, ±300s timestamp skew, multi-v1 rotation.
* Per-customer moka mutex (5-min TTL) — optimization only; correctness from PI ledger UNIQUE + Stripe idempotency keys.
* Branches on PaymentIntent response: `succeeded` → sync credit; `authentication_required` → save `pending_action_pi_id` + recovery_token (Phase 7 consumer); decline codes → log + 200; other → 503 retry.

**Codex P1 #1 + #2 fixes folded in:**
* StripeError struct in lit-billing-core preserves `error.payment_intent.id` so SCA recovery can stage the right PI id (not a regex'd error string).
* Webhook short-circuit gates on `enabled && pending_action_pi_id.is_none()` so an in-flight SCA can't be overwritten by a fresh `customer.updated`.

## Tests
* 19 unit tests (signature verification, SCA token gen, handler helpers).
* 9 integration tests against real Stripe + real Postgres: tampered/stale signature, non-customer.updated event, no-balance event, disabled, above-threshold, happy path, replay safety, cap reached, **pending_action_pauses_further_topups** (codex P1 #2 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)