### PR TITLE
Add wallet pill menu with copy + disconnect to dashboard

### DIFF
--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -131,6 +131,24 @@ export function logOut() {
   updateAuthUI();
 }
 
+/**
+ * Disconnect the connected browser wallet, then sign out. In ChainSecured mode
+ * the wallet IS the session, so tearing down the EIP-1193 / WalletConnect
+ * connection and clearing the session are the same user intent. The
+ * `onWalletChange` watcher also fires `logOut()` on disconnect, but we call it
+ * directly too so sign-out is synchronous (and correct if no live wallet
+ * connection is attached, e.g. after a page reload).
+ */
+async function disconnectWallet() {
+  try {
+    const { disconnect } = await import('../../wallet_connect.js');
+    disconnect();
+  } catch (e) {
+    console.warn('[auth] wallet disconnect failed:', e);
+  }
+  logOut();
+}
+
 /** Invalidate the cached SDK client; next getClient() rebuilds fresh. */
 export function resetClient() {
   _clientInstance = null;
@@ -533,7 +551,13 @@ function renderModeBadge() {
   if (isChainSecured) {
     const wallet = getChainSecuredWallet();
     const trunc = `${wallet.slice(0, 6)}\u2026${wallet.slice(-4)}`;
-    pillHtml = ` <button type="button" class="topbar-wallet-pill" id="topbar-wallet-pill" title="Copy wallet address" data-wallet="${escapeHtml(wallet)}">${escapeHtml(trunc)}</button>`;
+    pillHtml = ` <span class="topbar-wallet-wrap">
+        <button type="button" class="topbar-wallet-pill" id="topbar-wallet-pill" aria-haspopup="menu" aria-expanded="false" title="Wallet options" data-wallet="${escapeHtml(wallet)}">${escapeHtml(trunc)}<span class="topbar-wallet-chevron" aria-hidden="true">\u25be</span></button>
+        <div class="topbar-wallet-menu" id="topbar-wallet-menu" role="menu" aria-label="Wallet options" hidden>
+          <button type="button" class="topbar-wallet-menu-item" id="topbar-wallet-copy" role="menuitem">Copy address</button>
+          <button type="button" class="topbar-wallet-menu-item topbar-wallet-menu-danger" id="topbar-wallet-disconnect" role="menuitem">Disconnect wallet</button>
+        </div>
+      </span>`;
   }
   host.innerHTML = `<span class="topbar-mode-badge-wrap">
       <button type="button" class="topbar-mode-badge" id="topbar-mode-badge" aria-haspopup="dialog" aria-expanded="false">${escapeHtml(modeLabel)}</button>
@@ -563,11 +587,55 @@ function renderModeBadge() {
       }
     });
   }
+  wireWalletPillMenu();
+}
+
+/**
+ * Wire the ChainSecured wallet pill (topbar-left) as a popover menu:
+ * "Copy address" + "Disconnect wallet". Mirrors the mode-badge popover's
+ * open/close behavior (outside-click + Escape close). No-op when the pill is
+ * absent (API mode / unauthenticated).
+ */
+function wireWalletPillMenu() {
   const pill = document.getElementById('topbar-wallet-pill');
-  if (pill) {
-    pill.addEventListener('click', async () => {
+  const menu = document.getElementById('topbar-wallet-menu');
+  const copyBtn = document.getElementById('topbar-wallet-copy');
+  const disconnectBtn = document.getElementById('topbar-wallet-disconnect');
+  if (!pill || !menu) return;
+
+  const close = () => {
+    menu.hidden = true;
+    pill.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', onDocClick, true);
+    document.removeEventListener('keydown', onKeyDown, true);
+  };
+  const onDocClick = (ev) => {
+    if (!pill.contains(ev.target) && !menu.contains(ev.target)) close();
+  };
+  const onKeyDown = (ev) => { if (ev.key === 'Escape') close(); };
+
+  pill.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    const open = menu.hidden;
+    menu.hidden = !open;
+    pill.setAttribute('aria-expanded', String(open));
+    if (open) {
+      document.addEventListener('click', onDocClick, true);
+      document.addEventListener('keydown', onKeyDown, true);
+    }
+  });
+
+  if (copyBtn) {
+    copyBtn.addEventListener('click', async () => {
       const { copyToClipboard } = await import('./ui-utils.js');
-      await copyToClipboard(pill.dataset.wallet, pill);
+      await copyToClipboard(pill.dataset.wallet, copyBtn);
+      close();
+    });
+  }
+  if (disconnectBtn) {
+    disconnectBtn.addEventListener('click', () => {
+      close();
+      disconnectWallet();
     });
   }
 }

--- a/lit-static/dapps/dashboard/auth.js
+++ b/lit-static/dapps/dashboard/auth.js
@@ -285,6 +285,11 @@ let _clientInstance = null;
 let _clientBaseUrl = null;
 let _clientMode = null;
 
+// AbortController for the currently-open wallet pill menu's document listeners.
+// Tracked at module scope so a topbar rebuild (renderModeBadge) can abort a
+// prior render's listeners before its nodes are replaced. See wireWalletPillMenu.
+let _walletMenuAbort = null;
+
 // Fires after every successful client method call (Proxy below). Used by
 // billing.js to refresh the credit balance display after any API activity
 // (NODE-4971). Registered via setOnApiCallSuccess() from initBilling().
@@ -595,41 +600,59 @@ function renderModeBadge() {
  * "Copy address" + "Disconnect wallet". Mirrors the mode-badge popover's
  * open/close behavior (outside-click + Escape close). No-op when the pill is
  * absent (API mode / unauthenticated).
+ *
+ * The outside-click / Escape handlers are bound to an AbortController so they
+ * are always torn down on close — including the toggle-closed path and the
+ * case where `renderModeBadge()` rebuilds the topbar (replacing these nodes)
+ * while the menu is still open. Without that, a stale capture listener would
+ * linger holding a detached-node closure until the next document click.
  */
 function wireWalletPillMenu() {
   const pill = document.getElementById('topbar-wallet-pill');
   const menu = document.getElementById('topbar-wallet-menu');
   const copyBtn = document.getElementById('topbar-wallet-copy');
   const disconnectBtn = document.getElementById('topbar-wallet-disconnect');
+  // Abort any listeners left over from a prior render's open menu before the
+  // old nodes (which this rebuild replaced) leak their closures.
+  if (_walletMenuAbort) { _walletMenuAbort.abort(); _walletMenuAbort = null; }
   if (!pill || !menu) return;
 
+  let ctrl = null;
   const close = () => {
     menu.hidden = true;
     pill.setAttribute('aria-expanded', 'false');
-    document.removeEventListener('click', onDocClick, true);
-    document.removeEventListener('keydown', onKeyDown, true);
+    if (ctrl) {
+      ctrl.abort();
+      if (_walletMenuAbort === ctrl) _walletMenuAbort = null;
+      ctrl = null;
+    }
   };
-  const onDocClick = (ev) => {
-    if (!pill.contains(ev.target) && !menu.contains(ev.target)) close();
+  const open = () => {
+    menu.hidden = false;
+    pill.setAttribute('aria-expanded', 'true');
+    ctrl = new AbortController();
+    _walletMenuAbort = ctrl;
+    const { signal } = ctrl;
+    document.addEventListener('click', (ev) => {
+      if (!pill.contains(ev.target) && !menu.contains(ev.target)) close();
+    }, { capture: true, signal });
+    document.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Escape') close();
+    }, { capture: true, signal });
   };
-  const onKeyDown = (ev) => { if (ev.key === 'Escape') close(); };
 
   pill.addEventListener('click', (ev) => {
     ev.stopPropagation();
-    const open = menu.hidden;
-    menu.hidden = !open;
-    pill.setAttribute('aria-expanded', String(open));
-    if (open) {
-      document.addEventListener('click', onDocClick, true);
-      document.addEventListener('keydown', onKeyDown, true);
-    }
+    if (menu.hidden) open(); else close();
   });
 
   if (copyBtn) {
     copyBtn.addEventListener('click', async () => {
       const { copyToClipboard } = await import('./ui-utils.js');
       await copyToClipboard(pill.dataset.wallet, copyBtn);
-      close();
+      // Keep the menu open briefly so the button's "Copied!" feedback is
+      // visible (copyToClipboard restores the label at 1500ms), then close.
+      setTimeout(close, 1200);
     });
   }
   if (disconnectBtn) {

--- a/lit-static/dapps/dashboard/styles.css
+++ b/lit-static/dapps/dashboard/styles.css
@@ -915,6 +915,67 @@ body:not(.is-chainsecured) .is-chainsecured-only {
   background: rgba(255, 255, 255, 0.06);
 }
 
+.topbar-wallet-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.topbar-wallet-chevron {
+  font-size: 0.6rem;
+  margin-left: 0.3rem;
+  opacity: 0.7;
+}
+
+.topbar-wallet-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 0.35rem;
+  min-width: 180px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow), 0 10px 25px rgba(0, 0, 0, 0.15);
+  padding: 0.35rem 0;
+  z-index: 100;
+}
+
+.topbar-wallet-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s;
+  font-family: inherit;
+}
+
+.topbar-wallet-menu-item:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] .topbar-wallet-menu-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.topbar-wallet-menu-danger {
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.topbar-wallet-menu-danger:hover {
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--danger);
+}
+
+[data-theme="dark"] .topbar-wallet-menu-danger:hover {
+  background: rgba(248, 113, 113, 0.12);
+}
+
 .abi-drift-banner {
   padding: 0.75rem 1rem;
   margin: 0 0 1rem;


### PR DESCRIPTION
Turns the ChainSecured wallet address pill in the dashboard topbar into a popover menu. Clicking the pill now opens a small dropdown with **Copy address** and **Disconnect wallet** options instead of copying the address directly. Disconnect tears down the EIP-1193 / WalletConnect connection and signs out, since in ChainSecured mode the wallet *is* the session. The menu closes on outside-click or Escape, mirroring the existing mode-badge popover, and a chevron hints the pill is now interactive. Only affects ChainSecured mode (API mode has no persistent wallet); the pill's appearance is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)