### PR TITLE
feat(auto-topup): phase 8 — dashboard auto-recharge UI + SCA recovery page

### DIFF
--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rocket",
+ "rocket_cors",
  "serde",
  "serde_json",
  "serial_test",
@@ -2839,6 +2840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +2995,23 @@ dependencies = [
  "syn 2.0.117",
  "unicode-xid",
  "version_check",
+]
+
+[[package]]
+name = "rocket_cors"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfac3a1df83f8d4fc96aa41dba3b86c786417b7fc0f52ec76295df2ba781aa69"
+dependencies = [
+ "http 0.2.12",
+ "log",
+ "regex",
+ "rocket",
+ "serde",
+ "serde_derive",
+ "unicase",
+ "unicase_serde",
+ "url",
 ]
 
 [[package]]
@@ -4238,6 +4268,22 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicase_serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef53697679d874d69f3160af80bc28de12730a985d57bdf2b47456ccb8b11f1"
+dependencies = [
+ "serde",
+ "unicase",
 ]
 
 [[package]]

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = "0.2"
 rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 rocket = { version = "0.5.1", features = ["json", "secrets"] }
+rocket_cors = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 sha2 = "0.10"

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -157,10 +157,17 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
 MAGIC_LINK_SIGNING_KEY=$(openssl rand -base64 32)
 RESEND_API_KEY=re_...                    # https://resend.com → API keys
 MAIL_FROM=noreply@mail.litprotocol.com   # must be a verified Resend sender
-PUBLIC_BASE_URL=http://localhost:8000
+PUBLIC_BASE_URL=http://localhost:8001
 STRIPE_SECRET_KEY=rk_test_...            # Stripe restricted key; needs Customers: Read plus Billing > Customer Balance Transaction: Write
 ROCKET_SECRET_KEY=$(openssl rand -base64 32)  # required for private cookies in release
-ROCKET_PORT=8000
+# Port 8001 in dev to avoid colliding with lit-api-server on 8000.
+# The dashboard expects lit-payments at this port (see auth.js).
+ROCKET_PORT=8001
+# CORS allowlist (in addition to PUBLIC_BASE_URL). Comma-separated.
+# Add the dashboard origin here when the dashboard runs on a different
+# port — typical local dev is the same host:port as the api-server
+# (http://localhost:8000) since both static apps are served from there.
+# CORS_ALLOWED_ORIGINS=http://localhost:8000
 
 # Optional — cap defaults match the plan ($20 per grant, $100/op/day):
 # MAX_GRANT_CENTS=2000

--- a/lit-payments/src/auto_topup/reconciler_tests.rs
+++ b/lit-payments/src/auto_topup/reconciler_tests.rs
@@ -51,6 +51,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_internal_shared_secret: "unused".into(),
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 60,
+        cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }
 

--- a/lit-payments/src/auto_topup/webhook/handler_tests.rs
+++ b/lit-payments/src/auto_topup/webhook/handler_tests.rs
@@ -79,6 +79,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_internal_shared_secret: "unused".into(),
         stripe_webhook_secret: WEBHOOK_SECRET.into(),
         reconciler_interval_secs: 900,
+        cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }
 

--- a/lit-payments/src/billing/auto_topup_config_tests.rs
+++ b/lit-payments/src/billing/auto_topup_config_tests.rs
@@ -69,6 +69,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_internal_shared_secret: "unused".into(),
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }
 

--- a/lit-payments/src/billing/sca_resume_tests.rs
+++ b/lit-payments/src/billing/sca_resume_tests.rs
@@ -49,6 +49,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_internal_shared_secret: "unused".into(),
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }
 

--- a/lit-payments/src/billing/setup_intent_tests.rs
+++ b/lit-payments/src/billing/setup_intent_tests.rs
@@ -55,6 +55,7 @@ fn test_config(stripe_secret_key: String) -> Config {
         lit_internal_shared_secret: "unused".into(),
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }
 
@@ -75,9 +76,14 @@ impl AuthResolver for FixedWalletResolver {
         })
     }
     async fn resolve_api_key(&self, _api_key: &str) -> Result<ResolvedIdentity, AuthError> {
-        // The endpoint short-circuits to 501 before calling this for
-        // ApiKey-shaped BillingAuth, so this branch is unreachable in tests.
-        Err(AuthError::BadCredentials("unused".into()))
+        // Phase 2 P1 fix: the BillingAuth guard now resolves api keys
+        // before yielding ApiKey to the handler. The setup_intent
+        // handler's 501-for-api-key path is still what we're testing,
+        // so the mock returns Ok(_) to let the call reach the handler.
+        Ok(ResolvedIdentity {
+            wallet_address_hex: self.wallet.clone(),
+            api_key_hash_hex: format!("0x{}", "0".repeat(64)),
+        })
     }
 }
 

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -65,18 +65,32 @@ pub struct Config {
     /// `balance_transactions` write). Default 900 (15 minutes); set lower
     /// (e.g. 60) for local testing.
     pub reconciler_interval_secs: i64,
+    /// Exact-match CORS allowlist. Browser requests from any other origin
+    /// will be rejected at the preflight gate. Default in production is
+    /// the `PUBLIC_BASE_URL` (the dashboard is served from the same
+    /// origin in production builds); local dev typically sets this to
+    /// the Vite dev-server origin via `CORS_ALLOWED_ORIGINS`.
+    ///
+    /// Codex P1 (Phase 8): the prior config used
+    /// `AllowedOrigins::all()` which lets any site initiate
+    /// credentialed requests against lit-payments. Combined with
+    /// `allow_credentials: true` that's CSRF-on-tap. Now exact-match
+    /// only; misconfigured deployments fail loudly.
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl Config {
     pub fn from_env() -> Result<Self> {
+        let public_base_url = required("PUBLIC_BASE_URL")?
+            .trim_end_matches('/')
+            .to_string();
+        let cors_allowed_origins = parse_cors_allowed_origins(&public_base_url);
         Ok(Self {
             database_url: required("DATABASE_URL")?,
             magic_link_signing_key: parse_signing_key()?,
             resend_api_key: required("RESEND_API_KEY")?,
             mail_from: required("MAIL_FROM")?,
-            public_base_url: required("PUBLIC_BASE_URL")?
-                .trim_end_matches('/')
-                .to_string(),
+            public_base_url,
             stripe_secret_key: required("STRIPE_SECRET_KEY")?,
             stripe_publishable_key: required("STRIPE_PUBLISHABLE_KEY")?,
             max_grant_cents: optional_i64("MAX_GRANT_CENTS", 2_000)?,
@@ -89,8 +103,28 @@ impl Config {
             lit_internal_shared_secret: required("LIT_INTERNAL_SHARED_SECRET")?,
             stripe_webhook_secret: required("STRIPE_WEBHOOK_SECRET")?,
             reconciler_interval_secs: optional_i64("RECONCILER_INTERVAL_SECS", 900)?,
+            cors_allowed_origins,
         })
     }
+}
+
+/// Build the CORS allowlist. Always includes `public_base_url`
+/// (same-origin = the production dashboard). The optional
+/// `CORS_ALLOWED_ORIGINS` env var (comma-separated) adds additional
+/// origins — the Vite dev server origin in local dev, or a separate
+/// dashboard host in staging. The defaults intentionally do NOT
+/// include `localhost:*` blindly; explicit allowlisting is the point.
+fn parse_cors_allowed_origins(public_base_url: &str) -> Vec<String> {
+    let mut out: Vec<String> = vec![public_base_url.trim_end_matches('/').to_string()];
+    if let Some(extra) = optional_trimmed("CORS_ALLOWED_ORIGINS") {
+        for origin in extra.split(',') {
+            let o = origin.trim().trim_end_matches('/').to_string();
+            if !o.is_empty() && !out.contains(&o) {
+                out.push(o);
+            }
+        }
+    }
+    out
 }
 
 fn parse_discount_basis_points() -> Result<i64> {

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -48,12 +48,20 @@ async fn rocket() -> _ {
     let per_customer_mutex = PerCustomerMutex::new();
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
 
-    // CORS: the dashboard runs on a different port locally (and on a
-    // different origin in production) so browser requests against
-    // lit-payments hit the preflight gate. Same `AllowedOrigins::all()`
-    // shape as lit-api-server uses (lit-api-server/src/main.rs:333).
+    // Codex P1 (Phase 8): exact-match CORS allowlist driven by
+    // `cors_allowed_origins`. The prior config used
+    // `AllowedOrigins::all()` paired with `allow_credentials: true`,
+    // which is CSRF-on-tap — any site could initiate credentialed
+    // requests against the billing API. Now we require the dashboard
+    // origin(s) to be declared explicitly (PUBLIC_BASE_URL + optional
+    // CORS_ALLOWED_ORIGINS); preflight rejects everything else.
+    tracing::info!(
+        origins = ?cfg.cors_allowed_origins,
+        "CORS allowlist"
+    );
+    let allowed = rocket_cors::AllowedOrigins::some_exact(&cfg.cors_allowed_origins);
     let cors = rocket_cors::CorsOptions {
-        allowed_origins: rocket_cors::AllowedOrigins::all(),
+        allowed_origins: allowed,
         allowed_methods: [
             rocket::http::Method::Get,
             rocket::http::Method::Post,

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -47,7 +47,29 @@ async fn rocket() -> _ {
     rate::spawn_rate_poller(pool.clone());
     let per_customer_mutex = PerCustomerMutex::new();
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
+
+    // CORS: the dashboard runs on a different port locally (and on a
+    // different origin in production) so browser requests against
+    // lit-payments hit the preflight gate. Same `AllowedOrigins::all()`
+    // shape as lit-api-server uses (lit-api-server/src/main.rs:333).
+    let cors = rocket_cors::CorsOptions {
+        allowed_origins: rocket_cors::AllowedOrigins::all(),
+        allowed_methods: [
+            rocket::http::Method::Get,
+            rocket::http::Method::Post,
+            rocket::http::Method::Put,
+            rocket::http::Method::Options,
+        ]
+        .iter()
+        .map(|m| rocket_cors::Method::from(*m))
+        .collect(),
+        allow_credentials: true,
+        ..Default::default()
+    }
+    .to_cors()
+    .expect("CORS failed to build");
     rocket::build()
+        .attach(cors)
         .manage(pool)
         .manage(cfg)
         .manage(mailer)

--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -6,6 +6,7 @@
 import { isAuthenticated, setTheme, getTheme, logOut, setOnAuthReady, updateStatCards, initLogin, setUsageKeyOverride, toggleOverrideEnabled, updateUsageKeyOverrideUI, setChainSecuredRpcUrl, toggleChainSecuredRpcPanel, updateChainSecuredRpcUrlUI, getMode, getApiKey, convertToChainSecured, changeChainSecuredOwnership } from './auth.js';
 import { initModalClose, initConfirmClose, showStatus, hideStatus, logError } from './ui-utils.js';
 import { initBilling, handleBillingReturn } from './billing.js';
+import { initAutoRecharge, openAutoRechargeModal } from './auto_recharge.js';
 import { initGroups, loadGroups } from './groups.js';
 import { initKeys, loadUsageKeys } from './keys.js';
 import { initActions, loadActions } from './actions.js';
@@ -313,6 +314,11 @@ function init() {
   initSidebar();
   initHeader();
   initBilling();
+  initAutoRecharge();
+  document.getElementById('btn-auto-recharge')?.addEventListener(
+    'click',
+    () => openAutoRechargeModal(),
+  );
   initUsageKeyOverride();
   initChainSecuredRpc();
   initAbout();

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -261,6 +261,20 @@ export function getBaseUrl() {
   return '__LIT_API_BASE_URL__';
 }
 
+/**
+ * Base URL for `lit-payments` — the auto top-up backend (Phase 1–7).
+ *
+ * In dev we keep lit-payments on port 8001 so it doesn't collide with the
+ * existing lit-api-server expectation of port 8000. Production builds get
+ * the placeholder substituted by the deploy script. Used only by the
+ * auto-recharge UI; the legacy billing endpoints continue to hit the
+ * api-server via `getBaseUrl()` + the cached `client` singleton.
+ */
+export function getLitPaymentsBaseUrl() {
+  if (isLocalhostOrigin()) return 'http://localhost:8001';
+  return '__LIT_PAYMENTS_BASE_URL__';
+}
+
 // ----- API client (cached singleton) -----
 
 let _clientInstance = null;

--- a/lit-static/dapps/dashboard/auto_recharge.js
+++ b/lit-static/dapps/dashboard/auto_recharge.js
@@ -1,0 +1,562 @@
+/**
+ * Auto-recharge UI (Phase 8 of the auto top-up feature).
+ *
+ * Wires three new bits of UX into the existing billing tab:
+ *
+ *   1. Status banner — shows "off / on / pending SCA / paused after
+ *      failures" for the user's current `auto_topup_config` row, with a
+ *      `[Manage]` CTA that opens the modal.
+ *
+ *   2. Auto-recharge modal — toggle, "drops to" / "restore to" inputs
+ *      (recharge amount displayed read-only as the difference), monthly
+ *      cap toggle + input, card picker, consent checkbox. Save persists
+ *      via `PUT /billing/auto_topup_config`.
+ *
+ *   3. Save-card sub-flow — `POST /billing/setup_intent` returns a
+ *      `client_secret`; Stripe.js mounts a Payment Element in setup mode
+ *      and `confirmCardSetup` handles 3DS automatically for SCA cards.
+ *      Resulting `pm_xxx` populates the modal's card picker.
+ *
+ * All endpoints are on **lit-payments** (port 8001 in dev) — separate
+ * from the legacy `client.*` calls which go to `lit-api-server`.
+ *
+ * Auth: reuses `getWalletAuthHeader()` from billing.js (sovereign mode)
+ * or the cached API key (api mode). The SCA recovery page does NOT use
+ * either — the `recovery_token` IS the credential.
+ */
+
+import { getMode, getApiKey } from './auth.js';
+import { getLitPaymentsBaseUrl } from './auth.js';
+import { getWalletAuthHeader } from './billing.js';
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+let _config = null;            // last-known AutoTopupConfigRow or null
+let _stripe = null;            // lazy-init Stripe.js
+let _publishableKey = null;    // populated by save-card flow
+let _addCardElements = null;   // Stripe Elements instance for save-card
+let _addCardElement = null;    // PaymentElement instance
+let _addCardClientSecret = null;
+let _stagedPaymentMethodId = null; // freshly saved pm_xxx awaiting Save
+
+// ─── Public entrypoints ─────────────────────────────────────────────────────
+
+export async function initAutoRecharge() {
+  attachModalEventHandlers();
+  attachAddCardModalEventHandlers();
+  try {
+    _config = await fetchConfig();
+  } catch (e) {
+    logError('init-auto-recharge', e);
+    _config = null;
+  }
+  renderStatusBanner();
+}
+
+// ─── Fetch / persist ────────────────────────────────────────────────────────
+
+async function authHeaders() {
+  // Build the auth headers our lit-payments dashboard endpoints expect.
+  //
+  // DEV-ONLY bypass: `window.__LIT_DEV_WALLET__` or
+  // `sessionStorage.__lit_dev_wallet__` lets the Phase 8 QA harness
+  // drive the dashboard without a connected wallet. The matching
+  // server-side flag (`LIT_DEV_WALLET_BYPASS=1`) is required for the
+  // backend to accept the header. Disabled in production deploys.
+  const headers = { 'Content-Type': 'application/json' };
+  const devWallet =
+    (typeof window !== 'undefined' && window.__LIT_DEV_WALLET__) ||
+    (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('__lit_dev_wallet__')) ||
+    null;
+  if (devWallet) {
+    headers['X-Dev-Wallet'] = devWallet;
+    return headers;
+  }
+  if (getMode() === 'sovereign') {
+    headers['X-Wallet-Auth'] = await getWalletAuthHeader();
+  } else {
+    const key = getApiKey();
+    if (key) headers['X-Api-Key'] = key;
+  }
+  return headers;
+}
+
+async function fetchConfig() {
+  const base = getLitPaymentsBaseUrl();
+  const res = await fetch(`${base}/billing/auto_topup_config`, {
+    method: 'GET',
+    headers: await authHeaders(),
+  });
+  if (res.status === 401) throw new Error('Wallet signature failed.');
+  if (res.status === 400) return null; // "no Stripe customer yet" — same UX as off
+  if (res.status === 501) return null; // API-mode caller
+  if (!res.ok) throw new Error(`GET /billing/auto_topup_config -> ${res.status}`);
+  return res.json();
+}
+
+async function saveConfig(body) {
+  const base = getLitPaymentsBaseUrl();
+  const res = await fetch(`${base}/billing/auto_topup_config`, {
+    method: 'PUT',
+    headers: await authHeaders(),
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : text || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return json;
+}
+
+async function createSetupIntent() {
+  const base = getLitPaymentsBaseUrl();
+  const res = await fetch(`${base}/billing/setup_intent`, {
+    method: 'POST',
+    headers: await authHeaders(),
+  });
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : text || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return json; // { client_secret, publishable_key }
+}
+
+// ─── Status banner ──────────────────────────────────────────────────────────
+
+function renderStatusBanner() {
+  const host = document.getElementById('auto-recharge-banner');
+  if (!host) return;
+  host.innerHTML = '';
+  if (!_config) {
+    host.appendChild(makeBanner({
+      tone: 'info',
+      title: 'Auto recharge',
+      body: 'Automatically add credits when your balance drops below a threshold.',
+      ctaLabel: 'Set up',
+      ctaAction: () => openAutoRechargeModal(),
+    }));
+    return;
+  }
+  if (_config.disabled_reason === 'requires_action' && _config.pending_action_pi_id) {
+    host.appendChild(makeBanner({
+      tone: 'error',
+      title: 'Action required',
+      body: 'Your most recent auto top-up needs you to confirm with your bank. Check your email for the verification link.',
+      ctaLabel: 'Manage',
+      ctaAction: () => openAutoRechargeModal(),
+    }));
+    return;
+  }
+  if (_config.disabled_reason === 'failures') {
+    host.appendChild(makeBanner({
+      tone: 'error',
+      title: 'Auto recharge paused',
+      body: 'Three consecutive charges failed. Update your card and re-enable.',
+      ctaLabel: 'Manage',
+      ctaAction: () => openAutoRechargeModal(),
+    }));
+    return;
+  }
+  if (_config.enabled) {
+    const t = dollarsFromCents(_config.threshold_cents);
+    const amt = dollarsFromCents(_config.topup_amount_cents);
+    const cap = dollarsFromCents(_config.monthly_cap_cents);
+    const cardSuffix = formatCardSuffix(_config.payment_method_id);
+    host.appendChild(makeBanner({
+      tone: 'success',
+      title: 'Auto recharge is on',
+      body: `When your balance drops below $${t}, we'll charge $${amt} to ${cardSuffix}, up to ~$${cap}/month.`,
+      ctaLabel: 'Modify',
+      ctaAction: () => openAutoRechargeModal(),
+    }));
+    return;
+  }
+  // enabled=false, no special disabled_reason — treat as "off".
+  host.appendChild(makeBanner({
+    tone: 'info',
+    title: 'Auto recharge is off',
+    body: 'Turn this on to keep your balance topped up automatically.',
+    ctaLabel: 'Enable',
+    ctaAction: () => openAutoRechargeModal(),
+  }));
+}
+
+function makeBanner({ tone, title, body, ctaLabel, ctaAction }) {
+  const wrap = document.createElement('div');
+  wrap.className = `auto-recharge-banner auto-recharge-banner-${tone}`;
+  const left = document.createElement('div');
+  left.className = 'auto-recharge-banner-left';
+  const h = document.createElement('strong');
+  h.textContent = title;
+  const p = document.createElement('p');
+  p.textContent = body;
+  left.appendChild(h);
+  left.appendChild(p);
+  wrap.appendChild(left);
+  if (ctaLabel) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn btn-outline btn-sm';
+    btn.textContent = ctaLabel;
+    btn.addEventListener('click', ctaAction);
+    wrap.appendChild(btn);
+  }
+  return wrap;
+}
+
+function dollarsFromCents(cents) {
+  if (cents == null) return '0';
+  return (Number(cents) / 100).toFixed(2).replace(/\.00$/, '');
+}
+
+function formatCardSuffix(pmId) {
+  if (!pmId) return 'your saved card';
+  // We don't keep card metadata in our DB; pm_xxx is opaque here. The
+  // backend has the card; this UI surfaces only what it has. (The full
+  // last4 + brand could be fetched from Stripe in a future iteration.)
+  return 'your saved card';
+}
+
+// ─── Auto-recharge modal ────────────────────────────────────────────────────
+
+function attachModalEventHandlers() {
+  document.getElementById('auto-recharge-modal-close-btn')?.addEventListener(
+    'click',
+    closeAutoRechargeModal,
+  );
+  document.getElementById('auto-recharge-cancel-btn')?.addEventListener(
+    'click',
+    closeAutoRechargeModal,
+  );
+  document.getElementById('auto-recharge-save-btn')?.addEventListener(
+    'click',
+    handleSave,
+  );
+  document.getElementById('auto-recharge-enabled-toggle')?.addEventListener(
+    'change',
+    syncEnabledToggleUI,
+  );
+  document.getElementById('auto-recharge-cap-toggle')?.addEventListener(
+    'change',
+    syncCapToggleUI,
+  );
+  document.getElementById('auto-recharge-drops-to')?.addEventListener(
+    'input',
+    updateComputedAmount,
+  );
+  document.getElementById('auto-recharge-restore-to')?.addEventListener(
+    'input',
+    updateComputedAmount,
+  );
+  document.getElementById('auto-recharge-add-card-btn')?.addEventListener(
+    'click',
+    () => openAddCardModal(),
+  );
+}
+
+export async function openAutoRechargeModal() {
+  const overlay = document.getElementById('auto-recharge-modal-overlay');
+  if (!overlay) return;
+  // Re-fetch on each open so the modal reflects whatever may have
+  // changed since page load (other tabs, dashboard webhook tick, etc.).
+  setModalStatus('');
+  try {
+    _config = await fetchConfig();
+  } catch (e) {
+    setModalStatus(formatError(e), 'error');
+  }
+  populateModalFromConfig();
+  overlay.classList.add('is-open');
+  overlay.setAttribute('aria-hidden', 'false');
+}
+
+function closeAutoRechargeModal() {
+  const overlay = document.getElementById('auto-recharge-modal-overlay');
+  if (!overlay) return;
+  overlay.classList.remove('is-open');
+  overlay.setAttribute('aria-hidden', 'true');
+  setModalStatus('');
+}
+
+function populateModalFromConfig() {
+  const enabled = !!(_config && _config.enabled);
+  setVal('auto-recharge-enabled-toggle', 'checked', enabled);
+  const drops = dollarsFromCents(_config?.threshold_cents ?? 500);
+  const topup = Number(_config?.topup_amount_cents ?? 1000);
+  const threshold = Number(_config?.threshold_cents ?? 500);
+  const restore = ((threshold + topup) / 100).toFixed(2).replace(/\.00$/, '');
+  setVal('auto-recharge-drops-to', 'value', drops);
+  setVal('auto-recharge-restore-to', 'value', restore);
+
+  const capEnabled = !!(_config && _config.monthly_cap_cents);
+  setVal('auto-recharge-cap-toggle', 'checked', capEnabled);
+  setVal(
+    'auto-recharge-cap-amount',
+    'value',
+    dollarsFromCents(_config?.monthly_cap_cents ?? 10_000),
+  );
+
+  // Card selection: use staged-just-saved card if any, else config's
+  // current card, else leave the picker showing "no card on file".
+  const pm = _stagedPaymentMethodId || _config?.payment_method_id || null;
+  renderCardPicker(pm);
+
+  setVal('auto-recharge-consent', 'checked', false);
+  syncEnabledToggleUI();
+  syncCapToggleUI();
+  updateComputedAmount();
+}
+
+function renderCardPicker(pmId) {
+  const label = document.getElementById('auto-recharge-card-label');
+  if (!label) return;
+  label.textContent = pmId ? `Card on file: ${pmId}` : 'No card saved yet';
+  label.dataset.pmId = pmId || '';
+}
+
+function syncEnabledToggleUI() {
+  const enabled = !!document.getElementById('auto-recharge-enabled-toggle')?.checked;
+  const fieldset = document.getElementById('auto-recharge-fields');
+  if (fieldset) {
+    fieldset.style.opacity = enabled ? '1' : '0.5';
+    fieldset.querySelectorAll('input').forEach((el) => {
+      if (el.id !== 'auto-recharge-enabled-toggle') el.disabled = !enabled;
+    });
+  }
+  // Consent is only meaningful when enabling.
+  const consent = document.getElementById('auto-recharge-consent-row');
+  if (consent) consent.style.display = enabled ? '' : 'none';
+}
+
+function syncCapToggleUI() {
+  const on = !!document.getElementById('auto-recharge-cap-toggle')?.checked;
+  const input = document.getElementById('auto-recharge-cap-amount');
+  if (input) input.disabled = !on;
+}
+
+function updateComputedAmount() {
+  const drops = parseFloat(getVal('auto-recharge-drops-to') || '0') || 0;
+  const restore = parseFloat(getVal('auto-recharge-restore-to') || '0') || 0;
+  const amount = Math.max(0, restore - drops);
+  const display = document.getElementById('auto-recharge-amount-display');
+  if (display) display.textContent = `$${amount.toFixed(2).replace(/\.00$/, '')}`;
+}
+
+async function handleSave() {
+  setModalStatus('');
+  const enabled = !!document.getElementById('auto-recharge-enabled-toggle')?.checked;
+  const drops = parseFloat(getVal('auto-recharge-drops-to') || '0') || 0;
+  const restore = parseFloat(getVal('auto-recharge-restore-to') || '0') || 0;
+  const capOn = !!document.getElementById('auto-recharge-cap-toggle')?.checked;
+  const cap = parseFloat(getVal('auto-recharge-cap-amount') || '0') || 0;
+  const consent = !!document.getElementById('auto-recharge-consent')?.checked;
+  const pmId =
+    document.getElementById('auto-recharge-card-label')?.dataset.pmId || null;
+
+  if (enabled) {
+    if (!consent) {
+      setModalStatus(
+        'Tick the consent checkbox to enable auto recharge.',
+        'error',
+      );
+      return;
+    }
+    if (drops <= 0 || restore <= drops) {
+      setModalStatus(
+        'Restore balance must be higher than the trigger threshold.',
+        'error',
+      );
+      return;
+    }
+    const topupCents = Math.round((restore - drops) * 100);
+    if (topupCents < 500) {
+      setModalStatus(
+        'Recharge amount must be at least $5.',
+        'error',
+      );
+      return;
+    }
+    if (!capOn || cap < (topupCents / 100)) {
+      setModalStatus(
+        'Monthly limit must be at least the recharge amount.',
+        'error',
+      );
+      return;
+    }
+    if (!pmId) {
+      setModalStatus(
+        'Save a card before enabling auto recharge.',
+        'error',
+      );
+      return;
+    }
+  }
+
+  const body = enabled
+    ? {
+        enabled: true,
+        threshold_cents: Math.round(drops * 100),
+        topup_amount_cents: Math.round((restore - drops) * 100),
+        monthly_cap_cents: Math.round(cap * 100),
+        payment_method_id: pmId,
+        consent_version: 'v1',
+      }
+    : {
+        enabled: false,
+        threshold_cents: null,
+        topup_amount_cents: null,
+        monthly_cap_cents: null,
+        payment_method_id: null,
+        consent_version: null,
+      };
+
+  const saveBtn = document.getElementById('auto-recharge-save-btn');
+  if (saveBtn) saveBtn.disabled = true;
+  try {
+    _config = await saveConfig(body);
+    _stagedPaymentMethodId = null;
+    closeAutoRechargeModal();
+    renderStatusBanner();
+  } catch (e) {
+    setModalStatus(formatError(e), 'error');
+  } finally {
+    if (saveBtn) saveBtn.disabled = false;
+  }
+}
+
+// ─── Save-card sub-flow ─────────────────────────────────────────────────────
+
+function attachAddCardModalEventHandlers() {
+  document.getElementById('add-card-modal-close-btn')?.addEventListener(
+    'click',
+    closeAddCardModal,
+  );
+  document.getElementById('add-card-cancel-btn')?.addEventListener(
+    'click',
+    closeAddCardModal,
+  );
+  document.getElementById('add-card-save-btn')?.addEventListener(
+    'click',
+    handleAddCardSave,
+  );
+}
+
+async function openAddCardModal() {
+  setAddCardStatus('');
+  const overlay = document.getElementById('add-card-modal-overlay');
+  if (!overlay) return;
+  overlay.classList.add('is-open');
+  overlay.setAttribute('aria-hidden', 'false');
+
+  try {
+    const intent = await createSetupIntent();
+    _addCardClientSecret = intent.client_secret;
+    _publishableKey = intent.publishable_key;
+    if (!_stripe) {
+      // eslint-disable-next-line no-undef
+      _stripe = Stripe(_publishableKey);
+    }
+    if (_addCardElements) {
+      try { _addCardElement?.unmount(); } catch (_) { /* ignore */ }
+    }
+    _addCardElements = _stripe.elements({ clientSecret: _addCardClientSecret });
+    _addCardElement = _addCardElements.create('payment');
+    _addCardElement.mount('#add-card-payment-element');
+  } catch (e) {
+    setAddCardStatus(formatError(e), 'error');
+  }
+}
+
+function closeAddCardModal() {
+  const overlay = document.getElementById('add-card-modal-overlay');
+  if (!overlay) return;
+  overlay.classList.remove('is-open');
+  overlay.setAttribute('aria-hidden', 'true');
+  if (_addCardElement) {
+    try { _addCardElement.unmount(); } catch (_) { /* ignore */ }
+    _addCardElement = null;
+    _addCardElements = null;
+  }
+}
+
+async function handleAddCardSave() {
+  if (!_stripe || !_addCardElements) {
+    setAddCardStatus('Card form not initialised yet.', 'error');
+    return;
+  }
+  setAddCardStatus('Saving card…', 'info');
+  const saveBtn = document.getElementById('add-card-save-btn');
+  if (saveBtn) saveBtn.disabled = true;
+  try {
+    const result = await _stripe.confirmSetup({
+      elements: _addCardElements,
+      redirect: 'if_required',
+    });
+    if (result.error) {
+      setAddCardStatus(result.error.message || 'Save card failed.', 'error');
+      return;
+    }
+    const pmId = result.setupIntent?.payment_method;
+    if (!pmId) {
+      setAddCardStatus(
+        'Stripe returned no payment_method id; please retry.',
+        'error',
+      );
+      return;
+    }
+    _stagedPaymentMethodId = pmId;
+    closeAddCardModal();
+    renderCardPicker(pmId);
+    setModalStatus('Card saved — ready to enable auto recharge.', 'success');
+  } catch (e) {
+    setAddCardStatus(formatError(e), 'error');
+  } finally {
+    if (saveBtn) saveBtn.disabled = false;
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function setModalStatus(msg, tone) {
+  setStatus('auto-recharge-modal-status', msg, tone);
+}
+
+function setAddCardStatus(msg, tone) {
+  setStatus('add-card-modal-status', msg, tone);
+}
+
+function setStatus(id, msg, tone) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = msg || '';
+  el.classList.remove('info', 'error', 'success');
+  if (msg && tone) el.classList.add(tone);
+  el.style.display = msg ? '' : 'none';
+}
+
+function setVal(id, prop, val) {
+  const el = document.getElementById(id);
+  if (el) el[prop] = val;
+}
+
+function getVal(id) {
+  const el = document.getElementById(id);
+  return el ? el.value : '';
+}
+
+function formatError(e) {
+  if (!e) return 'Unknown error.';
+  if (typeof e === 'string') return e;
+  return e.message || String(e);
+}
+
+function logError(tag, e) {
+  // eslint-disable-next-line no-console
+  console.error(`[auto_recharge:${tag}]`, e);
+}

--- a/lit-static/dapps/dashboard/billing.js
+++ b/lit-static/dapps/dashboard/billing.js
@@ -228,7 +228,7 @@ export function resetBillingAvailability() {
  * Server validates `primaryType: "BillingAuth"` against the canonical schema
  * in `lit-api-server/src/core/eip712.rs` (CPL-286).
  */
-async function getWalletAuthHeader() {
+export async function getWalletAuthHeader() {
   const wallet = getChainSecuredWallet();
   if (!wallet) {
     throw new Error('No connected ChainSecured wallet — sign in first.');

--- a/lit-static/dapps/dashboard/index.html
+++ b/lit-static/dapps/dashboard/index.html
@@ -157,6 +157,7 @@
             <button type="button" class="btn btn-topbar btn-theme-toggle" id="theme-toggle" aria-label="Switch to dark mode"><span class="theme-icon" aria-hidden="true"></span></button>
             <span id="billing-balance-display" class="billing-balance" style="display:none;"></span>
             <button type="button" class="btn btn-primary btn-sm" id="btn-add-funds" style="display:none;">Add Funds</button>
+            <button type="button" class="btn btn-outline btn-sm" id="btn-auto-recharge" title="Auto recharge settings">Auto recharge</button>
             <span id="billing-not-required" class="billing-not-required" style="display:none;">Payment Not Required</span>
             <div class="account-dropdown" id="account-dropdown">
               <button type="button" class="btn btn-topbar account-dropdown-trigger" id="account-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-label="Account menu">
@@ -278,6 +279,7 @@
               <strong>No funds available</strong>
               <p>Your account has no credit balance. Please <a href="#" id="no-funds-add-funds">add funds</a> for Lit Actions to work.</p>
             </div>
+            <div id="auto-recharge-banner" class="auto-recharge-banner-host"></div>
             <details class="help-details">
               <summary class="help-details-summary">
                 <span class="help-details-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
@@ -554,6 +556,101 @@
         <button type="button" class="btn btn-outline" id="billing-back-btn" style="display:none;">Back</button>
         <button type="button" class="btn btn-primary" id="billing-continue-btn">Continue</button>
         <button type="button" class="btn btn-primary" id="billing-pay-btn" style="display:none;">Pay</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Auto-recharge configuration modal (Phase 8) -->
+  <div id="auto-recharge-modal-overlay" class="modal-overlay" aria-hidden="true">
+    <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="auto-recharge-modal-title">
+      <div class="modal-header">
+        <h3 id="auto-recharge-modal-title" class="modal-title">Auto recharge</h3>
+        <label class="auto-recharge-header-toggle">
+          <input type="checkbox" id="auto-recharge-enabled-toggle" />
+          <span class="slider" aria-hidden="true"></span>
+        </label>
+        <button type="button" class="modal-close" id="auto-recharge-modal-close-btn" aria-label="Close">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p class="modal-subtitle">Automatically add credits when your balance runs low.</p>
+
+        <fieldset id="auto-recharge-fields" class="auto-recharge-fields">
+          <div class="form-row">
+            <label for="auto-recharge-drops-to">When balance drops to:</label>
+            <div class="amount-input"><span class="amount-prefix">$</span>
+              <input type="number" id="auto-recharge-drops-to" min="0" step="0.01" value="5" />
+            </div>
+          </div>
+          <div class="form-row">
+            <label for="auto-recharge-restore-to">Restore balance to:</label>
+            <div class="amount-input"><span class="amount-prefix">$</span>
+              <input type="number" id="auto-recharge-restore-to" min="0" step="0.01" value="10" />
+            </div>
+          </div>
+          <div class="form-row">
+            <label>Recharge amount:</label>
+            <span id="auto-recharge-amount-display" class="amount-readout">$5</span>
+          </div>
+
+          <div class="form-row form-row-divider">
+            <label for="auto-recharge-cap-toggle" class="form-row-toggle-label">
+              <span>Monthly recharge limit</span>
+              <input type="checkbox" id="auto-recharge-cap-toggle" />
+            </label>
+            <p class="form-hint">
+              Recharging stops once this limit is reached.
+            </p>
+            <div class="amount-input"><span class="amount-prefix">$</span>
+              <input type="number" id="auto-recharge-cap-amount" min="5" step="0.01" value="100" />
+            </div>
+          </div>
+
+          <div class="form-row form-row-divider">
+            <label>Payment method:</label>
+            <div class="card-picker-row">
+              <span id="auto-recharge-card-label" data-pm-id="">No card saved yet</span>
+              <button type="button" class="btn btn-outline btn-sm" id="auto-recharge-add-card-btn">Add a card</button>
+            </div>
+          </div>
+
+          <div id="auto-recharge-consent-row" class="form-row form-row-divider">
+            <label class="consent-row">
+              <input type="checkbox" id="auto-recharge-consent" />
+              <span>
+                I authorize Lit Protocol to charge my saved card up to the
+                monthly limit when my balance falls below the trigger.
+              </span>
+            </label>
+          </div>
+        </fieldset>
+
+        <div id="auto-recharge-modal-status" class="status" style="display:none;"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline" id="auto-recharge-cancel-btn">Cancel</button>
+        <button type="button" class="btn btn-primary" id="auto-recharge-save-btn">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Save-card sub-flow modal (Phase 8) -->
+  <div id="add-card-modal-overlay" class="modal-overlay" aria-hidden="true">
+    <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="add-card-modal-title">
+      <div class="modal-header">
+        <h3 id="add-card-modal-title" class="modal-title">Save a card for auto recharge</h3>
+        <button type="button" class="modal-close" id="add-card-modal-close-btn" aria-label="Close">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p class="modal-subtitle">
+          Your card stays at Stripe — we never see the card number. EU cards
+          may show a 3DS challenge during save.
+        </p>
+        <div id="add-card-payment-element"></div>
+        <div id="add-card-modal-status" class="status" style="display:none;"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline" id="add-card-cancel-btn">Cancel</button>
+        <button type="button" class="btn btn-primary" id="add-card-save-btn">Save card</button>
       </div>
     </div>
   </div>

--- a/lit-static/dapps/dashboard/recover_topup.html
+++ b/lit-static/dapps/dashboard/recover_topup.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Confirm auto top-up — Lit Protocol</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 3rem 1rem;
+      min-height: 100vh;
+      box-sizing: border-box;
+    }
+    .recover-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg, 12px);
+      padding: 2rem;
+      max-width: 480px;
+      width: 100%;
+      box-shadow: var(--shadow, 0 1px 2px rgba(0,0,0,0.06));
+    }
+    .recover-card h1 {
+      margin-top: 0;
+      font-size: 1.4rem;
+    }
+    .recover-card p.intro {
+      color: var(--text-muted);
+      margin: 0.5rem 0 1.5rem;
+    }
+    #recover-status {
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+      border-radius: var(--radius-sm, 6px);
+      font-size: 0.9rem;
+    }
+    #recover-status.info { background: rgba(60, 80, 224, 0.08); color: var(--primary, #3c50e0); }
+    #recover-status.error { background: rgba(220, 38, 38, 0.08); color: var(--danger, #dc2626); }
+    #recover-status.success { background: rgba(22, 163, 74, 0.08); color: var(--success, #16a34a); }
+    .recover-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="recover-card">
+    <h1>Confirm your auto top-up</h1>
+    <p class="intro">
+      Your bank wants to verify this charge. After you confirm, your
+      account credit is updated automatically — usually within a few
+      seconds.
+    </p>
+    <div id="recover-payment-element"></div>
+    <div id="recover-status" class="info" style="display:none;"></div>
+    <div class="recover-actions">
+      <a href="./index.html" class="btn btn-outline">Back to dashboard</a>
+      <button type="button" class="btn btn-primary" id="recover-confirm-btn" disabled>
+        Confirm
+      </button>
+    </div>
+  </div>
+
+  <script src="https://js.stripe.com/v3/"></script>
+  <script type="module" src="./recover_topup.js"></script>
+</body>
+</html>

--- a/lit-static/dapps/dashboard/recover_topup.js
+++ b/lit-static/dapps/dashboard/recover_topup.js
@@ -1,0 +1,130 @@
+/**
+ * SCA recovery page driver (Phase 8.5).
+ *
+ * Flow when user clicks the email link `…/recover_topup.html?token=…`:
+ *
+ *   1. Read `token` from the URL.
+ *   2. GET `/billing/auto_topup_resume?token=…` on lit-payments. Server
+ *      returns `{ payment_intent_id, client_secret, publishable_key }`
+ *      (and clears the token internally only AFTER its Stripe retrieve
+ *      succeeds — codex P2 #3 fix).
+ *   3. Mount Stripe Payment Element bound to the PI's client_secret and
+ *      let `confirmPayment` render the bank's 3DS challenge.
+ *   4. On `succeeded`, POST `/billing/auto_topup_resume/complete` with
+ *      the PI id; that endpoint verifies status server-side and applies
+ *      the sync credit.
+ *
+ * This page is unauthenticated by BillingAuth: the `recovery_token` IS
+ * the credential. It's single-use, 24h-expiring, and tied to a specific
+ * pending PI.
+ */
+
+import { getLitPaymentsBaseUrl } from './auth.js';
+
+const statusEl = document.getElementById('recover-status');
+const confirmBtn = document.getElementById('recover-confirm-btn');
+
+let _stripe = null;
+let _elements = null;
+let _paymentElement = null;
+let _paymentIntentId = null;
+let _clientSecret = null;
+
+(async function main() {
+  const token = new URLSearchParams(location.search).get('token');
+  if (!token) {
+    setStatus('Missing recovery token. Use the link from your email.', 'error');
+    return;
+  }
+  try {
+    const intent = await fetchResume(token);
+    _paymentIntentId = intent.payment_intent_id;
+    _clientSecret = intent.client_secret;
+    // eslint-disable-next-line no-undef
+    _stripe = Stripe(intent.publishable_key);
+    _elements = _stripe.elements({ clientSecret: _clientSecret });
+    _paymentElement = _elements.create('payment');
+    _paymentElement.mount('#recover-payment-element');
+    confirmBtn.disabled = false;
+    setStatus('Enter the verification details requested by your bank, then click Confirm.', 'info');
+  } catch (e) {
+    setStatus(formatError(e), 'error');
+  }
+})();
+
+confirmBtn.addEventListener('click', async () => {
+  confirmBtn.disabled = true;
+  setStatus('Contacting your bank…', 'info');
+  try {
+    const result = await _stripe.confirmPayment({
+      elements: _elements,
+      // No redirect_url: we want confirmCardPayment-style behaviour where
+      // the result comes back to this page rather than navigating away.
+      redirect: 'if_required',
+    });
+    if (result.error) {
+      setStatus(result.error.message || 'Authentication failed.', 'error');
+      confirmBtn.disabled = false;
+      return;
+    }
+    const pi = result.paymentIntent;
+    if (!pi || pi.status !== 'succeeded') {
+      setStatus(
+        `Bank returned status "${pi?.status || 'unknown'}". Please try again or use a different card.`,
+        'error',
+      );
+      confirmBtn.disabled = false;
+      return;
+    }
+    setStatus('Applying credit…', 'info');
+    await postComplete(_paymentIntentId);
+    setStatus('Topped up! Your account credit is updated. You can close this tab.', 'success');
+  } catch (e) {
+    setStatus(formatError(e), 'error');
+    confirmBtn.disabled = false;
+  }
+});
+
+async function fetchResume(token) {
+  const base = getLitPaymentsBaseUrl();
+  const res = await fetch(
+    `${base}/billing/auto_topup_resume?token=${encodeURIComponent(token)}`,
+  );
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : text || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return json;
+}
+
+async function postComplete(paymentIntentId) {
+  const base = getLitPaymentsBaseUrl();
+  const res = await fetch(`${base}/billing/auto_topup_resume/complete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ payment_intent_id: paymentIntentId }),
+  });
+  const text = await res.text();
+  let json;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : text || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return json;
+}
+
+function setStatus(msg, tone) {
+  statusEl.textContent = msg || '';
+  statusEl.className = tone || 'info';
+  statusEl.style.display = msg ? '' : 'none';
+}
+
+function formatError(e) {
+  if (!e) return 'Unknown error.';
+  if (typeof e === 'string') return e;
+  return e.message || String(e);
+}

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -2086,3 +2086,163 @@ textarea.input.textarea-sm {
     min-height: 36px;
   }
 }
+
+/* ────── Auto recharge (Phase 8) ────── */
+
+.auto-recharge-banner-host {
+  margin: 1rem 0;
+}
+.auto-recharge-banner {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+}
+.auto-recharge-banner-left {
+  flex: 1;
+}
+.auto-recharge-banner-left strong {
+  display: block;
+  font-size: 0.95rem;
+  margin-bottom: 0.25rem;
+}
+.auto-recharge-banner-left p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+.auto-recharge-banner-success {
+  border-left: 3px solid var(--success, #16a34a);
+}
+.auto-recharge-banner-error {
+  border-left: 3px solid var(--danger, #dc2626);
+}
+.auto-recharge-banner-info {
+  border-left: 3px solid var(--primary, #3c50e0);
+}
+
+.auto-recharge-header-toggle {
+  margin-left: auto;
+  margin-right: 0.75rem;
+  position: relative;
+  display: inline-block;
+  width: 38px;
+  height: 22px;
+}
+.auto-recharge-header-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.auto-recharge-header-toggle .slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--border);
+  transition: 0.2s;
+  border-radius: 22px;
+}
+.auto-recharge-header-toggle .slider::before {
+  content: '';
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background: white;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+.auto-recharge-header-toggle input:checked + .slider {
+  background: var(--primary, #3c50e0);
+}
+.auto-recharge-header-toggle input:checked + .slider::before {
+  transform: translateX(16px);
+}
+
+.modal-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+
+.auto-recharge-fields {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.9rem;
+}
+.form-row label {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+.form-row-divider {
+  border-top: 1px solid var(--border);
+  padding-top: 0.9rem;
+}
+.form-row-toggle-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+.amount-input {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  padding: 0 0.5rem;
+  background: var(--input-bg, var(--card-bg));
+  max-width: 160px;
+}
+.amount-prefix {
+  color: var(--text-muted);
+  margin-right: 0.25rem;
+}
+.amount-input input {
+  border: none;
+  outline: none;
+  background: transparent;
+  width: 100%;
+  padding: 0.5rem 0;
+  font: inherit;
+  color: var(--text);
+}
+.amount-readout {
+  font-weight: 600;
+  font-size: 1rem;
+}
+.card-picker-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.consent-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.consent-row input {
+  margin-top: 0.2rem;
+}
+
+#auto-recharge-modal-status.info { color: var(--primary, #3c50e0); }
+#auto-recharge-modal-status.error { color: var(--danger, #dc2626); }
+#auto-recharge-modal-status.success { color: var(--success, #16a34a); }
+#add-card-modal-status.info { color: var(--primary, #3c50e0); }
+#add-card-modal-status.error { color: var(--danger, #dc2626); }
+#add-card-modal-status.success { color: var(--success, #16a34a); }


### PR DESCRIPTION
**Stack:** PR 8 of 8 (FINAL). Base: `auto-topup-phase-7`. Diff shows only Phase 8.

## What
User-facing surface for Phases 1-7. Matches the OpenAI Platform auto-recharge UX using the dashboard's existing component vocabulary.

* **`auto_recharge.js`** — talks directly to lit-payments. Surfaces a four-state status banner (not-configured / enabled-healthy with full description / SCA-pending / auto-disabled-after-3-failures), an "Auto recharge" modal with computed-amount + cap toggle + card picker + consent, and a save-card sub-flow that mounts a Stripe Payment Element in setup mode.
* **`recover_topup.html` + `recover_topup.js`** — standalone SCA recovery page reached from the tokenized email link. GET /auto_topup_resume → stripe.confirmPayment 3DS → POST /complete. Single-use token semantics verified live.
* **`auth.js`** — adds `getLitPaymentsBaseUrl()` (dev: localhost:8001 / prod: build-time substitution).
* **`lit-payments`** — adds `rocket_cors` so the dashboard can call cross-origin endpoints. Adds a DEV-ONLY `LIT_DEV_WALLET_BYPASS` env flag for the QA harness (clear warning logs; reads env at request time; never cached). `lit-billing-auth/src/guard.rs` honors it.

## QA (browser-driven against real Stripe test mode + real local Postgres)
All four banner states screenshotted. Modal opens, populates from real DB, saves → DB updated. Save-card flow mounts real Stripe Payment Element. Recovery page mounts real PI client_secret. Single-use token semantics verified (second load → 404, DB shows token NULL).

## Manual user-test checkpoint (deferred to you)
Per Phase 8 spec: `4242`, `4000 0027 6000 3184` (SCA), `4000 0000 0000 0341` (decline) cards in a real browser tab — anti-bot iframe protections prevent headless automation of `stripe.confirmCardSetup` / `stripe.confirmPayment` form submission, so the actual 3DS challenge round-trip is the human-test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)