### PR TITLE
chore(security): npm audit fix lit-actions docs deps (clears 11 alerts)

### DIFF
--- a/lit-actions/package-lock.json
+++ b/lit-actions/package-lock.json
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -1553,9 +1553,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -2456,9 +2456,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2483,9 +2483,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -2681,9 +2681,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2705,9 +2705,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2725,7 +2725,7 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/plans/dependabot.md
+++ b/plans/dependabot.md
@@ -162,10 +162,44 @@ gh api --method PATCH /repos/LIT-Protocol/chipotle/dependabot/alerts/<N> \
   `deny.toml` ignore entry; revisit when deno/rocket/Alloy ship dep bumps (the
   `deny.toml` "upstream watch" already tracks this).
 
-## Follow-ups (out of scope for this Rust-only plan)
+## Step 4 — first-party npm alerts
 
-- **87 first-party npm alerts** remain: `lit-api-server/blockchain/lit_node_express`
-  (39), `e2e/pnpm-lock.yaml` (27), `lit-actions/package-lock.json` (12),
-  `lit-payments/contracts/package-lock.json` (9). Worth a separate pass —
-  `npm audit fix` / `pnpm update` per project — but these gate real shipped code
-  so they need actual testing, not just lockfile bumps.
+All 87 are **dev/build tooling**, not API-server runtime (verified by reading each
+`package.json`). Triaged the two the team flagged as most relevant:
+
+### 4a. `lit-actions/package-lock.json` (12 alerts) — ✅ 11 fixed
+
+Only 3 declared deps: `documentation`, `prettier`, `typescript` (doc-gen + format,
+ships in nothing). All 12 alerts are transitive deps of `documentation`.
+`npm audit fix --package-lock-only` (semver-bounded, no `package.json` change)
+clears 11 — lodash, minimatch ×3, picomatch ×2, brace-expansion, diff, postcss.
+Verified `npm install` succeeds.
+- **Remaining:** `#27` vue-template-compiler (XSS) — no fix exists; it's
+  `documentation`'s abandoned Vue 2 transitive (only "fix" is downgrading
+  `documentation` to an *older* 6.2.0). Dismiss `tolerable_risk` (dev docs tool).
+
+### 4b. `lit-api-server/blockchain/lit_node_express/package-lock.json` (39 alerts)
+
+Misleading dir name — this is the **hardhat contracts project** (package name
+`contracts`; deps = hardhat / ethers / `@safe-global` SDKs). Runs at contract
+test/deploy time in CI/dev, never in the API-server runtime.
+
+A semver-bounded `npm audit fix` clears only ~5 low/med (lodash, follow-redirects,
+picomatch). The serious ones do **not** move by lockfile bump:
+- **3 critical + 8 high** (elliptic critical, ethers, axios ×many, ws@7,
+  `@ethersproject/signing-key`, zksync-ethers) are the **ethers-v5 subtree under
+  `hardhat-deploy@1.0.4`** — only fixed by `hardhat-deploy@2.x` (MAJOR/breaking) +
+  likely `@safe-global` SDK bumps. Real migration work; must re-run `hardhat test`.
+- **No in-range fix:** undici, uuid, cookie, hardhat, `@sentry/node`,
+  `@nomicfoundation/hardhat-ethers`.
+
+**Decision (pending):** either (a) do the `hardhat-deploy@2` migration as scoped,
+tested work, or (b) dismiss as `tolerable_risk` — dev/CI contract tooling, the
+vulnerable paths (elliptic malleability, axios SSRF) aren't reachable by an
+attacker in a trusted local/CI deploy context. Not churning the lockfile for the
+~5 low/med wins, since it leaves every critical/high in place.
+
+### 4c. Untouched
+
+`e2e/pnpm-lock.yaml` (27) and `lit-payments/contracts/package-lock.json` (9) — same
+dev/test-tooling profile; revisit with the same lens if needed.


### PR DESCRIPTION
Follow-up to #478, triaging the first-party npm Dependabot alerts. `lit-actions` only declares `documentation`/`prettier`/`typescript` (doc-gen tooling that ships in nothing), so a semver-bounded `npm audit fix --package-lock-only` clears 11 of its 12 transitive alerts (lodash, minimatch ×3, picomatch ×2, brace-expansion, diff, postcss) with no `package.json` change — verified `npm install` succeeds. The 12th (`vue-template-compiler` XSS) has no fix and should be dismissed `tolerable_risk`. `plans/dependabot.md` step 4 also records the `lit_node_express` contracts project: its 3 critical + 8 high alerts are the ethers-v5 subtree under `hardhat-deploy@1` (a breaking `hardhat-deploy@2` migration to fix), left as a scoped decision rather than partial lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)