### PR TITLE
feat(auto-topup): phase 6 — reconciler tokio task

### DIFF
--- a/lit-payments/src/auto_topup/db.rs
+++ b/lit-payments/src/auto_topup/db.rs
@@ -295,6 +295,43 @@ pub async fn mark_credit_completed(
     Ok(())
 }
 
+/// List all customer ids with `enabled = true`. Used by the reconciler
+/// to scope its PI scan to actually-active subscriptions.
+pub async fn list_enabled_customers(pool: &PgPool) -> Result<Vec<String>> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT customer_id FROM auto_topup_config WHERE enabled = true")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+/// Per-PI credit row (subset). `None` means no row exists yet.
+#[derive(Debug, Clone)]
+pub struct CreditRow {
+    pub payment_intent_id: String,
+    pub customer_id: String,
+    pub amount_cents: i64,
+    pub stripe_balance_transaction_id: Option<String>,
+}
+
+/// Fetch the credit row for a PI. Used by the reconciler to triage
+/// orphans (no row, or row with null balance_tx_id).
+pub async fn find_credit_row(pool: &PgPool, payment_intent_id: &str) -> Result<Option<CreditRow>> {
+    let row: Option<(String, String, i64, Option<String>)> = sqlx::query_as(
+        "SELECT payment_intent_id, customer_id, amount_cents, stripe_balance_transaction_id \
+         FROM auto_topup_credits WHERE payment_intent_id = $1",
+    )
+    .bind(payment_intent_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|r| CreditRow {
+        payment_intent_id: r.0,
+        customer_id: r.1,
+        amount_cents: r.2,
+        stripe_balance_transaction_id: r.3,
+    }))
+}
+
 /// Returns true if the error is a Postgres CHECK constraint violation
 /// (SQLSTATE 23514) on the `enabled_requires_config` constraint. Lets
 /// handlers map "you said enabled=true but didn't set all required fields"

--- a/lit-payments/src/auto_topup/db.rs
+++ b/lit-payments/src/auto_topup/db.rs
@@ -305,6 +305,22 @@ pub async fn list_enabled_customers(pool: &PgPool) -> Result<Vec<String>> {
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
+/// Codex P1 (Phase 6): reconciler must also visit customers who have a
+/// partial credit row (PI created, balance_tx never landed) even if the
+/// row has since been disabled — failures-threshold auto-disable flips
+/// `enabled=false`, but the orphaned credit row still needs the
+/// balance_transactions retry. Pre-fix the reconciler scoped exclusively
+/// to enabled customers and these stayed pending forever.
+pub async fn list_customers_with_partial_credits(pool: &PgPool) -> Result<Vec<String>> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT customer_id FROM auto_topup_credits \
+            WHERE stripe_balance_transaction_id IS NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 /// Per-PI credit row (subset). `None` means no row exists yet.
 #[derive(Debug, Clone)]
 pub struct CreditRow {
@@ -312,13 +328,20 @@ pub struct CreditRow {
     pub customer_id: String,
     pub amount_cents: i64,
     pub stripe_balance_transaction_id: Option<String>,
+    /// Used by the reconciler to age-gate partial retries (Codex P1
+    /// Phase 6). The webhook handler typically commits the balance_tx
+    /// within a few hundred ms of inserting the credit row, so a fresh
+    /// partial row is overwhelmingly likely to be the live webhook
+    /// flow's in-flight write, not a real orphan.
+    pub credited_at: OffsetDateTime,
 }
 
 /// Fetch the credit row for a PI. Used by the reconciler to triage
 /// orphans (no row, or row with null balance_tx_id).
 pub async fn find_credit_row(pool: &PgPool, payment_intent_id: &str) -> Result<Option<CreditRow>> {
-    let row: Option<(String, String, i64, Option<String>)> = sqlx::query_as(
-        "SELECT payment_intent_id, customer_id, amount_cents, stripe_balance_transaction_id \
+    let row: Option<(String, String, i64, Option<String>, OffsetDateTime)> = sqlx::query_as(
+        "SELECT payment_intent_id, customer_id, amount_cents, \
+                stripe_balance_transaction_id, credited_at \
          FROM auto_topup_credits WHERE payment_intent_id = $1",
     )
     .bind(payment_intent_id)
@@ -329,7 +352,73 @@ pub async fn find_credit_row(pool: &PgPool, payment_intent_id: &str) -> Result<O
         customer_id: r.1,
         amount_cents: r.2,
         stripe_balance_transaction_id: r.3,
+        credited_at: r.4,
     }))
+}
+
+/// SCA recovery: resolve a `recovery_token` to the
+/// `(customer_id, pending_action_pi_id)` it grants access to, WITHOUT
+/// invalidating it. Used by the GET resume endpoint to fetch the PI's
+/// client_secret from Stripe; the caller invalidates only after the
+/// Stripe call succeeds via [`clear_recovery_token_for_pi`].
+///
+/// Splitting lookup from invalidation (codex P2 #3) preserves the
+/// single-use semantic for the happy path while letting a transient
+/// Stripe failure leave the token usable for retry. A successful Stripe
+/// call always burns the token; a 503 from Stripe never does.
+pub async fn lookup_recovery_token(pool: &PgPool, token: &str) -> Result<Option<(String, String)>> {
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT customer_id, pending_action_pi_id FROM auto_topup_config \
+            WHERE recovery_token = $1 \
+              AND recovery_token_expires_at > now() \
+              AND pending_action_pi_id IS NOT NULL",
+    )
+    .bind(token)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Invalidate the recovery token for the given (customer, pi) pair. The
+/// WHERE clause matches on `pending_action_pi_id` so a race that landed
+/// on a different PI cannot accidentally clear the wrong row's token.
+pub async fn clear_recovery_token_for_pi(
+    pool: &PgPool,
+    customer_id: &str,
+    pi_id: &str,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE auto_topup_config \
+            SET recovery_token = NULL, recovery_token_expires_at = NULL \
+            WHERE customer_id = $1 AND pending_action_pi_id = $2",
+    )
+    .bind(customer_id)
+    .bind(pi_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Legacy atomic consume — kept for callers that already had the
+/// preserve-on-failure semantics handled at their level. Prefer the
+/// lookup + clear split above.
+#[allow(dead_code)]
+pub async fn consume_recovery_token(
+    pool: &PgPool,
+    token: &str,
+) -> Result<Option<(String, String)>> {
+    let row: Option<(String, String)> = sqlx::query_as(
+        "UPDATE auto_topup_config \
+            SET recovery_token = NULL, recovery_token_expires_at = NULL \
+            WHERE recovery_token = $1 \
+              AND recovery_token_expires_at > now() \
+              AND pending_action_pi_id IS NOT NULL \
+            RETURNING customer_id, pending_action_pi_id",
+    )
+    .bind(token)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
 }
 
 /// Returns true if the error is a Postgres CHECK constraint violation

--- a/lit-payments/src/auto_topup/mod.rs
+++ b/lit-payments/src/auto_topup/mod.rs
@@ -8,5 +8,9 @@
 //! so the SQL surface stays in one place.
 
 pub mod db;
+pub mod reconciler;
+
+#[cfg(test)]
+mod reconciler_tests;
 pub mod types;
 pub mod webhook;

--- a/lit-payments/src/auto_topup/reconciler.rs
+++ b/lit-payments/src/auto_topup/reconciler.rs
@@ -1,0 +1,210 @@
+//! Auto top-up reconciler.
+//!
+//! Plan §6 / §9: the sync-credit webhook handler can fail mid-flow:
+//!   - HTTP timeout on `paymentIntents.create` — the PI may still
+//!     succeed at Stripe but we never see the response.
+//!   - DB write timeout between `INSERT auto_topup_credits` and
+//!     `balance_transactions` — credit row exists, balance not credited.
+//!   - Process crash anywhere in the middle.
+//!
+//! The reconciler closes these gaps by sweeping each enabled customer's
+//! recent auto_topup PIs (last 7 days) every `RECONCILER_INTERVAL_SECS`
+//! and applying any missing credit work. The PI ledger
+//! (auto_topup_credits) + Stripe Idempotency-Key `credit:{pi.id}` make
+//! the sweep safe to run concurrently with the live webhook handler.
+//!
+//! Spawned from main.rs at startup; runs for the lifetime of the
+//! process. The process exits non-cleanly on shutdown (no graceful
+//! drain) — that's fine because the next reconciler tick on the
+//! restarted process picks up any work that was interrupted.
+
+use std::time::Duration;
+
+use ::time::OffsetDateTime;
+use anyhow::Context;
+use lit_billing_core::StripeClient;
+use serde_json::Value;
+use sqlx::PgPool;
+use tokio::time as tokio_time;
+
+use crate::auto_topup::db;
+use crate::config::Config;
+use crate::internal::client as internal_client;
+
+const LOOKBACK_DAYS: i64 = 7;
+
+/// Spawn the reconciler. Returns immediately; the loop runs in the
+/// background until the process exits.
+pub fn spawn(config: Config, stripe: StripeClient, pool: PgPool) {
+    let interval_secs = config.reconciler_interval_secs.max(10) as u64;
+    tracing::info!(
+        "auto_topup reconciler: interval = {interval_secs}s, lookback = {LOOKBACK_DAYS}d"
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio_time::interval(Duration::from_secs(interval_secs));
+        // First tick fires immediately; that's the desired behaviour
+        // (run-on-startup so a process restart catches in-flight work).
+        loop {
+            ticker.tick().await;
+            if let Err(e) = run_once(&config, &stripe, &pool).await {
+                tracing::warn!("auto_topup reconciler tick failed: {e:?}");
+            }
+        }
+    });
+}
+
+/// Single sweep across every enabled customer. Public for tests; the
+/// production scheduler in [`spawn`] is the only other caller.
+pub async fn run_once(config: &Config, stripe: &StripeClient, pool: &PgPool) -> anyhow::Result<()> {
+    let customers = db::list_enabled_customers(pool)
+        .await
+        .context("list enabled customers")?;
+    if customers.is_empty() {
+        return Ok(());
+    }
+    let since_unix =
+        (OffsetDateTime::now_utc() - ::time::Duration::days(LOOKBACK_DAYS)).unix_timestamp();
+    for customer_id in customers {
+        if let Err(e) = reconcile_customer(config, stripe, pool, &customer_id, since_unix).await {
+            tracing::warn!(customer_id, "reconcile_customer failed: {e:?}");
+        }
+    }
+    Ok(())
+}
+
+async fn reconcile_customer(
+    config: &Config,
+    stripe: &StripeClient,
+    pool: &PgPool,
+    customer_id: &str,
+    since_unix: i64,
+) -> anyhow::Result<()> {
+    let pis = list_succeeded_auto_topup_pis(stripe, customer_id, since_unix).await?;
+    for pi in pis {
+        let pi_id = match pi.get("id").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let amount = pi.get("amount").and_then(|v| v.as_i64()).unwrap_or(0);
+        if amount <= 0 {
+            continue;
+        }
+        match db::find_credit_row(pool, &pi_id).await? {
+            Some(row) if row.stripe_balance_transaction_id.is_some() => {
+                // Credited. Skip.
+            }
+            Some(_partial) => {
+                // Row exists but balance_tx never landed. Retry just the
+                // balance_transactions write (with the same idempotency
+                // key — Stripe dedupes if the prior attempt actually
+                // succeeded).
+                tracing::warn!(customer_id, pi_id, "reconciler: completing partial credit");
+                let bt_id = write_balance_transaction(stripe, customer_id, &pi_id, amount).await?;
+                db::mark_credit_completed(pool, &pi_id, &bt_id).await?;
+                let _ = invalidate_cache(config, customer_id).await;
+            }
+            None => {
+                // No DB row at all — webhook handler never reached the
+                // INSERT (process crash, HTTP timeout on PI create, or
+                // mid-air interruption). Do the full credit dance.
+                tracing::warn!(customer_id, pi_id, "reconciler: applying orphaned credit");
+                let inserted = db::try_insert_credit(pool, &pi_id, customer_id, amount).await?;
+                if !inserted {
+                    // Lost the race with the webhook handler — fine.
+                    continue;
+                }
+                let bt_id = write_balance_transaction(stripe, customer_id, &pi_id, amount).await?;
+                db::mark_credit_completed(pool, &pi_id, &bt_id).await?;
+                let _ = invalidate_cache(config, customer_id).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn list_succeeded_auto_topup_pis(
+    stripe: &StripeClient,
+    customer_id: &str,
+    since_unix: i64,
+) -> anyhow::Result<Vec<Value>> {
+    let mut out = Vec::new();
+    let mut starting_after: Option<String> = None;
+    let since_str = since_unix.to_string();
+    loop {
+        let mut params: Vec<(&str, &str)> = vec![
+            ("customer", customer_id),
+            ("limit", "100"),
+            ("created[gte]", since_str.as_str()),
+        ];
+        if let Some(ref s) = starting_after {
+            params.push(("starting_after", s.as_str()));
+        }
+        let resp = stripe
+            .get("payment_intents", &params)
+            .await
+            .context("payment_intents.list (reconciler)")?;
+        let arr = match resp.body.get("data").and_then(|d| d.as_array()) {
+            Some(arr) => arr.clone(),
+            None => break,
+        };
+        let has_more = resp
+            .body
+            .get("has_more")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let mut last_id: Option<String> = None;
+        for pi in arr.iter() {
+            let is_auto =
+                pi.pointer("/metadata/source").and_then(|v| v.as_str()) == Some("auto_topup");
+            let succeeded = pi.get("status").and_then(|v| v.as_str()) == Some("succeeded");
+            if is_auto && succeeded {
+                out.push(pi.clone());
+            }
+            last_id = pi.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+        }
+        if !has_more {
+            break;
+        }
+        match last_id {
+            Some(id) => starting_after = Some(id),
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+async fn write_balance_transaction(
+    stripe: &StripeClient,
+    customer_id: &str,
+    pi_id: &str,
+    amount_cents: i64,
+) -> anyhow::Result<String> {
+    let credit_idem = format!("credit:{pi_id}");
+    let neg = (-amount_cents).to_string();
+    let resp = stripe
+        .post_with_idempotency(
+            &format!("customers/{customer_id}/balance_transactions"),
+            &[
+                ("amount", neg.as_str()),
+                ("currency", "usd"),
+                ("description", &format!("Auto top-up via {pi_id}")),
+            ],
+            &credit_idem,
+        )
+        .await
+        .context("reconciler balance_transactions write")?;
+    let id = resp
+        .body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("balance_tx response missing id"))?
+        .to_string();
+    Ok(id)
+}
+
+async fn invalidate_cache(config: &Config, customer_id: &str) -> anyhow::Result<()> {
+    let client = internal_client::build_client()?;
+    let body = serde_json::json!({ "customer_id": customer_id });
+    internal_client::post_internal(&client, config, "/internal/invalidate_balance_cache", &body)
+        .await
+}

--- a/lit-payments/src/auto_topup/reconciler.rs
+++ b/lit-payments/src/auto_topup/reconciler.rs
@@ -18,6 +18,7 @@
 //! drain) — that's fine because the next reconciler tick on the
 //! restarted process picks up any work that was interrupted.
 
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use ::time::OffsetDateTime;
@@ -32,6 +33,16 @@ use crate::config::Config;
 use crate::internal::client as internal_client;
 
 const LOOKBACK_DAYS: i64 = 7;
+
+/// Minimum age before the reconciler retries a partial credit row. The
+/// webhook handler typically writes the balance_transactions row within
+/// a few hundred ms of inserting the credit row; a fresh partial row is
+/// almost certainly the live webhook flow still in-flight, not a real
+/// orphan. Retrying immediately would race with the webhook on the
+/// balance_transactions write — safe (Stripe Idempotency-Key dedupes)
+/// but wasteful and noisy in logs. 60s is a generous floor that still
+/// lets a true crash mid-flow recover within one reconciler tick.
+const MIN_PARTIAL_AGE_SECS: i64 = 60;
 
 /// Spawn the reconciler. Returns immediately; the loop runs in the
 /// background until the process exits.
@@ -53,18 +64,30 @@ pub fn spawn(config: Config, stripe: StripeClient, pool: PgPool) {
     });
 }
 
-/// Single sweep across every enabled customer. Public for tests; the
-/// production scheduler in [`spawn`] is the only other caller.
+/// Single sweep across every enabled customer plus any customer with an
+/// outstanding partial credit row. Public for tests; the production
+/// scheduler in [`spawn`] is the only other caller.
+///
+/// Codex P1 (Phase 6): scope is the UNION of (enabled customers, customers
+/// with partial credit rows). Restricting to enabled customers stranded
+/// partial credits whenever a row got auto-disabled (failures threshold)
+/// between the PI succeeding and the balance_transactions write landing.
 pub async fn run_once(config: &Config, stripe: &StripeClient, pool: &PgPool) -> anyhow::Result<()> {
-    let customers = db::list_enabled_customers(pool)
+    let enabled = db::list_enabled_customers(pool)
         .await
         .context("list enabled customers")?;
-    if customers.is_empty() {
+    let partial = db::list_customers_with_partial_credits(pool)
+        .await
+        .context("list partial-credit customers")?;
+    let mut all: BTreeSet<String> = BTreeSet::new();
+    all.extend(enabled);
+    all.extend(partial);
+    if all.is_empty() {
         return Ok(());
     }
     let since_unix =
         (OffsetDateTime::now_utc() - ::time::Duration::days(LOOKBACK_DAYS)).unix_timestamp();
-    for customer_id in customers {
+    for customer_id in all {
         if let Err(e) = reconcile_customer(config, stripe, pool, &customer_id, since_unix).await {
             tracing::warn!(customer_id, "reconcile_customer failed: {e:?}");
         }
@@ -93,11 +116,30 @@ async fn reconcile_customer(
             Some(row) if row.stripe_balance_transaction_id.is_some() => {
                 // Credited. Skip.
             }
-            Some(_partial) => {
+            Some(partial) => {
                 // Row exists but balance_tx never landed. Retry just the
                 // balance_transactions write (with the same idempotency
                 // key — Stripe dedupes if the prior attempt actually
                 // succeeded).
+                //
+                // Codex P1 (Phase 6): age-gate this retry. A partial row
+                // less than MIN_PARTIAL_AGE_SECS old is overwhelmingly
+                // likely to be the live webhook handler's in-flight
+                // balance_transactions write, not a real orphan. The
+                // idempotency-key makes the race safe but wasteful;
+                // waiting one minute keeps logs and Stripe-call volume
+                // sane while still catching real crashes on the next
+                // tick.
+                let age = OffsetDateTime::now_utc() - partial.credited_at;
+                if age.whole_seconds() < MIN_PARTIAL_AGE_SECS {
+                    tracing::debug!(
+                        customer_id,
+                        pi_id,
+                        age_secs = age.whole_seconds(),
+                        "reconciler: skipping fresh partial credit (live webhook in flight)"
+                    );
+                    continue;
+                }
                 tracing::warn!(customer_id, pi_id, "reconciler: completing partial credit");
                 let bt_id = write_balance_transaction(stripe, customer_id, &pi_id, amount).await?;
                 db::mark_credit_completed(pool, &pi_id, &bt_id).await?;

--- a/lit-payments/src/auto_topup/reconciler_tests.rs
+++ b/lit-payments/src/auto_topup/reconciler_tests.rs
@@ -182,9 +182,16 @@ async fn reconciler_completes_partial_credit() {
         create_succeeded_auto_topup_pi(&stripe, &cust, &pm, TEST_WALLET_RECONCILER_PARTIAL, 500)
             .await;
     // Simulate the "partial credit" state: row inserted, bt_id null.
+    // Backdate `credited_at` past the reconciler's MIN_PARTIAL_AGE_SECS
+    // (60s) age gate — fresh partials are intentionally skipped because
+    // they're overwhelmingly likely to be the live webhook's in-flight
+    // balance_tx write. An integration test simulating a crashed webhook
+    // is exactly the "real orphan" case, so we backdate to 5 minutes
+    // ago so the reconciler picks it up.
     sqlx::query(
-        "INSERT INTO auto_topup_credits (payment_intent_id, customer_id, amount_cents) \
-         VALUES ($1, $2, $3)",
+        "INSERT INTO auto_topup_credits \
+            (payment_intent_id, customer_id, amount_cents, credited_at) \
+         VALUES ($1, $2, $3, now() - interval '5 minutes')",
     )
     .bind(&pi_id)
     .bind(&cust)

--- a/lit-payments/src/auto_topup/reconciler_tests.rs
+++ b/lit-payments/src/auto_topup/reconciler_tests.rs
@@ -1,0 +1,267 @@
+//! Phase 6 integration tests for the reconciler.
+//!
+//! Tests exercise the three triage branches of `reconcile_customer`:
+//!   - Row exists with non-null `stripe_balance_transaction_id` → skip.
+//!   - Row exists with NULL `stripe_balance_transaction_id` → reconciler
+//!     re-runs `balance_transactions` (idempotency key suppresses dupes
+//!     at Stripe) and fills in the row.
+//!   - No row at all → reconciler INSERTs the credit row AND writes the
+//!     balance_transaction.
+//!
+//! Each test drives a real Stripe PI to `succeeded` by creating one
+//! synchronously off-session against an attached test card, then
+//! manipulates DB state to simulate the failure mode.
+
+use lit_billing_core::StripeClient;
+use serde_json::Value;
+use sqlx::PgPool;
+
+use crate::config::Config;
+
+const TEST_WALLET_RECONCILER_FULL: &str = "0x6060606060606060606060606060606060606060";
+const TEST_WALLET_RECONCILER_PARTIAL: &str = "0x7070707070707070707070707070707070707070";
+const TEST_WALLET_RECONCILER_SKIP: &str = "0x8080808080808080808080808080808080808080";
+
+fn stripe_key() -> Option<String> {
+    std::env::var("STRIPE_SECRET_KEY").ok().filter(|k| {
+        !k.trim().is_empty() && (k.starts_with("rk_test_") || k.starts_with("sk_test_"))
+    })
+}
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+fn test_config(stripe_secret_key: String, db_url: String) -> Config {
+    Config {
+        database_url: db_url,
+        magic_link_signing_key: vec![0u8; 32],
+        resend_api_key: "unused".into(),
+        mail_from: "unused".into(),
+        public_base_url: "http://unused".into(),
+        stripe_secret_key,
+        stripe_publishable_key: "pk_test_phase6".into(),
+        max_grant_cents: 0,
+        max_daily_per_operator_cents: 0,
+        litkey_discount_basis_points: 0,
+        litkey_chain: None,
+        lit_api_server_base_url: "http://127.0.0.1:1".into(),
+        lit_internal_shared_secret: "unused".into(),
+        stripe_webhook_secret: "unused".into(),
+        reconciler_interval_secs: 60,
+    }
+}
+
+/// Create a real auto_topup PaymentIntent in `succeeded` status by
+/// off-session-confirming against a test Visa. Returns (pi_id, amount).
+async fn create_succeeded_auto_topup_pi(
+    stripe: &StripeClient,
+    customer_id: &str,
+    pm_id: &str,
+    wallet: &str,
+    amount_cents: i64,
+) -> (String, i64) {
+    let amount_str = amount_cents.to_string();
+    let resp = stripe
+        .post(
+            "payment_intents",
+            &[
+                ("amount", amount_str.as_str()),
+                ("currency", "usd"),
+                ("customer", customer_id),
+                ("payment_method", pm_id),
+                ("off_session", "true"),
+                ("confirm", "true"),
+                ("metadata[source]", "auto_topup"),
+                ("metadata[wallet_address]", wallet),
+            ],
+        )
+        .await
+        .expect("create PI");
+    let pi_id = resp.body["id"].as_str().unwrap().to_string();
+    let status = resp.body["status"].as_str().unwrap();
+    assert_eq!(status, "succeeded", "expected succeeded PI, got {status}");
+    (pi_id, amount_cents)
+}
+
+async fn reset_for(pool: &PgPool, wallet: &str, customer_id: &str) {
+    let _ = sqlx::query("DELETE FROM auto_topup_credits WHERE customer_id = $1")
+        .bind(customer_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auto_topup_config WHERE wallet_address = $1")
+        .bind(wallet)
+        .execute(pool)
+        .await;
+}
+
+async fn seed_enabled(pool: &PgPool, customer_id: &str, wallet: &str, pm_id: &str) {
+    use crate::auto_topup::types::AutoTopupConfigUpsert;
+    let upsert = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(500),
+        topup_amount_cents: Some(500),
+        monthly_cap_cents: Some(10_000),
+        payment_method_id: Some(pm_id.into()),
+        consent_version: Some("v1".into()),
+    };
+    crate::auto_topup::db::upsert(pool, customer_id, wallet, &upsert)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_credits_orphan_pi_with_no_row() {
+    // Webhook handler crashed before INSERT. Reconciler must INSERT the
+    // credit row AND write the balance_transaction.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_RECONCILER_FULL,
+    )
+    .await;
+    let pm = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RECONCILER_FULL, &cust).await;
+    seed_enabled(&pool, &cust, TEST_WALLET_RECONCILER_FULL, &pm).await;
+
+    let (pi_id, amount) =
+        create_succeeded_auto_topup_pi(&stripe, &cust, &pm, TEST_WALLET_RECONCILER_FULL, 500).await;
+
+    let before: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM auto_topup_credits WHERE payment_intent_id = $1")
+            .bind(&pi_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(before.0, 0);
+
+    let cfg = test_config(key.clone(), url.clone());
+    super::reconciler::run_once(&cfg, &stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    let (row, bt): (i32, Option<String>) = sqlx::query_as(
+        "SELECT 1, stripe_balance_transaction_id FROM auto_topup_credits \
+         WHERE payment_intent_id = $1",
+    )
+    .bind(&pi_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row, 1, "orphan PI should have been credited");
+    assert!(bt.is_some(), "balance_tx must be set after reconciler");
+    let _ = amount;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_completes_partial_credit() {
+    // Webhook handler INSERTed the credit row but the balance_tx write
+    // never landed. Reconciler must retry that write (same idempotency
+    // key) and fill in stripe_balance_transaction_id.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_RECONCILER_PARTIAL,
+    )
+    .await;
+    let pm = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RECONCILER_PARTIAL, &cust).await;
+    seed_enabled(&pool, &cust, TEST_WALLET_RECONCILER_PARTIAL, &pm).await;
+
+    let (pi_id, amount) =
+        create_succeeded_auto_topup_pi(&stripe, &cust, &pm, TEST_WALLET_RECONCILER_PARTIAL, 500)
+            .await;
+    // Simulate the "partial credit" state: row inserted, bt_id null.
+    sqlx::query(
+        "INSERT INTO auto_topup_credits (payment_intent_id, customer_id, amount_cents) \
+         VALUES ($1, $2, $3)",
+    )
+    .bind(&pi_id)
+    .bind(&cust)
+    .bind(amount)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let cfg = test_config(key.clone(), url.clone());
+    super::reconciler::run_once(&cfg, &stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    let (bt,): (Option<String>,) = sqlx::query_as(
+        "SELECT stripe_balance_transaction_id FROM auto_topup_credits \
+         WHERE payment_intent_id = $1",
+    )
+    .bind(&pi_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        bt.is_some(),
+        "reconciler must fill in stripe_balance_transaction_id"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_skips_already_completed() {
+    // Row exists with non-null bt_id; reconciler must not touch it.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust = crate::billing::setup_intent_tests::ensure_unique_customer(
+        &stripe,
+        TEST_WALLET_RECONCILER_SKIP,
+    )
+    .await;
+    let pm = crate::billing::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RECONCILER_SKIP, &cust).await;
+    seed_enabled(&pool, &cust, TEST_WALLET_RECONCILER_SKIP, &pm).await;
+
+    let (pi_id, amount) =
+        create_succeeded_auto_topup_pi(&stripe, &cust, &pm, TEST_WALLET_RECONCILER_SKIP, 500).await;
+    sqlx::query(
+        "INSERT INTO auto_topup_credits (payment_intent_id, customer_id, amount_cents, stripe_balance_transaction_id) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(&pi_id)
+    .bind(&cust)
+    .bind(amount)
+    .bind("bt_already_credited_via_test_seed")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let cfg = test_config(key.clone(), url.clone());
+    super::reconciler::run_once(&cfg, &stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    // bt_id should still be the test seed value — reconciler did not touch.
+    let (bt,): (Option<String>,) = sqlx::query_as(
+        "SELECT stripe_balance_transaction_id FROM auto_topup_credits \
+         WHERE payment_intent_id = $1",
+    )
+    .bind(&pi_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        bt.as_deref(),
+        Some("bt_already_credited_via_test_seed"),
+        "reconciler must not overwrite completed rows"
+    );
+    // Avoid unused-variable lint on `amount` and `_` patterns.
+    let _ = Value::Null;
+}

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -46,6 +46,7 @@ async fn rocket() -> _ {
     );
     rate::spawn_rate_poller(pool.clone());
     let per_customer_mutex = PerCustomerMutex::new();
+    lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
     rocket::build()
         .manage(pool)
         .manage(cfg)


### PR DESCRIPTION
**Stack:** PR 6 of 8. Base: `auto-topup-phase-5`. Diff shows only Phase 6.

## What
Plan §9 load-bearing recovery layer. Spawned at startup, sweeps each enabled customer's auto_topup-tagged PIs from the last 7 days every `RECONCILER_INTERVAL_SECS` (default 900) and applies any missing credit work.

Three branches per PI:
* Row + non-null bt_id → skip (already credited)
* Row + NULL bt_id → retry balance_transactions with the same `credit:{pi.id}` idempotency key (Stripe dedupes if prior succeeded)
* No row → full credit: INSERT auto_topup_credits ON CONFLICT DO NOTHING + balance_transactions + UPDATE row

Safe to run concurrently with the Phase 5 webhook handler — PI ledger UNIQUE constraint + Stripe idempotency keys make every credit exactly-once.

## Tests
3 integration tests: orphan PI (no row → reconciler creates row + credits), partial credit (null bt_id → reconciler fills), completed row skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)