### PR TITLE
[codex] Harden CoW solver vault policy

### DIFF
--- a/examples/lit-solver-vault-cowswap/.env.example
+++ b/examples/lit-solver-vault-cowswap/.env.example
@@ -13,8 +13,9 @@ LIT_API_KEY=
 # reused for the action's on-chain reads AND as the network RPC for deploys
 # /transactions. Get a free app at https://dashboard.alchemy.com. Looks like:
 #   https://base-sepolia.g.alchemy.com/v2/<your-api-key>
-# (We deploy our own GPv2Settlement, so any EVM chain works; Base Sepolia is
-# fast + cheap. To use another chain, set COW_CHAIN_ID and edit the host
+# (We deploy our own GPv2Settlement, so the pattern is chain-portable, but these
+# scripts are wired to Base Sepolia. To use another chain, add a Hardhat network,
+# point the scripts at that RPC env var, set COW_CHAIN_ID, and edit the host
 # whitelist in action/cowPolicy.js.)
 ALCHEMY_BASE_SEPOLIA_URL=
 
@@ -26,9 +27,11 @@ ALCHEMY_BASE_SEPOLIA_URL=
 DEPLOYER_PRIVATE_KEY=
 
 # EOA the solver bot uses to submit the settle tx (the throwaway gas account).
-# In this demo it can be the same as DEPLOYER_PRIVATE_KEY. It holds NO inventory
-# and is NOT an allowlisted solver — only the vault is — so on its own it can
-# neither settle nor authorize a settlement.
+# Use a distinct key for the attack walkthrough. Reusing DEPLOYER_PRIVATE_KEY is
+# convenient for a smoke test, but it collapses the owner/auth-manager/solver
+# roles and no longer models a compromised solver-only box. This key holds NO
+# inventory and is NOT an allowlisted solver — only the vault is — so on its own
+# it can neither settle nor authorize a settlement.
 SOLVER_PRIVATE_KEY=
 
 
@@ -43,8 +46,8 @@ LIT_API_BASE=https://api.chipotle.litprotocol.com
 COLD_WALLET=
 
 # The trader (the party whose order gets filled). Defaults to the deployer for a
-# self-contained demo; set a distinct key to make the two roles obviously
-# separate. Needs no gas unless you give it a distinct address with no balance.
+# self-contained smoke test; set a distinct key to keep the roles separate.
+# Needs no gas unless you give it a distinct address with no balance.
 # TRADER_PRIVATE_KEY=
 
 # Demo order + vault sizing (mUSDC has 6 decimals, mWETH 18). The trader sells

--- a/examples/lit-solver-vault-cowswap/README.md
+++ b/examples/lit-solver-vault-cowswap/README.md
@@ -5,10 +5,10 @@ batches lives in a Lit Action, not on the solver's box — so a compromised bot
 can't push a self-dealing settlement, and operational guardrails are enforced at
 signing time.**
 
-**Fast enough to solve with: ~361 ms median warm** for a full policy
-authorization round-trip (vault config reads + EIP-712 order verification +
-Lit Action signing), measured live on Base Sepolia + Lit Chipotle. This is the
-latency added before the solver submits `settle()`.
+**Fast enough to solve with: hundreds of milliseconds warm** for a full
+policy authorization round-trip (vault config reads, EIP-712 order verification,
+and Lit Action signing), measured live on Base Sepolia + Lit Chipotle. This is
+the latency added before the solver submits `settle()`.
 
 This is the CoW sibling of [`lit-solver-vault`](../lit-solver-vault) (which ships
 a generic mock demo and a live **Across** relayer). Same custody story, a very
@@ -22,9 +22,9 @@ different settlement system — and the difference is the whole point.
 > onboarding with the CoW team. So this example deploys *its own*
 > `GPv2Settlement` + `GPv2AllowListAuthentication` on Base Sepolia — the
 > real, audited CoW contracts, from the published `@cowprotocol/contracts`
-> artifacts. Because we deploy our own settlement, **any EVM chain works**; we
-> use Base Sepolia for its fast (~2s) blocks. It allowlists the vault as the
-> solver, and runs a genuine `settle()` end-to-end
+> artifacts. Because we deploy our own settlement, the pattern is portable to
+> other EVM chains; these scripts are wired to Base Sepolia for its fast (~2s)
+> blocks. It allowlists the vault as the solver, and runs a genuine `settle()` end-to-end
 > against real EIP-712 order signatures. Just on an instance we control.
 
 ## Why this is a Lit-shaped problem (and why it's sharper for CoW)
@@ -44,10 +44,11 @@ the Across variant removes, with a bigger blast radius. Here:
   can't call `settle()` at all (it isn't on the allowlist); it can only *ask* the
   vault, and the vault only settles batches a Lit Action signed.
 - The Lit Action **builds the entire settlement** from the trader's signed order
-  and signs only that. There's no caller-supplied field — recipient, amounts,
-  clearing prices and interactions are all derived from the order — so a
-  compromised bot can't produce a self-dealing batch. Exfiltration isn't
-  "rejected," it's impossible by construction (same property as `acrossPolicy`).
+  and signs only that. The token pair must match the pair pinned on the vault;
+  recipient, amounts, clearing prices and interactions are all derived from the
+  order — so a compromised bot can't produce a self-dealing batch. Exfiltration
+  isn't "rejected," it's impossible by construction (same property as
+  `acrossPolicy`).
 - The vault's inventory is exposed to the settlement only through a **bounded,
   per-batch approval** that's reset to zero after the call — so even the
   settlement contract can never pull more than the one batch needs.
@@ -68,15 +69,17 @@ automatically.**
        ├─────────────────►│                          │
        │                  │ read rpc host ✓           │
        │                  │ read vault.settlement(),  │
+       │                  │ sellToken, buyToken,      │
        │                  │ killSwitch, maxFillAmount ├─────────►│
        │                  │◄──────────────────────────┤
-       │                  │ read settlement.domainSeparator()    │
+       │                  │ compute EIP-712 domain locally       │
        │                  │ verify trader EIP-712 order sig       │
+       │                  │ verify order token pair == vault pair │
        │                  │ build the WHOLE settle() batch:       │
        │                  │   tokens, clearing prices, the trade, │
        │                  │   + 2 inventory interactions          │
        │ sig + calldata   │ sign(keccak(calldata), pullToken,     │
-       │◄─────────────────┤ pullAmount, authDeadline, vault, cid) │
+       │◄─────────────────┤ pullAmount, authDeadline, vault, chain)│
        │                                                          │
        │ executeSettlement(calldata, pullToken, pullAmount, deadline, sig) ──►│
        │                                       recover(sig) == policySigner ✓ │
@@ -122,14 +125,14 @@ a compromised owner can widen the gate. The security story is about removing the
 
 | Path | Purpose |
 | --- | --- |
-| `action/cowPolicy.js` | The policy Lit Action. Reads the vault's pinned settlement + config, verifies the trader's EIP-712 order, **builds the entire `settle()` calldata** from it, enforces cap / kill switch, and signs the batch. |
-| `contracts/CowSolverVault.sol` | Inventory custody + the allowlisted solver. `executeSettlement` verifies a policy signature over the settle calldata, grants a bounded one-batch approval, forwards `settle`; `exit` sweeps to the cold wallet; cold-wallet changes are timelocked. |
+| `action/cowPolicy.js` | The policy Lit Action. Reads the vault's pinned settlement, token pair, and config; verifies the trader's EIP-712 order; **builds the entire `settle()` calldata** from it; enforces token pair / cap / kill switch / order expiry; and signs the batch. |
+| `contracts/CowSolverVault.sol` | Inventory custody + the allowlisted solver. Pins the settlement and demo token pair; `executeSettlement` verifies a policy signature over the settle calldata, grants a bounded one-batch approval, forwards `settle`; `exit` sweeps to the cold wallet; cold-wallet changes are timelocked. |
 | `contracts/MockERC20.sol` | Faucet tokens (a 6-dp "USDC" the trader sells, an 18-dp "WETH" the vault holds). |
 | `scripts/deploy-cow.js` | Deploys our own `GPv2AllowListAuthentication` + `GPv2Settlement` (real CoW artifacts), the tokens, and the vault; allowlists the vault; funds inventory. |
 | `scripts/setup-cow.js` | One-shot: compute the action CID, derive `policySigner`, create + wire the group/usage key, register the action, run the deploy. |
 | `scripts/order.js` | Plays the trader: mints the sell token, approves the VaultRelayer, signs an EIP-712 order (the intent). |
 | `scripts/solve.js` | Happy path: authorize via Lit, submit `executeSettlement`. |
-| `scripts/attack.js` | Three attacks, all defeated: tampered receiver, forged policy sig, and a non-solver trying to settle directly. |
+| `scripts/attack.js` | Four attacks, all defeated: tampered receiver, unpinned token pair, forged policy sig, and a non-solver trying to settle directly. |
 | `scripts/_cow.js` / `_chipotle.js` / `_env.js` | Shared helpers (CoW ABIs + order signing, Lit REST calls, `.env` upsert). |
 
 ## Walkthrough
@@ -143,8 +146,10 @@ npm install
 
 Set `LIT_API_KEY`, `ALCHEMY_BASE_SEPOLIA_URL` (a `base-sepolia.g.alchemy.com`
 URL — the action whitelists that host), `DEPLOYER_PRIVATE_KEY` (Base-Sepolia gas;
-it becomes the vault owner), and `SOLVER_PRIVATE_KEY` (the bot's gas account; can
-be the same key for testing). See the comments in `.env.example`.
+it becomes the vault owner), and `SOLVER_PRIVATE_KEY` (the bot's gas account).
+Use a distinct solver key for the attack walkthrough; using the deployer key is
+convenient for a smoke test but collapses the owner/auth-manager/solver roles.
+See the comments in `.env.example`.
 
 ### 2. Run setup
 
@@ -157,7 +162,8 @@ group (wildcard allowlist, bounded by the scoped usage key), mint a scoped usage
 key, derive the action's wallet (the vault's `policySigner`), register the action
 + add it to the group, then deploy the whole CoW stack (`scripts/deploy-cow.js`):
 our `GPv2AllowListAuthentication`, our `GPv2Settlement`, the two test tokens, the
-`CowSolverVault` (allowlisted as the solver, funded with mWETH inventory).
+`CowSolverVault` (pinning that token pair, allowlisted as the solver, funded with
+mWETH inventory).
 
 Re-running does a fresh setup top-to-bottom and orphans the previous
 group/key/contracts — the simplest reset for a docs example.
@@ -178,26 +184,28 @@ npm run solve
 npm run attack
 #   1. compromised bot rewrites the order receiver to itself -> policy refuses
 #      (the rebuilt batch no longer recovers to the order owner)
-#   2. bot forges a policy signature and calls executeSettlement -> reverts
+#   2. bot swaps the order buy token away from the vault-pinned pair -> policy refuses
+#   3. bot forges a policy signature and calls executeSettlement -> reverts
 #      InvalidPolicySignature
-#   3. bot calls GPv2Settlement.settle directly -> "GPv2: not a solver"
+#   4. bot calls GPv2Settlement.settle directly -> "GPv2: not a solver"
 #      (only the vault is allowlisted)
 ```
 
-`npm run solve` prints the policy authorization latency in milliseconds. The
-current live measurement on Base Sepolia + Lit Chipotle was **~361 ms median warm**
-for authorization-only samples (`538, 484, 322, 360, 361, 352 ms`; mean
-`~403 ms`). The first end-to-end solve in this run authorized in `1585 ms`, then
-warm solves authorized in `553 ms` and `502 ms`, so expect the first call after
-an action edit or cache miss to be slower while the CID is pinned/distributed.
+`npm run solve` prints the policy authorization latency in milliseconds. After
+adding the token-pair and expiry checks, a live Base Sepolia + Lit Chipotle solve
+authorized in **567 ms** and then settled on-chain. The previous authorization-only
+warm sample set, before those checks, measured **~361 ms median warm** (`538, 484,
+322, 360, 361, 352 ms`; mean `~403 ms`). The extra checks add more reads but keep
+them in the same concurrent RPC round-trip. Expect the first call after an action
+edit or cache miss to be slower while the CID is pinned/distributed.
 
-The action does its work in a **single RPC round-trip**: the three vault reads
-fire concurrently (`Promise.all`), the EIP-712 domain is computed locally rather
-than read (verified byte-for-byte against the deployed settlement), and the
-policy-key derivation is kicked off in parallel with the reads. The action only
-reads + signs — it does **not** wait for the settlement to mine; `solve.js`
-submits that tx after the authorization returns, so block inclusion / finality is
-chain latency on top of the Lit authorization.
+The action does its work in a **single RPC round-trip**: the vault reads and
+latest-block read fire concurrently (`Promise.all`), the EIP-712 domain is
+computed locally rather than read (verified byte-for-byte against the deployed
+settlement), and the policy-key derivation is kicked off in parallel with the
+reads. The action only reads + signs — it does **not** wait for the settlement to
+mine; `solve.js` submits that tx after the authorization returns, so block
+inclusion / finality is chain latency on top of the Lit authorization.
 
 ## Liveness & exit
 
@@ -227,11 +235,11 @@ guards your inventory — Lit can never block you from your money."*
   route inventory out. That interaction allowlist is the load-bearing, genuinely
   hard part, and it has no analog in the Across variant (a fill is one bound
   transfer). It's the main thing to build before this is more than a custody demo.
-- **Economic policy is minimal.** With arbitrary test tokens the action can't
-  price the trade, so it only checks the per-batch cap and exact-limit fill. A
-  production solver needs a real fee floor, a quote/orderbook check, an
-  output-token allowlist, and a **cumulative** exposure budget — the per-batch cap
-  alone doesn't bound total drain across many settlements. (`order.feeAmount` is
+- **Economic policy is minimal.** The demo pins one mUSDC/mWETH token pair, but
+  with arbitrary test tokens the action still can't price the trade. A production
+  solver needs a real fee floor, a quote/orderbook check, broader token-pair
+  allowlists, and a **cumulative** exposure budget — the per-batch cap alone
+  doesn't bound total drain across many settlements. (`order.feeAmount` is
   required to be 0 here so the batch stays exact; real orders may carry a fee.)
 - **Move policy config off-chain.** `killSwitch` / `maxFillAmount` live on the
   vault so updates are one tx and the action reads them with a plain `eth_call`.
@@ -252,7 +260,8 @@ guards your inventory — Lit can never block you from your money."*
   the order signature, so the policy's checks are belt-and-suspenders, not the
   only line of defense.
 - **Latency from the live run.** On June 8, 2026, the policy authorization path
-  measured `~361 ms` median warm against Base Sepolia + Lit Chipotle. This is the
+  measured `567 ms` for the first live solve after adding token-pair and expiry
+  checks; the prior authorization-only warm median was `~361 ms`. This is the
   extra solver-side wait before submitting `executeSettlement`; the subsequent
   `settle()` transaction still waits for normal chain inclusion.
 - **erc20 balances only.** The action builds sell / fill-or-kill / erc20 orders,

--- a/examples/lit-solver-vault-cowswap/action/cowPolicy.js
+++ b/examples/lit-solver-vault-cowswap/action/cowPolicy.js
@@ -33,11 +33,10 @@
 //   2. settlement target == the vault's pinned settlement (trust anchor).
 //   3. killSwitch on the vault is off.
 //   4. the order signature recovers to the claimed owner (EIP-712, sell order).
-//   5. order.feeAmount == 0 and amounts are non-zero (keeps the batch exact).
-//   6. order.buyAmount (the inventory spent) <= the vault's maxFillAmount.
-//
-// (order.validTo is enforced on-chain by the settlement when settle runs, so
-// the action doesn't need a clock for it.)
+//   5. order token pair matches the vault's pinned sellToken / buyToken.
+//   6. order.feeAmount == 0 and amounts are non-zero (keeps the batch exact).
+//   7. authDeadline does not outlive order.validTo.
+//   8. order.buyAmount (the inventory spent) <= the vault's maxFillAmount.
 //
 // js_params:
 //   vaultAddress   CowSolverVault address (Base Sepolia)
@@ -63,6 +62,8 @@ const ORDER_TYPE_STRING =
 
 const vaultIface = new ethers.utils.Interface([
   "function settlement() view returns (address)",
+  "function sellToken() view returns (address)",
+  "function buyToken() view returns (address)",
   "function killSwitch() view returns (bool)",
   "function maxFillAmount() view returns (uint256)",
 ]);
@@ -131,15 +132,17 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
   const keyPromise = Lit.Actions.getLitActionPrivateKey();
   keyPromise.catch(() => {});
 
-  // --- reads: the vault's pinned settlement + live policy config ----------
-  // The settlement is the trust anchor: we read it from the vault (its
-  // immutable), not from the caller, and build the batch for *that* contract.
-  // All three are independent, so one concurrent round-trip — and we compute the
-  // EIP-712 domain locally below rather than paying a second, dependent one.
-  const [settlement, killSwitch, maxFillAmount] = await Promise.all([
+  // --- reads: the vault's pinned settlement, token pair + live policy config -
+  // The settlement and token pair are trust anchors: we read them from the vault
+  // (its immutables), not from the caller, and build the batch for *that*
+  // contract and pair. These reads are independent, so one concurrent round-trip.
+  const [settlement, vaultSellToken, vaultBuyToken, killSwitch, maxFillAmount, latestBlock] = await Promise.all([
     readContract(rpcUrl, vaultAddress, vaultIface, "settlement", []),
+    readContract(rpcUrl, vaultAddress, vaultIface, "sellToken", []),
+    readContract(rpcUrl, vaultAddress, vaultIface, "buyToken", []),
     readContract(rpcUrl, vaultAddress, vaultIface, "killSwitch", []),
     readContract(rpcUrl, vaultAddress, vaultIface, "maxFillAmount", []),
+    rpc(rpcUrl, "eth_getBlockByNumber", ["latest", false]),
   ]);
 
   if (killSwitch) {
@@ -157,6 +160,13 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
   const sellAmount = ethers.BigNumber.from(order.sellAmount);
   const buyAmount = ethers.BigNumber.from(order.buyAmount);
   const feeAmount = ethers.BigNumber.from(order.feeAmount || "0");
+  const orderValidTo = Number(order.validTo);
+  const authDeadlineNum = Number(authDeadline);
+  const blockTimestamp = Number.parseInt(latestBlock.timestamp, 16);
+  const orderSellToken = ethers.utils.getAddress(order.sellToken);
+  const orderBuyToken = ethers.utils.getAddress(order.buyToken);
+  const allowedSellToken = ethers.utils.getAddress(vaultSellToken);
+  const allowedBuyToken = ethers.utils.getAddress(vaultBuyToken);
 
   if (!feeAmount.isZero()) {
     // A non-zero fee is pulled from the trader on top of sellAmount; the batch
@@ -167,6 +177,27 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
   }
   if (sellAmount.isZero() || buyAmount.isZero()) {
     return { authorized: false, reason: "order amounts must be non-zero" };
+  }
+  if (orderSellToken !== allowedSellToken || orderBuyToken !== allowedBuyToken) {
+    return {
+      authorized: false,
+      reason: `order token pair ${orderSellToken}/${orderBuyToken} does not match vault pair ${allowedSellToken}/${allowedBuyToken}`,
+    };
+  }
+  if (!Number.isSafeInteger(orderValidTo) || orderValidTo <= 0 || orderValidTo > 0xffffffff) {
+    return { authorized: false, reason: "order.validTo must be a positive uint32" };
+  }
+  if (!Number.isSafeInteger(blockTimestamp) || blockTimestamp <= 0) {
+    return { authorized: false, reason: "latest block timestamp unavailable" };
+  }
+  if (!Number.isSafeInteger(authDeadlineNum) || authDeadlineNum <= blockTimestamp) {
+    return { authorized: false, reason: "authDeadline must be in the future" };
+  }
+  if (orderValidTo <= blockTimestamp) {
+    return { authorized: false, reason: "order is expired" };
+  }
+  if (authDeadlineNum > orderValidTo) {
+    return { authorized: false, reason: "authDeadline must not exceed order.validTo" };
   }
   if (buyAmount.gt(ethers.BigNumber.from(maxFillAmount))) {
     return {
@@ -192,8 +223,8 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
   // tokens[0] = sellToken (what the trader gives up, ends up in the vault),
   // tokens[1] = buyToken  (what the vault pays out, from inventory).
   const tokens = [
-    ethers.utils.getAddress(order.sellToken),
-    ethers.utils.getAddress(order.buyToken),
+    orderSellToken,
+    orderBuyToken,
   ];
 
   // Clearing prices fill the sell order exactly at its limit:
@@ -209,7 +240,7 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
     receiver: ethers.utils.getAddress(order.receiver),
     sellAmount: sellAmount.toString(),
     buyAmount: buyAmount.toString(),
-    validTo: Number(order.validTo),
+    validTo: orderValidTo,
     appData: order.appData,
     feeAmount: "0",
     flags: 0, // sell order, fill-or-kill, erc20/erc20 balances, EIP-712 signing
@@ -265,7 +296,7 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
         ethers.utils.keccak256(settleCalldata),
         pullToken,
         pullAmount,
-        authDeadline,
+        authDeadlineNum,
         vaultAddress,
         chainId,
       ]
@@ -282,7 +313,7 @@ async function main({ vaultAddress, chainId, authDeadline, order, rpcUrl }) {
     settleCalldata,
     pullToken,
     pullAmount,
-    authDeadline,
+    authDeadline: authDeadlineNum,
     vaultAddress,
     chainId,
     receiver: trade.receiver,

--- a/examples/lit-solver-vault-cowswap/contracts/CowSolverVault.sol
+++ b/examples/lit-solver-vault-cowswap/contracts/CowSolverVault.sol
@@ -47,6 +47,11 @@ contract CowSolverVault {
     ///         honoring the modified action automatically.
     address public immutable policySigner;
 
+    /// @notice The exact token pair this demo vault will settle. The policy
+    ///         reads these and rejects orders for any other pair.
+    address public immutable sellToken;
+    address public immutable buyToken;
+
     /// @notice Local break-glass key. Restricts policy and sweeps to coldWallet.
     address public owner;
 
@@ -79,6 +84,7 @@ contract CowSolverVault {
     error AuthDeadlineTooFar();
     error KillSwitchEngaged();
     error OverCap();
+    error UnsupportedToken();
     error InvalidPolicySignature();
     error SettlementCallFailed();
     error NoPendingColdWalletChange();
@@ -103,16 +109,22 @@ contract CowSolverVault {
         address policySigner_,
         address owner_,
         address coldWallet_,
-        uint256 maxFillAmount_
+        uint256 maxFillAmount_,
+        address sellToken_,
+        address buyToken_
     ) {
         if (
             settlement_ == address(0) ||
             policySigner_ == address(0) ||
             owner_ == address(0) ||
-            coldWallet_ == address(0)
+            coldWallet_ == address(0) ||
+            sellToken_ == address(0) ||
+            buyToken_ == address(0)
         ) revert ZeroAddress();
         settlement = settlement_;
         policySigner = policySigner_;
+        sellToken = sellToken_;
+        buyToken = buyToken_;
         owner = owner_;
         coldWallet = coldWallet_;
         maxFillAmount = maxFillAmount_;
@@ -155,6 +167,7 @@ contract CowSolverVault {
         // kill switch or lowers the cap.
         if (killSwitch) revert KillSwitchEngaged();
         if (pullAmount > maxFillAmount) revert OverCap();
+        if (pullToken != buyToken) revert UnsupportedToken();
 
         bytes32 digest = keccak256(
             abi.encode(

--- a/examples/lit-solver-vault-cowswap/scripts/_cow.js
+++ b/examples/lit-solver-vault-cowswap/scripts/_cow.js
@@ -8,9 +8,11 @@
 // as the solver. The custody/policy story is exercised against the real settle()
 // machinery and real EIP-712 order signatures — just on an instance we control.
 //
-// Because we deploy our own settlement, ANY EVM chain works. We use Base Sepolia
-// (fast ~2s blocks, cheap, and matches the Across sibling); override COW_CHAIN_ID
-// + the RPC host whitelist in action/cowPolicy.js to run elsewhere.
+// Because we deploy our own settlement, the pattern is chain-portable, but these
+// scripts are wired to Base Sepolia (fast ~2s blocks, cheap, and matches the
+// Across sibling). To run elsewhere, add a Hardhat network, point the scripts at
+// that RPC env var, set COW_CHAIN_ID, and edit the RPC host whitelist in
+// action/cowPolicy.js.
 
 const fs = require("fs");
 const path = require("path");
@@ -50,6 +52,8 @@ const VAULT_ABI = [
   "function executeSettlement(bytes settleCalldata, address pullToken, uint256 pullAmount, uint256 authDeadline, bytes signature)",
   "function settlement() view returns (address)",
   "function policySigner() view returns (address)",
+  "function sellToken() view returns (address)",
+  "function buyToken() view returns (address)",
   "function killSwitch() view returns (bool)",
   "function maxFillAmount() view returns (uint256)",
   "function setKillSwitch(bool on)",
@@ -60,6 +64,7 @@ const VAULT_ABI = [
   "error AuthExpired()",
   "error KillSwitchEngaged()",
   "error OverCap()",
+  "error UnsupportedToken()",
 ];
 
 const MOCK_ERC20_ABI = [

--- a/examples/lit-solver-vault-cowswap/scripts/attack.js
+++ b/examples/lit-solver-vault-cowswap/scripts/attack.js
@@ -6,11 +6,14 @@
 //     no longer recovers to the order owner and the action refuses. The only
 //     settlement it will sign pays the trader's real receiver.
 //
-// (2) The bot goes around the action and calls executeSettlement directly with
+// (2) The bot tries to swap the buy token to an unpinned token. The action reads
+//     the vault's pinned pair and refuses before signing.
+//
+// (3) The bot goes around the action and calls executeSettlement directly with
 //     a self-dealing batch and a forged policy signature. The vault recovers the
 //     signer, sees it isn't the policy signer, and reverts. Inventory never moves.
 //
-// (3) The bot tries to call GPv2Settlement.settle directly — but the bot isn't
+// (4) The bot tries to call GPv2Settlement.settle directly — but the bot isn't
 //     an allowlisted solver (only the vault is), so the settlement rejects it.
 //     This is the property that makes the vault-as-solver design necessary.
 //
@@ -46,7 +49,7 @@ async function main() {
   const authParams = (ord) => ({
     vaultAddress: process.env.COW_VAULT_ADDRESS,
     chainId: CHAIN_ID,
-    authDeadline: Math.floor(Date.now() / 1000) + 600,
+    authDeadline: Math.min(Math.floor(Date.now() / 1000) + 600, Number(ord.validTo)),
     order: policyOrderParam(ord, ord.owner, ord.signature),
     rpcUrl: process.env.ALCHEMY_BASE_SEPOLIA_URL,
   });
@@ -64,8 +67,18 @@ async function main() {
   console.log(`  The only settlement Lit will sign pays ${good.receiver} (the real receiver),`);
   console.log(`  not the attacker ${ethers.utils.getAddress(attacker)}. Exfiltration impossible.`);
 
-  // (2) Forge a policy signature for a self-dealing batch.
-  console.log("\nAttack 2: bot calls executeSettlement with a forged policy signature...");
+  // (2) Swap the buy token to something other than the vault-pinned inventory token.
+  console.log("\nAttack 2: compromised bot swaps the order buy token...");
+  const wrongPair = { ...order, buyToken: attacker };
+  const wrongPairAuth = await requestSolveAuthorization(authParams(wrongPair));
+  if (wrongPairAuth && wrongPairAuth.authorized) {
+    console.error("  ✗ UNEXPECTED: policy authorized an unpinned token pair. This is a bug.");
+    process.exit(1);
+  }
+  console.log("  ✓ Policy refused:", wrongPairAuth && wrongPairAuth.reason);
+
+  // (3) Forge a policy signature for a self-dealing batch.
+  console.log("\nAttack 3: bot calls executeSettlement with a forged policy signature...");
   const vault = new ethers.Contract(process.env.COW_VAULT_ADDRESS, VAULT_ABI, solver);
   const fakeCalldata = "0xdeadbeef"; // contents don't matter; the sig check fails first
   const pullToken = order.buyToken;
@@ -95,8 +108,8 @@ async function main() {
     console.log("  No valid policy signature -> no settle -> inventory safe.");
   }
 
-  // (3) Bot tries to settle directly on GPv2Settlement — it isn't a solver.
-  console.log("\nAttack 3: bot calls GPv2Settlement.settle directly (not allowlisted)...");
+  // (4) Bot tries to settle directly on GPv2Settlement — it isn't a solver.
+  console.log("\nAttack 4: bot calls GPv2Settlement.settle directly (not allowlisted)...");
   const settlement = new ethers.Contract(process.env.COW_SETTLEMENT_ADDRESS, SETTLEMENT_ABI, solver);
   try {
     await settlement.callStatic.settle([], [], [], [[], [], []]);

--- a/examples/lit-solver-vault-cowswap/scripts/deploy-cow.js
+++ b/examples/lit-solver-vault-cowswap/scripts/deploy-cow.js
@@ -78,7 +78,15 @@ async function main() {
   // 4. The vault — the allowlisted solver. maxFillAmount is in buy-token units.
   const maxFill = hre.ethers.utils.parseEther(process.env.COW_MAX_FILL_WETH || "0.05");
   const Vault = await hre.ethers.getContractFactory("CowSolverVault");
-  const vault = await Vault.deploy(settlement.address, policySigner, owner, coldWallet, maxFill);
+  const vault = await Vault.deploy(
+    settlement.address,
+    policySigner,
+    owner,
+    coldWallet,
+    maxFill,
+    sellToken.address,
+    buyToken.address
+  );
   await vault.deployed();
   console.log("CowSolverVault:             ", vault.address);
 

--- a/examples/lit-solver-vault-cowswap/scripts/solve.js
+++ b/examples/lit-solver-vault-cowswap/scripts/solve.js
@@ -22,7 +22,11 @@ async function main() {
   }
 
   const order = JSON.parse(process.env.COW_ORDER);
-  const authDeadline = Math.floor(Date.now() / 1000) + 600;
+  const now = Math.floor(Date.now() / 1000);
+  const authDeadline = Math.min(now + 600, Number(order.validTo));
+  if (authDeadline <= now) {
+    throw new Error("COW_ORDER is expired; run `npm run order` to sign a fresh order");
+  }
 
   console.log("Requesting CoW settlement authorization from Lit...");
   const t0 = Date.now();


### PR DESCRIPTION
Adversarial review found that the CoW example accepted any valid trader-signed token pair, which let a colluding or compromised flow request vault inventory for an unpinned token. This hardens the demo by pinning the sell/buy token pair in `CowSolverVault`, having `cowPolicy` read and enforce that pair, adding an on-chain pull-token check, and rejecting authorizations that outlive the order or are already expired by the latest chain timestamp. It also updates the attack walkthrough, role-separation guidance, portability wording, and latency notes to match the new policy shape. Validated with `node --check` on the action/scripts, `npm run compile`, live `npm run setup && npm run order && npm run solve`, and `npm run attack` on Base Sepolia + Lit Chipotle.