### PR TITLE
docs: Chain Secured — concept page + standardize on API / ChainSecured mode terms

### DIFF
--- a/docs/architecture/authModel.mdx
+++ b/docs/architecture/authModel.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Authentication Model"
-description: "How accounts, API keys, PKPs, groups, and the TEE root key compose into a programmable KMS — and how self-sovereign vs SaaS emerges from configuration."
+description: "How accounts, API keys, PKPs, groups, and the TEE root key compose into a programmable KMS — and how API mode vs ChainSecured mode emerges from configuration."
 ---
 
 ## Core Insight
 
-There are no "modes." Self-sovereign vs SaaS is not a toggle — it's an emergent property of how you configure the same system. The only things that vary are:
+ChainSecured mode and API mode aren't a toggle in the code — they're an emergent property of how you configure the same system. The only things that vary are:
 
-1. **Who is the Account Owner** (TEE-derived wallet from Stytch auth vs SAFE vs raw EOA)
+1. **Who is the Account Owner** (a Lit-managed credential vs a SAFE or EOA you control)
 2. **What scopes the API keys have** (everything vs execute-only vs somewhere in between)
 
-A "self-sovereign" setup is just: owner = SAFE, API keys = execute-only. A "SaaS" setup is just: owner = TEE-derived wallet, API keys = broad scopes. The contracts don't know or care.
+A "ChainSecured-mode" setup is just: owner = a wallet you control (EOA/Safe), API keys = execute-only. An "API-mode" setup is just: owner = a Lit-managed credential, API keys = broad scopes. The contracts don't know or care.
 
 ---
 
@@ -23,8 +23,8 @@ The top-level identity. Just an address on Base. This address is the **owner** �
 The owner address can be:
 
 - An EOA (simple, but no recovery)
-- A TEE-derived wallet (SaaS happy path — user authenticates via Stytch with email/passkey/OAuth, TEE verifies the Stytch auth token and derives a deterministic wallet from the authenticated user ID)
-- A SAFE or any governance contract (self-sovereign — multisig, voting, timelocks, whatever)
+- A Lit-managed credential (API mode — the fast path: Lit holds the owner key and relays your writes)
+- A SAFE or any governance contract (ChainSecured mode — multisig, voting, timelocks, whatever)
 
 The contracts don't distinguish between these. `msg.sender == owner` is `msg.sender == owner`.
 
@@ -48,7 +48,7 @@ A key can have any combination of scopes. The owner grants scopes at registratio
 
 **Four of the seven scopes are per-group.** When you grant an API key `execute`, `group:manageActions`, `group:addPkp`, or `group:removePkp`, you specify _which groups_ it applies to. This is the key security property — a leaked onboarding key that has `group:addPkp(group_1)` can only add PKPs to group_1, not to some new insecure group that someone just created. And because it only has `group:addPkp` (not `group:removePkp`), it can't pull existing PKPs out of the group either.
 
-**Three scopes are account-wide.** `pkp:create` is account-wide because PKPs are created in the account's registry before being assigned to any group. Creating a PKP doesn't grant access to anything by itself — the PKP still has to be added to a group (which requires `group:addPkp` on that specific group) and someone has to have `execute` on that group to actually use it. `group:create` and `group:delete` are account-wide because groups aren't scoped to other groups. In SaaS mode, developers need these to build their app through the API. In self-sovereign mode, you simply don't grant these scopes to any API key, and then only the SAFE can create or delete groups.
+**Three scopes are account-wide.** `pkp:create` is account-wide because PKPs are created in the account's registry before being assigned to any group. Creating a PKP doesn't grant access to anything by itself — the PKP still has to be added to a group (which requires `group:addPkp` on that specific group) and someone has to have `execute` on that group to actually use it. `group:create` and `group:delete` are account-wide because groups aren't scoped to other groups. In API mode, developers need these to build their app through the API. In ChainSecured mode, you simply don't grant these scopes to any API key, and then only the SAFE can create or delete groups.
 
 **Everything else is owner-only:** adding/revoking API keys, updating scopes, transferring ownership. These are structural operations that affect the trust boundary itself.
 
@@ -89,10 +89,10 @@ The master secret managed by Phala's KMS. Access is governed by on-chain governa
 Account (owner address)
 │
 ├── API Keys (each with scopes)
-│     ├── key_dev:     [execute(*), pkp:create, group:create,             ← SaaS: broad scopes
+│     ├── key_dev:     [execute(*), pkp:create, group:create,             ← API mode: broad scopes
 │     │                 group:delete, group:manage*(*)]
-│     ├── key_server:  [execute(group_1)]                                 ← self-sovereign: execution only
-│     └── key_onboard: [pkp:create, group:addPkp(group_1)]               ← self-sovereign: onboarding
+│     ├── key_server:  [execute(group_1)]                                 ← ChainSecured: execution only
+│     └── key_onboard: [pkp:create, group:addPkp(group_1)]               ← ChainSecured: onboarding
 │
 ├── PKP Registry
 │     ├── pkp_001 (derivation path)
@@ -144,7 +144,7 @@ The Account Owner (SAFE, EOA, whatever) submits transactions directly to the per
 SAFE/EOA → tx → Permissions Contract (Base)
 ```
 
-This is how self-sovereign users handle governance operations. It's transparent and auditable — the SAFE proposal is visible on-chain before execution.
+This is how ChainSecured-mode users handle governance operations. It's transparent and auditable — the SAFE proposal is visible on-chain before execution.
 
 **Both paths write to the same contracts.** The contract authorization check is:
 
@@ -175,17 +175,17 @@ require(
 
 ---
 
-## Why Self-Sovereign Emerges from Configuration
+## Why ChainSecured Mode Emerges from Configuration
 
 Consider two setups:
 
-### Setup A: "SaaS mode"
+### Setup A: "API mode"
 
-- **Owner:** TEE-derived wallet (user authenticates via Stytch, TEE derives wallet from authenticated user ID)
+- **Owner:** a Lit-managed credential (the fast path)
 - **API key `dev_key`:** scopes = `[execute(*), pkp:create, group:create, group:delete, group:manageActions(*), group:addPkp(*), group:removePkp(*)]`
-- **Effect:** The developer can do everything via HTTP calls except manage API keys and transfer ownership (those are owner-only, done through the Stytch-authenticated dashboard). This is the full development experience — create groups, add actions, create PKPs, execute, iterate. Fast iteration, no multisig overhead. Recovery is via Stytch re-authentication — the TEE will derive the same wallet from the same user ID. When the app is production-ready, the developer can revoke the broad-scoped `dev_key` and replace it with purpose-built keys that have narrower scopes.
+- **Effect:** The developer can do everything via HTTP calls except manage API keys and transfer ownership (those are owner-only, done through the dashboard). This is the full development experience — create groups, add actions, create PKPs, execute, iterate. Fast iteration, no multisig overhead. Recovery is re-authenticating to the dashboard. When the app is production-ready, the developer can revoke the broad-scoped `dev_key` and replace it with purpose-built keys that have narrower scopes.
 
-### Setup B: "Self-sovereign mode"
+### Setup B: "ChainSecured mode"
 
 - **Owner:** A 3-of-5 SAFE
 - **API key `server_key`:** scopes = `[execute(group_1)]` — can only run actions on group_1
@@ -197,13 +197,13 @@ Consider two setups:
 
 ## Upgrade Flow Example: Swapping Actions in a Group
 
-### In SaaS mode (Setup A)
+### In API mode (Setup A)
 
 1. Pin new Lit Action JS to IPFS → get `QmNEW`
 2. `POST /groups/:id/actions` with `{add: ["QmNEW"], remove: ["QmOLD"]}` → TEE submits tx to update group
 3. Done. Next execution request uses new permissions. `dev_key` has `group:manageActions(*)`, so this is allowed on any group.
 
-### In self-sovereign mode (Setup B)
+### In ChainSecured mode (Setup B)
 
 1. Pin new Lit Action JS to IPFS → get `QmNEW`
 2. Propose a SAFE transaction batch:
@@ -229,25 +229,25 @@ This is the key reason `onboard_key` exists in Setup B — you don't want to hit
 
 ## Account Lifecycle
 
-### Onboarding (SaaS)
+### Onboarding (API mode)
 
-1. User signs up via Stytch (email, passkey, Google OAuth, etc.)
-2. TEE verifies the Stytch auth token and derives a deterministic wallet from the authenticated user ID → this becomes the Account Owner address
+1. User signs up through the dashboard
+2. The account is created with a Lit-managed owner credential → this becomes the Account Owner address
 3. System registers this on-chain as a new Account
 4. Owner creates a first group and a first API key with broad scopes
 5. User uses this API key for all HTTP interactions
 
-### Graduating to self-sovereign
+### Graduating to ChainSecured mode
 
 1. User deploys a SAFE on Base with their desired signer set
-2. User calls `transferOwnership(safeAddress)` — authenticated via Stytch (current owner) through the TEE relay
+2. User calls `transferOwnership(safeAddress)` — authorized by the current owner through the dashboard
 3. Account Owner is now the SAFE
 4. SAFE creates new API keys with restricted scopes, locked to specific groups (e.g. `server_key`, `onboard_key`)
 5. SAFE revokes the old broad-scoped API key
-6. Stytch is fully out of the loop — the SAFE is sovereign
+6. The managed credential is fully out of the loop — the SAFE is the sole on-chain owner
 
 ### Key rotation
 
-Owner registers a new API key address with the desired scopes, then revokes the old one. In SaaS mode, this is an HTTP call (TEE derives the owner wallet from Stytch auth and signs the tx). In self-sovereign mode, this requires a SAFE vote.
+Owner registers a new API key address with the desired scopes, then revokes the old one. In API mode, this is an HTTP call (the managed credential authorizes it). In ChainSecured mode, this requires a SAFE vote.
 
 ---

--- a/docs/architecture/chain-secured.mdx
+++ b/docs/architecture/chain-secured.mdx
@@ -3,7 +3,7 @@ title: "Chain Secured"
 description: "A key's authority lives in smart contracts on Base, and an attested TEE enforces those rules by reading the chain — on-chain authority, signing at API speed."
 ---
 
-Lit's core guarantee is simple to state: **a key's authority is on-chain state.** What a key may sign, which code is allowed to use it, and who can change those rules all live in smart contracts on Base. Nothing off-chain — no server, no API key, no operator, not even Lit — can move a key outside what the chain permits.
+Lit's core guarantee is simple to state: **a key's authority is on-chain state.** What a key may sign, which code is allowed to use it, and who can change those rules all live in smart contracts on Base. Nothing off-chain — no server, no API key, no operator, not even Lit — can make a key sign outside the rules currently on the chain.
 
 We call this **Chain Secured**.
 
@@ -11,7 +11,7 @@ We call this **Chain Secured**.
 
 Authorization isn't a flag in someone's database. It's on-chain state that you own:
 
-- **Account** — an address on Base that owns everything: a wallet you control (an EOA or Safe) in [ChainSecured mode](/management/account_modes), or a Lit-managed credential in API mode.
+- **Account** — an address on Base that owns everything: a wallet you control (an EOA or Safe) in **ChainSecured mode**, or a Lit-managed credential in **API mode**. See [API mode vs ChainSecured mode](/management/account_modes).
 - **API keys & scopes** — each key is registered on-chain with explicit, per-group scopes (`execute`, `group:addPkp`, and so on).
 - **PKPs & Groups** — a Group is the authorization policy: it binds the keys (PKPs) to the immutable Lit Actions (IPFS CIDs) allowed to use them.
 
@@ -24,7 +24,7 @@ require(
 );
 ```
 
-Changing a rule is an on-chain transaction — public, auditable, and authorized by an owner you control. Put a SAFE in the owner slot and it takes a multisig vote. See the [Authentication Model](/architecture/authModel) for the full permission matrix.
+Changing a rule is an on-chain transaction — public, auditable, and authorized by an owner you control. Put a Safe in the owner slot and it takes a multisig vote. See the [Authentication Model](/architecture/authModel) for the full permission matrix.
 
 ## An attested TEE enforces it — by reading
 
@@ -50,7 +50,7 @@ So you get the chain's guarantees — public, owner-controlled, auditable author
 Because authority lives on-chain and the TEE only ever enforces it:
 
 - A leaked execute-only key can invoke the actions it is already permitted to, and nothing else. It cannot add itself to new groups, swap in new code, or move funds outside policy.
-- Changing *what the rules are* requires an owner transaction on Base. Put the owner behind a SAFE and an evil admin with an execute key "can invoke existing actions but cannot change the rules."
+- Changing *what the rules are* requires an owner transaction on Base. Put the owner behind a Safe, and an evil admin holding an execute key can invoke existing actions but cannot change the rules.
 - The rules are visible to anyone, at any time. Don't trust — verify.
 
 ## Further reading

--- a/docs/architecture/chain-secured.mdx
+++ b/docs/architecture/chain-secured.mdx
@@ -1,0 +1,61 @@
+---
+title: "Chain Secured"
+description: "A key's authority lives in smart contracts on Base, and an attested TEE enforces those rules by reading the chain — on-chain authority, signing at API speed."
+---
+
+Lit's core guarantee is simple to state: **a key's authority is on-chain state.** What a key may sign, which code is allowed to use it, and who can change those rules all live in smart contracts on Base. Nothing off-chain — no server, no API key, no operator, not even Lit — can move a key outside what the chain permits.
+
+We call this **Chain Secured**.
+
+## The chain holds the authority
+
+Authorization isn't a flag in someone's database. It's on-chain state that you own:
+
+- **Account** — an address on Base that owns everything. It can be an EOA, a TEE-derived wallet, or a SAFE multisig.
+- **API keys & scopes** — each key is registered on-chain with explicit, per-group scopes (`execute`, `group:addPkp`, and so on).
+- **PKPs & Groups** — a Group is the authorization policy: it binds the keys (PKPs) to the immutable Lit Actions (IPFS CIDs) allowed to use them.
+
+The contract is the authority. Every privileged operation comes down to one check:
+
+```solidity
+require(
+  msg.sender == accountOwner ||
+  isAPIKeyWithScope(msg.sender, requiredScope, groupId)
+);
+```
+
+Changing a rule is an on-chain transaction — public, auditable, and authorized by an owner you control. Put a SAFE in the owner slot and it takes a multisig vote. See the [Authentication Model](/architecture/authModel) for the full permission matrix.
+
+## An attested TEE enforces it — by reading
+
+On-chain rules are only as strong as what enforces them. In Lit, that's a sealed TEE that **reads** the contracts on every request:
+
+1. A request arrives: an API key, and "run action `QmABC` with `pkp_001`."
+2. The TEE reads on-chain — does this key have `execute` scope on a group where both `QmABC` and `pkp_001` are listed?
+3. If yes, it derives the key inside the enclave, runs the action, and signs. If no, it refuses.
+
+Key material never leaves the enclave, and the enclave can only run code that on-chain governance has whitelisted — so the read is trustworthy, not just convenient. You can verify the exact enclave yourself: see [Security & Verification](/architecture/verification/index) and [On-Chain KMS](/architecture/verification/onchain-kms).
+
+## Why it scales: write the rules, read to enforce
+
+The split between authority and enforcement is the point:
+
+- **Setting or changing a rule is a write** — one on-chain transaction, only when you configure or govern.
+- **Using a rule is a read** — the TEE reads current on-chain state and signs in the enclave. No per-operation transaction, no gas, no waiting on a block.
+
+So you get the chain's guarantees — public, owner-controlled, auditable authority — without paying the chain's throughput cost on every signature. Use smart-contract rails where they create trust, and reads where you need speed. The result is authority on-chain, signing at the speed of an API call.
+
+## What Chain Secured locks down
+
+Because authority lives on-chain and the TEE only ever enforces it:
+
+- A leaked execute-only key can invoke the actions it is already permitted to, and nothing else. It cannot add itself to new groups, swap in new code, or move funds outside policy.
+- Changing *what the rules are* requires an owner transaction on Base. Put the owner behind a SAFE and an evil admin with an execute key "can invoke existing actions but cannot change the rules."
+- The rules are visible to anyone, at any time. Don't trust — verify.
+
+## Further reading
+
+- [Authentication Model](/architecture/authModel) — entities, scopes, and the full permission matrix
+- [System Diagram](/architecture/diagram) — on-chain vs TEE boundaries and management paths
+- [On-Chain KMS](/architecture/verification/onchain-kms) — how Base contracts gate root-key release
+- [Security & Verification](/architecture/verification/index) — attestation and the full chain of trust

--- a/docs/architecture/chain-secured.mdx
+++ b/docs/architecture/chain-secured.mdx
@@ -11,7 +11,7 @@ We call this **Chain Secured**.
 
 Authorization isn't a flag in someone's database. It's on-chain state that you own:
 
-- **Account** — an address on Base that owns everything. It can be an EOA, a TEE-derived wallet, or a SAFE multisig.
+- **Account** — an address on Base that owns everything: a wallet you control (an EOA or Safe) in [ChainSecured mode](/management/account_modes), or a Lit-managed credential in API mode.
 - **API keys & scopes** — each key is registered on-chain with explicit, per-group scopes (`execute`, `group:addPkp`, and so on).
 - **PKPs & Groups** — a Group is the authorization policy: it binds the keys (PKPs) to the immutable Lit Actions (IPFS CIDs) allowed to use them.
 

--- a/docs/architecture/diagram.mdx
+++ b/docs/architecture/diagram.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Entity Relationships"
-description: "Entity relationships, on-chain vs TEE boundaries, and how self-sovereign vs SaaS emerges from configuration — not modes."
+description: "Entity relationships, on-chain vs TEE boundaries, and how API mode vs ChainSecured mode emerges from configuration."
 ---
 
 <Note>
-  **Core Insight:** There are no "modes." Self-sovereign vs SaaS is an **emergent property** of how you configure the same system. The only things that vary are **who is the Account Owner** (TEE-derived wallet vs SAFE vs EOA) and **what scopes the API keys have**. The contracts don't know or care.
+  **Core Insight:** API mode and ChainSecured mode aren't a toggle in the code — they're an **emergent property** of how you configure the same system. The only things that vary are **who owns the account** (a Lit-managed credential vs a SAFE or EOA you control) and **what scopes the API keys have**. The contracts don't know or care.
 </Note>
 
 ---
@@ -17,7 +17,7 @@ The system spans four distinct trust boundaries. Understanding what lives where 
 
 | Entity | Description |
 |---|---|
-| **Account Owner** | Top-level identity. An address on Base that can do everything. Can be an EOA, TEE-derived wallet (Stytch auth), or SAFE/governance contract. **Ultimate authority.** |
+| **Account Owner** | Top-level identity. An address on Base that can do everything. A SAFE or EOA you control (ChainSecured mode), or a Lit-managed credential (API mode). **Ultimate authority.** |
 | **API Key (Private Key)** | User holds the private key locally. Sent to TEE over HTTPS per-request. TEE derives the address and checks scopes on-chain. |
 | **SAFE / Governance** | Optional. Multisig, timelocks, voting. Submits txs directly to chain for structural changes — TEE not involved. |
 
@@ -54,7 +54,7 @@ The system spans four distinct trust boundaries. Understanding what lives where 
 USER / EXTERNAL                ON-CHAIN (BASE)             TEE ENCLAVE
 ─────────────────────────────  ──────────────────────────  ──────────────────────────────
 Account Owner                  Account Contract             Root Key
- EOA / SAFE / TEE-derived   ──▶  owner address registered    master secret, never exported
+ EOA / SAFE / Lit-managed   ──▶  owner address registered    master secret, never exported
       │ owns                                                      │ derives
       │                        API Key Registry             Auth + Key Derivation
 API Key (private key)       ──▶  address → scopes mapping ◀──    verify scopes, derive keys
@@ -99,7 +99,7 @@ TEE checks scopes and submits the transaction on the user's behalf.
 User + API Key  →  TEE (verify scopes)  →  Permissions Contract
 ```
 
-### Path B: Direct to Chain *(self-sovereign)*
+### Path B: Direct to Chain *(ChainSecured mode)*
 
 Owner submits transactions directly — TEE is not involved.
 
@@ -144,17 +144,17 @@ SAFE / EOA  →  Permissions Contract
 
 The same system, two very different security postures — determined entirely by who the owner is and what scopes the keys carry.
 
-### SaaS Mode
+### API Mode
 
-*Fast iteration, broad scopes, Stytch recovery*
+*Fast iteration, broad scopes, managed recovery*
 
 | | |
 |---|---|
-| **Owner** | TEE-derived wallet from Stytch auth (email / passkey / OAuth) |
+| **Owner** | A Lit-managed credential |
 | **API Key** | `dev_key` with all scopes: `execute(*)`, `pkp:create`, `group:create`, `group:delete`, `group:manageActions(*)`, `group:addPkp(*)`, `group:removePkp(*)` |
-| **Effect** | Developer does everything via HTTP. Only API key management and ownership transfer require Stytch-authenticated dashboard. Recovery = Stytch re-auth. |
+| **Effect** | Developer does everything via HTTP. Only API key management and ownership transfer require the dashboard. Recovery = re-authenticating to the dashboard. |
 
-### Self-Sovereign Mode
+### ChainSecured Mode
 
 *Auditable governance, restricted scopes, SAFE multisig*
 

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -18,17 +18,11 @@ All authorization state lives on-chain in a set of smart contracts: an Account c
 **Lit Actions (IPFS)**
 Lit Actions are immutable JavaScript programs stored on IPFS and referenced by content ID (CID). They are not owned by anyone — they are public, reusable, and content-addressed, similar to npm packages. The TEE fetches the action by CID at execution time and runs it inside a sandboxed JS environment that has access to the derived key material.
 
-## Self-Sovereign vs SaaS
+## API mode vs ChainSecured mode
 
-There are no modes. Whether you operate in a self-sovereign or SaaS posture is an emergent property of who owns the Account contract and what scopes your API keys carry.
+Who owns the account is a configuration choice, not a fork in the code. In **API mode**, a Lit-managed credential owns the account and relays your admin writes — the fastest way to start. In **ChainSecured mode**, a wallet you control (an EOA or Safe) owns the account on-chain and signs every change itself — fully self-custodied, with an on-chain audit trail. Both run the same contracts and the same Lit Actions; only account ownership and how writes are signed differ.
 
-| | SaaS | Self-Sovereign |
-|---|---|---|
-| **Account Owner** | TEE-derived wallet (Stytch auth) | 3-of-5 SAFE multisig on Base |
-| **API Key Scopes** | All scopes — full access via HTTP | Purpose-built keys with minimal scopes |
-| **Structural Changes** | Via TEE relay (Stytch-authenticated) | SAFE vote → direct on-chain tx |
-| **Key Recovery** | Stytch re-authentication | SAFE signers |
-| **Leaked Key Blast Radius** | High | Minimal — scoped to specific groups |
+See [API Mode vs ChainSecured Mode](/management/account_modes) for the side-by-side and the migration path.
 
 ## Further Reading
 

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -5,6 +5,8 @@ description: "How Lit Chipotle's three composable layers — TEE enclave, on-cha
 
 Lit Chipotle is built on three composable layers that each handle a distinct concern. Understanding the separation makes it easier to reason about security, auditability, and where your own code fits in.
 
+The throughline: **your keys' authority lives on-chain, and an attested TEE enforces it by reading the chain.** We call this [Chain Secured](/architecture/chain-secured) — on-chain authority, signing at the speed of an API call.
+
 ## The Three Layers
 
 **TEE Enclave (Phala / dstack)**
@@ -30,6 +32,7 @@ There are no modes. Whether you operate in a self-sovereign or SaaS posture is a
 
 ## Further Reading
 
+- [Chain Secured](/architecture/chain-secured) — why your keys' authority lives on-chain, and how an attested TEE enforces it by reading
 - [Verify the TEE in 30 seconds](/architecture/verification/quick-verify) — one-click Phala Trust Center report for the live API
 - [Auth Model & Permission Matrix](/architecture/authModel) — detailed entity boundaries, execution flow, and the full permission matrix
 - [System Diagram](/architecture/diagram) — entity relationships, on-chain vs TEE boundaries, and management paths

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,6 +57,7 @@
             "group": "Architecture",
             "pages": [
               "architecture/index",
+              "architecture/chain-secured",
               "architecture/groups",
               "architecture/authModel",
               "architecture/self-hosting",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -54,6 +54,9 @@ Patterns you can build on one programmable runtime.
 How the runtime works and how trust is established.
 
 <CardGroup cols={2}>
+  <Card title="Chain Secured" icon="link" href="/architecture/chain-secured">
+    Your keys' authority lives on-chain; an attested TEE enforces it by reading the chain.
+  </Card>
   <Card title="Architecture" icon="layer-group" href="/architecture/index">
     The three layers: chain-secured TEE, on-chain permissions, and IPFS-hosted actions.
   </Card>
@@ -74,7 +77,7 @@ Account ownership, billing, and key management.
 
 <CardGroup cols={3}>
   <Card title="Account Modes" icon="users-gear" href="/management/account_modes">
-    SaaS vs. self-sovereign — picking an ownership model and migrating between them.
+    API mode vs. ChainSecured mode — picking an ownership model and migrating between them.
   </Card>
   <Card title="API Keys" icon="key" href="/management/api_keys">
     Account keys vs. usage keys, and how to scope them.

--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -38,9 +38,10 @@ actions, registering PKPs, minting usage keys, etc.
 | Lit Action execution     | Usage API key in `X-Api-Key`                          | Usage API key in `X-Api-Key` (minted from contract)  |
 | Billing                  | Stripe credits on the account                         | Stripe credits on the account (same flow)            |
 
-ChainSecured mode is referred to as *self-sovereign* in some internal
-material. They are the same thing — wallet ownership of the account on
-Base, with no required server round-trip for admin writes.
+In the SDK and contracts, ChainSecured mode is the `sovereign` mode
+(`mode: 'sovereign'`); earlier material called it *self-sovereign*. Same
+thing — wallet ownership of the account on Base, with no required server
+round-trip for admin writes.
 
 ## When to pick which
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -58,4 +58,5 @@ The Dashboard is just your human-friendly configuration tool. Once your account 
 - [Lit Actions Overview](/lit-actions/index) — what they are and how they run
 - [Examples](/lit-actions/examples) — signing, encryption, HTTP fetching, contract calls
 - [Architecture](/architecture/index) — the TEE / on-chain / IPFS layers
+- [Chain Secured](/architecture/chain-secured) — why your keys' authority lives on-chain, and how an attested TEE enforces it
 - [OpenAPI Spec](https://api.chipotle.litprotocol.com/core/v1/openapi.json) / [Swagger UI](https://api.chipotle.litprotocol.com/core/v1/swagger-ui)


### PR DESCRIPTION
Two related things, one coherent change: name the **Chain Secured** principle the docs already describe, and retire the older "self-sovereign vs SaaS" wording in favor of the shipped product terms.

## 1. Chain Secured concept page
New `architecture/chain-secured.mdx` — names the guarantee the architecture already implies but never framed: **a key's authority lives in on-chain smart contracts on Base, and an attested TEE enforces it by reading the chain.** Four beats: the chain holds authority → an attested TEE enforces by reading → why that scales (write the rule once, read to enforce — no per-op tx) → what it locks down. Surfaced as the first page after the Architecture Overview, named in the Overview intro, added to the home **Concepts** card group, and linked from the Quickstart's Next steps.

## 2. Terminology: API mode / ChainSecured mode
The management pages + SDK/contracts already use **API mode** (managed) and **ChainSecured mode** (`mode: 'sovereign'` — you own the account on-chain). The architecture/home pages still said "self-sovereign vs SaaS." Standardized them:
- `authModel`, `diagram`, architecture `Overview`, top-level home — renamed throughout; the Overview's duplicate comparison table is now a tight summary that links the canonical [account-modes](/management/account_modes) page.
- Per CTO: stopped belaboring the **API-mode** owner mechanism (dropped the Stytch/derivation detail that didn't earn its place). The depth stays on the **ChainSecured** side, where it matters.
- The account-modes bridge note now points at the SDK `sovereign` param so code and prose line up.

## Verified
- **0 broken internal links, 0 broken nav entries** (checked across all 35 pages, on this branch).
- No `self-sovereign` / `SaaS` / `Stytch` left in prose — the only `sovereign` references are the real SDK param + one bridge note.
- Live preview renders: Overview shows the new section, `authModel` uses the new terms with zero old ones, home Concepts card present, diagram clean.

Preview: https://litprotocol-docs-chain-secured.mintlify.app/architecture/chain-secured

🤖 Generated with [Claude Code](https://claude.com/claude-code)