### PR TITLE
fix(k6-smoke): select accounts.next.json on main, not accounts.dev.json

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -29,7 +29,7 @@ on:
         required: false
         type: string
       accounts_file:
-        description: "Optional accounts file override (e.g. ./k6/data/accounts.next.json)"
+        description: "Optional accounts file override, relative to the k6/ dir (e.g. ./data/accounts.next.json)"
         required: false
         type: string
 
@@ -37,7 +37,9 @@ jobs:
   k6-smoke:
     runs-on: self-hosted
     env:
-      K6_ACCOUNTS_FILE: ${{ inputs.accounts_file || (github.ref_name == 'next' && './data/accounts.next.json' || './data/accounts.dev.json') }}
+      # `main` is the deploy branch and targets chipotle-next (test.chipotle.litprotocol.com);
+      # the legacy `next` branch is retired. chipotle-dev is deprecated.
+      K6_ACCOUNTS_FILE: ${{ inputs.accounts_file || (github.ref_name == 'main' && './data/accounts.next.json' || './data/accounts.dev.json') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The k6 smoke test failed on the deploy after merging #495, with two failures that are really one root cause:

- `topUp/createPaymentIntent` → `400 Invalid API key: account not found for API key`
- `litAction` → `402 Payment Required`

## Root cause

#495 switched the deploy branch from `next` → `main` (see `deploy-staging.yml:141-143`: *"the `next` git branch is retired; `main` is the deploy branch and targets the chipotle-next staging app"*).

But `k6-smoke.yml` still selected the accounts file off the **old** branch name:

```yaml
K6_ACCOUNTS_FILE: ${{ inputs.accounts_file || (github.ref_name == 'next' && './data/accounts.next.json' || './data/accounts.dev.json') }}
```

`github.ref_name == 'next'` is now always false, so the smoke test fell through to **`accounts.dev.json`** — API keys seeded against the deprecated **chipotle-dev** environment. Hitting chipotle-next (`test.chipotle.litprotocol.com`) with chipotle-dev keys produces exactly the failures above. `deploy-staging.yml:451-455` calls k6-smoke with only `api_root_url`, so nothing overrode it.

## Fix

- Select `accounts.next.json` when `github.ref_name == 'main'`, the current deploy branch.
- Drive-by: fix the `workflow_dispatch` `accounts_file` help text — k6 `open()` resolves relative to the `k6/` script dir, so overrides are `./data/...`, not `./k6/data/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)