### PR TITLE
feat(auto-topup): phase 7 — SCA resume endpoints with codex P2 token-preserve fix

### DIFF
--- a/lit-payments/src/billing/mod.rs
+++ b/lit-payments/src/billing/mod.rs
@@ -7,9 +7,12 @@
 //! `X-Internal-Secret` channel (see `auth_resolver::HttpAuthResolver`).
 
 pub mod auto_topup_config;
+pub mod sca_resume;
 pub mod setup_intent;
 
 #[cfg(test)]
 mod auto_topup_config_tests;
+#[cfg(test)]
+mod sca_resume_tests;
 #[cfg(test)]
 pub(crate) mod setup_intent_tests;

--- a/lit-payments/src/billing/sca_resume.rs
+++ b/lit-payments/src/billing/sca_resume.rs
@@ -235,7 +235,30 @@ pub async fn post_auto_topup_resume_complete(
                 "Could not record your credit; try again.",
             )
         })?;
-    if claimed {
+    // Codex P1 (Phase 7): when claimed=false, a prior path already wrote
+    // the credit row — but it may be a partial (balance_tx_id NULL) left
+    // over from a mid-flow crash on the original webhook delivery. Treat
+    // partials the same as a fresh claim: run the balance_transactions
+    // write under the same idempotency key. The Stripe Idempotency-Key
+    // guarantees we don't double-credit if the prior attempt actually
+    // landed at Stripe but failed on the DB write. Pre-fix this branch
+    // returned `credited: false` and left the partial unrepaired,
+    // forcing the user to wait for the reconciler tick.
+    let needs_balance_tx = if claimed {
+        true
+    } else {
+        match db::find_credit_row(pool, &pi_id).await {
+            Ok(Some(row)) => row.stripe_balance_transaction_id.is_none(),
+            Ok(None) => false,
+            Err(e) => {
+                tracing::warn!(
+                    "resume/complete: find_credit_row failed (treating as fully credited): {e}"
+                );
+                false
+            }
+        }
+    };
+    if needs_balance_tx {
         let credit_idem = format!("credit:{pi_id}");
         let neg = (-amount).to_string();
         let bt_resp = stripe
@@ -275,7 +298,7 @@ pub async fn post_auto_topup_resume_complete(
     let _ = invalidate_cache(cfg, &customer_id).await;
 
     Ok(Json(serde_json::json!({
-        "credited": claimed,
+        "credited": needs_balance_tx,
         "payment_intent_id": pi_id,
     })))
 }

--- a/lit-payments/src/billing/sca_resume.rs
+++ b/lit-payments/src/billing/sca_resume.rs
@@ -1,0 +1,287 @@
+//! `GET /billing/auto_topup_resume?token=...` and
+//! `POST /billing/auto_topup_resume/complete` — the SCA recovery handoff
+//! consumed by the dashboard recovery page.
+//!
+//! Flow (plan §6a):
+//!   1. The webhook handler hits `authentication_required` on an
+//!      off-session PaymentIntent. It stashes the `pi_id` and a fresh
+//!      `recovery_token` on the `auto_topup_config` row and emails the
+//!      user a link of the form `…/recover_topup?token={token}`.
+//!   2. The dashboard recovery page reads `token` from the query string
+//!      and calls `GET /billing/auto_topup_resume?token=...`. That
+//!      endpoint **single-use-consumes** the token (Postgres atomic
+//!      UPDATE) and returns the PI's Stripe `client_secret`.
+//!   3. Stripe.js renders the bank's 3DS challenge inside its iframe;
+//!      on success, the dashboard calls `POST
+//!      /billing/auto_topup_resume/complete` with the PI id. That
+//!      endpoint re-fetches the PI to verify it's `succeeded`, applies
+//!      the sync credit, and clears the pending state on the config row.
+//!
+//! Both endpoints are intentionally unauthenticated by the BillingAuth
+//! guard: the `recovery_token` IS the credential (one-time, 32 random
+//! bytes). Treating it like a session bearer token keeps the recovery
+//! page flow simple — the user does not need to re-sign EIP-712 just to
+//! complete a charge they already authorised.
+
+use lit_billing_core::StripeClient;
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::{State, get, post};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::auto_topup::db;
+use crate::config::Config;
+use crate::internal::client as internal_client;
+
+#[derive(Debug, Serialize)]
+pub struct ResumeResponse {
+    pub payment_intent_id: String,
+    pub client_secret: String,
+    pub publishable_key: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    pub error: &'static str,
+    pub message: String,
+}
+
+fn err(status: Status, code: &'static str, msg: impl Into<String>) -> (Status, Json<ErrorBody>) {
+    (
+        status,
+        Json(ErrorBody {
+            error: code,
+            message: msg.into(),
+        }),
+    )
+}
+
+#[get("/billing/auto_topup_resume?<token>")]
+pub async fn get_auto_topup_resume(
+    token: &str,
+    cfg: &State<Config>,
+    stripe: &State<StripeClient>,
+    pool: &State<PgPool>,
+) -> Result<Json<ResumeResponse>, (Status, Json<ErrorBody>)> {
+    if token.trim().is_empty() {
+        return Err(err(
+            Status::NotFound,
+            "invalid_token",
+            "Recovery link is invalid or expired.",
+        ));
+    }
+    // Codex P2 #3: split lookup from consume. The token used to be
+    // burned atomically up front; a transient Stripe failure on the
+    // next line would 503 the request and the user's second click would
+    // 404 with no recovery path. Now we LOOK UP without consuming, call
+    // Stripe, and only invalidate the token AFTER Stripe succeeds.
+    //
+    // Single-use guarantee still holds for the happy path: a successful
+    // GET clears the token; the next GET sees no row. A failed Stripe
+    // call leaves the token usable for retry (the bug we're fixing).
+    let (customer_id, pi_id) = db::lookup_recovery_token(pool, token)
+        .await
+        .map_err(|e| {
+            tracing::error!("auto_topup_resume GET: db error: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "db_unavailable",
+                "Could not look up your recovery; try again.",
+            )
+        })?
+        .ok_or_else(|| {
+            err(
+                Status::NotFound,
+                "invalid_token",
+                "Recovery link is invalid or expired.",
+            )
+        })?;
+
+    let resp = stripe
+        .get(&format!("payment_intents/{pi_id}"), &[])
+        .await
+        .map_err(|e| {
+            tracing::error!("auto_topup_resume GET: Stripe error: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "stripe_unavailable",
+                "Could not retrieve your pending top-up; try again.",
+            )
+        })?;
+    let client_secret = resp
+        .body
+        .get("client_secret")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            err(
+                Status::ServiceUnavailable,
+                "stripe_response_malformed",
+                "Stripe response missing client_secret.",
+            )
+        })?
+        .to_string();
+
+    // Stripe call succeeded — now safe to burn the token. We log but
+    // don't fail the response if the clear errors; the user already has
+    // their client_secret. A leftover token is a small replay window
+    // (24h max), not a correctness break.
+    if let Err(e) = db::clear_recovery_token_for_pi(pool, &customer_id, &pi_id).await {
+        tracing::warn!(
+            customer_id = %customer_id,
+            pi_id = %pi_id,
+            "auto_topup_resume GET: clear_recovery_token_for_pi failed: {e}"
+        );
+    }
+
+    Ok(Json(ResumeResponse {
+        payment_intent_id: pi_id,
+        client_secret,
+        publishable_key: cfg.stripe_publishable_key.clone(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompleteRequest {
+    pub payment_intent_id: String,
+}
+
+/// Called by the dashboard after `stripe.confirmCardPayment` returns
+/// `succeeded`. Verifies status server-side against Stripe (do not trust
+/// the client claim), applies the sync credit, and clears pending state.
+///
+/// Idempotent: the `auto_topup_credits` UNIQUE constraint guarantees a
+/// repeated call doesn't double-credit; a successful call clears the
+/// config-row pending fields so subsequent calls see no work.
+#[post(
+    "/billing/auto_topup_resume/complete",
+    format = "json",
+    data = "<body>"
+)]
+pub async fn post_auto_topup_resume_complete(
+    body: Json<CompleteRequest>,
+    cfg: &State<Config>,
+    stripe: &State<StripeClient>,
+    pool: &State<PgPool>,
+) -> Result<Json<serde_json::Value>, (Status, Json<ErrorBody>)> {
+    let pi_id = body.into_inner().payment_intent_id;
+    if pi_id.trim().is_empty() {
+        return Err(err(
+            Status::BadRequest,
+            "missing_pi_id",
+            "payment_intent_id is required.",
+        ));
+    }
+
+    let pi = stripe
+        .get(&format!("payment_intents/{pi_id}"), &[])
+        .await
+        .map_err(|e| {
+            tracing::error!("resume/complete: Stripe retrieve failed: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "stripe_unavailable",
+                "Could not verify your top-up; try again.",
+            )
+        })?
+        .body;
+
+    let status_str = pi.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status_str != "succeeded" {
+        return Err(err(
+            Status::BadRequest,
+            "pi_not_succeeded",
+            format!(
+                "Your top-up has not completed yet (status: {status_str}). Finish the bank verification first."
+            ),
+        ));
+    }
+    // Defence in depth: only credit PIs we minted.
+    if pi.pointer("/metadata/source").and_then(|v| v.as_str()) != Some("auto_topup") {
+        return Err(err(
+            Status::BadRequest,
+            "not_auto_topup_pi",
+            "That PaymentIntent is not an auto top-up.",
+        ));
+    }
+
+    let customer_id = pi
+        .get("customer")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            err(
+                Status::BadRequest,
+                "pi_missing_customer",
+                "PaymentIntent is missing a customer reference.",
+            )
+        })?
+        .to_string();
+    let amount = pi.get("amount").and_then(|v| v.as_i64()).unwrap_or(0);
+    if amount <= 0 {
+        return Err(err(
+            Status::BadRequest,
+            "pi_amount_invalid",
+            "PaymentIntent amount is invalid.",
+        ));
+    }
+
+    let claimed = db::try_insert_credit(pool, &pi_id, &customer_id, amount)
+        .await
+        .map_err(|e| {
+            tracing::error!("resume/complete: try_insert_credit failed: {e}");
+            err(
+                Status::ServiceUnavailable,
+                "db_unavailable",
+                "Could not record your credit; try again.",
+            )
+        })?;
+    if claimed {
+        let credit_idem = format!("credit:{pi_id}");
+        let neg = (-amount).to_string();
+        let bt_resp = stripe
+            .post_with_idempotency(
+                &format!("customers/{customer_id}/balance_transactions"),
+                &[
+                    ("amount", neg.as_str()),
+                    ("currency", "usd"),
+                    ("description", &format!("Auto top-up via {pi_id}")),
+                ],
+                &credit_idem,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("resume/complete: balance_tx failed: {e}");
+                err(
+                    Status::ServiceUnavailable,
+                    "stripe_unavailable",
+                    "Could not credit your account; try again.",
+                )
+            })?;
+        let bt_id = bt_resp
+            .body
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                err(
+                    Status::ServiceUnavailable,
+                    "stripe_response_malformed",
+                    "Stripe response missing balance_transaction id.",
+                )
+            })?
+            .to_string();
+        let _ = db::mark_credit_completed(pool, &pi_id, &bt_id).await;
+    }
+    let _ = db::clear_pending_action(pool, &customer_id, &pi_id).await;
+    let _ = invalidate_cache(cfg, &customer_id).await;
+
+    Ok(Json(serde_json::json!({
+        "credited": claimed,
+        "payment_intent_id": pi_id,
+    })))
+}
+
+async fn invalidate_cache(cfg: &Config, customer_id: &str) -> anyhow::Result<()> {
+    let client = internal_client::build_client()?;
+    let body = serde_json::json!({ "customer_id": customer_id });
+    internal_client::post_internal(&client, cfg, "/internal/invalidate_balance_cache", &body).await
+}

--- a/lit-payments/src/billing/sca_resume_tests.rs
+++ b/lit-payments/src/billing/sca_resume_tests.rs
@@ -1,0 +1,421 @@
+//! Phase 7 integration tests for the SCA resume endpoints.
+//!
+//! These hit real Stripe (PaymentIntent retrieve, balance_transactions)
+//! and real local Postgres. Silent-skip when STRIPE_SECRET_KEY /
+//! DATABASE_URL missing.
+
+use lit_billing_core::StripeClient;
+use rocket::http::{ContentType, Status};
+use rocket::local::asynchronous::Client;
+use rocket::{Rocket, routes};
+use serde_json::Value;
+use sqlx::PgPool;
+use time::OffsetDateTime;
+
+use crate::auto_topup::types::AutoTopupConfigUpsert;
+use crate::config::Config;
+
+const TEST_WALLET_RESUME_GET: &str = "0x9090909090909090909090909090909090909090";
+const TEST_WALLET_RESUME_EXPIRED: &str = "0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1";
+const TEST_WALLET_RESUME_COMPLETE: &str = "0xb2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2";
+const TEST_WALLET_RESUME_TRANSIENT: &str = "0xc3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3";
+
+fn stripe_key() -> Option<String> {
+    std::env::var("STRIPE_SECRET_KEY").ok().filter(|k| {
+        !k.trim().is_empty() && (k.starts_with("rk_test_") || k.starts_with("sk_test_"))
+    })
+}
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+fn test_config(stripe_secret_key: String, db_url: String) -> Config {
+    Config {
+        database_url: db_url,
+        magic_link_signing_key: vec![0u8; 32],
+        resend_api_key: "unused".into(),
+        mail_from: "unused".into(),
+        public_base_url: "http://unused".into(),
+        stripe_secret_key,
+        stripe_publishable_key: "pk_test_phase7_test".into(),
+        max_grant_cents: 0,
+        max_daily_per_operator_cents: 0,
+        litkey_discount_basis_points: 0,
+        litkey_chain: None,
+        lit_api_server_base_url: "http://127.0.0.1:1".into(),
+        lit_internal_shared_secret: "unused".into(),
+        stripe_webhook_secret: "unused".into(),
+        reconciler_interval_secs: 900,
+    }
+}
+
+async fn build_client(key: String, url: String) -> Client {
+    let cfg = test_config(key.clone(), url.clone());
+    let stripe = StripeClient::new(key).expect("stripe client");
+    let pool = PgPool::connect(&url).await.expect("connect db");
+    let rocket = Rocket::build()
+        .manage(cfg)
+        .manage(stripe)
+        .manage(pool)
+        .mount(
+            "/",
+            routes![
+                super::sca_resume::get_auto_topup_resume,
+                super::sca_resume::post_auto_topup_resume_complete,
+            ],
+        );
+    Client::tracked(rocket).await.expect("rocket client")
+}
+
+async fn reset_for(pool: &PgPool, wallet: &str, customer_id: &str) {
+    let _ = sqlx::query("DELETE FROM auto_topup_credits WHERE customer_id = $1")
+        .bind(customer_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auto_topup_config WHERE wallet_address = $1")
+        .bind(wallet)
+        .execute(pool)
+        .await;
+}
+
+/// Build a row with the SCA pending state pre-populated. Mirrors what
+/// the webhook handler would have written when it hit
+/// authentication_required.
+async fn seed_pending_row(
+    pool: &PgPool,
+    customer_id: &str,
+    wallet: &str,
+    pm_id: &str,
+    pi_id: &str,
+    token: &str,
+    expires_at: OffsetDateTime,
+) {
+    // First UPSERT a normal enabled row, then overwrite the pending
+    // fields directly. (The high-level upsert helper deliberately doesn't
+    // accept those — the webhook handler is the only legitimate writer
+    // in production.)
+    let upsert = AutoTopupConfigUpsert {
+        enabled: true,
+        threshold_cents: Some(500),
+        topup_amount_cents: Some(500),
+        monthly_cap_cents: Some(10_000),
+        payment_method_id: Some(pm_id.into()),
+        consent_version: Some("v1".into()),
+    };
+    crate::auto_topup::db::upsert(pool, customer_id, wallet, &upsert)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE auto_topup_config \
+            SET pending_action_pi_id = $1, pending_action_at = $2, \
+                recovery_token = $3, recovery_token_expires_at = $4, \
+                disabled_reason = 'requires_action' \
+            WHERE customer_id = $5",
+    )
+    .bind(pi_id)
+    .bind(OffsetDateTime::now_utc())
+    .bind(token)
+    .bind(expires_at)
+    .bind(customer_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Create a real `succeeded` auto_topup PaymentIntent for tests that need
+/// one. Used by the `/complete` happy-path test.
+async fn create_succeeded_pi(
+    stripe: &StripeClient,
+    customer_id: &str,
+    pm_id: &str,
+    wallet: &str,
+) -> String {
+    let resp = stripe
+        .post(
+            "payment_intents",
+            &[
+                ("amount", "500"),
+                ("currency", "usd"),
+                ("customer", customer_id),
+                ("payment_method", pm_id),
+                ("off_session", "true"),
+                ("confirm", "true"),
+                ("metadata[source]", "auto_topup"),
+                ("metadata[wallet_address]", wallet),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.body["status"].as_str().unwrap(), "succeeded");
+    resp.body["id"].as_str().unwrap().to_string()
+}
+
+/// Create a synthetic PaymentIntent we never confirm. Used for the GET
+/// tests which only need a retrievable id; the actual PI status doesn't
+/// matter because the GET endpoint just returns the client_secret.
+async fn create_unconfirmed_pi(stripe: &StripeClient, customer_id: &str, wallet: &str) -> String {
+    let resp = stripe
+        .post(
+            "payment_intents",
+            &[
+                ("amount", "500"),
+                ("currency", "usd"),
+                ("customer", customer_id),
+                ("metadata[source]", "auto_topup"),
+                ("metadata[wallet_address]", wallet),
+            ],
+        )
+        .await
+        .unwrap();
+    resp.body["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn get_resume_with_valid_token_returns_client_secret() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_RESUME_GET).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RESUME_GET, &cust).await;
+    let pm = super::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pi_id = create_unconfirmed_pi(&stripe, &cust, TEST_WALLET_RESUME_GET).await;
+    let token = "phase7-test-token-aaa-deterministic";
+    let expires = OffsetDateTime::now_utc() + ::time::Duration::hours(1);
+    seed_pending_row(
+        &pool,
+        &cust,
+        TEST_WALLET_RESUME_GET,
+        &pm,
+        &pi_id,
+        token,
+        expires,
+    )
+    .await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let resp = client
+        .get(format!("/billing/auto_topup_resume?token={token}"))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::Ok);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["payment_intent_id"], pi_id);
+    assert!(
+        body["client_secret"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with(&pi_id),
+        "client_secret should begin with PI id"
+    );
+
+    // Second GET with the same token must 404 (single-use).
+    let resp2 = client
+        .get(format!("/billing/auto_topup_resume?token={token}"))
+        .dispatch()
+        .await;
+    assert_eq!(resp2.status(), Status::NotFound);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn get_resume_with_expired_token_returns_404() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_RESUME_EXPIRED)
+            .await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RESUME_EXPIRED, &cust).await;
+    let pm = super::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pi_id = create_unconfirmed_pi(&stripe, &cust, TEST_WALLET_RESUME_EXPIRED).await;
+    let token = "phase7-test-token-expired-bbb";
+    let already_expired = OffsetDateTime::now_utc() - ::time::Duration::hours(1);
+    seed_pending_row(
+        &pool,
+        &cust,
+        TEST_WALLET_RESUME_EXPIRED,
+        &pm,
+        &pi_id,
+        token,
+        already_expired,
+    )
+    .await;
+
+    let client = build_client(key, url).await;
+    let resp = client
+        .get(format!("/billing/auto_topup_resume?token={token}"))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::NotFound);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn get_resume_with_unknown_token_returns_404() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let client = build_client(key, url).await;
+    let resp = client
+        .get("/billing/auto_topup_resume?token=never-issued-this-token")
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::NotFound);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn complete_with_succeeded_pi_credits_and_clears_pending() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_RESUME_COMPLETE)
+            .await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RESUME_COMPLETE, &cust).await;
+    let pm = super::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    let pi_id = create_succeeded_pi(&stripe, &cust, &pm, TEST_WALLET_RESUME_COMPLETE).await;
+    // Pretend the webhook handler queued this PI as the SCA-pending one.
+    let token = "phase7-test-token-complete-ccc";
+    let expires = OffsetDateTime::now_utc() + ::time::Duration::hours(1);
+    seed_pending_row(
+        &pool,
+        &cust,
+        TEST_WALLET_RESUME_COMPLETE,
+        &pm,
+        &pi_id,
+        token,
+        expires,
+    )
+    .await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let body = serde_json::to_string(&serde_json::json!({
+        "payment_intent_id": pi_id,
+    }))
+    .unwrap();
+    let resp = client
+        .post("/billing/auto_topup_resume/complete")
+        .header(ContentType::JSON)
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(
+        resp.status(),
+        Status::Ok,
+        "body: {}",
+        resp.into_string().await.unwrap_or_default()
+    );
+
+    // Credit row inserted with non-null bt_id.
+    let (bt,): (Option<String>,) = sqlx::query_as(
+        "SELECT stripe_balance_transaction_id FROM auto_topup_credits \
+         WHERE payment_intent_id = $1",
+    )
+    .bind(&pi_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(bt.is_some());
+
+    // Pending state cleared.
+    let (pending,): (Option<String>,) =
+        sqlx::query_as("SELECT pending_action_pi_id FROM auto_topup_config WHERE customer_id = $1")
+            .bind(&cust)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(pending.is_none());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn complete_rejects_non_succeeded_pi() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_RESUME_COMPLETE)
+            .await;
+    let pi_id = create_unconfirmed_pi(&stripe, &cust, TEST_WALLET_RESUME_COMPLETE).await;
+    let client = build_client(key, url).await;
+    let body = serde_json::to_string(&serde_json::json!({"payment_intent_id": pi_id})).unwrap();
+    let resp = client
+        .post("/billing/auto_topup_resume/complete")
+        .header(ContentType::JSON)
+        .body(body)
+        .dispatch()
+        .await;
+    assert_eq!(resp.status(), Status::BadRequest);
+    let body: Value = resp.into_json().await.unwrap();
+    assert_eq!(body["error"], "pi_not_succeeded");
+}
+
+/// Codex P2 #3 regression: when the Stripe retrieve fails, the recovery
+/// token MUST stay valid so the user can retry. We can't easily inject
+/// "Stripe is down" against the real API, so we inject the failure
+/// case the resolver actually hits in the wild: a `pending_action_pi_id`
+/// that no longer exists at Stripe (deleted in test cleanup, or never
+/// created). That triggers `stripe_unavailable` (4xx from Stripe → our
+/// error mapping) — pre-fix, the token had already been consumed by the
+/// lookup so the next call 404'd. Post-fix, the token survives.
+#[tokio::test]
+#[serial_test::serial]
+async fn get_resume_preserves_token_on_stripe_failure() {
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key.clone()).unwrap();
+    let cust =
+        super::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET_RESUME_TRANSIENT)
+            .await;
+    let pool = PgPool::connect(&url).await.unwrap();
+    reset_for(&pool, TEST_WALLET_RESUME_TRANSIENT, &cust).await;
+    let pm = super::setup_intent_tests::attach_test_card(&stripe, &cust).await;
+    // Wire a recovery token to a NONEXISTENT PI id. The handler's Stripe
+    // GET will fail; we want to verify the token survives.
+    let token = "phase7-transient-retry-token-ddd";
+    let expires = OffsetDateTime::now_utc() + ::time::Duration::hours(1);
+    seed_pending_row(
+        &pool,
+        &cust,
+        TEST_WALLET_RESUME_TRANSIENT,
+        &pm,
+        "pi_does_not_exist_at_stripe_yyy",
+        token,
+        expires,
+    )
+    .await;
+
+    let client = build_client(key.clone(), url.clone()).await;
+    let resp = client
+        .get(format!("/billing/auto_topup_resume?token={token}"))
+        .dispatch()
+        .await;
+    // Pre-fix this assertion would say 404 because the lookup consumed
+    // the token before the Stripe call. Post-fix we expect 503 (the
+    // Stripe call failed) AND the token row is intact.
+    assert_eq!(
+        resp.status(),
+        Status::ServiceUnavailable,
+        "Stripe retrieve on bogus PI should yield 503"
+    );
+
+    let (token_after,): (Option<String>,) =
+        sqlx::query_as("SELECT recovery_token FROM auto_topup_config WHERE customer_id = $1")
+            .bind(&cust)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        token_after.as_deref(),
+        Some(token),
+        "transient Stripe failure must NOT burn the recovery token"
+    );
+}

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -79,6 +79,8 @@ async fn rocket() -> _ {
                 billing_routes::setup_intent::setup_intent,
                 billing_routes::auto_topup_config::get_auto_topup_config,
                 billing_routes::auto_topup_config::put_auto_topup_config,
+                billing_routes::sca_resume::get_auto_topup_resume,
+                billing_routes::sca_resume::post_auto_topup_resume_complete,
                 webhook_handler::stripe_webhook,
             ],
         )


### PR DESCRIPTION
**Stack:** PR 7 of 8. Base: `auto-topup-phase-6`. Diff shows only Phase 7.

## What
Plan §6a SCA recovery flow. Two unauthenticated endpoints driven by the one-time `recovery_token` issued by the Phase 5 webhook handler when an off-session PI returns `authentication_required`.

* **GET /billing/auto_topup_resume?token=…** — non-consuming lookup, fetches the PI's client_secret from Stripe, then atomically clears the token only AFTER the Stripe retrieve succeeds. Transient Stripe failures leave the token usable for retry. Single-use guarantee for the happy path is preserved (success burns the token; reload after success → 404). **Codex P2 #3 fix incorporated.**
* **POST /billing/auto_topup_resume/complete** — body `{payment_intent_id}`. Re-fetches the PI server-side, verifies `status=succeeded` AND `metadata.source=auto_topup`, runs the sync credit path. Idempotent — repeated calls don't double-credit.

DB primitives:
* `lookup_recovery_token` (read-only)
* `clear_recovery_token_for_pi` (atomic NULL'ing keyed by pi_id)
* `consume_recovery_token` (legacy one-shot, kept dead-allowed)

## Tests
6 integration tests against real Stripe + real Postgres:
* get_resume_with_valid_token_returns_client_secret (+ second-read 404)
* get_resume_with_expired_token_returns_404
* get_resume_with_unknown_token_returns_404
* **get_resume_preserves_token_on_stripe_failure** (codex P2 #3 regression)
* complete_with_succeeded_pi_credits_and_clears_pending
* complete_rejects_non_succeeded_pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)