### PR TITLE
ci(deploy): zero-downtime ping-pong cutover for chipotle-next (CI-only re-land)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,8 @@
 # Deploy lit-api-server + lit-actions + otel-collector to Phala CVM
 #
-# Deployment targets:
-#   push to next → chipotle-next (direct automated deploy)
-#   push to main → chipotle-dev  (direct automated deploy)
+# Deployment target:
+#   push to main → chipotle-next (zero-downtime ping-pong cutover; test.chipotle.litprotocol.com)
+#   The `next` git branch is retired and chipotle-dev is deprecated — main is the deploy branch now.
 #
 # For production (v* tag) deploys, see deploy-prod-1-propose.yml and deploy-prod-2-execute.yml.
 #
@@ -37,6 +37,13 @@
 #                    ${DOCKER_IMAGE}-otel-collector
 #   DOCKERHUB_USERNAME - Docker Hub username
 #
+# Optional GitHub vars — enable zero-downtime ping-pong (else legacy single-CVM in-place deploy):
+#   NEXT_CVM_A / NEXT_CVM_B - the two long-lived chipotle-next instance names (same app_id, prod2 + prod4)
+#   Which one is LIVE is derived from DNS at deploy time (the public domain's CNAME →
+#   the live node's gateway); there is no stored live-pointer var to drift.
+#   Both instances' Phala devices MUST be allowlisted on the app's AppAuth contract
+#   (`phala cvms device-allowlist`) so the shared app_id derives keys on either node.
+#
 # Required Phala CVM encrypted env vars (per instance, set via Phala Cloud Dashboard):
 #   BASE_CHAIN_RPC             - RPC endpoint for the chain
 #   GCP_SERVICE_ACCOUNT_JSON   - GCP service account key (raw JSON or base64-encoded)
@@ -49,14 +56,17 @@
 
 name: "Deploy Staging"
 
-# Only one deploy job per-branch: abort any running job on same branch when a new commit is pushed.
+# Serialize deploys per-branch. cancel-in-progress is FALSE on purpose: a cutover
+# is multi-step (deploy → verify → claim → stop old) and cancelling it midway can
+# leave the old instance running / un-stopped. Let an in-flight deploy finish; a
+# newer push queues behind it.
 concurrency:
   group: deploy-phala-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   push:
-    branches: [main, next]
+    branches: [main]
   workflow_dispatch:
     inputs:
       phala_cvm_name:
@@ -95,7 +105,16 @@ jobs:
   determine-target:
     runs-on: self-hosted
     outputs:
-      phala_app_name: ${{ steps.set.outputs.phala_app_name }}
+      # target_cvm = the CVM this run deploys to (the COLD one in ping-pong mode).
+      # phala_app_name is kept as an alias of target_cvm for backward compat.
+      phala_app_name: ${{ steps.set.outputs.target_cvm }}
+      target_cvm: ${{ steps.set.outputs.target_cvm }}
+      # prev_live_cvm = the instance that was live before this deploy; stopped
+      # after the new one is confirmed serving the public domain. Empty in
+      # legacy single-CVM mode (nothing to retire).
+      prev_live_cvm: ${{ steps.set.outputs.prev_live_cvm }}
+      # pingpong = "true" when the instance-pair vars are configured.
+      pingpong: ${{ steps.set.outputs.pingpong }}
       base_url: ${{ steps.set.outputs.base_url }}
       api_root_url: ${{ steps.set.outputs.api_root_url }}
       instance_type: ${{ steps.set.outputs.instance_type }}
@@ -103,41 +122,98 @@ jobs:
       node_config: ${{ steps.set.outputs.node_config }}
       domain: ${{ steps.set.outputs.domain }}
     steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Phala CLI
+        run: npm install -g phala
       - name: Set deployment target
         id: set
+        env:
+          INPUT_CVM: ${{ inputs.phala_cvm_name }}
+          # The two long-lived instance names (set as repo Actions vars to enable
+          # ping-pong; leave unset for legacy single-CVM in-place deploy). Which
+          # one is LIVE is derived from DNS at runtime, not stored — see below.
+          NEXT_CVM_A: ${{ vars.NEXT_CVM_A }}
+          NEXT_CVM_B: ${{ vars.NEXT_CVM_B }}
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
         run: |
+          # The `next` git branch is retired; `main` is the deploy branch and
+          # targets the chipotle-next staging app (test.chipotle.litprotocol.com),
+          # ping-ponged across its two instances. chipotle-dev is deprecated.
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            DEFAULT_APP_NAME="chipotle-dev"
-            echo "instance_type=tdx.large" >> "$GITHUB_OUTPUT"
-            echo "gcp_project_id=chipotle-dev" >> "$GITHUB_OUTPUT"
-            echo "node_config=NodeConfig.main.toml" >> "$GITHUB_OUTPUT"
-            DOMAIN="test.chipotle.litprotocol.com"
-          elif [ "${{ github.ref }}" = "refs/heads/next" ]; then
-            # Default targets the current prod replica provisioned via
-            # `phala instances add`. Shares the same app_id (0x969a8c14...)
-            # and derived keys as previous chipotle-next instances. To roll a
-            # new replica onto a different Phala node (zero-downtime upgrade),
-            # supply the `phala_cvm_name` input on a manual run instead of
-            # editing this default.
             DEFAULT_APP_NAME="chipotle-next-rep-sa6xj"
+            CVM_A="$NEXT_CVM_A"; CVM_B="$NEXT_CVM_B"
             echo "instance_type=tdx.small" >> "$GITHUB_OUTPUT"
             echo "gcp_project_id=chipotle-next" >> "$GITHUB_OUTPUT"
             echo "node_config=NodeConfig.next.toml" >> "$GITHUB_OUTPUT"
             DOMAIN="test.chipotle.litprotocol.com"
           else
-            echo "Unsupported branch for deployment"
+            echo "Unsupported ref '${{ github.ref }}' — deploy from main (or manual dispatch)."
             exit 1
           fi
 
-          # A manual workflow_dispatch run may override the target CVM via the
-          # phala_cvm_name input. This is empty on push events, so automated
-          # deploys keep using the branch default selected above.
-          PHALA_APP_NAME="${{ inputs.phala_cvm_name }}"
-          if [ -z "$PHALA_APP_NAME" ]; then
-            PHALA_APP_NAME="$DEFAULT_APP_NAME"
+          # Resolve a domain's CNAME target (no trailing dot) via dig, DoH fallback.
+          resolve_cname() {
+            # Prefer the zone's AUTHORITATIVE nameserver (no caching-resolver lag —
+            # critical when a previous run just cut over and a new run must read the
+            # current live node). Fall back to the default resolver, then DoH.
+            local d="$1" zone ns out=""
+            zone="${d#*.}"                                  # test.chipotle.litprotocol.com → chipotle.litprotocol.com
+            ns=$(dig +short NS "$zone" 2>/dev/null | head -1)
+            [ -n "$ns" ] && out=$(dig +short CNAME "$d" "@${ns}" 2>/dev/null | head -1 | sed 's/\.$//')
+            [ -z "$out" ] && out=$(dig +short CNAME "$d" 2>/dev/null | head -1 | sed 's/\.$//')
+            if [ -z "$out" ]; then
+              out=$(curl -s -H 'accept: application/dns-json' \
+                "https://1.1.1.1/dns-query?name=${d}&type=CNAME" 2>/dev/null \
+                | jq -r '.Answer[]? | select(.type==5) | .data' | head -1 | sed 's/\.$//')
+            fi
+            echo "$out"
+          }
+
+          # --- Ping-pong target selection (STATELESS) ---
+          # The LIVE instance is whichever the public domain currently points at.
+          # We read the domain's CNAME (→ the live node's gateway) and match it to
+          # each candidate CVM's gateway via `phala cvms get`. The OTHER instance
+          # is the cold deploy target. No stored "live" var → it can't drift, can't
+          # be corrupted by a cancelled run, and we can never deploy onto the box
+          # that is actually serving. Both instances share one app_id (one KMS
+          # identity); both nodes' devices must be on-chain allowlisted.
+          PINGPONG="false"; PREV=""; TARGET=""; LIVE_CVM=""
+          if [ -n "$CVM_A" ] && [ -n "$CVM_B" ]; then
+            PINGPONG="true"
+            LIVE_GW=$(resolve_cname "$DOMAIN")
+            GW_A=$(phala cvms get "$CVM_A" --json 2>/dev/null | jq -r '.gateway.cname // empty' | sed 's/\.$//')
+            GW_B=$(phala cvms get "$CVM_B" --json 2>/dev/null | jq -r '.gateway.cname // empty' | sed 's/\.$//')
+            if [ -n "$LIVE_GW" ] && [ "$LIVE_GW" = "$GW_A" ]; then LIVE_CVM="$CVM_A";
+            elif [ -n "$LIVE_GW" ] && [ "$LIVE_GW" = "$GW_B" ]; then LIVE_CVM="$CVM_B"; fi
+            PREV="$LIVE_CVM"
+            echo "Live gateway from DNS: '${LIVE_GW:-<none>}' → live CVM: '${LIVE_CVM:-<unknown>}' (A gw='$GW_A' B gw='$GW_B')"
+            if [ -n "$INPUT_CVM" ]; then
+              TARGET="$INPUT_CVM"
+            elif [ "$LIVE_CVM" = "$CVM_A" ]; then TARGET="$CVM_B";
+            elif [ "$LIVE_CVM" = "$CVM_B" ]; then TARGET="$CVM_A";
+            else
+              echo "::error::Could not determine the live instance from DNS (domain CNAME='${LIVE_GW:-empty}'; A gw='$GW_A'; B gw='$GW_B'). Pass phala_cvm_name to override."
+              exit 1
+            fi
+            # Never deploy onto the instance that is currently serving the domain.
+            if [ -n "$LIVE_CVM" ] && [ "$TARGET" = "$LIVE_CVM" ]; then
+              echo "::error::Refusing to deploy to the currently-live instance '$TARGET'. Target the cold one (or omit phala_cvm_name to auto-pick)."
+              exit 1
+            fi
+          else
+            TARGET="$DEFAULT_APP_NAME"
+            if [ -n "$INPUT_CVM" ]; then TARGET="$INPUT_CVM"; fi
           fi
-          echo "Deploying to Phala CVM: ${PHALA_APP_NAME}"
-          echo "phala_app_name=${PHALA_APP_NAME}" >> "$GITHUB_OUTPUT"
+          # Never retire the box we just deployed to.
+          if [ "$PREV" = "$TARGET" ]; then PREV=""; fi
+
+          echo "Ping-pong mode: $PINGPONG"
+          echo "Deploying to (cold) CVM: $TARGET ; retire after cutover: ${PREV:-<none>}"
+          echo "target_cvm=${TARGET}" >> "$GITHUB_OUTPUT"
+          echo "prev_live_cvm=${PREV}" >> "$GITHUB_OUTPUT"
+          echo "pingpong=${PINGPONG}" >> "$GITHUB_OUTPUT"
 
           echo "domain=${DOMAIN}" >> "$GITHUB_OUTPUT"
           echo "base_url=https://${DOMAIN}" >> "$GITHUB_OUTPUT"
@@ -341,18 +417,28 @@ jobs:
 
   wait-for-api-available:
     needs: [deploy, determine-target, detect-changes]
-    if: ${{ !cancelled() && needs.determine-target.result == 'success' && needs.detect-changes.result == 'success' && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') }}
+    # Only verify when a deploy actually happened. The cold instance is normally
+    # STOPPED between deploys, so on a no-op push (deploy_needed=false) there is
+    # nothing running at the cold URL to check — skip the whole verify chain.
+    if: ${{ needs.detect-changes.outputs.deploy_needed == 'true' && needs.deploy.result == 'success' }}
     uses: ./.github/workflows/wait-for-api-restart.yml
     with:
-      api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
+      # Verify the freshly-deployed (cold) CVM on its OWN default Phala URL
+      # (*-8000.*.phala.network), not the shared public domain — which the old
+      # instance still owns until cutover. wait-for-api-restart resolves the
+      # direct URL from the CVM name via `phala cvms get`.
+      phala_app_name: ${{ needs.determine-target.outputs.target_cvm }}
       expected_sha: ${{ needs.detect-changes.outputs.deploy_needed == 'true' && github.sha || '' }}
       runner: '["self-hosted"]'
+    secrets:
+      PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
   verify-attestation:
     needs: [wait-for-api-available, determine-target]
     uses: ./.github/workflows/verify-attestation.yml
     with:
-      base_url: ${{ needs.determine-target.outputs.base_url }}
+      # Attest the cold box directly (its resolved default URL), pre-cutover.
+      base_url: ${{ needs.wait-for-api-available.outputs.base_url }}
       runner: '["self-hosted"]'
 
   openapi-spec-check:
@@ -373,3 +459,147 @@ jobs:
     uses: ./.github/workflows/k6-correctness.yml
     with:
       api_root_url: ${{ needs.wait-for-api-available.outputs.api_root_url }}
+
+  # ───────────────────────── Zero-downtime cutover (ping-pong) ─────────────────────────
+  # The cold CVM's dstack-ingress auto-claims the public domain on boot (as soon
+  # as lit-api-server's container starts — docker-compose service_started; there
+  # is no /health gate). After the cold box has
+  # passed all checks above on its direct URL, confirm the PUBLIC domain now
+  # serves the new version (DNS cutover propagated), THEN stop the old instance.
+  # No "live pointer" to record — the next deploy derives the live instance from
+  # DNS (see determine-target). Both jobs are no-ops outside ping-pong mode.
+
+  confirm-cutover:
+    needs: [determine-target, detect-changes, wait-for-api-available, verify-attestation, openapi-spec-check, k6-smoke, k6-correctness]
+    if: ${{ needs.determine-target.outputs.pingpong == 'true' && needs.detect-changes.outputs.deploy_needed == 'true' }}
+    uses: ./.github/workflows/wait-for-api-restart.yml
+    with:
+      # PUBLIC domain this time — wait until the cold box's auto-claim has rolled
+      # over and the live domain reports the new SHA. The new SHA exists
+      # only on the freshly-deployed cold box, so this serving the new SHA implies
+      # the cold box owns the domain. (stop-old-cvm re-checks the CNAME to be sure,
+      # covering the same-commit-redeploy edge where both boxes share a SHA.)
+      api_root_url: ${{ needs.determine-target.outputs.api_root_url }}
+      expected_sha: ${{ github.sha }}
+      timeout: 300
+      runner: '["self-hosted"]'
+
+  stop-old-cvm:
+    needs: [determine-target, detect-changes, confirm-cutover]
+    if: ${{ needs.determine-target.outputs.pingpong == 'true' && needs.determine-target.outputs.prev_live_cvm != '' && needs.detect-changes.outputs.deploy_needed == 'true' }}
+    runs-on: self-hosted
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Phala CLI
+        run: npm install -g phala
+      - name: Stop the old instance — only if the domain has moved OFF it
+        # Guard against stranding the public domain: resolve the live domain's
+        # CNAME and refuse to stop OLD if the domain still points at OLD's gateway
+        # (cutover didn't actually move). Use `stop` (not delete) so the cert
+        # volume + identity persist as a warm rollback / next flip target.
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+        run: |
+          OLD="${{ needs.determine-target.outputs.prev_live_cvm }}"
+          DOMAIN="${{ needs.determine-target.outputs.domain }}"
+          resolve_cname() {
+            # Prefer the zone's AUTHORITATIVE nameserver (no caching-resolver lag —
+            # critical when a previous run just cut over and a new run must read the
+            # current live node). Fall back to the default resolver, then DoH.
+            local d="$1" zone ns out=""
+            zone="${d#*.}"                                  # test.chipotle.litprotocol.com → chipotle.litprotocol.com
+            ns=$(dig +short NS "$zone" 2>/dev/null | head -1)
+            [ -n "$ns" ] && out=$(dig +short CNAME "$d" "@${ns}" 2>/dev/null | head -1 | sed 's/\.$//')
+            [ -z "$out" ] && out=$(dig +short CNAME "$d" 2>/dev/null | head -1 | sed 's/\.$//')
+            if [ -z "$out" ]; then
+              out=$(curl -s -H 'accept: application/dns-json' \
+                "https://1.1.1.1/dns-query?name=${d}&type=CNAME" 2>/dev/null \
+                | jq -r '.Answer[]? | select(.type==5) | .data' | head -1 | sed 's/\.$//')
+            fi
+            echo "$out"
+          }
+          LIVE_GW=$(resolve_cname "$DOMAIN")
+          OLD_GW=$(phala cvms get "$OLD" --json 2>/dev/null | jq -r '.gateway.cname // empty' | sed 's/\.$//')
+          if [ -z "$LIVE_GW" ]; then
+            echo "::error::Could not resolve $DOMAIN; refusing to stop $OLD."
+            exit 1
+          fi
+          if [ "$LIVE_GW" = "$OLD_GW" ]; then
+            echo "::error::Public domain still points at OLD instance '$OLD' (gw=$OLD_GW). Cutover did not move the domain — NOT stopping it (would cause an outage)."
+            exit 1
+          fi
+          echo "Domain now on '$LIVE_GW' (off old '$OLD_GW'); stopping old instance: $OLD"
+          phala cvms stop "$OLD"
+
+  # Post-cutover auto-rollback. The cold box auto-claims the domain at boot (as
+  # soon as the container starts), BEFORE the deeper checks (attestation/openapi/k6)
+  # run. If any of
+  # those fail, the new box is live-but-bad — flip the public domain back to the
+  # still-running old instance and stop the bad new box. Both instances share one
+  # app_id, so the _dstack-app-address TXT is identical; only the CNAME (→ node
+  # gateway) needs to move back. Runs ONLY on a verify failure after the new box
+  # came up (if it never came up, it never claimed, and the old box still serves).
+  rollback-on-failure:
+    needs: [determine-target, detect-changes, deploy, wait-for-api-available, verify-attestation, openapi-spec-check, k6-smoke, k6-correctness]
+    if: >-
+      ${{ always()
+          && needs.determine-target.outputs.pingpong == 'true'
+          && needs.detect-changes.outputs.deploy_needed == 'true'
+          && needs.deploy.result == 'success'
+          && needs.wait-for-api-available.result == 'success'
+          && needs.determine-target.outputs.prev_live_cvm != ''
+          && (needs.verify-attestation.result == 'failure'
+              || needs.openapi-spec-check.result == 'failure'
+              || needs.k6-smoke.result == 'failure'
+              || needs.k6-correctness.result == 'failure') }}
+    runs-on: self-hosted
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Phala CLI + AWS CLI
+        run: |
+          npm install -g phala
+          command -v aws >/dev/null 2>&1 || python3 -m pip install --quiet --user awscli
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Roll the domain back to the previous instance, stop the bad one
+        env:
+          PHALA_CLOUD_API_KEY: ${{ secrets.PHALA_CLOUD_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CERTBOT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CERTBOT_AWS_SECRET_ACCESS_KEY }}
+          CERTBOT_AWS_ROLE_ARN: ${{ secrets.CERTBOT_AWS_ROLE_ARN }}
+          AWS_DEFAULT_REGION: ${{ vars.CERTBOT_AWS_REGION }}
+        run: |
+          set -euo pipefail
+          OLD="${{ needs.determine-target.outputs.prev_live_cvm }}"
+          NEW="${{ needs.determine-target.outputs.target_cvm }}"
+          DOMAIN="${{ needs.determine-target.outputs.domain }}"
+          OLD_GW=$(phala cvms get "$OLD" --json 2>/dev/null | jq -r '.gateway.cname // empty' | sed 's/\.$//')
+          [ -n "$OLD_GW" ] || { echo "::error::Rollback: cannot resolve old gateway for $OLD"; exit 1; }
+
+          # Assume the Route 53 role (same creds the CVMs use for DNS-01).
+          CREDS=$(aws sts assume-role --role-arn "$CERTBOT_AWS_ROLE_ARN" \
+            --role-session-name pingpong-rollback --query Credentials --output json)
+          export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .AccessKeyId)
+          export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .SecretAccessKey)
+          export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .SessionToken)
+
+          ZONE_DNS="${DOMAIN#*.}"   # test.chipotle.litprotocol.com → chipotle.litprotocol.com
+          ZONE=$(aws route53 list-hosted-zones-by-name --dns-name "$ZONE_DNS" \
+            --query 'HostedZones[0].Id' --output text | sed 's#/hostedzone/##')
+          [ -n "$ZONE" ] || { echo "::error::Rollback: could not find hosted zone for $ZONE_DNS"; exit 1; }
+
+          CB=$(mktemp)
+          printf '{"Comment":"pingpong rollback","Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"%s","Type":"CNAME","TTL":30,"ResourceRecords":[{"Value":"%s"}]}}]}\n' "$DOMAIN" "$OLD_GW" > "$CB"
+          echo "Rollback: pointing $DOMAIN CNAME back to old gateway $OLD_GW"
+          aws route53 change-resource-record-sets --hosted-zone-id "$ZONE" --change-batch "file://$CB"
+          rm -f "$CB"
+
+          # Stop the bad new box so its renewal daemon can't re-claim the CNAME.
+          unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+          echo "Rollback: stopping bad new instance $NEW"
+          phala cvms stop "$NEW" || true
+          echo "::error::Post-cutover verification failed — rolled $DOMAIN back to $OLD and stopped $NEW. Investigate the new build before redeploying."
+          exit 1

--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -26,6 +26,9 @@ on:
       api_root_url:
         description: "API base URL (e.g. https://example.com/core/v1)"
         value: ${{ jobs.wait.outputs.api_root_url }}
+      base_url:
+        description: "Site base URL without the /core/v1 suffix (e.g. https://example.com)"
+        value: ${{ jobs.wait.outputs.base_url }}
     inputs:
       expected_sha:
         description: "Expected git commit SHA for the new deployment (omit to skip version check)"
@@ -60,6 +63,7 @@ jobs:
     runs-on: ${{ fromJson(inputs.runner) }}
     outputs:
       api_root_url: ${{ steps.resolve-url.outputs.api_root_url }}
+      base_url: ${{ steps.resolve-url.outputs.base_url }}
     steps:
       - name: Checkout (for git describe)
         if: inputs.expected_sha != ''
@@ -106,6 +110,7 @@ jobs:
             exit 1
           fi
           echo "api_root_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+          echo "base_url=${BASE_URL%/core/v1}" >> "$GITHUB_OUTPUT"
           echo "API base URL: $BASE_URL"
 
       - name: Wait for expected version

--- a/plans/zero-downtime-pingpong-deploy.md
+++ b/plans/zero-downtime-pingpong-deploy.md
@@ -1,0 +1,216 @@
+# Zero-Downtime Ping-Pong Deploys on Phala (prod2 ↔ prod4)
+
+> **Update (2026-06-15) — the `/health` healthcheck gate was dropped.** The first
+> attempt at this (PR #437) added a `lit-api-server` healthcheck (+ `curl` in the
+> Dockerfile) and gated the ingress on `service_healthy` so the domain only claimed
+> once `/health` passed. That broke deploys (the gate prevented `dstack-ingress`
+> from starting / claiming the domain) and was reverted (#493). This re-landing keeps
+> **only the CI side** — `dstack-ingress` now depends on `lit-api-server:
+> service_started` (claims the domain as soon as the container starts, no `/health`
+> gate). The boot→ready exposure window is covered by the CI flow: verify on the cold
+> box's direct URL, then `confirm-cutover`, with `rollback-on-failure` flipping the
+> domain back if any post-cutover check fails. So in the sections below, treat every
+> "add a healthcheck + `service_healthy` dependency" recommendation as **not done on
+> purpose** — the CI verify + auto-rollback is the mitigation instead.
+
+**Status:** Design settled (validated by a manual prod cutover 2026-06-02). Ready to automate.
+**Scope:** One app, two long-lived instances on two Phala nodes. Each deploy targets the *cold* node; the new CVM's `dstack-ingress` **auto-claims** the custom domain on boot (the cutover); the old node is shut down once the new one is verified. Single `app_id` → one identity / shared keys preserved. Do `next`/staging first, then prod.
+
+---
+
+## 1. Goal
+
+Today every deploy mutates the **single live CVM in place** → container restart → ~30s–2min of **downtime** while `wait-for-api-restart.yml` polls for it to return.
+
+Instead: keep **two warm instances of the same app** on two nodes (prod2 + prod4). Each deploy:
+
+1. Targets whichever node is **cold** (not serving).
+2. Brings up the new code there and waits until it's **healthy on its own default Phala URL**.
+3. Lets the cold CVM's `dstack-ingress` **auto-claim** the custom domain (rewrites Route 53 → its node's gateway). The old node keeps serving cached clients until DNS rolls over.
+4. **Shuts down the old node** once the new one is confirmed serving.
+
+Next deploy flips direction. Both nodes run the **same `app_id`** (shared KMS identity / derived keys), so the node's on-chain identity and signing keys are continuous across cutovers.
+
+---
+
+## 2. Current state
+
+| Thing | Today |
+|---|---|
+| `next` app | `chipotle-next` — instance `chipotle-next-rep-sa6xj` (prod2, `app_id 0x969a8c14…`) |
+| `dev` app | `chipotle-dev` (prod5, `app_id f8fce543…`) |
+| prod app | `chipotle-prod` — instance `chipotle-prod-rep-r68r6`, Safe-owned `app_id` |
+| Staging domain | `test.chipotle.litprotocol.com` (prod domain = `vars.DOMAIN_PROD`) |
+| Deploy trigger | push `next` → `deploy-staging.yml`; `v*` tag → `deploy-prod-1/2/3` |
+| Cutover today | none — in-place restart of the one live CVM (downtime) |
+| Target override | `phala_cvm_name` `workflow_dispatch` input (#434) lets a manual run target a specific instance |
+| DNS / TLS | each CVM's `dstack-ingress` obtains an LE cert (DNS-01 via Route 53) **and auto-creates the routing DNS records** for `DOMAIN` |
+
+Relevant files: `.github/workflows/deploy-staging.yml`, `deploy-prod-1-propose.yml`, `deploy-prod-2-execute-manual.yml`, `wait-for-api-restart.yml`, `manual_phala-add-device.yml`, `lit-api-server/blockchain/lit_node_express/tasks/propose-add-device.ts`, `docker-compose.phala.yml`, `justfile.deploy`.
+
+---
+
+## 3. How the cutover works (the load-bearing mechanism)
+
+From the `dstack-ingress` source (`scripts/entrypoint.sh`, `dnsman.py`) + empirical testing: on **boot**, for its `DOMAIN`, the ingress writes three Route 53 records and obtains a cert:
+
+| Record | Name | Value | Purpose |
+|---|---|---|---|
+| **ALIAS/CNAME** | `<domain>` | `_.dstack-base-prodN.phala.network` | points domain at that node's gateway |
+| **TXT** | `_dstack-app-address.<domain>` | `<app_id>:443` | gateway reads this to route the domain to the app |
+| **CAA** | `<domain>` | LE + (optionally) an `accounturi` restriction | issuance policy (`SET_CAA=false` to skip) |
+
+Request flow: client → CNAME → node gateway → gateway reads the TXT, finds the app's authorized instance **on that node**, TLS-passthrough to the CVM's ingress → terminates TLS with its `<domain>` cert → proxies to `lit-api-server:8000`.
+
+**The cutover is the auto-claim itself.** When the cold node's CVM boots, its ingress rewrites the ALIAS (→ its own node's gateway) + TXT. That *is* the flip — no CI-managed Route 53 needed. Cert issuance is via DNS-01 (`_acme-challenge` TXT), independent of routing, so the cold node gets a valid cert before/while it claims.
+
+**Why one `app_id` works across nodes — the on-chain device allowlist.** Each Phala node has a distinct `device_id`. The app's on-chain **AppAuth/DstackApp** contract has an `addDevice(deviceId)` allowlist, and the **KMS only releases the app's keys to allowlisted devices** (`manual_phala-add-device.yml`, `propose-add-device.ts`). Allowlist *both* nodes' devices and a single-`app_id` instance runs as a full citizen on either node — derives the same keys **and** the gateway serves its custom domain. This is what makes ping-pong possible without separate apps.
+
+> Correction to an earlier draft: a quick `phala cvms replicate` test (which does **not** run `addDevice`) produced a replica the gateway refused to serve the custom domain for, which wrongly looked like "single app_id is impossible / need two separate apps." The real cause was the missing on-chain device authorization. The manual prod cutover on 2026-06-02 (prod4→prod2, same `app_id`) proves the single-`app_id` model works when the device is allowlisted.
+
+---
+
+## 4. Architecture
+
+One app per environment, `app_id` fixed. Two long-lived instances, one per node, **both devices allowlisted on-chain**. Exactly one is "live" (owns the domain) at a time.
+
+```
+              test.chipotle.litprotocol.com   ← owned by whichever node last claimed it
+                                 │  (ALIAS + _dstack-app-address TXT, written by the live CVM's ingress)
+              ┌──────────────────┴──────────────────┐
+              ▼ (when prod2 live)                    ▼ (when prod4 live)
+ ┌──────────────────────────────────┐   ┌──────────────────────────────────┐
+ │ NODE prod2                        │   │ NODE prod4                        │
+ │ same app_id, device allowlisted   │   │ same app_id, device allowlisted   │
+ │ default URL: <appid>-8000         │   │ default URL: <appid>-8000         │
+ │   .dstack-base-prod2…             │   │   .dstack-base-prod4…             │
+ │ holds cert for the custom domain  │   │ holds cert for the custom domain  │
+ └──────────────────────────────────┘   └──────────────────────────────────┘
+        ▲ CI verifies the cold node here (default Phala URL) before cutover
+```
+
+- **Same `app_id` on both nodes** → one identity, shared derived keys; clients/contracts see a stable node. (This is why we don't use two separate apps.)
+- **The live node owns the domain**; the gateway serves the domain from exactly **one** instance (it does **not** load-balance across instances — verified). Switching = the other node re-claiming on boot.
+- **Verification uses the default Phala URL** (`<app_id>-8000.dstack-base-prodN…`), served by the gateway's own wildcard cert — reachable before the custom domain is involved. `wait-for-api-restart.yml` already resolves this via `phala cvms get`.
+
+---
+
+## 5. The deploy / cutover flow
+
+```
+deploy (push to next, or tag for prod)
+  └─ build (unchanged: 3 images, sigstore-signed, digest-pinned)
+  └─ select-target: read "last live node" → target the COLD node's CVM
+        (manual override available via phala_cvm_name)
+  └─ deploy new code to the COLD node's CVM
+        (its ingress will auto-claim the domain on boot)
+  └─ wait-for-api-restart  (phala_app_name = cold CVM, expected_sha)  ← default Phala URL
+  └─ verify-attestation / openapi-spec-check / k6-smoke  ← against the cold default URL
+  └─ confirm cutover: poll the PUBLIC domain until it serves the new SHA + /health  (the ingress claim has propagated)
+  └─ shut down the OLD node's CVM   (only after the above is green)
+  └─ record the new live node (so the next deploy targets the other one)
+```
+
+- **All gating happens on the cold node's default Phala URL before we depend on the cutover** — the new code is proven healthy before traffic shifts.
+- **Don't stop the old node until the public domain is confirmed serving the new node.** The old node is the rollback target and the bridge for cached-DNS clients during rollover.
+- prod keeps its Safe / on-chain compose-hash governance gate **before** the deploy; the cutover is the same auto-claim mechanism after verification.
+
+### The health-gate subtlety (the one real risk)
+
+The ingress claims the domain *on boot*, and `docker-compose.phala.yml` currently has `dstack-ingress depends_on lit-api-server: condition: service_started` (**not** `service_healthy`). So the domain can flip to the new node before `lit-api-server` is actually ready → a window where DNS-refreshed clients hit a not-ready box. Two mitigations, do both:
+
+1. **Add a healthcheck to `lit-api-server`** and change the ingress to `depends_on: { lit-api-server: { condition: service_healthy } }` so the claim only happens once the backend is serving.
+2. **Keep the old node running** until CI confirms the public domain serves the new SHA (cached-DNS clients stay on the healthy old node during rollover; low DNS TTL shrinks the window).
+
+---
+
+## 6. Tracking which node is live
+
+The deploy must pick the **cold** node. Both instances share one `app_id`, so the `_dstack-app-address` TXT (=`app_id:443`) can't tell them apart — track by **node / CVM name**, not app_id:
+
+- **Stored pointer (recommended):** a GitHub Actions variable (e.g. `NEXT_LIVE_CVM`) updated at the end of each successful deploy; deploy targets "the other one." Simple, explicit.
+- **Cross-check from reality:** the live ALIAS (`_dstack-app-address.<domain>` resolves to the node gateway in the CNAME) tells you which **node** currently serves; confirm the stored pointer matches before trusting it.
+- `phala_cvm_name` (#434) remains the manual override / break-glass.
+
+---
+
+## 7. CI changes
+
+**`deploy-staging.yml`** (and the prod execute workflow):
+- `select-target` step: read `NEXT_LIVE_CVM` (or live DNS) → set the cold CVM as the deploy target (instead of the hardcoded per-branch default).
+- After `wait-for-api-restart` + verification on the cold default URL, add a **confirm-cutover** step (poll public domain for new SHA/health) and a **shutdown-old** step (`phala cvms stop`/delete the previously-live CVM), then **update `NEXT_LIVE_CVM`**.
+- Keep the existing gates (`verify-attestation`, `openapi-spec-check`, `k6-smoke`, `k6-correctness`); point the pre-cutover ones at the cold default URL.
+
+**`docker-compose.phala.yml`:** add the `lit-api-server` healthcheck + ingress `service_healthy` dependency (§5).
+
+**Provisioning (one-time):** ensure both nodes' `device_id`s are allowlisted on the app's AppAuth contract (`manual_phala-add-device.yml` for EOA-owned `next`/`dev`; `propose-add-device.ts` → Safe for prod). Keep both CVMs long-lived so each cold deploy is an **in-place upgrade** (cert volume persists — see §8).
+
+---
+
+## 8. Robustness notes
+
+- **Let's Encrypt rate limit — keep CVMs long-lived.** LE caps **5 certs/week per exact hostname**. A *fresh* CVM boot issues a new cert; an **in-place upgrade reuses the persisted `cert-data` volume** (no reissue). So: deploy by upgrading the two standing CVMs in place, *not* by reprovisioning fresh CVMs each time. Only node *migrations* (new device) should issue a cert — well under 5/week. (We hit this limit during testing by reprovisioning the same hostname repeatedly.)
+- **Rollback** = bring the old node back / let it re-claim (it still has its cert and is an allowlisted instance), or just don't stop it until the new node is green. Sub-minute.
+- **Split-brain:** during rollover both nodes are briefly up serving the same app/keys. Fine for stateless request serving; if any single-writer assumption exists (e.g. a leader-only background loop), confirm it tolerates a brief overlap, or shut the old node promptly after cutover.
+- **CAA:** keep `SET_CAA=false` (or a CAA with no `accounturi` lock) so either node's ACME account can always (re)issue — verified the `chipotle`/`dev` zones currently have **no** `accounturi` restriction.
+- **Cost:** two warm CVMs per environment ≈ 2× compute. Accepted tradeoff for zero downtime.
+
+---
+
+## 9. What we proved (Phase 0, dev zone, 2026-06-01→02)
+
+All in the isolated `dev.litprotocol.com` zone with a least-privilege key; never touched `chipotle`/staging/prod.
+
+- ✅ **Cert coexistence** — two independent ACME accounts both issued for one hostname (DNS-01); CAA is not a blocker (no `accounturi` lock).
+- ✅ **In-CVM cert issuance via assumed role works** — `dstack-ingress` got a real LE cert using a dev-scoped IAM role (`CERTBOT_AWS_ROLE_ARN`).
+- ✅ **Custom-domain routing works on `dstack-base-*` gateways for our own app** (a fresh `--kms base` primary served the custom domain). It does **not** work on `dstack-pha-*` gateways (the `--kms phala` default tier) — the real apps are `--kms base`, so this is fine.
+- ✅ **The auto-claim cutover is real** — a booting CVM's ingress rewrites ALIAS+TXT to itself; DNS reaches authoritative INSYNC in seconds; rollback (re-point) is symmetric.
+- ✅ **Gateway serves a domain from one instance, not load-balanced** — 40/40 requests hit the primary even with a healthy same-node co-tenant. (Good: ping-pong wants single-owner, switched by re-claim.)
+- ❌→✅ **`phala cvms replicate` (no `addDevice`) replica couldn't serve the custom domain** for 8+ min. Root cause = missing on-chain device authorization, **not** a fundamental limit. The manual prod cutover (same `app_id`, allowlisted device) works — hence the single-`app_id` design here.
+- ⚠️ **LE 5/week/hostname rate limit** is real and easy to hit when iterating — drove the "long-lived CVMs / in-place upgrade" rule in §8.
+
+---
+
+## 10. Open questions / confirm before automating
+
+1. **Cutover health timing** — confirm adding the `lit-api-server` healthcheck + ingress `service_healthy` dependency actually delays the domain claim until the API is ready (test on a dev box).
+2. **`phala cvms stop` vs `delete` for the old node** — stop (keep as warm rollback, cheaper than redeploy) vs delete. Prefer **stop** so the cert volume + identity persist for the next flip back.
+3. **Both prod nodes' devices allowlisted?** Verify prod2 **and** prod4 `device_id`s are on the prod AppAuth allowlist (Safe-owned) before relying on prod4↔prod2.
+4. **`NEXT_LIVE_CVM` source of truth** — Actions variable vs derived-from-DNS; pick one and make the deploy fail loudly if they disagree.
+5. **Background/singleton work** — does anything in `lit-api-server` assume a single live instance (triggers, listeners)? Affects the split-brain note (§8).
+
+---
+
+## 11. Phased rollout
+
+**Phase 0 — de-risk (done).** §9. Mechanism, cert behavior, auto-claim, and the device-allowlist requirement all validated in dev; manual prod cutover confirms the single-`app_id` flow end-to-end.
+
+**Phase 1 — staging automation.** Add the healthcheck + `service_healthy` dependency to `docker-compose.phala.yml`. Rewrite `deploy-staging.yml` to select the cold node, deploy in place, verify on the default URL, confirm public cutover, stop the old node, record `NEXT_LIVE_CVM`. Dogfood on `next` with intentional alternating deploys.
+
+**Phase 2 — production.** Apply the same flow to `deploy-prod-2-execute-manual.yml`, keeping the Safe/on-chain compose-hash gate before deploy and the device allowlist for both prod nodes. Cutover stays the auto-claim; rollback = don't-stop-old-until-green.
+
+---
+
+## 12. Task checklist
+
+- [ ] Confirm prod2 **and** prod4 `device_id`s are allowlisted on each app's AppAuth contract (`manual_phala-add-device.yml` / `propose-add-device.ts`).
+- [ ] `docker-compose.phala.yml`: add `lit-api-server` healthcheck + ingress `depends_on: service_healthy`.
+- [ ] `deploy-staging.yml`: add `select-target` (cold node from `NEXT_LIVE_CVM` / live DNS), keep verification on the cold default Phala URL.
+- [ ] Add **confirm-cutover** (poll public domain for new SHA/health) + **stop-old-node** steps; update `NEXT_LIVE_CVM` on success.
+- [ ] Ensure deploys are **in-place upgrades** of two standing CVMs (preserve `cert-data`; avoid LE rate limit).
+- [ ] Rollback runbook: re-start / re-claim the old node (don't stop it until the new node is green).
+- [ ] Port the same flow into `deploy-prod-2-execute-manual.yml` after the Safe/on-chain gate.
+- [ ] Decide `phala cvms stop` vs `delete` for the old node (prefer stop).
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Domain claimed before new API is ready | `lit-api-server` healthcheck + ingress `service_healthy`; keep old node up until public domain confirmed |
+| LE 5-cert/week/hostname limit | Long-lived CVMs, in-place upgrades (reuse `cert-data`); only migrations issue certs |
+| Stale "which node is live" pointer | Cross-check `NEXT_LIVE_CVM` against live DNS; fail loudly on mismatch |
+| New node's device not allowlisted | Allowlist both devices up front; verify before cutover (KMS won't release keys otherwise) |
+| Split-brain during rollover | Brief overlap is fine for stateless serving; confirm any singleton/background work tolerates it; stop old node promptly |
+| Doubled infra cost | Accepted for zero downtime |


### PR DESCRIPTION
Re-lands the zero-downtime ping-pong cutover from #437 (reverted in #493) as **CI-only**, dropping the `/health` healthcheck gate that broke deploys — so `docker-compose.phala.yml` and `Dockerfile.lit-api-server` are unchanged from `main` (no healthcheck, no `curl`, `SET_CAA` stays `true`, ingress keeps `depends_on: service_started`). Pushes to `main` now deploy to the cold `chipotle-next` instance (DNS-derived target selection), verify on its direct Phala URL, confirm the public-domain cutover, stop the old instance, and auto-rollback the DNS on any post-cutover verify failure. `wait-for-api-restart.yml` gains a `base_url` output so attestation targets the cold box directly. The boot→ready window (the claim happens on container start, not `/health`) is covered by that CI verify + rollback flow. `plans/zero-downtime-pingpong-deploy.md` documents the design with a note explaining why the healthcheck was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)