### PR TITLE
chore(deny): document per-entry blockers + bump generator's stale rand

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -99,27 +99,62 @@ yanked = "warn"
 #   proc-macro-error}. Cleared RUSTSEC-2026-0105 (core2) and RUSTSEC-2024-0370
 #   (proc-macro-error) -> both removed. (Bumping multiaddr to 0.18 would not
 #   have sufficed: multihash 0.19 still requires the yanked core2 0.4.0.)
+# - 2026-06-09: reqwest 0.11 -> 0.12 in lit-core (#471) moved lit-core's own
+#   HTTP client off rustls 0.21; and the LIT rust-ipfs-api fork made multiaddr
+#   optional (#472), clearing core2 + proc-macro-error. Then a full
+#   blocker audit of every remaining entry (reverse-dep traced across all 7 CI
+#   workspaces) + bumped the generator workspace's stale rand 0.8.5->0.8.6 /
+#   0.9.2->0.9.4 (alloy-signer-local; lockfile-only, matches what lit-api-server
+#   and lit-payments already resolved). That generator rand was the ONLY
+#   non-structural source left in the backlog. See the blocker summary below.
+#
+# ── BLOCKER SUMMARY (2026-06-09 audit) ───────────────────────────────────────
+# Every remaining entry is held by a source we cannot move without either
+# forking an upstream dep or waiting for an upstream release. Grouped by blocker:
+#
+#   deno (frozen transitive pins, lit-actions)      9 entries:
+#       2026-0009 (time 0.3.44 <- swc/serde), 2026-0049/0098/0099/0104
+#       (rustls-webpki 0.102.8 <- rustls =0.23.40), 2026-0118/0119
+#       (hickory 0.25.2), 2026-0097 (rand =0.8.5), 2025-0141 (bincode 1.x),
+#       2023-0071 (rsa 0.9.9). Fix = a deno release that bumps these, or
+#       forking deno (explicitly rejected — see 2026-06-09 deno note above).
+#   rocket 0.5.1 (no released rustls-0.23 build)    co-blocks 4 entries:
+#       2026-0098/0099/0104 (webpki 0.101.7), 2025-0134 (rustls-pemfile).
+#       Only 0.6.0-dev (git) uses rustls 0.23; a framework swap clears NONE of
+#       these alone because deno also fires the webpki trio. Not worth it.
+#   Alloy                                            2 entries:
+#       2026-0173 (proc-macro-error2), part of 2024-0436 (paste).
+#   no upstream fix exists at all                    4 entries:
+#       2023-0071 (rsa Marvin, no const-time impl), 2026-0118 (hickory, only
+#       0.26-beta), 2024-0436 (paste, crate abandoned), 2025-0141 (bincode 1.x
+#       EOL). These stay even if every framework above moves.
+#   (groups overlap: e.g. rsa/hickory/bincode are both deno-pinned AND fixless.)
+#
+# CONCLUSION: without forking deno/rocket/Alloy, NO further entry can be
+# removed today. The remaining work is not code — it is upstream watch: re-run
+# `cargo deny` after deno and Alloy releases and drop entries as their dep
+# bumps land. The generator rand bump above was the last in-house lever.
 #
 # Suggested triage order: vulnerabilities > unsound > unmaintained.
 ignore = [
     # ── vulnerabilities ───────────────────────────────────────────────────────
-    { id = "RUSTSEC-2023-0071", reason = "Marvin Attack timing sidechannel in rsa — still present via dcap-qvl dev dependency; pre-existing" },
-    { id = "RUSTSEC-2026-0009", reason = "time DoS via stack exhaustion — still present in lit-actions (time 0.3.47 cascades serde 1.0.228 which breaks swc_config/swc_common from deno chain); cleared in lit-core and lit-api-server" },
-    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki CRL distribution-point matching — now only via deno_runtime's rustls-webpki 0.102.8 in lit-actions; cleared elsewhere by bumping rustls-webpki 0.103.9->0.103.13" },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints — via deno's 0.102.8 (lit-actions) and rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-api-server); 0.103 line cleared via cargo update" },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name constraints — via deno's 0.102.8 (lit-actions) and rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-api-server); 0.103 line cleared via cargo update" },
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic — via deno's 0.102.8 (lit-actions) and rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-api-server); 0.103 line cleared via cargo update" },
-    { id = "RUSTSEC-2026-0118", reason = "hickory NSEC3 unbounded loop — no upstream fix yet" },
-    { id = "RUSTSEC-2026-0119", reason = "hickory DNS O(n^2) name compression — pinned by deno_runtime chain" },
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing sidechannel — NO upstream fix exists (constant-time RSA unimplemented). Present via deno_crypto/deno_node_crypto (rsa 0.9.9, lit-actions) and the dcap-qvl DEV dependency (rsa 0.9.10, lit-api-server). BLOCKER: no patched rsa release + deno transitive. Not removable." },
+    { id = "RUSTSEC-2026-0009", reason = "time parsing DoS (stack exhaustion) — fixed in >=0.3.47. Fires only in lit-actions: time 0.3.44 held <0.3.47 by the deno chain (deno_ast =0.53.2 -> swc; 0.3.47 pulls serde 1.0.228 which breaks swc_config/swc_common). Cleared everywhere else (0.3.47). BLOCKER: deno_ast/swc serde pin. WAITING ON: deno bumping deno_ast/swc. Not removable without forking deno." },
+    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki CRL distribution-point matching — fixed in 0.103. Fires only via deno_tls/deno_fetch (rustls-webpki 0.102.8, locked by rustls =0.23.40) in lit-actions; cleared elsewhere (0.103.13). BLOCKER: deno_tls's rustls pin. WAITING ON: deno bumping rustls past 0.23.40. Not removable without forking deno." },
+    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki URI name constraints — fixed in 0.103. TWO blockers: deno_tls's 0.102.8 (lit-actions) AND rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-core/lit-api-server). WAITING ON: deno (rustls >0.23.40) AND a rocket release on rustls 0.23 (only in unreleased 0.6.0-dev). Not removable without forking deno and/or git-pinning rocket." },
+    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki DNS wildcard name constraints — fixed in 0.103. TWO blockers: deno_tls's 0.102.8 (lit-actions) AND rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-core/lit-api-server). WAITING ON: deno (rustls >0.23.40) AND a rocket release on rustls 0.23 (only in unreleased 0.6.0-dev). Not removable without forking deno and/or git-pinning rocket." },
+    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki CRL parsing panic — fixed in 0.103. TWO blockers: deno_tls's 0.102.8 (lit-actions) AND rocket 0.5.1's rustls 0.21 -> rustls-webpki 0.101.7 (lit-core/lit-api-server). WAITING ON: deno (rustls >0.23.40) AND a rocket release on rustls 0.23 (only in unreleased 0.6.0-dev). Not removable without forking deno and/or git-pinning rocket." },
+    { id = "RUSTSEC-2026-0118", reason = "hickory NSEC3 unbounded loop — NO stable fix released (only 0.26.0-beta.1+). hickory-proto 0.25.2 via deno_net (lit-actions). BLOCKER: no stable hickory fix + deno transitive. WAITING ON: hickory 0.26 stable AND deno adopting it. Not removable." },
+    { id = "RUSTSEC-2026-0119", reason = "hickory DNS O(n^2) name compression — fixed in >=0.26.1. hickory-proto 0.25.2 via deno_net (lit-actions). BLOCKER: deno's hickory 0.25 pin. WAITING ON: deno adopting hickory 0.26. Not removable without forking deno." },
 
     # ── unsound ───────────────────────────────────────────────────────────────
-    { id = "RUSTSEC-2026-0097", reason = "rand custom logger unsound — still present via rand 0.8.5 pinned in lit-actions and Alloy's rand in generator/payments; cleared in lit-api-server after rand 0.8.5->0.8.6 / 0.9.2->0.9.4" },
+    { id = "RUSTSEC-2026-0097", reason = "rand RngCore fill_bytes unsound — fixed in >=0.8.6 / >=0.9.3. Fires only in lit-actions: rand =0.8.5 hard-pinned by deno_crypto/deno_kv/deno_ast. Cleared in lit-api-server/payments (0.8.6/0.9.4) and the generator workspace (lockfile bumped 0.8.5->0.8.6, 0.9.2->0.9.4 via alloy-signer-local). BLOCKER: deno's rand =0.8.5 pin. WAITING ON: deno bumping rand. Not removable without forking deno." },
 
     # ── unmaintained ──────────────────────────────────────────────────────────
-    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — pre-existing" },
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — pre-existing" },
-    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained — pre-existing" },
-    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained — transitive via alloy-sol-macro; no safe upgrade available" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — NO successor (crate abandoned; 1.0.15 is final). Ubiquitous transitive: deno chain (lit-actions) and the Alloy stack (alloy-primitives etc., lit-api-server/generator/payments/triggers). WAITING ON: deno + Alloy + wider ecosystem dropping paste. Not removable." },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained (folded into rustls-pki-types) — rustls-pemfile 1.0.4 via rocket_http 0.5.1 AND the zerossl fork's reqwest 0.11.27 (lit-core/lit-actions). BLOCKER: rocket has no released rustls-0.23 version. WAITING ON: a rocket release on rustls 0.23 (unreleased 0.6) + bumping zerossl's reqwest to 0.12. Not removable without git-pinning rocket." },
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.x unmaintained (2.x is a non-drop-in rewrite) — bincode 1.3.3 via deno_kv (lit-actions). BLOCKER: deno_kv's bincode 1.x pin. WAITING ON: deno_kv migrating to bincode 2.x. Not removable without forking deno." },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained — via alloy-sol-macro/alloy-sol-macro-expander (lit-api-server/generator/payments). BLOCKER: Alloy's proc-macro-error2 dep. WAITING ON: Alloy dropping proc-macro-error2. Not removable without forking Alloy." },
 ]
 
 [sources]

--- a/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -310,7 +310,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -485,7 +485,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror",
 ]
 
@@ -810,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -820,7 +820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1583,7 +1583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2698,7 +2698,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2743,7 +2743,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2798,9 +2798,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3001,8 +3001,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -3222,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -3234,7 +3234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 


### PR DESCRIPTION
Documents the *why* behind every remaining `deny.toml` ignore entry and confirms the backlog is now structurally bottomed-out.

**deny.toml** — each of the 13 ignore reasons is rewritten with the vulnerable crate+version, the exact dep that pins it, whether an upstream fix exists, and what release we're waiting on. A new blocker-summary section groups the entries by root cause — **deno frozen pins (9), rocket 0.5.1 co-blocks (4), Alloy (2), no-fix-exists (4)** — and records the conclusion: **without forking deno/rocket/Alloy, no further entry is removable today**; the remaining work is upstream-watch (re-run `cargo deny` as deno/Alloy ship dep bumps), not code.

**generator rand bump** — `rust_generator_and_deployer` still locked the vulnerable rand 0.8.5/0.9.2 while lit-api-server and lit-payments already resolved 0.8.6/0.9.4 under the same Alloy 1.8.3. Bumped it (lockfile-only, patch-level). This was the **only** non-structural source left in the entire backlog; RUSTSEC-2026-0097 is now justified purely by deno's `rand =0.8.5` pin.

Verified: `cargo deny check advisories` green on lit-actions, lit-core, lit-api-server; generator lock consistent under `--locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)