### PR TITLE
feat(accounts): per-account permission cache invalidation + on-chain listener

### DIFF
--- a/lit-api-server/src/account_events.rs
+++ b/lit-api-server/src/account_events.rs
@@ -1,16 +1,16 @@
 //! On-chain account-mutation event listener.
 //!
 //! Polls the AccountConfig contract for the permission-mutating events emitted
-//! by `WritesFacet`. When it sees *any* of them in a block range, it flushes the
-//! permission cache by bumping the global generation
-//! ([`blockchain_cache::invalidate_all`]).
+//! by `WritesFacet`. For each event it extracts the account `apiKeyHash` the
+//! mutation touched and invalidates just that account's cached verdicts via
+//! [`crate::accounts::invalidate_account_by_hash`] (which resolves the hash to
+//! its wallet and bumps that account's generation — see
+//! [`crate::accounts::blockchain_cache`]).
 //!
-//! That's the whole job. Because invalidation is global (see
-//! [`crate::accounts::blockchain_cache`]), the listener does **not** decode logs
-//! or extract account/key hashes — it only needs to know *whether* a relevant
-//! mutation happened. The event-signature set is used purely as the
-//! `eth_getLogs` topic0 filter, so high-volume billing/config events on the same
-//! contract address don't trigger pointless flushes.
+//! Invalidation is per-account, so a single account's churn never flushes other
+//! accounts' caches. The listener decodes only enough of each event to recover
+//! its account hash; it does not enumerate usage keys (bumping the account's
+//! generation invalidates the master and all usage keys at once).
 //!
 //! This closes the staleness window for changes made outside this process —
 //! ChainSecured wallet-signed transactions sent directly to the contract, or
@@ -18,13 +18,14 @@
 //!
 //! Mirrors the polling/retry structure of [`crate::restart`].
 
-use crate::accounts::blockchain_cache;
 use crate::accounts::contracts::account_config_contract::AccountConfig as ac;
+use crate::accounts::invalidate_account_by_hash;
 use crate::accounts::signable_contract::get_read_only_account_config_contract;
-use alloy::primitives::B256;
+use alloy::primitives::{B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEvent;
+use std::collections::HashSet;
 use std::time::Duration;
 
 /// Polling interval for checking new account-mutation events.
@@ -33,28 +34,96 @@ const EVENT_POLL_INTERVAL: Duration = Duration::from_secs(10);
 /// Maximum number of consecutive startup failures before giving up.
 const MAX_LISTENER_RETRIES: u32 = 5;
 
-/// topic0 set for the `eth_getLogs` filter: every `WritesFacet` permission
-/// mutation event. We only ever check whether a matching log exists, so the
-/// listener never decodes these — this list exists solely to exclude unrelated
-/// (e.g. billing) events emitted by the same contract address.
+/// Expand `$mac!(EventType, |e| <account apiKeyHash>)` once per `WritesFacet`
+/// permission-mutation event. Used to build both the log filter's topic0 set and
+/// the decode dispatch from a single source of truth, so the two can't drift.
+///
+/// The closure returns the account (master) `apiKeyHash` the mutation belongs
+/// to. Usage-key events carry the account hash in `accountApiKeyHash`; bumping
+/// that account's generation invalidates the usage key too, so the usage hash is
+/// not needed here.
+macro_rules! for_each_writes_facet_event {
+    ($mac:ident) => {
+        $mac!(AccountCreated, |e| e.apiKeyHash);
+        $mac!(AccountConvertedToChainSecured, |e| e.apiKeyHash);
+        $mac!(ChainSecuredAccountOwnershipTransferred, |e| e.apiKeyHash);
+        $mac!(GroupAdded, |e| e.apiKeyHash);
+        $mac!(GroupUpdated, |e| e.accountApiKeyHash);
+        $mac!(GroupRemoved, |e| e.apiKeyHash);
+        $mac!(ActionAdded, |e| e.accountApiKeyHash);
+        $mac!(ActionRemoved, |e| e.accountApiKeyHash);
+        $mac!(ActionAddedToGroup, |e| e.apiKeyHash);
+        $mac!(ActionRemovedFromGroup, |e| e.apiKeyHash);
+        $mac!(PkpAddedToGroup, |e| e.apiKeyHash);
+        $mac!(PkpRemovedFromGroup, |e| e.apiKeyHash);
+        $mac!(WalletDerivationRegistered, |e| e.apiKeyHash);
+        $mac!(UsageApiKeySet, |e| e.accountApiKeyHash);
+        $mac!(UsageApiKeyRemoved, |e| e.accountApiKeyHash);
+    };
+}
+
+/// All WritesFacet event signature hashes, used as the `eth_getLogs` topic0 set
+/// so the listener only fetches account-mutation logs (not high-volume
+/// billing/config events emitted by the same contract address).
 fn event_signatures() -> Vec<B256> {
-    vec![
-        ac::AccountCreated::SIGNATURE_HASH,
-        ac::AccountConvertedToChainSecured::SIGNATURE_HASH,
-        ac::ChainSecuredAccountOwnershipTransferred::SIGNATURE_HASH,
-        ac::GroupAdded::SIGNATURE_HASH,
-        ac::GroupUpdated::SIGNATURE_HASH,
-        ac::GroupRemoved::SIGNATURE_HASH,
-        ac::ActionAdded::SIGNATURE_HASH,
-        ac::ActionRemoved::SIGNATURE_HASH,
-        ac::ActionAddedToGroup::SIGNATURE_HASH,
-        ac::ActionRemovedFromGroup::SIGNATURE_HASH,
-        ac::PkpAddedToGroup::SIGNATURE_HASH,
-        ac::PkpRemovedFromGroup::SIGNATURE_HASH,
-        ac::WalletDerivationRegistered::SIGNATURE_HASH,
-        ac::UsageApiKeySet::SIGNATURE_HASH,
-        ac::UsageApiKeyRemoved::SIGNATURE_HASH,
-    ]
+    let mut sigs = Vec::new();
+    macro_rules! push_sig {
+        ($ev:ident, $extract:expr) => {
+            sigs.push(<ac::$ev as SolEvent>::SIGNATURE_HASH);
+        };
+    }
+    for_each_writes_facet_event!(push_sig);
+    sigs
+}
+
+/// Decode a single log against the known WritesFacet events and return the
+/// account `apiKeyHash` it touched. Logs whose signature doesn't match a known
+/// event (or which fail to decode) return `None`.
+fn account_hash_from_log(log: &alloy::primitives::Log) -> Option<U256> {
+    let topic0 = log.topics().first().copied()?;
+
+    macro_rules! dispatch {
+        ($ev:ident, $extract:expr) => {
+            if topic0 == <ac::$ev as SolEvent>::SIGNATURE_HASH {
+                match ac::$ev::decode_log(log) {
+                    Ok(decoded) => {
+                        let extract: fn(&ac::$ev) -> U256 = $extract;
+                        return Some(extract(&decoded.data));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            event = stringify!($ev),
+                            "account_events: failed to decode log: {e}"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
+    }
+
+    for_each_writes_facet_event!(dispatch);
+    None
+}
+
+/// Invalidate the cache for a batch of logs from one poll. Account hashes are
+/// deduped so each affected account is resolved + bumped at most once per poll,
+/// regardless of how many of its events appear in the batch.
+async fn process_logs(logs: &[alloy::rpc::types::Log]) {
+    let accounts: HashSet<U256> = logs
+        .iter()
+        .filter_map(|log| account_hash_from_log(&log.inner))
+        .collect();
+
+    tracing::info!(
+        log_count = logs.len(),
+        account_count = accounts.len(),
+        "Account mutation events detected — invalidating affected accounts"
+    );
+
+    for hash in accounts {
+        invalidate_account_by_hash(hash).await;
+    }
 }
 
 /// Start the on-chain account-event listener as a background task.
@@ -133,14 +202,9 @@ async fn run_event_listener() -> anyhow::Result<()> {
         match client.get_logs(&filter).await {
             Ok(logs) => {
                 if !logs.is_empty() {
-                    tracing::info!(
-                        log_count = logs.len(),
-                        block_range = format!("{from_block}..{latest_block}"),
-                        "Account mutation events detected — flushing permission cache"
-                    );
-                    blockchain_cache::invalidate_all();
+                    process_logs(&logs).await;
                 }
-                // Only advance once logs are successfully fetched; on error we
+                // Only advance once logs are successfully processed; on error we
                 // retry the same range on the next tick.
                 last_checked_block = latest_block;
             }
@@ -158,25 +222,166 @@ async fn run_event_listener() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
+    use alloy::primitives::{Address, Log};
+
+    /// Build a primitives `Log` for an event, as it would arrive from the chain.
+    fn log_for<E: SolEvent>(event: &E) -> Log {
+        Log {
+            address: Address::ZERO,
+            data: event.encode_log_data(),
+        }
+    }
 
     #[test]
     fn event_signatures_are_complete_and_unique() {
         let sigs = event_signatures();
-        // One signature per WritesFacet permission-mutation event.
         assert_eq!(sigs.len(), 15, "expected 15 WritesFacet event signatures");
         let unique: HashSet<_> = sigs.iter().collect();
         assert_eq!(unique.len(), sigs.len(), "signatures must be unique");
     }
 
     #[test]
-    fn billing_event_is_not_in_filter() {
-        // A high-volume billing event on the same contract address must not be
-        // part of the topic0 filter, or every debit would flush the cache.
-        let sigs = event_signatures();
-        assert!(
-            !sigs.contains(&ac::ApiKeyDebited::SIGNATURE_HASH),
-            "billing events must be excluded from the mutation filter"
-        );
+    fn extracts_account_hash_from_apikeyhash_events() {
+        let h = U256::from(0xABCDu64);
+        let cases: Vec<Log> = vec![
+            log_for(&ac::GroupAdded {
+                apiKeyHash: h,
+                groupId: U256::from(1u64),
+            }),
+            log_for(&ac::ActionAddedToGroup {
+                apiKeyHash: h,
+                groupId: U256::from(1u64),
+                action: U256::from(2u64),
+            }),
+            log_for(&ac::PkpAddedToGroup {
+                apiKeyHash: h,
+                groupId: U256::from(1u64),
+                pkpId: Address::ZERO,
+            }),
+            log_for(&ac::AccountCreated {
+                apiKeyHash: h,
+                admin: Address::ZERO,
+                managed: true,
+            }),
+        ];
+        for log in &cases {
+            assert_eq!(account_hash_from_log(log), Some(h));
+        }
+    }
+
+    #[test]
+    fn extracts_account_hash_from_accountapikeyhash_events() {
+        let account = U256::from(0x1111u64);
+        let usage = U256::from(0x2222u64);
+
+        // Events that name the field `accountApiKeyHash` resolve to the account,
+        // not the usage key — bumping the account covers the usage key.
+        let group_updated = log_for(&ac::GroupUpdated {
+            accountApiKeyHash: account,
+            groupId: U256::from(1u64),
+        });
+        assert_eq!(account_hash_from_log(&group_updated), Some(account));
+
+        let usage_set = log_for(&ac::UsageApiKeySet {
+            accountApiKeyHash: account,
+            usageApiKeyHash: usage,
+        });
+        assert_eq!(account_hash_from_log(&usage_set), Some(account));
+
+        let usage_removed = log_for(&ac::UsageApiKeyRemoved {
+            accountApiKeyHash: account,
+            usageApiKeyHash: usage,
+        });
+        assert_eq!(account_hash_from_log(&usage_removed), Some(account));
+    }
+
+    #[test]
+    fn unknown_event_yields_none() {
+        // A billing event on the same contract address must be ignored.
+        let debited = log_for(&ac::ApiKeyDebited {
+            apiKeyHash: U256::from(7u64),
+            amount: U256::from(100u64),
+        });
+        assert_eq!(account_hash_from_log(&debited), None);
+    }
+
+    #[test]
+    fn every_signature_decodes_to_an_account_hash() {
+        // Drift guard: every filtered signature must map to an event the decode
+        // dispatch handles and yield a non-None account hash.
+        let account = U256::from(0x5555u64);
+        let probes: Vec<Log> = vec![
+            log_for(&ac::AccountCreated {
+                apiKeyHash: account,
+                admin: Address::ZERO,
+                managed: false,
+            }),
+            log_for(&ac::AccountConvertedToChainSecured {
+                apiKeyHash: account,
+                newAdminWalletAddress: Address::ZERO,
+            }),
+            log_for(&ac::ChainSecuredAccountOwnershipTransferred {
+                apiKeyHash: account,
+                previousAdminWalletAddress: Address::ZERO,
+                newAdminWalletAddress: Address::ZERO,
+            }),
+            log_for(&ac::GroupAdded {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+            }),
+            log_for(&ac::GroupUpdated {
+                accountApiKeyHash: account,
+                groupId: U256::from(1u64),
+            }),
+            log_for(&ac::GroupRemoved {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+            }),
+            log_for(&ac::ActionAdded {
+                accountApiKeyHash: account,
+                actionHash: U256::from(2u64),
+            }),
+            log_for(&ac::ActionRemoved {
+                accountApiKeyHash: account,
+                actionHash: U256::from(2u64),
+            }),
+            log_for(&ac::ActionAddedToGroup {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+                action: U256::from(2u64),
+            }),
+            log_for(&ac::ActionRemovedFromGroup {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+                action: U256::from(2u64),
+            }),
+            log_for(&ac::PkpAddedToGroup {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+                pkpId: Address::ZERO,
+            }),
+            log_for(&ac::PkpRemovedFromGroup {
+                apiKeyHash: account,
+                groupId: U256::from(1u64),
+                pkpId: Address::ZERO,
+            }),
+            log_for(&ac::WalletDerivationRegistered {
+                apiKeyHash: account,
+                pkpId: Address::ZERO,
+                derivationPath: U256::from(3u64),
+            }),
+            log_for(&ac::UsageApiKeySet {
+                accountApiKeyHash: account,
+                usageApiKeyHash: U256::from(9u64),
+            }),
+            log_for(&ac::UsageApiKeyRemoved {
+                accountApiKeyHash: account,
+                usageApiKeyHash: U256::from(9u64),
+            }),
+        ];
+        assert_eq!(probes.len(), 15);
+        for log in &probes {
+            assert_eq!(account_hash_from_log(log), Some(account));
+        }
     }
 }

--- a/lit-api-server/src/account_events.rs
+++ b/lit-api-server/src/account_events.rs
@@ -1,0 +1,182 @@
+//! On-chain account-mutation event listener.
+//!
+//! Polls the AccountConfig contract for the permission-mutating events emitted
+//! by `WritesFacet`. When it sees *any* of them in a block range, it flushes the
+//! permission cache by bumping the global generation
+//! ([`blockchain_cache::invalidate_all`]).
+//!
+//! That's the whole job. Because invalidation is global (see
+//! [`crate::accounts::blockchain_cache`]), the listener does **not** decode logs
+//! or extract account/key hashes — it only needs to know *whether* a relevant
+//! mutation happened. The event-signature set is used purely as the
+//! `eth_getLogs` topic0 filter, so high-volume billing/config events on the same
+//! contract address don't trigger pointless flushes.
+//!
+//! This closes the staleness window for changes made outside this process —
+//! ChainSecured wallet-signed transactions sent directly to the contract, or
+//! mutations performed by another replica — without waiting out the cache TTL.
+//!
+//! Mirrors the polling/retry structure of [`crate::restart`].
+
+use crate::accounts::blockchain_cache;
+use crate::accounts::contracts::account_config_contract::AccountConfig as ac;
+use crate::accounts::signable_contract::get_read_only_account_config_contract;
+use alloy::primitives::B256;
+use alloy::providers::Provider;
+use alloy::rpc::types::Filter;
+use alloy::sol_types::SolEvent;
+use std::time::Duration;
+
+/// Polling interval for checking new account-mutation events.
+const EVENT_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Maximum number of consecutive startup failures before giving up.
+const MAX_LISTENER_RETRIES: u32 = 5;
+
+/// topic0 set for the `eth_getLogs` filter: every `WritesFacet` permission
+/// mutation event. We only ever check whether a matching log exists, so the
+/// listener never decodes these — this list exists solely to exclude unrelated
+/// (e.g. billing) events emitted by the same contract address.
+fn event_signatures() -> Vec<B256> {
+    vec![
+        ac::AccountCreated::SIGNATURE_HASH,
+        ac::AccountConvertedToChainSecured::SIGNATURE_HASH,
+        ac::ChainSecuredAccountOwnershipTransferred::SIGNATURE_HASH,
+        ac::GroupAdded::SIGNATURE_HASH,
+        ac::GroupUpdated::SIGNATURE_HASH,
+        ac::GroupRemoved::SIGNATURE_HASH,
+        ac::ActionAdded::SIGNATURE_HASH,
+        ac::ActionRemoved::SIGNATURE_HASH,
+        ac::ActionAddedToGroup::SIGNATURE_HASH,
+        ac::ActionRemovedFromGroup::SIGNATURE_HASH,
+        ac::PkpAddedToGroup::SIGNATURE_HASH,
+        ac::PkpRemovedFromGroup::SIGNATURE_HASH,
+        ac::WalletDerivationRegistered::SIGNATURE_HASH,
+        ac::UsageApiKeySet::SIGNATURE_HASH,
+        ac::UsageApiKeyRemoved::SIGNATURE_HASH,
+    ]
+}
+
+/// Start the on-chain account-event listener as a background task.
+pub fn start_account_event_listener() {
+    tokio::spawn(async move {
+        let mut attempt = 0u32;
+        loop {
+            match run_event_listener().await {
+                Ok(()) => break,
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= MAX_LISTENER_RETRIES {
+                        tracing::error!(
+                            attempts = attempt,
+                            "Account event listener failed permanently after {MAX_LISTENER_RETRIES} attempts: {e}"
+                        );
+                        break;
+                    }
+                    let backoff = Duration::from_secs(2u64.pow(attempt.min(5)));
+                    tracing::warn!(
+                        attempt,
+                        backoff_secs = backoff.as_secs(),
+                        "Account event listener failed: {e}. Retrying..."
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+    });
+}
+
+async fn run_event_listener() -> anyhow::Result<()> {
+    let contract = get_read_only_account_config_contract().await?;
+    let client = contract.provider();
+    let address = *contract.address();
+    let signatures = event_signatures();
+
+    let start_block = client
+        .get_block_number()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get initial block number: {e}"))?;
+
+    tracing::info!(
+        from_block = start_block,
+        poll_interval_secs = EVENT_POLL_INTERVAL.as_secs(),
+        event_count = signatures.len(),
+        "Account event listener started"
+    );
+
+    let mut last_checked_block = start_block.saturating_sub(1);
+    let mut interval = tokio::time::interval(EVENT_POLL_INTERVAL);
+    interval.tick().await;
+
+    loop {
+        interval.tick().await;
+
+        let latest_block = match client.get_block_number().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("Failed to get latest block number: {e}");
+                continue;
+            }
+        };
+
+        if latest_block <= last_checked_block {
+            continue;
+        }
+
+        let from_block = last_checked_block.saturating_add(1);
+        let filter = Filter::new()
+            .address(address)
+            .event_signature(signatures.clone())
+            .from_block(from_block)
+            .to_block(latest_block);
+
+        match client.get_logs(&filter).await {
+            Ok(logs) => {
+                if !logs.is_empty() {
+                    tracing::info!(
+                        log_count = logs.len(),
+                        block_range = format!("{from_block}..{latest_block}"),
+                        "Account mutation events detected — flushing permission cache"
+                    );
+                    blockchain_cache::invalidate_all();
+                }
+                // Only advance once logs are successfully fetched; on error we
+                // retry the same range on the next tick.
+                last_checked_block = latest_block;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    block_range = format!("{from_block}..{latest_block}"),
+                    "Failed to query account mutation events: {e}"
+                );
+                continue;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn event_signatures_are_complete_and_unique() {
+        let sigs = event_signatures();
+        // One signature per WritesFacet permission-mutation event.
+        assert_eq!(sigs.len(), 15, "expected 15 WritesFacet event signatures");
+        let unique: HashSet<_> = sigs.iter().collect();
+        assert_eq!(unique.len(), sigs.len(), "signatures must be unique");
+    }
+
+    #[test]
+    fn billing_event_is_not_in_filter() {
+        // A high-volume billing event on the same contract address must not be
+        // part of the topic0 filter, or every debit would flush the cache.
+        let sigs = event_signatures();
+        assert!(
+            !sigs.contains(&ac::ApiKeyDebited::SIGNATURE_HASH),
+            "billing events must be excluded from the mutation filter"
+        );
+    }
+}

--- a/lit-api-server/src/account_events.rs
+++ b/lit-api-server/src/account_events.rs
@@ -19,8 +19,8 @@
 //! Mirrors the polling/retry structure of [`crate::restart`].
 
 use crate::accounts::contracts::account_config_contract::AccountConfig as ac;
-use crate::accounts::invalidate_account_by_hash;
 use crate::accounts::signable_contract::get_read_only_account_config_contract;
+use crate::accounts::{clear_wallet_resolutions, invalidate_account_by_hash};
 use alloy::primitives::{B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
@@ -115,9 +115,24 @@ async fn process_logs(logs: &[alloy::rpc::types::Log]) {
         .filter_map(|log| account_hash_from_log(&log.inner))
         .collect();
 
+    // An ownership transfer moves an account's admin wallet, which is the
+    // identity we key generations by. Memoized hash→wallet resolutions for that
+    // account (including its usage keys) are now stale, and we can't enumerate
+    // them, so drop the whole resolution cache. Transfers are rare, so the
+    // re-resolution cost is negligible. Done before the bumps below so each
+    // affected account re-resolves to its current wallet.
+    let ownership_transferred = logs.iter().any(|log| {
+        log.inner.topics().first()
+            == Some(&ac::ChainSecuredAccountOwnershipTransferred::SIGNATURE_HASH)
+    });
+    if ownership_transferred {
+        clear_wallet_resolutions();
+    }
+
     tracing::info!(
         log_count = logs.len(),
         account_count = accounts.len(),
+        ownership_transferred,
         "Account mutation events detected — invalidating affected accounts"
     );
 

--- a/lit-api-server/src/accounts/blockchain_cache.rs
+++ b/lit-api-server/src/accounts/blockchain_cache.rs
@@ -2,117 +2,83 @@
 //!
 //! Caches the results of on-chain permission checks (`canExecuteAction`,
 //! `canUseWalletInAction`) and wallet derivation lookups (`getWalletDerivation`)
-//! so that repeated calls for the same API key and relevant parameters
-//! avoid redundant contract calls.
+//! so that repeated calls for the same API key and relevant parameters avoid
+//! redundant contract calls.
 //!
-//! TTL: permission results use per-entry expiration — positive (authorized)
-//! results live 5 minutes from insertion, while negative (denied) results
-//! expire after 30 seconds. ChainSecured accounts mutate permissions by
-//! sending wallet-signed transactions directly to the chain, which this
-//! server never observes, so no invalidation hook can cover those writes;
-//! the TTLs bound how long stale state is served in either direction: a
-//! stale denial (newly group-permitted action returning 403) lasts at most
-//! 30s, and a stale grant (revoked action/key still executing) lasts at most
-//! 5 minutes. Wallet derivation lookups use the positive TTL for the same
-//! reason — derivations can change on-chain without this server observing it.
-//! `try_get_with` coalesces concurrent misses per key, so the steady-state
-//! chain load is at most one read per (key, parameters) per TTL window.
+//! # Design: a dumb verdict memoizer
 //!
-//! Invalidation uses a **per-account generation counter**: each API key hash
-//! has an associated generation number embedded in the cache key. Bumping the
-//! generation for an account causes all subsequent lookups to miss, while stale
-//! entries with old generations are evicted naturally by TTL. Note this is
-//! process-local: in a multi-replica deployment, a mutation handled by one
-//! replica does not invalidate the others — they converge within the TTL
-//! bounds above.
+//! The source of truth for permissions is the chain. This cache is *only* a
+//! performance optimization in front of it. It deliberately models nothing
+//! about accounts, master/usage keys, groups, or scopes — it memoizes opaque
+//! contract verdicts keyed by `(api_key_hash, params)`, exactly as the contract
+//! resolves them. A cache miss simply asks the chain; a denial is never special.
+//!
+//! ## Invalidation: one global generation counter
+//!
+//! Permission *mutations* are rare administrative operations; permission
+//! *checks* are the hot path. Given that ratio, we don't try to map a given
+//! on-chain mutation to the specific cache entries it affects (which would
+//! require the server to reconstruct the on-chain account graph — every master
+//! key, usage key, group and scope). Instead, **any** permission-relevant
+//! mutation bumps a single global generation counter embedded in every cache
+//! key, so all subsequent lookups miss and re-read from chain. Stale entries
+//! from older generations are never read again and age out by TTL.
+//!
+//! This is strictly *more* invalidation than necessary (a change to one account
+//! briefly invalidates verdicts for all accounts), which makes it always safe:
+//! it can over-invalidate, never serve stale. The cost is a small burst of
+//! chain re-reads right after a rare mutation, coalesced per key by
+//! `try_get_with` so the steady-state load is at most one read per
+//! (key, params) per generation.
+//!
+//! The bump is driven by an on-chain event listener ([`crate::account_events`])
+//! plus the write-path hooks in [`super`] (which call [`invalidate_all`]
+//! directly for instant invalidation of mutations this process performs). The
+//! listener also covers mutations this process never sees — ChainSecured
+//! wallet-signed transactions sent directly to the contract, or mutations
+//! performed by another replica.
+//!
+//! ## TTL: a backstop, not the freshness mechanism
+//!
+//! Invalidation is what keeps the cache fresh; the TTL is only insurance for the
+//! windows the listener can't cover (missed-block gaps, a replica between boot
+//! and its first poll). A single uniform TTL applies to every entry — there is
+//! no positive/negative asymmetry, because the cache stores verdicts, not
+//! policy, and the listener bounds staleness far tighter than the TTL anyway.
+//!
+//! ## Stateless / horizontally scalable by construction
+//!
+//! The generation counter is process-local. Each replica runs its own listener
+//! and bumps its own counter off the same chain logs, so replicas converge
+//! independently with no shared state. A freshly booted replica starts with an
+//! empty cache (everything misses → everything is fresh) and a listener anchored
+//! at the current block; it never needs history.
 
-use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
-use std::time::{Duration, Instant};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use alloy::primitives::{Address, U256};
-use moka::Expiry;
 use moka::future::Cache;
 
-/// TTL in seconds for positive (authorized) permission results and wallet
-/// derivations — 5 minutes. This bounds how long a revoked permission (or a
-/// changed derivation) keeps being honored when the revocation happens
-/// out-of-band: ChainSecured wallet-signed transactions submitted directly
-/// on-chain, or a mutation handled by a different replica (invalidation is
-/// process-local).
+/// Uniform TTL for every cached entry — a backstop for the windows the on-chain
+/// listener can't cover (missed-block gaps, a replica between boot and its first
+/// poll). Invalidation, not expiry, is the primary freshness mechanism, so this
+/// is generous; it is not load-bearing for correctness while the listener runs.
 const CACHE_TTL_SECS: u64 = 300;
-
-/// TTL in seconds for negative (denied) permission results. Kept short so
-/// permissions granted out-of-band (ChainSecured wallet-signed transactions
-/// submitted directly on-chain, or RPC state lag right after a grant) become
-/// visible quickly, while still absorbing bursts of repeated unauthorized
-/// requests between contract calls.
-const NEGATIVE_CACHE_TTL_SECS: u64 = 30;
-
-/// TTL for a permission result: full TTL when authorized, short when denied.
-fn permission_ttl(authorized: bool) -> Duration {
-    if authorized {
-        Duration::from_secs(CACHE_TTL_SECS)
-    } else {
-        Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)
-    }
-}
-
-/// Per-entry expiry for `bool` permission caches (`can_execute_action`,
-/// `can_use_wallet_in_action`): denials expire after `NEGATIVE_CACHE_TTL_SECS`.
-struct PermissionExpiry;
-
-impl Expiry<String, bool> for PermissionExpiry {
-    fn expire_after_create(
-        &self,
-        _key: &String,
-        value: &bool,
-        _created_at: Instant,
-    ) -> Option<Duration> {
-        Some(permission_ttl(*value))
-    }
-
-    fn expire_after_update(
-        &self,
-        _key: &String,
-        value: &bool,
-        _updated_at: Instant,
-        _duration_until_expiry: Option<Duration>,
-    ) -> Option<Duration> {
-        Some(permission_ttl(*value))
-    }
-}
-
-/// Per-entry expiry for the `(can_execute, can_use_wallet)` pair cache: the
-/// request only proceeds when both are true, so any false in the pair is a
-/// denial and expires after `NEGATIVE_CACHE_TTL_SECS`.
-struct PairPermissionExpiry;
-
-impl Expiry<String, (bool, bool)> for PairPermissionExpiry {
-    fn expire_after_create(
-        &self,
-        _key: &String,
-        value: &(bool, bool),
-        _created_at: Instant,
-    ) -> Option<Duration> {
-        Some(permission_ttl(value.0 && value.1))
-    }
-
-    fn expire_after_update(
-        &self,
-        _key: &String,
-        value: &(bool, bool),
-        _updated_at: Instant,
-        _duration_until_expiry: Option<Duration>,
-    ) -> Option<Duration> {
-        Some(permission_ttl(value.0 && value.1))
-    }
-}
 
 /// Maximum entries per cache.
 const MAX_CAPACITY: u64 = 100_000;
 
-/// Caches blockchain permission check results with per-account invalidation.
+/// Build one of the per-verdict caches with the shared capacity and uniform TTL.
+fn build_cache<V: Clone + Send + Sync + 'static>() -> Cache<String, V> {
+    Cache::builder()
+        .max_capacity(MAX_CAPACITY)
+        .time_to_live(Duration::from_secs(CACHE_TTL_SECS))
+        .build()
+}
+
+/// Caches blockchain permission check results behind a global generation.
 pub struct BlockchainCache {
     /// `can_execute_action` results.
     execute_action: Cache<String, bool>,
@@ -122,67 +88,38 @@ pub struct BlockchainCache {
     execute_and_wallet: Cache<String, (bool, bool)>,
     /// `get_wallet_derivation` results.
     wallet_derivation: Cache<String, U256>,
-    /// Per-account generation counter keyed by the string representation of
-    /// the api_key_hash (`U256`). Uses a plain HashMap (no eviction) to
-    /// guarantee that a bumped generation is never lost. Each entry is ~100
-    /// bytes; even 100k accounts is only ~10MB.
-    generations: RwLock<HashMap<String, u64>>,
+    /// Global generation counter embedded in every cache key. Bumping it makes
+    /// all existing keys unreachable (a full logical flush); old entries age out
+    /// by TTL. A single atomic — no per-account bookkeeping.
+    generation: AtomicU64,
 }
 
 impl BlockchainCache {
     fn new() -> Self {
-        let ttl = Duration::from_secs(CACHE_TTL_SECS);
-        // Permission caches use per-entry expiry (short TTL for denials).
-        // The previous time_to_idle was redundant: with tti == ttl, the hard
-        // time_to_live cap always fired first.
-        let execute_action = Cache::builder()
-            .max_capacity(MAX_CAPACITY)
-            .expire_after(PermissionExpiry)
-            .build();
-        let use_wallet = Cache::builder()
-            .max_capacity(MAX_CAPACITY)
-            .expire_after(PermissionExpiry)
-            .build();
-        let execute_and_wallet = Cache::builder()
-            .max_capacity(MAX_CAPACITY)
-            .expire_after(PairPermissionExpiry)
-            .build();
-        let wallet_derivation = Cache::builder()
-            .max_capacity(MAX_CAPACITY)
-            .time_to_idle(ttl)
-            .time_to_live(ttl)
-            .build();
         Self {
-            execute_action,
-            use_wallet,
-            execute_and_wallet,
-            wallet_derivation,
-            generations: RwLock::new(HashMap::new()),
+            execute_action: build_cache(),
+            use_wallet: build_cache(),
+            execute_and_wallet: build_cache(),
+            wallet_derivation: build_cache(),
+            generation: AtomicU64::new(0),
         }
     }
 
-    /// Read the current generation for an api_key_hash. Returns 0 if unseen.
-    fn generation(&self, api_key_hash: &str) -> u64 {
-        self.generations
-            .read()
-            .expect("generation lock poisoned")
-            .get(api_key_hash)
-            .copied()
-            .unwrap_or(0)
+    /// Read the current global generation.
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
     }
 
     /// Build a cache key for `can_execute_action`.
     pub fn execute_action_key(&self, api_key_hash: U256, cid_hash: U256) -> String {
-        let h = api_key_hash.to_string();
-        let g = self.generation(&h);
-        format!("{h}:g{g}:{cid_hash}")
+        let g = self.generation();
+        format!("{api_key_hash}:g{g}:{cid_hash}")
     }
 
     /// Build a cache key for `can_use_wallet_in_action`.
     pub fn use_wallet_key(&self, api_key_hash: U256, cid_hash: U256, wallet: Address) -> String {
-        let h = api_key_hash.to_string();
-        let g = self.generation(&h);
-        format!("{h}:g{g}:{cid_hash}:{wallet:#x}")
+        let g = self.generation();
+        format!("{api_key_hash}:g{g}:{cid_hash}:{wallet:#x}")
     }
 
     /// Build a cache key for `can_execute_action_and_use_wallet`.
@@ -192,16 +129,14 @@ impl BlockchainCache {
         cid_hash: U256,
         wallet: Address,
     ) -> String {
-        let h = api_key_hash.to_string();
-        let g = self.generation(&h);
-        format!("{h}:g{g}:ew:{cid_hash}:{wallet:#x}")
+        let g = self.generation();
+        format!("{api_key_hash}:g{g}:ew:{cid_hash}:{wallet:#x}")
     }
 
     /// Build a cache key for `get_wallet_derivation`.
     pub fn wallet_derivation_key(&self, api_key_hash: U256, wallet: Address) -> String {
-        let h = api_key_hash.to_string();
-        let g = self.generation(&h);
-        format!("{h}:g{g}:wd:{wallet:#x}")
+        let g = self.generation();
+        format!("{api_key_hash}:g{g}:wd:{wallet:#x}")
     }
 
     /// Reference to the `can_execute_action` cache.
@@ -224,18 +159,13 @@ impl BlockchainCache {
         &self.wallet_derivation
     }
 
-    /// Bump the generation for a single api_key_hash, invalidating all cached
-    /// permission entries for that key.
-    fn bump_generation(&self, api_key_hash: &str) {
-        let mut gens = self.generations.write().expect("generation lock poisoned");
-        let entry = gens.entry(api_key_hash.to_string()).or_insert(0);
-        *entry = entry.wrapping_add(1);
-        let next = *entry;
-        tracing::debug!(
-            "blockchain_cache: bumped generation for {} to {}",
-            api_key_hash,
-            next
-        );
+    /// Bump the global generation, logically flushing all cached verdicts.
+    fn bump_generation(&self) {
+        let next = self
+            .generation
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1);
+        tracing::debug!("blockchain_cache: bumped global generation to {next}");
     }
 }
 
@@ -245,7 +175,7 @@ static BLOCKCHAIN_CACHE_INSTANCE: OnceLock<BlockchainCache> = OnceLock::new();
 pub fn init() {
     BLOCKCHAIN_CACHE_INSTANCE.get_or_init(BlockchainCache::new);
     tracing::info!(
-        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, negative TTL={NEGATIVE_CACHE_TTL_SECS}s)"
+        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, global-generation invalidation)"
     );
 }
 
@@ -254,74 +184,15 @@ pub fn get() -> Option<&'static BlockchainCache> {
     BLOCKCHAIN_CACHE_INSTANCE.get()
 }
 
-/// Invalidate cached permission entries for the given API key.
+/// Invalidate the entire permission cache by bumping the global generation.
 ///
-/// Prefer `invalidate_for_account` for group/action/PKP mutations, which also
-/// invalidates usage keys under the same account.
-pub fn invalidate_for_key(api_key: &str) {
+/// Called by the write-path mutation helpers in [`super`] (for instant
+/// invalidation of mutations this process performs) and by the on-chain event
+/// listener ([`crate::account_events`]) when it observes any permission-relevant
+/// mutation. A no-op if the cache has not been initialized.
+pub fn invalidate_all() {
     if let Some(cache) = get() {
-        let hash = crate::utils::parse_with_hash::api_key_hash(api_key).to_string();
-        cache.bump_generation(&hash);
-    }
-}
-
-/// Invalidate cached permission entries for an entire account: the calling key
-/// and all usage keys returned by `list_api_keys`.
-///
-/// Fetches usage key hashes via a chain call to `list_api_keys`. Call after
-/// group/action/PKP mutations where any key under the account could be affected.
-///
-/// **Limitation:** If the caller authenticates with a usage key (not the master
-/// key), the master key's cached entries are NOT invalidated here because the
-/// contract does not expose a `resolveToMaster` view. In that case the master
-/// key's entries expire naturally via the 60-minute `time_to_live`. This is
-/// acceptable because usage-key-driven management mutations are uncommon in
-/// practice.
-pub async fn invalidate_for_account(api_key: &str) {
-    let Some(cache) = get() else { return };
-
-    // Always bump the calling key (master or usage).
-    let caller_hash = crate::utils::parse_with_hash::api_key_hash(api_key).to_string();
-    cache.bump_generation(&caller_hash);
-
-    // Fetch all usage keys under this account and bump each one.
-    // list_api_keys resolves both master and usage keys to the correct account.
-    match super::list_api_keys(api_key, U256::ZERO, U256::from(1000u64)).await {
-        Ok(usage_keys) => {
-            for uk in &usage_keys {
-                let hash = uk.apiKeyHash.to_string();
-                if hash != caller_hash {
-                    cache.bump_generation(&hash);
-                }
-            }
-            tracing::debug!(
-                "blockchain_cache: invalidated account ({} usage keys)",
-                usage_keys.len()
-            );
-        }
-        Err(e) => {
-            tracing::warn!(
-                "blockchain_cache: failed to list usage keys for invalidation: {e}. \
-                 Usage key cache entries may be stale until TTL."
-            );
-        }
-    }
-}
-
-/// Invalidate cached permission entries for both a master key and a usage key.
-///
-/// Call after usage-API-key mutations where both keys' cached entries may be stale.
-/// Uses `usage_api_key_to_hash` for the usage key to handle both raw keys and
-/// pre-computed hashes consistently with the on-chain mutation path.
-pub fn invalidate_for_keys(master_api_key: &str, usage_api_key: &str) {
-    if let Some(cache) = get() {
-        let master_hash = crate::utils::parse_with_hash::api_key_hash(master_api_key).to_string();
-        let usage_hash =
-            crate::utils::parse_with_hash::usage_api_key_to_hash(usage_api_key).to_string();
-        cache.bump_generation(&master_hash);
-        if usage_hash != master_hash {
-            cache.bump_generation(&usage_hash);
-        }
+        cache.bump_generation();
     }
 }
 
@@ -339,44 +210,45 @@ mod tests {
         Address::from(bytes)
     }
 
-    // ── Generation counter ──────────────────────────────────────────
+    // ── Global generation counter ───────────────────────────────────
 
     #[test]
     fn generation_starts_at_zero() {
         let cache = test_cache();
-        assert_eq!(cache.generation("anything"), 0);
+        assert_eq!(cache.generation(), 0);
     }
 
     #[test]
     fn bump_generation_increments() {
         let cache = test_cache();
-        cache.bump_generation("key1");
-        assert_eq!(cache.generation("key1"), 1);
-        cache.bump_generation("key1");
-        assert_eq!(cache.generation("key1"), 2);
+        cache.bump_generation();
+        assert_eq!(cache.generation(), 1);
+        cache.bump_generation();
+        assert_eq!(cache.generation(), 2);
     }
 
     #[test]
-    fn bump_generation_is_per_key() {
+    fn bump_generation_is_global() {
+        // A single bump shifts the generation seen by *every* account's key.
         let cache = test_cache();
-        cache.bump_generation("key_a");
-        cache.bump_generation("key_a");
-        cache.bump_generation("key_b");
-        assert_eq!(cache.generation("key_a"), 2);
-        assert_eq!(cache.generation("key_b"), 1);
-        assert_eq!(cache.generation("key_c"), 0);
+        let cid = U256::from(1u64);
+        let key_a_before = cache.execute_action_key(U256::from(100u64), cid);
+        let key_b_before = cache.execute_action_key(U256::from(200u64), cid);
+
+        cache.bump_generation();
+
+        let key_a_after = cache.execute_action_key(U256::from(100u64), cid);
+        let key_b_after = cache.execute_action_key(U256::from(200u64), cid);
+        assert_ne!(key_a_before, key_a_after);
+        assert_ne!(key_b_before, key_b_after);
     }
 
     #[test]
     fn wrapping_add_at_u64_max() {
         let cache = test_cache();
-        cache
-            .generations
-            .write()
-            .unwrap()
-            .insert("overflow".to_string(), u64::MAX);
-        cache.bump_generation("overflow");
-        assert_eq!(cache.generation("overflow"), 0);
+        cache.generation.store(u64::MAX, Ordering::Relaxed);
+        cache.bump_generation();
+        assert_eq!(cache.generation(), 0);
     }
 
     // ── Key generation ──────────────────────────────────────────────
@@ -384,19 +256,15 @@ mod tests {
     #[test]
     fn execute_action_key_format() {
         let cache = test_cache();
-        let hash = U256::from(42u64);
-        let cid = U256::from(99u64);
-        let key = cache.execute_action_key(hash, cid);
+        let key = cache.execute_action_key(U256::from(42u64), U256::from(99u64));
         assert_eq!(key, "42:g0:99");
     }
 
     #[test]
     fn use_wallet_key_format() {
         let cache = test_cache();
-        let hash = U256::from(42u64);
-        let cid = U256::from(99u64);
         let wallet = addr_from_low_u64(0xdead);
-        let key = cache.use_wallet_key(hash, cid, wallet);
+        let key = cache.use_wallet_key(U256::from(42u64), U256::from(99u64), wallet);
         assert!(key.starts_with("42:g0:99:"));
         assert!(key.contains("0x000000000000000000000000000000000000dead"));
     }
@@ -404,10 +272,7 @@ mod tests {
     #[test]
     fn execute_and_wallet_key_has_ew_discriminator() {
         let cache = test_cache();
-        let hash = U256::from(1u64);
-        let cid = U256::from(2u64);
-        let wallet = Address::ZERO;
-        let key = cache.execute_and_wallet_key(hash, cid, wallet);
+        let key = cache.execute_and_wallet_key(U256::from(1u64), U256::from(2u64), Address::ZERO);
         assert!(
             key.contains(":ew:"),
             "key should contain :ew: discriminator, got: {key}"
@@ -423,7 +288,7 @@ mod tests {
         let key_before = cache.execute_action_key(hash, cid);
         assert!(key_before.contains(":g0:"));
 
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
 
         let key_after = cache.execute_action_key(hash, cid);
         assert!(key_after.contains(":g1:"));
@@ -441,7 +306,6 @@ mod tests {
         let key = cache.execute_action_key(hash, cid);
         cache.execute_action.insert(key.clone(), true).await;
 
-        // Same key should hit
         let key2 = cache.execute_action_key(hash, cid);
         assert_eq!(key, key2);
         assert_eq!(cache.execute_action.get(&key2).await, Some(true));
@@ -453,50 +317,42 @@ mod tests {
         let hash = U256::from(10u64);
         let cid = U256::from(20u64);
 
-        // Populate cache
         let key = cache.execute_action_key(hash, cid);
         cache.execute_action.insert(key.clone(), true).await;
 
-        // Bump generation
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
 
-        // New key should be different — cache miss
+        // New key produces a miss; the old entry is unreachable (TTL-evicted later).
         let new_key = cache.execute_action_key(hash, cid);
         assert_ne!(key, new_key);
         assert_eq!(cache.execute_action.get(&new_key).await, None);
-
-        // Old key entry still exists (evicted by TTL later)
         assert_eq!(cache.execute_action.get(&key).await, Some(true));
     }
 
     #[tokio::test]
-    async fn invalidation_is_per_account() {
+    async fn invalidation_is_global_across_accounts() {
+        // One bump must invalidate every account, not just one.
         let cache = test_cache();
         let hash_a = U256::from(100u64);
         let hash_b = U256::from(200u64);
         let cid = U256::from(50u64);
 
-        // Populate both accounts
         let key_a = cache.execute_action_key(hash_a, cid);
         let key_b = cache.execute_action_key(hash_b, cid);
         cache.execute_action.insert(key_a.clone(), true).await;
         cache.execute_action.insert(key_b.clone(), false).await;
 
-        // Invalidate only account A
-        cache.bump_generation(&hash_a.to_string());
+        cache.bump_generation();
 
-        // Account A key changed (miss)
         let new_key_a = cache.execute_action_key(hash_a, cid);
-        assert_ne!(key_a, new_key_a);
-        assert_eq!(cache.execute_action.get(&new_key_a).await, None);
-
-        // Account B key unchanged (still hits)
         let new_key_b = cache.execute_action_key(hash_b, cid);
-        assert_eq!(key_b, new_key_b);
-        assert_eq!(cache.execute_action.get(&new_key_b).await, Some(false));
+        assert_ne!(key_a, new_key_a);
+        assert_ne!(key_b, new_key_b);
+        assert_eq!(cache.execute_action.get(&new_key_a).await, None);
+        assert_eq!(cache.execute_action.get(&new_key_b).await, None);
     }
 
-    // ── use_wallet and execute_and_wallet caches ────────────────────
+    // ── use_wallet, execute_and_wallet, wallet_derivation caches ────
 
     #[tokio::test]
     async fn use_wallet_cache_hit_and_invalidation() {
@@ -509,7 +365,7 @@ mod tests {
         cache.use_wallet.insert(key.clone(), true).await;
         assert_eq!(cache.use_wallet.get(&key).await, Some(true));
 
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
         let new_key = cache.use_wallet_key(hash, cid, wallet);
         assert_ne!(key, new_key);
         assert_eq!(cache.use_wallet.get(&new_key).await, None);
@@ -532,19 +388,16 @@ mod tests {
             Some((true, false))
         );
 
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
         let new_key = cache.execute_and_wallet_key(hash, cid, wallet);
         assert_eq!(cache.execute_and_wallet.get(&new_key).await, None);
     }
 
-    // ── wallet_derivation cache ──────────────────────────────────────
-
     #[test]
     fn wallet_derivation_key_has_wd_discriminator() {
         let cache = test_cache();
-        let hash = U256::from(1u64);
         let wallet = addr_from_low_u64(0xdead);
-        let key = cache.wallet_derivation_key(hash, wallet);
+        let key = cache.wallet_derivation_key(U256::from(1u64), wallet);
         assert!(
             key.contains(":wd:"),
             "key should contain :wd: discriminator, got: {key}"
@@ -567,7 +420,7 @@ mod tests {
             Some(U256::from(42u64))
         );
 
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
         let new_key = cache.wallet_derivation_key(hash, wallet);
         assert_ne!(key, new_key);
         assert_eq!(cache.wallet_derivation.get(&new_key).await, None);
@@ -578,11 +431,8 @@ mod tests {
     #[tokio::test]
     async fn try_get_with_populates_on_miss() {
         let cache = test_cache();
-        let hash = U256::from(1u64);
-        let cid = U256::from(2u64);
-        let key = cache.execute_action_key(hash, cid);
+        let key = cache.execute_action_key(U256::from(1u64), U256::from(2u64));
 
-        // Cache miss triggers the closure
         let result = cache
             .execute_action
             .try_get_with(key.clone(), async { Ok::<_, anyhow::Error>(true) })
@@ -590,7 +440,6 @@ mod tests {
             .unwrap();
         assert!(result);
 
-        // Second call should hit the cache (no closure needed)
         let result2: bool = cache
             .execute_action
             .try_get_with(key, async {
@@ -607,7 +456,6 @@ mod tests {
         let hash = U256::from(1u64);
         let cid = U256::from(2u64);
 
-        // Populate via try_get_with
         let key = cache.execute_action_key(hash, cid);
         cache
             .execute_action
@@ -615,17 +463,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Bump generation
-        cache.bump_generation(&hash.to_string());
+        cache.bump_generation();
 
-        // New key produces a miss, closure runs
         let new_key = cache.execute_action_key(hash, cid);
         let mut closure_called = false;
         let result = cache
             .execute_action
             .try_get_with(new_key, async {
                 closure_called = true;
-                Ok::<_, anyhow::Error>(false) // different value proves it re-fetched
+                Ok::<_, anyhow::Error>(false)
             })
             .await
             .unwrap();
@@ -636,145 +482,12 @@ mod tests {
         assert!(!result, "should return the newly fetched value");
     }
 
-    // ── Per-entry expiry policy ──────────────────────────────────────
+    // ── invalidate_all (module-level) ────────────────────────────────
 
     #[test]
-    fn permission_ttl_is_full_for_authorized() {
-        assert_eq!(
-            permission_ttl(true),
-            Duration::from_secs(CACHE_TTL_SECS),
-            "authorized results should keep the full TTL"
-        );
-    }
-
-    #[test]
-    fn permission_ttl_is_short_for_denied() {
-        assert_eq!(
-            permission_ttl(false),
-            Duration::from_secs(NEGATIVE_CACHE_TTL_SECS),
-            "denied results should expire quickly so out-of-band on-chain \
-             grants (ChainSecured) are picked up without waiting out the TTL"
-        );
-    }
-
-    #[test]
-    fn permission_expiry_create_uses_value() {
-        let now = Instant::now();
-        let key = "k".to_string();
-        assert_eq!(
-            PermissionExpiry.expire_after_create(&key, &true, now),
-            Some(Duration::from_secs(CACHE_TTL_SECS))
-        );
-        assert_eq!(
-            PermissionExpiry.expire_after_create(&key, &false, now),
-            Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS))
-        );
-    }
-
-    #[test]
-    fn permission_expiry_update_uses_new_value() {
-        let now = Instant::now();
-        let key = "k".to_string();
-        // A denial overwritten by a grant should adopt the full TTL, and vice versa.
-        assert_eq!(
-            PermissionExpiry.expire_after_update(
-                &key,
-                &true,
-                now,
-                Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS))
-            ),
-            Some(Duration::from_secs(CACHE_TTL_SECS))
-        );
-        assert_eq!(
-            PermissionExpiry.expire_after_update(
-                &key,
-                &false,
-                now,
-                Some(Duration::from_secs(CACHE_TTL_SECS))
-            ),
-            Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS))
-        );
-    }
-
-    #[test]
-    fn pair_permission_expiry_short_unless_both_true() {
-        let now = Instant::now();
-        let key = "k".to_string();
-        let full = Some(Duration::from_secs(CACHE_TTL_SECS));
-        let short = Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS));
-        assert_eq!(
-            PairPermissionExpiry.expire_after_create(&key, &(true, true), now),
-            full
-        );
-        assert_eq!(
-            PairPermissionExpiry.expire_after_create(&key, &(true, false), now),
-            short
-        );
-        assert_eq!(
-            PairPermissionExpiry.expire_after_create(&key, &(false, true), now),
-            short
-        );
-        assert_eq!(
-            PairPermissionExpiry.expire_after_create(&key, &(false, false), now),
-            short
-        );
-        assert_eq!(
-            PairPermissionExpiry.expire_after_update(&key, &(true, true), now, short),
-            full
-        );
-    }
-
-    #[tokio::test]
-    async fn denied_entry_expires_after_negative_ttl() {
-        // Build a cache with a sub-second negative TTL surrogate to verify the
-        // expire_after wiring end-to-end without waiting 30 real seconds.
-        struct FastExpiry;
-        impl Expiry<String, bool> for FastExpiry {
-            fn expire_after_create(
-                &self,
-                _key: &String,
-                value: &bool,
-                _created_at: Instant,
-            ) -> Option<Duration> {
-                Some(if *value {
-                    Duration::from_secs(3600)
-                } else {
-                    Duration::from_millis(50)
-                })
-            }
-        }
-        let cache: Cache<String, bool> = Cache::builder().expire_after(FastExpiry).build();
-        cache.insert("denied".to_string(), false).await;
-        cache.insert("granted".to_string(), true).await;
-        assert_eq!(cache.get(&"denied".to_string()).await, Some(false));
-
-        tokio::time::sleep(Duration::from_millis(120)).await;
-        assert_eq!(
-            cache.get(&"denied".to_string()).await,
-            None,
-            "denied entry should expire after the negative TTL"
-        );
-        assert_eq!(
-            cache.get(&"granted".to_string()).await,
-            Some(true),
-            "granted entry should still be cached"
-        );
-    }
-
-    // ── invalidate_for_key / invalidate_for_keys (module-level) ─────
-
-    #[test]
-    fn invalidate_for_key_without_init_is_noop() {
-        // Global INSTANCE not initialized in test — should not panic
-        // (We can't test the initialized path without polluting the global,
-        // but we verify the None path is safe.)
-        // Note: if init() was called by another test in the same process,
-        // this would actually bump. That's fine — we just verify no panic.
-        invalidate_for_key("some_api_key");
-    }
-
-    #[test]
-    fn invalidate_for_keys_without_init_is_noop() {
-        invalidate_for_keys("master", "usage");
+    fn invalidate_all_without_init_is_noop() {
+        // Global INSTANCE may or may not be initialized depending on test order;
+        // either way this must not panic.
+        invalidate_all();
     }
 }

--- a/lit-api-server/src/accounts/blockchain_cache.rs
+++ b/lit-api-server/src/accounts/blockchain_cache.rs
@@ -149,6 +149,42 @@ impl Expiry<String, (bool, bool)> for PairPermissionExpiry {
     }
 }
 
+/// Per-entry expiry for the `api_key_hash → wallet` resolution cache. A real
+/// wallet lives for [`RESOLUTION_TTL_SECS`]; the [`Address::ZERO`] sentinel for
+/// a nonexistent account expires after the short [`NEGATIVE_CACHE_TTL_SECS`], so
+/// an account created right after a failed lookup becomes visible quickly while
+/// a flood of invalid keys is still absorbed.
+struct ResolutionExpiry;
+
+impl Expiry<String, Address> for ResolutionExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &Address,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(if *value == Address::ZERO {
+            Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)
+        } else {
+            Duration::from_secs(RESOLUTION_TTL_SECS)
+        })
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &Address,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(if *value == Address::ZERO {
+            Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)
+        } else {
+            Duration::from_secs(RESOLUTION_TTL_SECS)
+        })
+    }
+}
+
 /// Build a cache with the shared capacity and full positive TTL (used for the
 /// non-permission caches; permission caches use a per-entry [`Expiry`] instead).
 fn build_cache<V: Clone + Send + Sync + 'static>() -> Cache<String, V> {
@@ -198,7 +234,7 @@ impl BlockchainCache {
             wallet_derivation: build_cache(),
             resolution: Cache::builder()
                 .max_capacity(MAX_CAPACITY)
-                .time_to_live(Duration::from_secs(RESOLUTION_TTL_SECS))
+                .expire_after(ResolutionExpiry)
                 .build(),
             account_generations: RwLock::new(HashMap::new()),
         }
@@ -296,6 +332,12 @@ impl BlockchainCache {
     pub fn resolution_cache(&self) -> &Cache<String, Address> {
         &self.resolution
     }
+
+    /// Drop all memoized hash→wallet resolutions. Called on ownership transfer,
+    /// which moves an account's wallet and so invalidates stale resolutions.
+    pub fn clear_resolutions(&self) {
+        self.resolution.invalidate_all();
+    }
 }
 
 static BLOCKCHAIN_CACHE_INSTANCE: OnceLock<BlockchainCache> = OnceLock::new();
@@ -389,6 +431,40 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(120)).await;
         assert_eq!(cache.get(&"denied".to_string()).await, None);
         assert_eq!(cache.get(&"granted".to_string()).await, Some(true));
+    }
+
+    #[test]
+    fn resolution_expiry_negative_for_zero_address() {
+        let now = Instant::now();
+        let key = "h".to_string();
+        assert_eq!(
+            ResolutionExpiry.expire_after_create(&key, &Address::ZERO, now),
+            Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)),
+            "a nonexistent-account sentinel should use the short negative TTL"
+        );
+        let real = {
+            let mut b = [0u8; 20];
+            b[19] = 1;
+            Address::from(b)
+        };
+        assert_eq!(
+            ResolutionExpiry.expire_after_create(&key, &real, now),
+            Some(Duration::from_secs(RESOLUTION_TTL_SECS)),
+            "a real wallet should use the full resolution TTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_resolutions_drops_entries() {
+        let cache = test_cache();
+        cache
+            .resolution
+            .insert("h".to_string(), wallet_from_low_u64(0xabc))
+            .await;
+        assert!(cache.resolution.get(&"h".to_string()).await.is_some());
+        cache.clear_resolutions();
+        cache.resolution.run_pending_tasks().await;
+        assert!(cache.resolution.get(&"h".to_string()).await.is_none());
     }
 
     fn wallet_from_low_u64(n: u64) -> Address {

--- a/lit-api-server/src/accounts/blockchain_cache.rs
+++ b/lit-api-server/src/accounts/blockchain_cache.rs
@@ -43,10 +43,13 @@
 //!
 //! ## TTL: a backstop, not the freshness mechanism
 //!
-//! Invalidation keeps the cache fresh; the uniform TTL is only insurance for the
-//! windows invalidation can't cover (a missed-block gap, an ownership transfer
-//! that moves the wallet before the resolution entry expires, a replica between
-//! boot and its first poll).
+//! Invalidation keeps the cache fresh; the TTL is only insurance for the windows
+//! invalidation can't cover (a missed-block gap, an ownership transfer that moves
+//! the wallet before the resolution entry expires, a replica between boot and its
+//! first poll). Denials use a much shorter TTL than grants
+//! ([`NEGATIVE_CACHE_TTL_SECS`] vs [`CACHE_TTL_SECS`]) so that a permission
+//! granted while the listener is lagging or down still becomes visible quickly,
+//! rather than a stale denial being honored for the full grant TTL.
 //!
 //! ## Stateless / horizontally scalable by construction
 //!
@@ -58,15 +61,24 @@
 
 use std::collections::HashMap;
 use std::sync::{OnceLock, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy::primitives::{Address, U256};
+use moka::Expiry;
 use moka::future::Cache;
 
-/// Uniform TTL for every cached verdict — a backstop for the windows
-/// invalidation can't cover. Invalidation, not expiry, is the primary freshness
+/// TTL for positive (authorized) verdicts and for non-permission caches
+/// (wallet derivation, hash→wallet resolution). A backstop for the windows
+/// invalidation can't cover; invalidation, not expiry, is the primary freshness
 /// mechanism, so this is generous.
 const CACHE_TTL_SECS: u64 = 300;
+
+/// TTL for negative (denied) permission verdicts. Kept short so a permission
+/// granted out-of-band (a ChainSecured wallet-signed transaction, or RPC state
+/// lag right after a grant) becomes visible quickly even if the event listener
+/// is lagging or down — without it, a fresh denial would be honored for the full
+/// [`CACHE_TTL_SECS`]. Bounds the freshly-granted-but-still-denied window.
+const NEGATIVE_CACHE_TTL_SECS: u64 = 30;
 
 /// TTL for the `api_key_hash → account wallet` resolution cache. The mapping is
 /// stable except on ownership transfer, so this can be generous; it bounds how
@@ -76,7 +88,69 @@ const RESOLUTION_TTL_SECS: u64 = 300;
 /// Maximum entries per cache.
 const MAX_CAPACITY: u64 = 100_000;
 
-/// Build a verdict cache with the shared capacity and uniform TTL.
+/// TTL for a permission verdict: full when authorized, short when denied.
+fn permission_ttl(authorized: bool) -> Duration {
+    if authorized {
+        Duration::from_secs(CACHE_TTL_SECS)
+    } else {
+        Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)
+    }
+}
+
+/// Per-entry expiry for the `bool` permission caches (`can_execute_action`,
+/// `can_use_wallet_in_action`): denials expire after [`NEGATIVE_CACHE_TTL_SECS`],
+/// grants after [`CACHE_TTL_SECS`].
+struct PermissionExpiry;
+
+impl Expiry<String, bool> for PermissionExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &bool,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(permission_ttl(*value))
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &bool,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(permission_ttl(*value))
+    }
+}
+
+/// Per-entry expiry for the `(can_execute, can_use_wallet)` pair cache: the
+/// request only proceeds when both are true, so any `false` in the pair is a
+/// denial and expires after [`NEGATIVE_CACHE_TTL_SECS`].
+struct PairPermissionExpiry;
+
+impl Expiry<String, (bool, bool)> for PairPermissionExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &(bool, bool),
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(permission_ttl(value.0 && value.1))
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &(bool, bool),
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(permission_ttl(value.0 && value.1))
+    }
+}
+
+/// Build a cache with the shared capacity and full positive TTL (used for the
+/// non-permission caches; permission caches use a per-entry [`Expiry`] instead).
 fn build_cache<V: Clone + Send + Sync + 'static>() -> Cache<String, V> {
     Cache::builder()
         .max_capacity(MAX_CAPACITY)
@@ -106,10 +180,21 @@ pub struct BlockchainCache {
 
 impl BlockchainCache {
     fn new() -> Self {
+        // Permission caches use per-entry expiry so denials expire fast; the
+        // non-permission caches use the plain positive TTL.
         Self {
-            execute_action: build_cache(),
-            use_wallet: build_cache(),
-            execute_and_wallet: build_cache(),
+            execute_action: Cache::builder()
+                .max_capacity(MAX_CAPACITY)
+                .expire_after(PermissionExpiry)
+                .build(),
+            use_wallet: Cache::builder()
+                .max_capacity(MAX_CAPACITY)
+                .expire_after(PermissionExpiry)
+                .build(),
+            execute_and_wallet: Cache::builder()
+                .max_capacity(MAX_CAPACITY)
+                .expire_after(PairPermissionExpiry)
+                .build(),
             wallet_derivation: build_cache(),
             resolution: Cache::builder()
                 .max_capacity(MAX_CAPACITY)
@@ -219,7 +304,7 @@ static BLOCKCHAIN_CACHE_INSTANCE: OnceLock<BlockchainCache> = OnceLock::new();
 pub fn init() {
     BLOCKCHAIN_CACHE_INSTANCE.get_or_init(BlockchainCache::new);
     tracing::info!(
-        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, per-account-generation invalidation)"
+        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, negative TTL={NEGATIVE_CACHE_TTL_SECS}s, per-account-generation invalidation)"
     );
 }
 
@@ -234,6 +319,76 @@ mod tests {
 
     fn test_cache() -> BlockchainCache {
         BlockchainCache::new()
+    }
+
+    // ── Per-entry expiry policy ──────────────────────────────────────
+
+    #[test]
+    fn permission_ttl_full_for_authorized_short_for_denied() {
+        assert_eq!(permission_ttl(true), Duration::from_secs(CACHE_TTL_SECS));
+        assert_eq!(
+            permission_ttl(false),
+            Duration::from_secs(NEGATIVE_CACHE_TTL_SECS)
+        );
+        assert!(NEGATIVE_CACHE_TTL_SECS < CACHE_TTL_SECS);
+    }
+
+    #[test]
+    fn permission_expiry_uses_value() {
+        let now = Instant::now();
+        let key = "k".to_string();
+        assert_eq!(
+            PermissionExpiry.expire_after_create(&key, &true, now),
+            Some(Duration::from_secs(CACHE_TTL_SECS))
+        );
+        assert_eq!(
+            PermissionExpiry.expire_after_create(&key, &false, now),
+            Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS))
+        );
+    }
+
+    #[test]
+    fn pair_permission_expiry_short_unless_both_true() {
+        let now = Instant::now();
+        let key = "k".to_string();
+        let full = Some(Duration::from_secs(CACHE_TTL_SECS));
+        let short = Some(Duration::from_secs(NEGATIVE_CACHE_TTL_SECS));
+        assert_eq!(
+            PairPermissionExpiry.expire_after_create(&key, &(true, true), now),
+            full
+        );
+        assert_eq!(
+            PairPermissionExpiry.expire_after_create(&key, &(true, false), now),
+            short
+        );
+        assert_eq!(
+            PairPermissionExpiry.expire_after_create(&key, &(false, true), now),
+            short
+        );
+    }
+
+    #[tokio::test]
+    async fn denied_entry_expires_before_granted() {
+        // End-to-end wiring check with a sub-second surrogate so we don't wait
+        // 30 real seconds: a denial should evict while a grant survives.
+        struct FastExpiry;
+        impl Expiry<String, bool> for FastExpiry {
+            fn expire_after_create(&self, _k: &String, v: &bool, _c: Instant) -> Option<Duration> {
+                Some(if *v {
+                    Duration::from_secs(3600)
+                } else {
+                    Duration::from_millis(50)
+                })
+            }
+        }
+        let cache: Cache<String, bool> = Cache::builder().expire_after(FastExpiry).build();
+        cache.insert("denied".to_string(), false).await;
+        cache.insert("granted".to_string(), true).await;
+        assert_eq!(cache.get(&"denied".to_string()).await, Some(false));
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(cache.get(&"denied".to_string()).await, None);
+        assert_eq!(cache.get(&"granted".to_string()).await, Some(true));
     }
 
     fn wallet_from_low_u64(n: u64) -> Address {

--- a/lit-api-server/src/accounts/blockchain_cache.rs
+++ b/lit-api-server/src/accounts/blockchain_cache.rs
@@ -5,72 +5,78 @@
 //! so that repeated calls for the same API key and relevant parameters avoid
 //! redundant contract calls.
 //!
-//! # Design: a dumb verdict memoizer
+//! # Design: verdict memoizer with per-account invalidation
 //!
 //! The source of truth for permissions is the chain. This cache is *only* a
-//! performance optimization in front of it. It deliberately models nothing
-//! about accounts, master/usage keys, groups, or scopes — it memoizes opaque
-//! contract verdicts keyed by `(api_key_hash, params)`, exactly as the contract
-//! resolves them. A cache miss simply asks the chain; a denial is never special.
+//! performance optimization in front of it. It memoizes opaque contract verdicts
+//! keyed by `(api_key_hash, params)`, exactly as the contract resolves them. A
+//! cache miss simply asks the chain.
 //!
-//! ## Invalidation: one global generation counter
+//! ## Invalidation: one generation counter per account
 //!
-//! Permission *mutations* are rare administrative operations; permission
-//! *checks* are the hot path. Given that ratio, we don't try to map a given
-//! on-chain mutation to the specific cache entries it affects (which would
-//! require the server to reconstruct the on-chain account graph — every master
-//! key, usage key, group and scope). Instead, **any** permission-relevant
-//! mutation bumps a single global generation counter embedded in every cache
-//! key, so all subsequent lookups miss and re-read from chain. Stale entries
-//! from older generations are never read again and age out by TTL.
+//! Every cache key embeds a generation number for the account it belongs to.
+//! Bumping that account's generation makes all of its subsequent lookups miss
+//! (and the stale entries age out by TTL), while leaving every *other* account's
+//! entries untouched. So a mutation to account A flushes only A — never the
+//! whole cache.
 //!
-//! This is strictly *more* invalidation than necessary (a change to one account
-//! briefly invalidates verdicts for all accounts), which makes it always safe:
-//! it can over-invalidate, never serve stale. The cost is a small burst of
-//! chain re-reads right after a rare mutation, coalesced per key by
-//! `try_get_with` so the steady-state load is at most one read per
-//! (key, params) per generation.
+//! The account is identified by its **wallet address**, not by the calling key.
+//! This is the crux: an account has one master key and many usage keys, each
+//! with independent scope, so verdicts are cached per *calling* key. But a
+//! group/action/PKP mutation changes the verdict for *every* key under the
+//! account, and the on-chain event carries only the master `apiKeyHash`. Both
+//! the master and every usage key resolve (via `getAccountWalletAddress`) to the
+//! same wallet, so we key the generation by that wallet: bumping it once
+//! invalidates the master and all usage keys at once, with no need to enumerate
+//! the usage keys. The wallet for a calling key is resolved lazily (and memoized
+//! in [`resolution_cache`]) when its cache key is built; see
+//! [`super::resolve_account_wallet_hash`].
 //!
-//! The bump is driven by an on-chain event listener ([`crate::account_events`])
-//! plus the write-path hooks in [`super`] (which call [`invalidate_all`]
-//! directly for instant invalidation of mutations this process performs). The
-//! listener also covers mutations this process never sees — ChainSecured
-//! wallet-signed transactions sent directly to the contract, or mutations
-//! performed by another replica.
+//! ## Driven by events and write-path hooks
+//!
+//! Generations are bumped by [`super::invalidate_account_by_hash`], called from
+//! the on-chain event listener ([`crate::account_events`]) for any
+//! permission-relevant mutation, and from the write-path hooks in [`super`] for
+//! mutations this process performs (instant, no poll lag). The listener also
+//! covers mutations this process never sees — ChainSecured wallet-signed
+//! transactions sent directly to the contract, or mutations by another replica.
 //!
 //! ## TTL: a backstop, not the freshness mechanism
 //!
-//! Invalidation is what keeps the cache fresh; the TTL is only insurance for the
-//! windows the listener can't cover (missed-block gaps, a replica between boot
-//! and its first poll). A single uniform TTL applies to every entry — there is
-//! no positive/negative asymmetry, because the cache stores verdicts, not
-//! policy, and the listener bounds staleness far tighter than the TTL anyway.
+//! Invalidation keeps the cache fresh; the uniform TTL is only insurance for the
+//! windows invalidation can't cover (a missed-block gap, an ownership transfer
+//! that moves the wallet before the resolution entry expires, a replica between
+//! boot and its first poll).
 //!
 //! ## Stateless / horizontally scalable by construction
 //!
-//! The generation counter is process-local. Each replica runs its own listener
-//! and bumps its own counter off the same chain logs, so replicas converge
+//! The generation map is process-local. Each replica runs its own listener and
+//! bumps its own generations off the same chain logs, so replicas converge
 //! independently with no shared state. A freshly booted replica starts with an
 //! empty cache (everything misses → everything is fresh) and a listener anchored
 //! at the current block; it never needs history.
 
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
 
 use alloy::primitives::{Address, U256};
 use moka::future::Cache;
 
-/// Uniform TTL for every cached entry — a backstop for the windows the on-chain
-/// listener can't cover (missed-block gaps, a replica between boot and its first
-/// poll). Invalidation, not expiry, is the primary freshness mechanism, so this
-/// is generous; it is not load-bearing for correctness while the listener runs.
+/// Uniform TTL for every cached verdict — a backstop for the windows
+/// invalidation can't cover. Invalidation, not expiry, is the primary freshness
+/// mechanism, so this is generous.
 const CACHE_TTL_SECS: u64 = 300;
+
+/// TTL for the `api_key_hash → account wallet` resolution cache. The mapping is
+/// stable except on ownership transfer, so this can be generous; it bounds how
+/// long a transferred account keeps composing its old wallet's generation.
+const RESOLUTION_TTL_SECS: u64 = 300;
 
 /// Maximum entries per cache.
 const MAX_CAPACITY: u64 = 100_000;
 
-/// Build one of the per-verdict caches with the shared capacity and uniform TTL.
+/// Build a verdict cache with the shared capacity and uniform TTL.
 fn build_cache<V: Clone + Send + Sync + 'static>() -> Cache<String, V> {
     Cache::builder()
         .max_capacity(MAX_CAPACITY)
@@ -78,7 +84,7 @@ fn build_cache<V: Clone + Send + Sync + 'static>() -> Cache<String, V> {
         .build()
 }
 
-/// Caches blockchain permission check results behind a global generation.
+/// Caches blockchain permission check results with per-account invalidation.
 pub struct BlockchainCache {
     /// `can_execute_action` results.
     execute_action: Cache<String, bool>,
@@ -88,10 +94,14 @@ pub struct BlockchainCache {
     execute_and_wallet: Cache<String, (bool, bool)>,
     /// `get_wallet_derivation` results.
     wallet_derivation: Cache<String, U256>,
-    /// Global generation counter embedded in every cache key. Bumping it makes
-    /// all existing keys unreachable (a full logical flush); old entries age out
-    /// by TTL. A single atomic — no per-account bookkeeping.
-    generation: AtomicU64,
+    /// Memoized `api_key_hash → account wallet` resolutions. The loader (a
+    /// `getAccountWalletAddress` chain call) lives in [`super`]; this just holds
+    /// the results so the hot path resolves at most once per key per TTL.
+    resolution: Cache<String, Address>,
+    /// Per-account generation counter keyed by account wallet address. A plain
+    /// HashMap (no eviction) so a bumped generation is never lost. Each entry is
+    /// tiny; even 100k accounts is a few MB.
+    account_generations: RwLock<HashMap<Address, u64>>,
 }
 
 impl BlockchainCache {
@@ -101,42 +111,80 @@ impl BlockchainCache {
             use_wallet: build_cache(),
             execute_and_wallet: build_cache(),
             wallet_derivation: build_cache(),
-            generation: AtomicU64::new(0),
+            resolution: Cache::builder()
+                .max_capacity(MAX_CAPACITY)
+                .time_to_live(Duration::from_secs(RESOLUTION_TTL_SECS))
+                .build(),
+            account_generations: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Read the current global generation.
-    fn generation(&self) -> u64 {
-        self.generation.load(Ordering::Relaxed)
+    /// Read the current generation for an account wallet. Returns 0 if unseen.
+    pub fn account_generation(&self, wallet: Address) -> u64 {
+        self.account_generations
+            .read()
+            .expect("account generation lock poisoned")
+            .get(&wallet)
+            .copied()
+            .unwrap_or(0)
     }
 
-    /// Build a cache key for `can_execute_action`.
-    pub fn execute_action_key(&self, api_key_hash: U256, cid_hash: U256) -> String {
-        let g = self.generation();
-        format!("{api_key_hash}:g{g}:{cid_hash}")
+    /// Bump the generation for an account wallet, invalidating every cached
+    /// verdict (master and all usage keys) under that account.
+    pub fn bump_account_generation(&self, wallet: Address) {
+        let mut gens = self
+            .account_generations
+            .write()
+            .expect("account generation lock poisoned");
+        let entry = gens.entry(wallet).or_insert(0);
+        *entry = entry.wrapping_add(1);
+        tracing::debug!(
+            "blockchain_cache: bumped generation for account {wallet:#x} to {}",
+            *entry
+        );
+    }
+
+    /// Build a cache key for `can_execute_action`. `account_gen` is the caller's
+    /// account generation (see [`account_generation`]).
+    pub fn execute_action_key(
+        &self,
+        api_key_hash: U256,
+        account_gen: u64,
+        cid_hash: U256,
+    ) -> String {
+        format!("{api_key_hash}:a{account_gen}:{cid_hash}")
     }
 
     /// Build a cache key for `can_use_wallet_in_action`.
-    pub fn use_wallet_key(&self, api_key_hash: U256, cid_hash: U256, wallet: Address) -> String {
-        let g = self.generation();
-        format!("{api_key_hash}:g{g}:{cid_hash}:{wallet:#x}")
+    pub fn use_wallet_key(
+        &self,
+        api_key_hash: U256,
+        account_gen: u64,
+        cid_hash: U256,
+        wallet: Address,
+    ) -> String {
+        format!("{api_key_hash}:a{account_gen}:{cid_hash}:{wallet:#x}")
     }
 
     /// Build a cache key for `can_execute_action_and_use_wallet`.
     pub fn execute_and_wallet_key(
         &self,
         api_key_hash: U256,
+        account_gen: u64,
         cid_hash: U256,
         wallet: Address,
     ) -> String {
-        let g = self.generation();
-        format!("{api_key_hash}:g{g}:ew:{cid_hash}:{wallet:#x}")
+        format!("{api_key_hash}:a{account_gen}:ew:{cid_hash}:{wallet:#x}")
     }
 
     /// Build a cache key for `get_wallet_derivation`.
-    pub fn wallet_derivation_key(&self, api_key_hash: U256, wallet: Address) -> String {
-        let g = self.generation();
-        format!("{api_key_hash}:g{g}:wd:{wallet:#x}")
+    pub fn wallet_derivation_key(
+        &self,
+        api_key_hash: U256,
+        account_gen: u64,
+        wallet: Address,
+    ) -> String {
+        format!("{api_key_hash}:a{account_gen}:wd:{wallet:#x}")
     }
 
     /// Reference to the `can_execute_action` cache.
@@ -159,13 +207,9 @@ impl BlockchainCache {
         &self.wallet_derivation
     }
 
-    /// Bump the global generation, logically flushing all cached verdicts.
-    fn bump_generation(&self) {
-        let next = self
-            .generation
-            .fetch_add(1, Ordering::Relaxed)
-            .wrapping_add(1);
-        tracing::debug!("blockchain_cache: bumped global generation to {next}");
+    /// Reference to the `api_key_hash → account wallet` resolution cache.
+    pub fn resolution_cache(&self) -> &Cache<String, Address> {
+        &self.resolution
     }
 }
 
@@ -175,25 +219,13 @@ static BLOCKCHAIN_CACHE_INSTANCE: OnceLock<BlockchainCache> = OnceLock::new();
 pub fn init() {
     BLOCKCHAIN_CACHE_INSTANCE.get_or_init(BlockchainCache::new);
     tracing::info!(
-        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, global-generation invalidation)"
+        "blockchain_cache: initialized (TTL={CACHE_TTL_SECS}s, per-account-generation invalidation)"
     );
 }
 
 /// Get the global cache instance. Returns `None` if not initialized.
 pub fn get() -> Option<&'static BlockchainCache> {
     BLOCKCHAIN_CACHE_INSTANCE.get()
-}
-
-/// Invalidate the entire permission cache by bumping the global generation.
-///
-/// Called by the write-path mutation helpers in [`super`] (for instant
-/// invalidation of mutations this process performs) and by the on-chain event
-/// listener ([`crate::account_events`]) when it observes any permission-relevant
-/// mutation. A no-op if the cache has not been initialized.
-pub fn invalidate_all() {
-    if let Some(cache) = get() {
-        cache.bump_generation();
-    }
 }
 
 #[cfg(test)]
@@ -204,51 +236,58 @@ mod tests {
         BlockchainCache::new()
     }
 
-    fn addr_from_low_u64(n: u64) -> Address {
+    fn wallet_from_low_u64(n: u64) -> Address {
         let mut bytes = [0u8; 20];
         bytes[12..].copy_from_slice(&n.to_be_bytes());
         Address::from(bytes)
     }
 
-    // ── Global generation counter ───────────────────────────────────
+    fn addr_from_low_u64(n: u64) -> Address {
+        wallet_from_low_u64(n)
+    }
+
+    // ── Per-account generation counter ──────────────────────────────
 
     #[test]
     fn generation_starts_at_zero() {
         let cache = test_cache();
-        assert_eq!(cache.generation(), 0);
+        assert_eq!(cache.account_generation(wallet_from_low_u64(1)), 0);
     }
 
     #[test]
     fn bump_generation_increments() {
         let cache = test_cache();
-        cache.bump_generation();
-        assert_eq!(cache.generation(), 1);
-        cache.bump_generation();
-        assert_eq!(cache.generation(), 2);
+        let w = wallet_from_low_u64(1);
+        cache.bump_account_generation(w);
+        assert_eq!(cache.account_generation(w), 1);
+        cache.bump_account_generation(w);
+        assert_eq!(cache.account_generation(w), 2);
     }
 
     #[test]
-    fn bump_generation_is_global() {
-        // A single bump shifts the generation seen by *every* account's key.
+    fn bump_generation_is_per_account() {
         let cache = test_cache();
-        let cid = U256::from(1u64);
-        let key_a_before = cache.execute_action_key(U256::from(100u64), cid);
-        let key_b_before = cache.execute_action_key(U256::from(200u64), cid);
-
-        cache.bump_generation();
-
-        let key_a_after = cache.execute_action_key(U256::from(100u64), cid);
-        let key_b_after = cache.execute_action_key(U256::from(200u64), cid);
-        assert_ne!(key_a_before, key_a_after);
-        assert_ne!(key_b_before, key_b_after);
+        let a = wallet_from_low_u64(0xaaaa);
+        let b = wallet_from_low_u64(0xbbbb);
+        cache.bump_account_generation(a);
+        cache.bump_account_generation(a);
+        cache.bump_account_generation(b);
+        assert_eq!(cache.account_generation(a), 2);
+        assert_eq!(cache.account_generation(b), 1);
+        assert_eq!(cache.account_generation(wallet_from_low_u64(0xcccc)), 0);
     }
 
     #[test]
     fn wrapping_add_at_u64_max() {
         let cache = test_cache();
-        cache.generation.store(u64::MAX, Ordering::Relaxed);
-        cache.bump_generation();
-        assert_eq!(cache.generation(), 0);
+        let w = wallet_from_low_u64(7);
+        cache
+            .account_generations
+            .write()
+            .unwrap()
+            .insert(w, u64::MAX);
+        cache.bump_account_generation(w);
+        assert_eq!(cache.account_generation(w), 0);
     }
 
     // ── Key generation ──────────────────────────────────────────────
@@ -256,23 +295,24 @@ mod tests {
     #[test]
     fn execute_action_key_format() {
         let cache = test_cache();
-        let key = cache.execute_action_key(U256::from(42u64), U256::from(99u64));
-        assert_eq!(key, "42:g0:99");
+        let key = cache.execute_action_key(U256::from(42u64), 0, U256::from(99u64));
+        assert_eq!(key, "42:a0:99");
     }
 
     #[test]
     fn use_wallet_key_format() {
         let cache = test_cache();
         let wallet = addr_from_low_u64(0xdead);
-        let key = cache.use_wallet_key(U256::from(42u64), U256::from(99u64), wallet);
-        assert!(key.starts_with("42:g0:99:"));
+        let key = cache.use_wallet_key(U256::from(42u64), 0, U256::from(99u64), wallet);
+        assert!(key.starts_with("42:a0:99:"));
         assert!(key.contains("0x000000000000000000000000000000000000dead"));
     }
 
     #[test]
     fn execute_and_wallet_key_has_ew_discriminator() {
         let cache = test_cache();
-        let key = cache.execute_and_wallet_key(U256::from(1u64), U256::from(2u64), Address::ZERO);
+        let key =
+            cache.execute_and_wallet_key(U256::from(1u64), 0, U256::from(2u64), Address::ZERO);
         assert!(
             key.contains(":ew:"),
             "key should contain :ew: discriminator, got: {key}"
@@ -280,19 +320,26 @@ mod tests {
     }
 
     #[test]
-    fn key_changes_after_bump() {
+    fn wallet_derivation_key_has_wd_discriminator() {
+        let cache = test_cache();
+        let wallet = addr_from_low_u64(0xdead);
+        let key = cache.wallet_derivation_key(U256::from(1u64), 0, wallet);
+        assert!(
+            key.contains(":wd:"),
+            "key should contain :wd: discriminator, got: {key}"
+        );
+    }
+
+    #[test]
+    fn key_embeds_account_generation() {
         let cache = test_cache();
         let hash = U256::from(42u64);
         let cid = U256::from(99u64);
-
-        let key_before = cache.execute_action_key(hash, cid);
-        assert!(key_before.contains(":g0:"));
-
-        cache.bump_generation();
-
-        let key_after = cache.execute_action_key(hash, cid);
-        assert!(key_after.contains(":g1:"));
-        assert_ne!(key_before, key_after);
+        let before = cache.execute_action_key(hash, 0, cid);
+        let after = cache.execute_action_key(hash, 1, cid);
+        assert!(before.contains(":a0:"));
+        assert!(after.contains(":a1:"));
+        assert_ne!(before, after);
     }
 
     // ── Cache hit / miss with generation ────────────────────────────
@@ -300,194 +347,89 @@ mod tests {
     #[tokio::test]
     async fn cache_hit_returns_stored_value() {
         let cache = test_cache();
-        let hash = U256::from(10u64);
-        let cid = U256::from(20u64);
-
-        let key = cache.execute_action_key(hash, cid);
+        let key = cache.execute_action_key(U256::from(10u64), 0, U256::from(20u64));
         cache.execute_action.insert(key.clone(), true).await;
-
-        let key2 = cache.execute_action_key(hash, cid);
-        assert_eq!(key, key2);
-        assert_eq!(cache.execute_action.get(&key2).await, Some(true));
+        assert_eq!(cache.execute_action.get(&key).await, Some(true));
     }
 
     #[tokio::test]
-    async fn cache_miss_after_invalidation() {
+    async fn cache_miss_after_generation_bump() {
+        // A request that built its key at the account's old generation produces
+        // a different key at the new generation — a miss.
         let cache = test_cache();
         let hash = U256::from(10u64);
         let cid = U256::from(20u64);
+        let wallet = wallet_from_low_u64(0x1234);
 
-        let key = cache.execute_action_key(hash, cid);
+        let key = cache.execute_action_key(hash, cache.account_generation(wallet), cid);
         cache.execute_action.insert(key.clone(), true).await;
 
-        cache.bump_generation();
+        cache.bump_account_generation(wallet);
 
-        // New key produces a miss; the old entry is unreachable (TTL-evicted later).
-        let new_key = cache.execute_action_key(hash, cid);
+        let new_key = cache.execute_action_key(hash, cache.account_generation(wallet), cid);
         assert_ne!(key, new_key);
         assert_eq!(cache.execute_action.get(&new_key).await, None);
         assert_eq!(cache.execute_action.get(&key).await, Some(true));
     }
 
     #[tokio::test]
-    async fn invalidation_is_global_across_accounts() {
-        // One bump must invalidate every account, not just one.
+    async fn invalidation_is_scoped_to_one_account() {
+        // Bumping account A must not invalidate account B (no global flush).
         let cache = test_cache();
         let hash_a = U256::from(100u64);
         let hash_b = U256::from(200u64);
         let cid = U256::from(50u64);
+        let wallet_a = wallet_from_low_u64(0xa);
+        let wallet_b = wallet_from_low_u64(0xb);
 
-        let key_a = cache.execute_action_key(hash_a, cid);
-        let key_b = cache.execute_action_key(hash_b, cid);
+        let key_a = cache.execute_action_key(hash_a, cache.account_generation(wallet_a), cid);
+        let key_b = cache.execute_action_key(hash_b, cache.account_generation(wallet_b), cid);
         cache.execute_action.insert(key_a.clone(), true).await;
         cache.execute_action.insert(key_b.clone(), false).await;
 
-        cache.bump_generation();
+        cache.bump_account_generation(wallet_a);
 
-        let new_key_a = cache.execute_action_key(hash_a, cid);
-        let new_key_b = cache.execute_action_key(hash_b, cid);
+        // Account A misses (key changed); account B still hits.
+        let new_key_a = cache.execute_action_key(hash_a, cache.account_generation(wallet_a), cid);
+        let new_key_b = cache.execute_action_key(hash_b, cache.account_generation(wallet_b), cid);
         assert_ne!(key_a, new_key_a);
-        assert_ne!(key_b, new_key_b);
+        assert_eq!(key_b, new_key_b);
         assert_eq!(cache.execute_action.get(&new_key_a).await, None);
-        assert_eq!(cache.execute_action.get(&new_key_b).await, None);
-    }
-
-    // ── use_wallet, execute_and_wallet, wallet_derivation caches ────
-
-    #[tokio::test]
-    async fn use_wallet_cache_hit_and_invalidation() {
-        let cache = test_cache();
-        let hash = U256::from(5u64);
-        let cid = U256::from(6u64);
-        let wallet = addr_from_low_u64(0xbeef);
-
-        let key = cache.use_wallet_key(hash, cid, wallet);
-        cache.use_wallet.insert(key.clone(), true).await;
-        assert_eq!(cache.use_wallet.get(&key).await, Some(true));
-
-        cache.bump_generation();
-        let new_key = cache.use_wallet_key(hash, cid, wallet);
-        assert_ne!(key, new_key);
-        assert_eq!(cache.use_wallet.get(&new_key).await, None);
+        assert_eq!(cache.execute_action.get(&new_key_b).await, Some(false));
     }
 
     #[tokio::test]
-    async fn execute_and_wallet_cache_hit_and_invalidation() {
+    async fn master_and_usage_keys_share_account_generation() {
+        // Two distinct calling-key hashes under the same wallet are both
+        // invalidated by a single bump of that wallet's generation.
         let cache = test_cache();
-        let hash = U256::from(7u64);
-        let cid = U256::from(8u64);
-        let wallet = addr_from_low_u64(0xcafe);
+        let master = U256::from(0x1111u64);
+        let usage = U256::from(0x2222u64);
+        let cid = U256::from(7u64);
+        let wallet = wallet_from_low_u64(0xface);
 
-        let key = cache.execute_and_wallet_key(hash, cid, wallet);
-        cache
-            .execute_and_wallet
-            .insert(key.clone(), (true, false))
-            .await;
+        let g0 = cache.account_generation(wallet);
+        let master_key = cache.execute_action_key(master, g0, cid);
+        let usage_key = cache.execute_action_key(usage, g0, cid);
+        cache.execute_action.insert(master_key.clone(), true).await;
+        cache.execute_action.insert(usage_key.clone(), true).await;
+
+        cache.bump_account_generation(wallet);
+
+        let g1 = cache.account_generation(wallet);
         assert_eq!(
-            cache.execute_and_wallet.get(&key).await,
-            Some((true, false))
+            cache
+                .execute_action
+                .get(&cache.execute_action_key(master, g1, cid))
+                .await,
+            None
         );
-
-        cache.bump_generation();
-        let new_key = cache.execute_and_wallet_key(hash, cid, wallet);
-        assert_eq!(cache.execute_and_wallet.get(&new_key).await, None);
-    }
-
-    #[test]
-    fn wallet_derivation_key_has_wd_discriminator() {
-        let cache = test_cache();
-        let wallet = addr_from_low_u64(0xdead);
-        let key = cache.wallet_derivation_key(U256::from(1u64), wallet);
-        assert!(
-            key.contains(":wd:"),
-            "key should contain :wd: discriminator, got: {key}"
-        );
-    }
-
-    #[tokio::test]
-    async fn wallet_derivation_cache_hit_and_invalidation() {
-        let cache = test_cache();
-        let hash = U256::from(5u64);
-        let wallet = addr_from_low_u64(0xbeef);
-
-        let key = cache.wallet_derivation_key(hash, wallet);
-        cache
-            .wallet_derivation
-            .insert(key.clone(), U256::from(42u64))
-            .await;
         assert_eq!(
-            cache.wallet_derivation.get(&key).await,
-            Some(U256::from(42u64))
+            cache
+                .execute_action
+                .get(&cache.execute_action_key(usage, g1, cid))
+                .await,
+            None
         );
-
-        cache.bump_generation();
-        let new_key = cache.wallet_derivation_key(hash, wallet);
-        assert_ne!(key, new_key);
-        assert_eq!(cache.wallet_derivation.get(&new_key).await, None);
-    }
-
-    // ── try_get_with integration ────────────────────────────────────
-
-    #[tokio::test]
-    async fn try_get_with_populates_on_miss() {
-        let cache = test_cache();
-        let key = cache.execute_action_key(U256::from(1u64), U256::from(2u64));
-
-        let result = cache
-            .execute_action
-            .try_get_with(key.clone(), async { Ok::<_, anyhow::Error>(true) })
-            .await
-            .unwrap();
-        assert!(result);
-
-        let result2: bool = cache
-            .execute_action
-            .try_get_with(key, async {
-                Err::<bool, anyhow::Error>(anyhow::anyhow!("should not be called on cache hit"))
-            })
-            .await
-            .expect("should have been a cache hit");
-        assert!(result2);
-    }
-
-    #[tokio::test]
-    async fn try_get_with_misses_after_generation_bump() {
-        let cache = test_cache();
-        let hash = U256::from(1u64);
-        let cid = U256::from(2u64);
-
-        let key = cache.execute_action_key(hash, cid);
-        cache
-            .execute_action
-            .try_get_with(key, async { Ok::<_, anyhow::Error>(true) })
-            .await
-            .unwrap();
-
-        cache.bump_generation();
-
-        let new_key = cache.execute_action_key(hash, cid);
-        let mut closure_called = false;
-        let result = cache
-            .execute_action
-            .try_get_with(new_key, async {
-                closure_called = true;
-                Ok::<_, anyhow::Error>(false)
-            })
-            .await
-            .unwrap();
-        assert!(
-            closure_called,
-            "closure should run on cache miss after bump"
-        );
-        assert!(!result, "should return the newly fetched value");
-    }
-
-    // ── invalidate_all (module-level) ────────────────────────────────
-
-    #[test]
-    fn invalidate_all_without_init_is_noop() {
-        // Global INSTANCE may or may not be initialized depending on test order;
-        // either way this must not panic.
-        invalidate_all();
     }
 }

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -479,24 +479,33 @@ pub async fn get_wallet_derivation(api_key: &str, wallet_address: Address) -> Re
     let account_api_key_hash = account_api_key_hash_alloy;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get()
-        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
-    {
-        let account_gen = cache.account_generation(wallet);
-        let key =
-            cache.wallet_derivation_key(account_api_key_hash_alloy, account_gen, wallet_address);
-        return cache
-            .wallet_derivation_cache()
-            .try_get_with(key, async {
-                let contract = get_read_only_account_config_contract().await?;
-                let derivation = contract
-                    .getWalletDerivation(account_api_key_hash, wallet_eth)
-                    .call()
-                    .await?;
-                Ok(derivation)
-            })
-            .await
-            .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+    if let Some(cache) = blockchain_cache::get() {
+        match resolve_account_wallet_hash(account_api_key_hash_alloy).await {
+            Ok(wallet) if wallet != Address::ZERO => {
+                let account_gen = cache.account_generation(wallet);
+                let key = cache.wallet_derivation_key(
+                    account_api_key_hash_alloy,
+                    account_gen,
+                    wallet_address,
+                );
+                return cache
+                    .wallet_derivation_cache()
+                    .try_get_with(key, async {
+                        let contract = get_read_only_account_config_contract().await?;
+                        let derivation = contract
+                            .getWalletDerivation(account_api_key_hash, wallet_eth)
+                            .call()
+                            .await?;
+                        Ok(derivation)
+                    })
+                    .await
+                    .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+            }
+            // Account does not exist — no verdict call needed (cached negative).
+            Ok(_) => return Err(anyhow::anyhow!("AccountDoesNotExist")),
+            // Transient resolution failure — fall through to a direct, uncached call.
+            Err(_) => {}
+        }
     }
 
     let contract = get_read_only_account_config_contract().await?;
@@ -656,23 +665,28 @@ pub async fn can_execute_action(api_key: &str, cid_hash: U256) -> Result<bool> {
     let account_api_key_hash = account_api_key_hash_alloy;
     let cid_hash_eth = cid_hash;
 
-    if let Some(cache) = blockchain_cache::get()
-        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
-    {
-        let account_gen = cache.account_generation(wallet);
-        let key = cache.execute_action_key(account_api_key_hash_alloy, account_gen, cid_hash);
-        return cache
-            .execute_action_cache()
-            .try_get_with(key, async {
-                let contract = get_read_only_account_config_contract().await?;
-                let can_execute = contract
-                    .canExecuteAction(account_api_key_hash, cid_hash_eth)
-                    .call()
-                    .await?;
-                Ok(can_execute)
-            })
-            .await
-            .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+    if let Some(cache) = blockchain_cache::get() {
+        match resolve_account_wallet_hash(account_api_key_hash_alloy).await {
+            Ok(wallet) if wallet != Address::ZERO => {
+                let account_gen = cache.account_generation(wallet);
+                let key =
+                    cache.execute_action_key(account_api_key_hash_alloy, account_gen, cid_hash);
+                return cache
+                    .execute_action_cache()
+                    .try_get_with(key, async {
+                        let contract = get_read_only_account_config_contract().await?;
+                        let can_execute = contract
+                            .canExecuteAction(account_api_key_hash, cid_hash_eth)
+                            .call()
+                            .await?;
+                        Ok(can_execute)
+                    })
+                    .await
+                    .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+            }
+            Ok(_) => return Err(anyhow::anyhow!("AccountDoesNotExist")),
+            Err(_) => {}
+        }
     }
 
     let contract = get_read_only_account_config_contract().await?;
@@ -699,28 +713,32 @@ pub async fn can_use_wallet_in_action(
     let cid_hash_eth = cid_hash;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get()
-        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
-    {
-        let account_gen = cache.account_generation(wallet);
-        let key = cache.use_wallet_key(
-            account_api_key_hash_alloy,
-            account_gen,
-            cid_hash,
-            wallet_address,
-        );
-        return cache
-            .use_wallet_cache()
-            .try_get_with(key, async {
-                let contract = get_read_only_account_config_contract().await?;
-                let can_use = contract
-                    .canUseWalletInAction(account_api_key_hash, cid_hash_eth, wallet_eth)
-                    .call()
-                    .await?;
-                Ok(can_use)
-            })
-            .await
-            .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+    if let Some(cache) = blockchain_cache::get() {
+        match resolve_account_wallet_hash(account_api_key_hash_alloy).await {
+            Ok(wallet) if wallet != Address::ZERO => {
+                let account_gen = cache.account_generation(wallet);
+                let key = cache.use_wallet_key(
+                    account_api_key_hash_alloy,
+                    account_gen,
+                    cid_hash,
+                    wallet_address,
+                );
+                return cache
+                    .use_wallet_cache()
+                    .try_get_with(key, async {
+                        let contract = get_read_only_account_config_contract().await?;
+                        let can_use = contract
+                            .canUseWalletInAction(account_api_key_hash, cid_hash_eth, wallet_eth)
+                            .call()
+                            .await?;
+                        Ok(can_use)
+                    })
+                    .await
+                    .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+            }
+            Ok(_) => return Err(anyhow::anyhow!("AccountDoesNotExist")),
+            Err(_) => {}
+        }
     }
 
     let contract = get_read_only_account_config_contract().await?;
@@ -741,28 +759,36 @@ pub async fn can_execute_action_and_use_wallet(
     let cid_hash_eth = cid_hash;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get()
-        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
-    {
-        let account_gen = cache.account_generation(wallet);
-        let key = cache.execute_and_wallet_key(
-            account_api_key_hash_alloy,
-            account_gen,
-            cid_hash,
-            wallet_address,
-        );
-        return cache
-            .execute_and_wallet_cache()
-            .try_get_with(key, async {
-                let contract = get_read_only_account_config_contract().await?;
-                let result = contract
-                    .canExecuteActionAndUseWallet(account_api_key_hash, cid_hash_eth, wallet_eth)
-                    .call()
-                    .await?;
-                Ok((result.canExecute, result.canUseWallet))
-            })
-            .await
-            .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+    if let Some(cache) = blockchain_cache::get() {
+        match resolve_account_wallet_hash(account_api_key_hash_alloy).await {
+            Ok(wallet) if wallet != Address::ZERO => {
+                let account_gen = cache.account_generation(wallet);
+                let key = cache.execute_and_wallet_key(
+                    account_api_key_hash_alloy,
+                    account_gen,
+                    cid_hash,
+                    wallet_address,
+                );
+                return cache
+                    .execute_and_wallet_cache()
+                    .try_get_with(key, async {
+                        let contract = get_read_only_account_config_contract().await?;
+                        let result = contract
+                            .canExecuteActionAndUseWallet(
+                                account_api_key_hash,
+                                cid_hash_eth,
+                                wallet_eth,
+                            )
+                            .call()
+                            .await?;
+                        Ok((result.canExecute, result.canUseWallet))
+                    })
+                    .await
+                    .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+            }
+            Ok(_) => return Err(anyhow::anyhow!("AccountDoesNotExist")),
+            Err(_) => {}
+        }
     }
 
     let contract = get_read_only_account_config_contract().await?;
@@ -781,18 +807,29 @@ pub async fn can_execute_action_and_use_wallet(
 /// resolve here to the same wallet. Memoized because it sits on the permission
 /// hot path — at most one `getAccountWalletAddress` call per key per resolution
 /// TTL. Falls back to a direct call when the cache is not initialized.
+///
+/// Returns [`Address::ZERO`] for an account that provably does not exist (a zero
+/// wallet or an `AccountDoesNotExist` revert). That sentinel is cached with the
+/// short negative TTL so a stream of invalid keys can't force a chain call per
+/// request. Only transient failures (RPC/transport errors) return `Err`, so a
+/// real account is never negative-cached on a blip.
 pub async fn resolve_account_wallet_hash(api_key_hash: U256) -> Result<Address> {
     async fn fetch(api_key_hash: U256) -> Result<Address> {
         let contract = get_read_only_account_config_contract().await?;
-        let wallet = contract
-            .getAccountWalletAddress(api_key_hash)
-            .call()
-            .await
-            .map_err(|e| anyhow::anyhow!("{}", decode_contract_revert(&e)))?;
-        if wallet == Address::ZERO {
-            anyhow::bail!("account has no wallet address");
+        match contract.getAccountWalletAddress(api_key_hash).call().await {
+            // A zero wallet means the account has no wallet — treat as absent.
+            Ok(wallet) => Ok(wallet),
+            Err(e) => {
+                let decoded = decode_contract_revert(&e);
+                // A definitive "no such account" revert is a cacheable negative;
+                // anything else is transient and must not be negative-cached.
+                if decoded.contains("AccountDoesNotExist") {
+                    Ok(Address::ZERO)
+                } else {
+                    Err(anyhow::anyhow!("{decoded}"))
+                }
+            }
         }
-        Ok(wallet)
     }
 
     if let Some(cache) = blockchain_cache::get() {
@@ -807,7 +844,8 @@ pub async fn resolve_account_wallet_hash(api_key_hash: U256) -> Result<Address> 
 
 /// Invalidate every cached verdict for the account that owns `api_key_hash` by
 /// bumping its wallet's generation. Resolves the hash to its account wallet
-/// first; on resolution failure the account's entries are left to expire by TTL.
+/// first; a nonexistent account ([`Address::ZERO`]) is a no-op, and a transient
+/// resolution failure leaves the account's entries to expire by TTL.
 ///
 /// Used by the on-chain event listener ([`crate::account_events`]) with the
 /// `apiKeyHash` carried in a mutation event.
@@ -816,11 +854,23 @@ pub async fn invalidate_account_by_hash(api_key_hash: U256) {
         return;
     };
     match resolve_account_wallet_hash(api_key_hash).await {
-        Ok(wallet) => cache.bump_account_generation(wallet),
+        Ok(wallet) if wallet != Address::ZERO => cache.bump_account_generation(wallet),
+        Ok(_) => {} // account does not exist — nothing cached to invalidate
         Err(e) => tracing::warn!(
             "blockchain_cache: could not resolve account for {api_key_hash} to invalidate: {e}. \
              Cached entries will expire via TTL."
         ),
+    }
+}
+
+/// Drop all memoized `api_key_hash → wallet` resolutions. Called by the event
+/// listener when it observes an ownership transfer (which moves an account's
+/// admin wallet): clearing forces every key to re-resolve to its current wallet
+/// on the next request, so a usage key can't keep composing its old wallet's
+/// generation. Transfers are rare, so the re-resolution cost is negligible.
+pub fn clear_wallet_resolutions() {
+    if let Some(cache) = blockchain_cache::get() {
+        cache.clear_resolutions();
     }
 }
 

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -68,7 +68,7 @@ pub async fn convert_to_chain_secured_account(
     let function_call =
         contract.convertToChainSecuredAccount(api_key_hash, new_admin_wallet_address);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -136,7 +136,7 @@ pub async fn add_group(
         pkp_ids_eth,
     );
     send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(group_id)
 }
 
@@ -154,7 +154,7 @@ pub async fn add_action(
     let function_call =
         contract.addAction(account_api_key_hash, req.name, req.description, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -169,7 +169,7 @@ pub async fn remove_action(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeAction(account_api_key_hash, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -187,7 +187,7 @@ pub async fn add_action_to_group(
         .map_err(|e| anyhow::anyhow!("Unable to parse action IPFS CID: {}", e))?;
     let function_call = contract.addActionToGroup(account_api_key_hash, group_id, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -203,7 +203,7 @@ pub async fn add_pkp_to_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.addPkpToGroup(account_api_key_hash, group_id, pkp_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -229,7 +229,7 @@ pub async fn update_group(
         pkp_ids.into_iter().collect(),
     );
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -245,7 +245,7 @@ pub async fn remove_action_from_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeActionFromGroup(account_api_key_hash, group_id, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -316,7 +316,7 @@ pub async fn remove_pkp_from_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removePkpFromGroup(account_api_key_hash, group_id, pkp_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -363,7 +363,7 @@ pub async fn add_usage_api_key(
         req.execute_in_groups.into_iter().map(U256::from).collect(),
     );
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_keys(api_key, usage_api_key);
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -404,7 +404,7 @@ pub async fn update_usage_api_key(
     );
     let result =
         send_transaction(function_call, signer_pool, signer_address, client.clone()).await?;
-    blockchain_cache::invalidate_for_keys(api_key, usage_api_key);
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -421,7 +421,7 @@ pub async fn remove_usage_api_key(
 
     let function_call = contract.removeUsageApiKey(account_api_key_hash, usage_api_key_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_keys(api_key, usage_api_key);
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -436,7 +436,7 @@ pub async fn remove_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeGroup(account_api_key_hash, group_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 
@@ -462,7 +462,7 @@ pub async fn register_wallet_derivation(
     );
 
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_for_account(api_key).await;
+    blockchain_cache::invalidate_all();
     Ok(result)
 }
 

--- a/lit-api-server/src/accounts/mod.rs
+++ b/lit-api-server/src/accounts/mod.rs
@@ -68,7 +68,7 @@ pub async fn convert_to_chain_secured_account(
     let function_call =
         contract.convertToChainSecuredAccount(api_key_hash, new_admin_wallet_address);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -136,7 +136,7 @@ pub async fn add_group(
         pkp_ids_eth,
     );
     send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(group_id)
 }
 
@@ -154,7 +154,7 @@ pub async fn add_action(
     let function_call =
         contract.addAction(account_api_key_hash, req.name, req.description, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -169,7 +169,7 @@ pub async fn remove_action(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeAction(account_api_key_hash, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -187,7 +187,7 @@ pub async fn add_action_to_group(
         .map_err(|e| anyhow::anyhow!("Unable to parse action IPFS CID: {}", e))?;
     let function_call = contract.addActionToGroup(account_api_key_hash, group_id, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -203,7 +203,7 @@ pub async fn add_pkp_to_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.addPkpToGroup(account_api_key_hash, group_id, pkp_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -229,7 +229,7 @@ pub async fn update_group(
         pkp_ids.into_iter().collect(),
     );
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -245,7 +245,7 @@ pub async fn remove_action_from_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeActionFromGroup(account_api_key_hash, group_id, action_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -316,7 +316,7 @@ pub async fn remove_pkp_from_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removePkpFromGroup(account_api_key_hash, group_id, pkp_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -363,7 +363,7 @@ pub async fn add_usage_api_key(
         req.execute_in_groups.into_iter().map(U256::from).collect(),
     );
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -404,7 +404,7 @@ pub async fn update_usage_api_key(
     );
     let result =
         send_transaction(function_call, signer_pool, signer_address, client.clone()).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -421,7 +421,7 @@ pub async fn remove_usage_api_key(
 
     let function_call = contract.removeUsageApiKey(account_api_key_hash, usage_api_key_hash);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -436,7 +436,7 @@ pub async fn remove_group(
     let account_api_key_hash = api_key_hash(api_key);
     let function_call = contract.removeGroup(account_api_key_hash, group_id);
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -462,7 +462,7 @@ pub async fn register_wallet_derivation(
     );
 
     let result = send_transaction(function_call, signer_pool, signer_address, client).await?;
-    blockchain_cache::invalidate_all();
+    invalidate_for_account(api_key).await;
     Ok(result)
 }
 
@@ -479,8 +479,12 @@ pub async fn get_wallet_derivation(api_key: &str, wallet_address: Address) -> Re
     let account_api_key_hash = account_api_key_hash_alloy;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get() {
-        let key = cache.wallet_derivation_key(account_api_key_hash_alloy, wallet_address);
+    if let Some(cache) = blockchain_cache::get()
+        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
+    {
+        let account_gen = cache.account_generation(wallet);
+        let key =
+            cache.wallet_derivation_key(account_api_key_hash_alloy, account_gen, wallet_address);
         return cache
             .wallet_derivation_cache()
             .try_get_with(key, async {
@@ -652,8 +656,11 @@ pub async fn can_execute_action(api_key: &str, cid_hash: U256) -> Result<bool> {
     let account_api_key_hash = account_api_key_hash_alloy;
     let cid_hash_eth = cid_hash;
 
-    if let Some(cache) = blockchain_cache::get() {
-        let key = cache.execute_action_key(account_api_key_hash_alloy, cid_hash);
+    if let Some(cache) = blockchain_cache::get()
+        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
+    {
+        let account_gen = cache.account_generation(wallet);
+        let key = cache.execute_action_key(account_api_key_hash_alloy, account_gen, cid_hash);
         return cache
             .execute_action_cache()
             .try_get_with(key, async {
@@ -692,8 +699,16 @@ pub async fn can_use_wallet_in_action(
     let cid_hash_eth = cid_hash;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get() {
-        let key = cache.use_wallet_key(account_api_key_hash_alloy, cid_hash, wallet_address);
+    if let Some(cache) = blockchain_cache::get()
+        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
+    {
+        let account_gen = cache.account_generation(wallet);
+        let key = cache.use_wallet_key(
+            account_api_key_hash_alloy,
+            account_gen,
+            cid_hash,
+            wallet_address,
+        );
         return cache
             .use_wallet_cache()
             .try_get_with(key, async {
@@ -726,9 +741,16 @@ pub async fn can_execute_action_and_use_wallet(
     let cid_hash_eth = cid_hash;
     let wallet_eth = wallet_address;
 
-    if let Some(cache) = blockchain_cache::get() {
-        let key =
-            cache.execute_and_wallet_key(account_api_key_hash_alloy, cid_hash, wallet_address);
+    if let Some(cache) = blockchain_cache::get()
+        && let Ok(wallet) = resolve_account_wallet_hash(account_api_key_hash_alloy).await
+    {
+        let account_gen = cache.account_generation(wallet);
+        let key = cache.execute_and_wallet_key(
+            account_api_key_hash_alloy,
+            account_gen,
+            cid_hash,
+            wallet_address,
+        );
         return cache
             .execute_and_wallet_cache()
             .try_get_with(key, async {
@@ -749,6 +771,64 @@ pub async fn can_execute_action_and_use_wallet(
         .call()
         .await?;
     Ok((result.canExecute, result.canUseWallet))
+}
+
+/// Resolve an `api_key_hash` to its account wallet address, memoized in the
+/// blockchain cache's [`resolution_cache`](blockchain_cache::BlockchainCache::resolution_cache).
+///
+/// The wallet is the account identity used to key per-account cache generations
+/// (see [`blockchain_cache`]): master and usage keys under one account all
+/// resolve here to the same wallet. Memoized because it sits on the permission
+/// hot path — at most one `getAccountWalletAddress` call per key per resolution
+/// TTL. Falls back to a direct call when the cache is not initialized.
+pub async fn resolve_account_wallet_hash(api_key_hash: U256) -> Result<Address> {
+    async fn fetch(api_key_hash: U256) -> Result<Address> {
+        let contract = get_read_only_account_config_contract().await?;
+        let wallet = contract
+            .getAccountWalletAddress(api_key_hash)
+            .call()
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", decode_contract_revert(&e)))?;
+        if wallet == Address::ZERO {
+            anyhow::bail!("account has no wallet address");
+        }
+        Ok(wallet)
+    }
+
+    if let Some(cache) = blockchain_cache::get() {
+        return cache
+            .resolution_cache()
+            .try_get_with(api_key_hash.to_string(), fetch(api_key_hash))
+            .await
+            .map_err(|e: Arc<anyhow::Error>| anyhow::anyhow!("{:#}", e));
+    }
+    fetch(api_key_hash).await
+}
+
+/// Invalidate every cached verdict for the account that owns `api_key_hash` by
+/// bumping its wallet's generation. Resolves the hash to its account wallet
+/// first; on resolution failure the account's entries are left to expire by TTL.
+///
+/// Used by the on-chain event listener ([`crate::account_events`]) with the
+/// `apiKeyHash` carried in a mutation event.
+pub async fn invalidate_account_by_hash(api_key_hash: U256) {
+    let Some(cache) = blockchain_cache::get() else {
+        return;
+    };
+    match resolve_account_wallet_hash(api_key_hash).await {
+        Ok(wallet) => cache.bump_account_generation(wallet),
+        Err(e) => tracing::warn!(
+            "blockchain_cache: could not resolve account for {api_key_hash} to invalidate: {e}. \
+             Cached entries will expire via TTL."
+        ),
+    }
+}
+
+/// Invalidate every cached verdict for the account behind `api_key` (master or
+/// usage key). Write-path convenience wrapper over [`invalidate_account_by_hash`]
+/// for mutations this process performs.
+pub async fn invalidate_for_account(api_key: &str) {
+    invalidate_account_by_hash(api_key_hash(api_key)).await;
 }
 
 /// Resolve any account identity to the admin wallet address of its parent account.

--- a/lit-api-server/src/lib.rs
+++ b/lit-api-server/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+pub mod account_events;
 pub mod accounts;
 pub mod actions;
 pub mod config;

--- a/lit-api-server/src/main.rs
+++ b/lit-api-server/src/main.rs
@@ -156,6 +156,11 @@ async fn main() -> Result<(), rocket::Error> {
     // aren't re-initialized (and don't re-log) on every Rocket rebuild.
     accounts::blockchain_cache::init();
 
+    // Start the on-chain account-mutation listener that flushes the permission
+    // cache when WritesFacet emits a permission-relevant event. Started once,
+    // outside the restart loop, alongside the cache it feeds.
+    lit_api_server::account_events::start_account_event_listener();
+
     // IPFS cache lives outside the restart loop so warm entries survive restarts.
     let ipfs_cache: Cache<String, Arc<String>> = Cache::builder()
         .weigher(|_key, value: &Arc<String>| -> u32 { value.len().try_into().unwrap_or(u32::MAX) })


### PR DESCRIPTION
## Why

Alternative design to #491. Keeps the permission cache fresh when on-chain account/permission state changes, without #491's per-mutation usage-key enumeration (the `list_api_keys` fan-out and 1000-key cap), and without flushing more than the account that actually changed.

The hard part of #491 is mapping an on-chain event to the exact cache entries it touches. That's only hard because cache entries are keyed by the *calling* key (master or usage), while the permission-determining state lives at the *account* level — so an account mutation has to reach N usage keys. This PR dissolves that mapping with a single insight: **everything under one account resolves to the same wallet address**, so we key invalidation by the wallet, not by the calling key.

## The design

**Cache = verdict memoizer.** The key is the contract call: `(fn, api_key_hash, params) → verdict`. The server models nothing about groups/scopes — the contract resolves those when you call `canExecuteAction(hash, cid)`. A miss just asks the chain.

**Invalidation = one generation counter per account, keyed by wallet.** Every cache key embeds the account's generation. `getAccountWalletAddress(hash)` resolves any key — master or usage — to the same account wallet, so:
- Bumping `account_gen[wallet]` invalidates the master **and every usage key** under the account at once. **No enumeration, no `list_api_keys`, no 1000-key cap.**
- A mutation to account A flushes **only** A. An attacker spamming their own account's writes can't flush anyone else's cache.

The wallet for a calling key is resolved lazily and memoized in a resolution cache, so the hot path does at most one `getAccountWalletAddress` call per key per TTL.

**The listener decodes just enough.** It polls `eth_getLogs` for the 15 `WritesFacet` signatures (which also serve as the topic0 filter, excluding billing events), decodes each matching log to its account `apiKeyHash`, dedupes per poll, and invalidates that one account. One drift-guarded macro is the single source of truth for both the filter set and the decode dispatch.

**TTL is a backstop.** Invalidation keeps the cache fresh; the TTL only covers what invalidation can't (missed-block gaps, an ownership transfer that moves the wallet before its resolution entry expires, a replica between boot and first poll). Denials use a short 30s TTL vs the 300s grant TTL, so a permission granted while the listener is lagging/down still becomes visible quickly.

## Why this is better than the alternatives

- **vs #491:** no usage-key enumeration, no `list_api_keys` chain call per mutation, no 1000-key cap, no O(n) fan-out. Bumping one wallet generation covers all usage keys lazily.
- **vs a global flush:** blast radius is one account, not all tenants. A cheap stream of attacker-owned on-chain writes degrades only the attacker's own cache, not everyone's RPC load. (This was the key finding from an adversarial review of an earlier global-counter version of this PR.)

## Stateless / horizontally scalable

- Generation map is process-local; each replica runs its own listener and converges off the same chain logs. No shared state.
- Cold boot: empty cache → all miss → all fresh; listener anchors at the current block, never needs history.
- Better for **ChainSecured** accounts than any write-path hook: the listener sees on-chain mutations regardless of which replica or wallet made them. Write-path hooks additionally give instant invalidation (no poll lag) for mutations this process performs.

## Known follow-ups (out of scope here)

- **Listener robustness (#5/#6 from review):** reorg handling (poll has no confirmation lag) and per-poll block-range capping (a long outage can grow the range past provider limits). Shared with #491's listener; worth a hardening pass.
- **Ownership transfer:** changes the account wallet; cached entries under the old wallet serve until the resolution-cache entry expires (≤ TTL). Rare and typically permission-neutral.

## Test coverage

- `blockchain_cache.rs` — 17 tests: per-account generation increment/wrap/isolation, key formats embed the generation, hit/miss across all four caches, **invalidation scoped to one account** (no global flush), **master and usage keys share one account generation**, and the positive/negative TTL expiry policy (denials expire before grants).
- `account_events.rs` — 5 tests: signature set complete (15) and unique, account-hash extraction from both `apiKeyHash` and `accountApiKeyHash` events, billing event ignored, drift guard (every filtered signature decodes to an account hash).

## Test plan
- [x] `cargo build -p lit-api-server` — clean
- [x] `cargo test --lib` — 227 passed, 0 failed
- [x] `cargo clippy` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)