### PR TITLE
docs(pricing): add enterprise pricing section with contact form

### DIFF
--- a/docs/management/pricing.mdx
+++ b/docs/management/pricing.mdx
@@ -73,6 +73,12 @@ Paying with the **LITKEY** token gets you a **25% discount** vs. credit card pri
 
 ---
 
+## Enterprise Pricing
+
+Need higher volume, custom terms, or dedicated support? Reach out for enterprise pricing by filling out [this form](https://docs.google.com/forms/d/e/1FAIpQLScBVsg-NhdMIC1H1mozh2zaVX0V4WtmEPSPrtmqVtnj_3qqNw/viewform) and our team will get in touch.
+
+---
+
 ## Credit Balance
 
 Your current balance is always visible in the top-right corner of the dashboard once you're logged in. A negative balance (displayed as a credit) means funds are available. Credits are depleted as you make metered API calls.


### PR DESCRIPTION
Adds an Enterprise Pricing section to the management pricing page, directing users to a Google Form to reach out for enterprise pricing (higher volume, custom terms, dedicated support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)