### PR TITLE
chore(deny): drop dead pinata-sdk dep to clear failure CVEs (RUSTSEC-2019-0036/2020-0036)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,11 @@ yanked = "warn"
 #   tokio (tokio::fs / tokio::io / tokio::time, fs4's "tokio" feature, and
 #   futures::StreamExt for the IPFS stream). async-std is gone from every
 #   workspace graph -> removed RUSTSEC-2025-0052.
+# - 2026-06-09: dropped lit-core's `pinata` feature and the pinata-sdk 1.1.0
+#   dependency (its only API, Config::pinata_client(), was never called and
+#   the feature was enabled nowhere). pinata-sdk was the sole consumer of the
+#   abandoned `failure` crate -> removed RUSTSEC-2019-0036 and
+#   RUSTSEC-2020-0036.
 #
 # Suggested triage order: vulnerabilities > unsound > unmaintained.
 ignore = [
@@ -86,11 +91,9 @@ ignore = [
     { id = "RUSTSEC-2026-0119", reason = "hickory DNS O(n^2) name compression — pinned by deno_runtime chain" },
 
     # ── unsound ───────────────────────────────────────────────────────────────
-    { id = "RUSTSEC-2019-0036", reason = "failure type confusion — transitive; pre-existing" },
     { id = "RUSTSEC-2026-0097", reason = "rand custom logger unsound — still present via rand 0.8.5 pinned in lit-actions and Alloy's rand in generator/payments; cleared in lit-api-server after rand 0.8.5->0.8.6 / 0.9.2->0.9.4" },
 
     # ── unmaintained ──────────────────────────────────────────────────────────
-    { id = "RUSTSEC-2020-0036", reason = "failure deprecated — transitive; pre-existing" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained — lit-core-derive no longer uses it; now only via multihash-derive 0.8.1 in the LIT rust-ipfs-api fork's multihash 0.17 chain (lit-core), same blocker as RUSTSEC-2026-0105" },
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — pre-existing" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — pre-existing" },

--- a/lit-core/Cargo.lock
+++ b/lit-core/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -674,41 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,37 +720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -952,28 +886,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -1631,12 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,7 +1832,6 @@ dependencies = [
  "lit-core-derive",
  "log",
  "once_cell",
- "pinata-sdk",
  "regex",
  "serde",
  "serde_json",
@@ -2549,22 +2454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pinata-sdk"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc47c8f8fdb02310c4cec4a8d5b5521c1c7e5b0d107cf83278f3330fd7238760"
-dependencies = [
- "derive_builder",
- "failure",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "walkdir",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,7 +2718,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -3369,12 +3257,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"

--- a/lit-core/lit-core/Cargo.toml
+++ b/lit-core/lit-core/Cargo.toml
@@ -9,7 +9,6 @@ exclude = ["resources/test/"]
 [features]
 default = []
 ipfs = ["ipfs-api-backend-hyper", "ipfs-hasher", "ipfs-unixfs", "fs4", "bytes", "bs58", "tokio", "futures"]
-pinata = ["pinata-sdk"]
 asn1 = ["asn1-rs"]
 cli = ["termion"]
 logging-core = ["env_logger"]
@@ -36,7 +35,6 @@ ipfs-unixfs = { version = "0.2.0", optional = true }
 libc = { version = "0.2", optional = true }
 log = { version = "0.4.17", features = ["kv_unstable", "kv_unstable_serde"] }
 once_cell.workspace = true
-pinata-sdk = { version = "1.1.0", optional = true }
 regex = { version = "1" }
 serde.workspace = true
 serde_json.workspace = true

--- a/lit-core/lit-core/src/config/mod.rs
+++ b/lit-core/lit-core/src/config/mod.rs
@@ -8,8 +8,6 @@ use std::str::FromStr;
 use config::{Config, Environment, File, Map, Value};
 #[cfg(feature = "ipfs")]
 use ipfs_api_backend_hyper::{IpfsApi, IpfsClient, TryFromUri};
-#[cfg(feature = "pinata")]
-use pinata_sdk::PinataApi;
 #[cfg(feature = "cli")]
 use termion::input::TermRead;
 
@@ -498,16 +496,6 @@ impl LitConfig {
 
             Ok(remotes)
         }
-    }
-
-    #[cfg(feature = "pinata")]
-    #[inline]
-    pub fn pinata_client(&self) -> Result<PinataApi> {
-        PinataApi::new(
-            self.get_checked_string("pinata.api_key")?,
-            self.get_checked_string("pinata.api_secret")?,
-        )
-        .map_err(|e| unexpected_err(e, None))
     }
 
     // Subnet


### PR DESCRIPTION
## What

Removes lit-core's `pinata` feature and its `pinata-sdk` 1.1.0 dependency, which were **dead code**, to clear two more allowlisted advisories.

## Why it's safe

- The `pinata` feature is **enabled by no workspace** (not in `default`, no `features = [...]` activates it).
- Its only API — `Config::pinata_client()` — is **never called anywhere** in the monorepo (verified).
- The `"pinata"` string in the test config (`keyed.config.toml`) is just an IPFS *remote name* (string data), unrelated to the sdk — untouched.

`pinata-sdk` 1.1.0 (the latest release) hard-depends on the abandoned **`failure`** crate, which was the sole source of:
- **RUSTSEC-2019-0036** (failure type confusion, unsound)
- **RUSTSEC-2020-0036** (failure deprecated, unmaintained)

## Changes

- `lit-core/lit-core/Cargo.toml`: drop the `pinata` feature and `pinata-sdk` dep.
- `config/mod.rs`: drop the `pinata` import and `pinata_client()`.
- `deny.toml`: remove RUSTSEC-2019-0036 and RUSTSEC-2020-0036 (now `advisory-not-detected` in all six workspaces) + history note.

Lockfile diff is **removal-only**: pinata-sdk, failure, failure_derive, and the darling/derive_builder chain it pulled.

## Verification

- `cargo deny check … advisories sources` → ok in all six workspaces; both advisories cleared.
- `cargo clippy --locked --all-features -- -D warnings` + `cargo fmt --check` → clean (lit-core).
- `cargo build -p lit-core --all-features` → green.

## Remaining allowlist

Down to 15 entries, all blocked on upstreams we don't fully control: the **deno_core/deno_runtime fork bump** (~6: time/hickory/bincode/rustls-webpki/rand), the **LIT rust-ipfs-api fork** multihash bump (proc-macro-error + yanked core2), **rocket 0.5** off rustls 0.21, and the Alloy/reqwest/rsa chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)