### PR TITLE
ci: remove global foundry-toolchain concurrency lock

### DIFF
--- a/.github/workflows/contract-bindings-check.yml
+++ b/.github/workflows/contract-bindings-check.yml
@@ -19,9 +19,6 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: contract-bindings
     runs-on: self-hosted
-    concurrency:
-      group: foundry-toolchain
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -19,9 +19,6 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     name: forge-test
     runs-on: self-hosted
-    concurrency:
-      group: foundry-toolchain
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The contract bindings / forge test checks frequently fail with:

> Canceling since a higher priority waiting request for foundry-toolchain exists

### Root cause

Both `contract-bindings-check.yml` and `contract-tests.yml` declare the **same** job-level concurrency group, unscoped by ref:

```yaml
concurrency:
  group: foundry-toolchain
  cancel-in-progress: false
```

A GitHub concurrency group keeps at most **one running + one pending** job. With `cancel-in-progress: false`, a third in-flight request cancels the older **pending** one — which surfaces as the error above.

Because the group string is global (shared across **both** workflows and **every** branch/PR/push), the threshold is trivially exceeded: every PR already fires *both* jobs into the group (1 running, 1 pending), so any concurrent push/PR cancels the pending one.

### Why the lock existed

Added in #410 to stop two Foundry installs racing on the shared self-hosted runner's `$HOME/.foundry`. But that same PR also made the install **conditional**:

```yaml
- name: Install Foundry
  if: steps.foundry-toolchain.outputs.installed != 'true'
```

So once a runner has forge `v1.5.1`, every later job skips the install entirely and can't race. The lock only guards a narrow cold-start / version-bump window, while penalizing *every* job with serialization + cancellations.

## Change

Remove the `concurrency:` block from both workflows. The workflow-level `concurrency: ${{ github.workflow }}-${{ github.ref }}` still cancels superseded runs of the same PR correctly.

## Risk / follow-up

Worst case is a rare install race if multiple install-needing jobs hit a cold runner simultaneously (fixable with a re-run). Durable follow-up: pre-install forge `v1.5.1` on the runner so the install step is always skipped and the race can't occur at all — then this lock stays gone for good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)