### PR TITLE
chore(deny): drop core2 + proc-macro-error advisories via optional multiaddr in ipfs fork

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,13 @@ yanked = "warn"
 #   tokio (tokio::fs / tokio::io / tokio::time, fs4's "tokio" feature, and
 #   futures::StreamExt for the IPFS stream). async-std is gone from every
 #   workspace graph -> removed RUSTSEC-2025-0052.
+# - 2026-06-09: made `multiaddr` optional (default-off `with-multiaddr` feature)
+#   in the LIT rust-ipfs-api fork. lit-core builds its IPFS client via
+#   from_str(uri) and never uses the multiaddr constructors, so it no longer
+#   pulls multiaddr -> multihash 0.17 -> {core2, multihash-derive ->
+#   proc-macro-error}. Cleared RUSTSEC-2026-0105 (core2) and RUSTSEC-2024-0370
+#   (proc-macro-error) -> both removed. (Bumping multiaddr to 0.18 would not
+#   have sufficed: multihash 0.19 still requires the yanked core2 0.4.0.)
 #
 # Suggested triage order: vulnerabilities > unsound > unmaintained.
 ignore = [
@@ -91,11 +98,9 @@ ignore = [
 
     # ── unmaintained ──────────────────────────────────────────────────────────
     { id = "RUSTSEC-2020-0036", reason = "failure deprecated — transitive; pre-existing" },
-    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained — lit-core-derive no longer uses it; now only via multihash-derive 0.8.1 in the LIT rust-ipfs-api fork's multihash 0.17 chain (lit-core), same blocker as RUSTSEC-2026-0105" },
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — pre-existing" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — pre-existing" },
     { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — pre-existing" },
-    { id = "RUSTSEC-2026-0105", reason = "core2 unmaintained, all versions yanked — pre-existing" },
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained — transitive via alloy-sol-macro; no safe upgrade available" },
 ]
 

--- a/lit-core/Cargo.lock
+++ b/lit-core/Cargo.lock
@@ -468,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8709d481fb78b9808f34a1b4b4fadd08a15a0971052c18bc2b751faefaed595e"
 dependencies = [
  "multibase 0.8.0",
- "multihash 0.11.4",
+ "multihash",
  "unsigned-varint 0.3.3",
 ]
 
@@ -614,15 +614,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1704,7 +1695,7 @@ checksum = "6b8a253fc120dd6c624b7beb0a82330fc0135e0a9cec685bf039a07ba032af1e"
 [[package]]
 name = "ipfs-api-backend-hyper"
 version = "0.6.0"
-source = "git+https://github.com/LIT-Protocol/rust-ipfs-api?branch=lit-remote-pinning#c3f4a92213a9edf74312acd4902564bcfbe5c9da"
+source = "git+https://github.com/LIT-Protocol/rust-ipfs-api?branch=lit-remote-pinning#bf93fa47ea9a384c7437b4b67f8f9b01df793ca6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1720,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "ipfs-api-prelude"
 version = "0.6.0"
-source = "git+https://github.com/LIT-Protocol/rust-ipfs-api?branch=lit-remote-pinning#c3f4a92213a9edf74312acd4902564bcfbe5c9da"
+source = "git+https://github.com/LIT-Protocol/rust-ipfs-api?branch=lit-remote-pinning#bf93fa47ea9a384c7437b4b67f8f9b01df793ca6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1729,7 +1720,6 @@ dependencies = [
  "dirs",
  "futures",
  "http 0.2.12",
- "multiaddr",
  "multibase 0.9.1",
  "serde",
  "serde_json",
@@ -1759,7 +1749,7 @@ dependencies = [
  "cid",
  "either",
  "filetime",
- "multihash 0.11.4",
+ "multihash",
  "quick-protobuf",
  "sha2 0.9.9",
 ]
@@ -2106,25 +2096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multiaddr"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "log",
- "multibase 0.9.1",
- "multihash 0.17.0",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.7.2",
- "url",
-]
-
-[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,31 +2130,6 @@ dependencies = [
  "sha2 0.9.9",
  "sha3",
  "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "multihash"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
-dependencies = [
- "core2",
- "multihash-derive",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -2598,40 +2544,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror 1.0.69",
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -3365,12 +3277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,15 +3692,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -4126,12 +4023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4367,7 +4258,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Clears two pre-existing advisory-backlog entries from `deny.toml`:
- **RUSTSEC-2026-0105** — `core2` unmaintained / all versions yanked
- **RUSTSEC-2024-0370** — `proc-macro-error` unmaintained

Both entered lit-core's graph through the LIT `rust-ipfs-api` fork:

```
ipfs-api-prelude → multiaddr 0.17 → multihash 0.17.0
  ├─ core2 0.4.0                        → RUSTSEC-2026-0105
  └─ multihash-derive 0.8.1 → proc-macro-error → RUSTSEC-2024-0370
```

`multiaddr` is used only by the `from_multiaddr*` / `from_ipfs_config` constructors. lit-core builds its client via `IpfsClient::from_str(uri)` and never touches that path, so the dependency was pure dead weight.

## How

1. **Fork change (merged):** LIT-Protocol/rust-ipfs-api#1 makes `multiaddr` optional behind a default-off `with-multiaddr` feature.
2. **This PR:** `cargo update` bumps the fork ref to `bf93fa47`, dropping `multiaddr → multihash 0.17 → {core2, multihash-derive → proc-macro-error}` (plus proc-macro-crate, static_assertions, toml 0.5.11, unsigned-varint 0.7.2). Removes the two now-unnecessary `deny.toml` ignore entries.

> Note: bumping `multiaddr` to 0.18 would **not** have sufficed — `multihash 0.19` still requires the same yanked `core2 0.4.0`. Making the dep optional is what removes core2.

No code changes: lit-core's CID logic runs on a separate `multihash 0.11.4` / `ipfs-unixfs` subtree, untouched here.

## Validation

- `cargo build`/`cargo test -p lit-core --features ipfs` ✓ (CID test passes)
- `cargo deny check advisories sources` → `advisories ok, sources ok` (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)