### PR TITLE
fix(build): stop git_version stamping lit-api-server "-modified"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,10 @@
 # Local env / temp files
 **/.env
 **/.env.*
-!**/.env.example
+# Re-include all committed *.example env templates. They are tracked in git;
+# dropping any of them (e.g. .env.local.example) removes a tracked file from the
+# build context, which makes `git describe --dirty` stamp the binary "-modified".
+!**/.env*.example
 **/.DS_Store
 **/tmp/
 **/coverage/

--- a/Dockerfile.lit-api-server
+++ b/Dockerfile.lit-api-server
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY . .
 
-RUN cd lit-api-server && cargo build --release --features production --bin lit-api-server
+RUN cd lit-api-server && cargo build --locked --release --features production --bin lit-api-server
 
 FROM debian:bookworm-slim AS runtime
 


### PR DESCRIPTION
## Summary
- Fixes the `deploy-staging` "wait for api available" gate, which never converged because the running API reported `v1.1.9-3-g935b023-modified` while CI expected `v1.1.9-3-g935b023f`. The `-modified` suffix comes from `git_version!()` running `git describe --dirty` at build time against a dirty tree.
- `.dockerignore`: broaden `!**/.env.example` to `!**/.env*.example`. The tracked template `examples/lit-solver-vault/dashboard/.env.local.example` was matched by `**/.env.*` and not rescued by the old negation, so it was dropped from the build context — `git describe` saw a deleted tracked file and stamped `-modified` on every build.
- `Dockerfile.lit-api-server`: add `--locked` to `cargo build` so a `Cargo.lock` update during the build cannot dirty the tree (secondary `-modified` source) and to keep builds reproducible.

## Testing
- Not run (CI build; verify on next `deploy-staging` run that `/core/v1/version` reports a version with no `-modified` suffix and the gate passes).
