### PR TITLE
ci: detect global Foundry install to avoid reinstall collisions

### DIFF
--- a/.github/workflows/contract-bindings-check.yml
+++ b/.github/workflows/contract-bindings-check.yml
@@ -34,8 +34,17 @@ jobs:
       - name: Check Foundry toolchain
         id: foundry-toolchain
         run: |
-          if command -v forge >/dev/null 2>&1 && forge --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
-            forge --version
+          # The global install on the shared runner lives in ~/.foundry/bin, which
+          # is only on PATH via the user's shell profile. GH Actions steps run in a
+          # non-login shell that doesn't source it, so probe the known location too.
+          forge_bin="$(command -v forge || true)"
+          if [ -z "$forge_bin" ] && [ -x "$HOME/.foundry/bin/forge" ]; then
+            forge_bin="$HOME/.foundry/bin/forge"
+          fi
+          if [ -n "$forge_bin" ] && "$forge_bin" --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
+            "$forge_bin" --version
+            # Put it on PATH for later steps so they don't trigger a reinstall.
+            echo "$(dirname "$forge_bin")" >> "$GITHUB_PATH"
             echo "installed=true" >> "$GITHUB_OUTPUT"
           else
             echo "installed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -38,8 +38,17 @@ jobs:
       - name: Check Foundry toolchain
         id: foundry-toolchain
         run: |
-          if command -v forge >/dev/null 2>&1 && forge --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
-            forge --version
+          # The global install on the shared runner lives in ~/.foundry/bin, which
+          # is only on PATH via the user's shell profile. GH Actions steps run in a
+          # non-login shell that doesn't source it, so probe the known location too.
+          forge_bin="$(command -v forge || true)"
+          if [ -z "$forge_bin" ] && [ -x "$HOME/.foundry/bin/forge" ]; then
+            forge_bin="$HOME/.foundry/bin/forge"
+          fi
+          if [ -n "$forge_bin" ] && "$forge_bin" --version | grep -Eq '(^|[^0-9])1\.5\.1([^0-9]|$)'; then
+            "$forge_bin" --version
+            # Put it on PATH for later steps so they don't trigger a reinstall.
+            echo "$(dirname "$forge_bin")" >> "$GITHUB_PATH"
             echo "installed=true" >> "$GITHUB_OUTPUT"
           else
             echo "installed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The `forge-test` and `contract-bindings-check` jobs were reinstalling Foundry on every run even though the shared runner already has it globally in `~/.foundry/bin` — that directory is only on PATH via the user's shell profile, which GH Actions' non-login step shells don't source, so `command -v forge` came up empty and the guard always set `installed=false`. The needless reinstall intermittently collided with another job running `forge` on the shared runner, producing the `'forge' is currently running` error. Both workflows now probe `~/.foundry/bin` explicitly and, when the pinned version is present, export its directory to `$GITHUB_PATH` so later steps reuse it without reinstalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)