### PR TITLE
fix(ci): prevent shell injection in manual_phala-add-device.yml (CPL-298)

### DIFF
--- a/.github/workflows/manual_phala-add-device.yml
+++ b/.github/workflows/manual_phala-add-device.yml
@@ -47,15 +47,18 @@ jobs:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
           PRIVATE_KEY: ${{ secrets.PHALA_DSTACKAPP_PRIVATE_KEY }}
           ETH_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
+          INPUT_APP_ID: ${{ inputs.app_id }}
+          INPUT_DEVICE_ID: ${{ inputs.device_id }}
         run: |
           phala allow-devices add \
-            "${{ inputs.app_id }}" \
-            "${{ inputs.device_id }}" \
+            "$INPUT_APP_ID" \
+            "$INPUT_DEVICE_ID" \
             --wait
 
       - name: Show updated allowlist
         env:
           PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
           ETH_RPC_URL: ${{ secrets.BASE_CHAIN_RPC }}
+          INPUT_APP_ID: ${{ inputs.app_id }}
         run: |
-          phala allow-devices list "${{ inputs.app_id }}"
+          phala allow-devices list "$INPUT_APP_ID"


### PR DESCRIPTION
## Summary

Fixes [CPL-298] — a CRITICAL shell-injection vulnerability in `.github/workflows/manual_phala-add-device.yml`.

The `${{ inputs.app_id }}` and `${{ inputs.device_id }}` workflow_dispatch inputs were inlined directly into `run:` shell bodies while `PHALA_DSTACKAPP_PRIVATE_KEY` (the Base mainnet DstackApp owner key) was in scope. A caller with `workflow_dispatch:write` could supply shell metacharacters in either input to execute arbitrary commands with that key reachable — enabling exfiltration and allowlisting attacker-controlled Phala devices on Base mainnet.

The fix moves both inputs into `env:` indirection and references them as quoted `"$INPUT_*"` shell variables. GitHub now sets each input as a literal env-var value (never parsed as shell), and the quoted reference passes it as a single inert argument — metacharacters lose their meaning.

## Test plan
- [x] Confirmed no `${{ inputs.* }}` expressions remain in any `run:` block (only inside `env:`)
- [x] Verified the diff is exactly the injection fix, no behavioral change to the `phala allow-devices` calls

Out of scope (tracked separately per the ticket): 40-char SHA action pinning, and `environment: production-phala` with required reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)