### PR TITLE
feat(lit-approvals): email-approval as an action library + Neon shared store (D6.1)

### DIFF
--- a/lit-approvals/.gitignore
+++ b/lit-approvals/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/lit-approvals/README.md
+++ b/lit-approvals/README.md
@@ -1,0 +1,101 @@
+# @lit-protocol/lit-approvals
+
+The email-approval primitive (plan D6/M3) re-implemented as **action logic** —
+no `ApprovalService` in lit-api-server. State lives in an **untrusted shared
+store** (Neon over HTTP), the attestation is **signed in-TEE with the approval
+action's CID-bound key**, and verification is **in-TEE action JS**. This fixes
+the v1 in-memory store, which dropped pending approvals on every horizontal
+scale-out / ping-pong deploy (plan D6.1).
+
+> Library code only — like `lit-venues`, it bundles to an IIFE for inlining
+> into a Lit Action. It is reachable from the runtime because Neon's serverless
+> SQL endpoint and Resend are plain HTTPS (`fetch` / `Lit.Actions.proxiedFetch`).
+
+## Architecture
+
+```
+phase 1  (approval ACTION, in-TEE)   requestApproval()  → issue id+OTP, write pending row to Neon, email link
+   ↓
+human    (approval PAGE, flows)       recordSubmission() → record click + typed OTP   (cannot approve)
+   ↓
+phase 2  (approval ACTION, in-TEE)   checkApproval()    → verify OTP vs TEE-keyed HMAC, SIGN attestation, consume
+   ↓
+consume  (consuming ACTION, in-TEE)  verifyApproval()   → check signature + approvalId + request_hash + expiry
+```
+
+One CID-bound key (`Lit.Actions.getLitActionPrivateKey()`) powers both the OTP
+HMAC (domain-separated) and the secp256k1 attestation signature. Consuming
+actions pin the signer pubkey (`publicKeyHex(...)`) — the analog of the old
+`LIT_APPROVAL_ATTESTATION_PUBKEY`, but now a CID-bound identity no service holds.
+
+## Threat model — what an untrusted store CANNOT do
+
+Assume the adversary can **read and write every Neon row** (malicious DB admin,
+leaked connection string, Neon itself):
+
+- **Cannot forge an approval.** Approval is proven by the secp256k1 signature
+  over `(approvalId, requestHash, status, expiry)`. The adversary doesn't hold
+  the signing key, so any row they fabricate fails `verifyApproval`. *(Tested:
+  "malicious store admin", "signer key isolation".)*
+- **Cannot substitute a real attestation onto another operation/approval.** The
+  signed payload binds `approvalId` and `request_hash`; a mismatch is rejected.
+  This is why naïve "encrypt-and-compare" was rejected — encryption isn't
+  authentication. *(Tested: "operation binding", "ciphertext/attestation
+  substitution".)*
+- **Cannot brute-force the OTP from the store.** Only `HMAC(otpKey, id:otp)` is
+  stored; `otpKey` is derived in-TEE and never persisted, so the low-entropy
+  6-digit OTP can't be recovered or guessed offline.
+- **Can deny / DoS** (delete rows, withhold). That's availability, not
+  integrity — acceptable and unavoidable for any shared store.
+
+**Single-use** is enforced atomically on consume (`finalizeConsume`), but an
+adversary with DB write can roll a `consumed` flag back. True anti-replay must
+therefore live at the **execution layer**: bind `request_hash` to the
+operation's own idempotency key (chain nonce, venue `clientOrderId`) so a
+replayed approval still can't execute twice.
+
+**L1 vs L2.** L1 (link-click only) is notification-grade and unbound — a store
+adversary *can* fake an L1 click, so L1 must never gate fund movement.
+`verifyApproval` refuses an unbound attestation wherever a `request_hash` is
+expected. L2 (OTP step-up) is required for money movement and is what the
+threat-model guarantees above protect.
+
+## Build
+
+```sh
+npm install
+npm test         # vitest — threat model is encoded as tests
+npm run build    # esbuild → dist/lit-approvals.iife.js (+ .mjs)
+npm run typecheck
+```
+
+## Usage sketch (inside the approval action)
+
+```js
+// dist/lit-approvals.iife.js concatenated above → global `LitApprovals`
+const signingKey = await Lit.Actions.getLitActionPrivateKey();
+const store = LitApprovals.neonStore(LitApprovals.neonHttpQuery(neonConnStr, fetch));
+
+// phase 1
+const { approvalId, otp } = await LitApprovals.requestApproval({
+  store, signingKey, to: user.email, summary: 'Sweep 0.1 BTC to cold storage',
+  assurance: 'L2', ttlSec: 600,
+  requestHash: LitApprovals.sha256Hex(`${amount}|${dest}|${venue}|${nonce}`),
+  approvalBaseUrl: 'https://flows.litprotocol.com/approvals',
+  sendEmail: (m) => sendViaResend(resendKey, m),  // action calls Resend directly
+});
+// return otp to the requesting app (email is notification only)
+
+// phase 2 (next tick / webhook / manual re-invoke)
+const { approved, attestation } = await LitApprovals.checkApproval({ store, signingKey, approvalId });
+
+// consuming action
+const payload = LitApprovals.verifyApproval({
+  attestation, approvalId, expectedRequestHash, signerPubKeyHex,  // pinned
+});
+```
+
+The connection string is a full-access credential — **seal it** (don't pass it
+as a plaintext action param). The exact Neon HTTP wire shape (`neonHttpQuery`)
+must be validated against live Neon on the dev deploy; the tested seam is the
+`NeonQuery` executor.

--- a/lit-approvals/package-lock.json
+++ b/lit-approvals/package-lock.json
@@ -1,0 +1,2134 @@
+{
+  "name": "@lit-protocol/lit-approvals",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lit-protocol/lit-approvals",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.0",
+        "@noble/hashes": "^1.8.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.6.3",
+        "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/lit-approvals/package.json
+++ b/lit-approvals/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@lit-protocol/lit-approvals",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Email-approval primitive as a Lit Action library: untrusted shared store (Neon over HTTP), in-TEE attestation signing with the action's CID-bound key, in-TEE verification. No Node built-ins.",
+  "type": "module",
+  "main": "./dist/lit-approvals.mjs",
+  "scripts": {
+    "build": "node scripts/bundle.mjs",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@noble/curves": "^1.9.0",
+    "@noble/hashes": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.6.3",
+    "vitest": "^3.0.0"
+  }
+}

--- a/lit-approvals/schema.sql
+++ b/lit-approvals/schema.sql
@@ -1,0 +1,22 @@
+-- lit-approvals shared store (Neon). Run once per environment.
+-- This store is UNTRUSTED: it provides shared state that survives horizontal
+-- scaling + ping-pong deploys, but integrity comes from the signed attestation
+-- (verified in-TEE), never from DB access control. See README "Threat model".
+
+create table if not exists lit_approvals (
+  approval_id    text primary key,
+  approver       text not null,
+  assurance      text not null check (assurance in ('L1','L2')),
+  request_hash   text not null default '',   -- operation binding; empty = L1
+  status         text not null default 'pending',  -- pending|consumed|denied|expired
+  otp_hmac       text not null default '',   -- HMAC(otpKey, id:otp); otpKey is TEE-held
+  clicked        boolean not null default false,
+  submitted_otp  text,                       -- written by the (untrusted) approval page
+  attestation    text,                       -- signed envelope, written once on consume
+  created_at_ms  bigint not null,
+  expires_at_ms  bigint not null
+);
+
+-- Optional: reap expired/consumed rows on a schedule.
+create index if not exists lit_approvals_status_idx on lit_approvals (status);
+create index if not exists lit_approvals_expires_idx on lit_approvals (expires_at_ms);

--- a/lit-approvals/scripts/bundle.mjs
+++ b/lit-approvals/scripts/bundle.mjs
@@ -1,0 +1,25 @@
+import { build } from 'esbuild';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+// IIFE for inline embedding in Lit Action code (actions are plain scripts, not
+// modules) — exposes `LitApprovals` as a global. ESM build is the future
+// integrity-pinned CDN import path.
+const targets = [
+  { format: 'iife', globalName: 'LitApprovals', outfile: 'dist/lit-approvals.iife.js' },
+  { format: 'esm', outfile: 'dist/lit-approvals.mjs' },
+];
+
+for (const t of targets) {
+  await build({
+    entryPoints: ['src/index.ts'],
+    bundle: true,
+    target: 'es2022',
+    minify: false,
+    legalComments: 'inline',
+    ...t,
+  });
+  const buf = readFileSync(t.outfile);
+  const sha384 = createHash('sha384').update(buf).digest('base64');
+  console.log(`${t.outfile}: ${buf.length} bytes  integrity=sha384-${sha384}`);
+}

--- a/lit-approvals/src/approvals.ts
+++ b/lit-approvals/src/approvals.ts
@@ -1,0 +1,250 @@
+/**
+ * The email-approval primitive, as action logic (no server). Three entry
+ * points map to the two-phase flow:
+ *
+ *   requestApproval()  — phase 1, in-TEE: issue nonce + OTP, persist a pending
+ *                        row to the (untrusted) shared store, send the email.
+ *   recordSubmission() — out-of-TEE, on the approval page (flows): record that
+ *                        the human clicked / typed an OTP. Cannot approve.
+ *   checkApproval()    — phase 2, in-TEE: validate the human action against the
+ *                        TEE-keyed OTP HMAC, then SIGN the attestation with the
+ *                        action's CID-bound key and consume the row.
+ *   verifyApproval()   — in the consuming action, in-TEE: verify the signed
+ *                        attestation against the pinned signer pubkey AND bind
+ *                        it to the operation's request_hash. Fails closed.
+ */
+
+import {
+  deriveOtpKey,
+  genApprovalId,
+  genOtp,
+  otpHmacHex,
+  publicKeyHex,
+  signPayload,
+  timingSafeEqualHex,
+  verifyPayloadSig,
+  type RandomBytes,
+  defaultRandomBytes,
+} from './crypto';
+import type {
+  ApprovalStore,
+  Assurance,
+  AttestationEnvelope,
+  AttestationPayload,
+  FetchLike,
+} from './types';
+
+function nowMsOf(nowMs?: number): number {
+  return nowMs ?? Date.now();
+}
+
+/** Canonical, fixed-key-order serialization — the EXACT bytes that are signed
+ *  and that the verifier re-parses. */
+function serializePayload(p: AttestationPayload): string {
+  return JSON.stringify({
+    schema: p.schema,
+    approval_id: p.approval_id,
+    approver: p.approver,
+    assurance: p.assurance,
+    request_hash: p.request_hash,
+    status: p.status,
+    approved_at_ms: p.approved_at_ms,
+    expires_at_ms: p.expires_at_ms,
+  });
+}
+
+export interface RequestApprovalInput {
+  store: ApprovalStore;
+  /** The action's CID-bound private key (`Lit.Actions.getLitActionPrivateKey()`). */
+  signingKey: string | Uint8Array;
+  to: string;
+  /** Human-readable operation summary for the email body. */
+  summary: string;
+  assurance: Assurance;
+  ttlSec: number;
+  /** Operation binding (e.g. sha256 of amount|dest|venue|nonce). Empty for L1. */
+  requestHash?: string;
+  /** Base URL of the approval page (flows). The link is `${base}/${approvalId}`. */
+  approvalBaseUrl: string;
+  sendEmail: (msg: { to: string; subject: string; text: string }) => Promise<void>;
+  nowMs?: number;
+  randomBytes?: RandomBytes;
+}
+
+export interface RequestApprovalResult {
+  approvalId: string;
+  /** Present for L2 — returned to the REQUESTING app (email is notification
+   *  only). undefined for L1. */
+  otp?: string;
+  approvalUrl: string;
+}
+
+export async function requestApproval(input: RequestApprovalInput): Promise<RequestApprovalResult> {
+  const rand = input.randomBytes ?? defaultRandomBytes;
+  if (input.assurance === 'L2' && !input.requestHash) {
+    throw new Error('lit-approvals: L2 (fund-moving) approval requires a requestHash');
+  }
+  const approvalId = genApprovalId(rand);
+  const now = nowMsOf(input.nowMs);
+  const otp = input.assurance === 'L2' ? genOtp(rand) : '';
+  const otpKey = deriveOtpKey(input.signingKey);
+  const otpHmac = otp ? otpHmacHex(otpKey, approvalId, otp) : '';
+
+  await input.store.insertPending({
+    approvalId,
+    approver: input.to,
+    assurance: input.assurance,
+    requestHash: input.requestHash ?? '',
+    status: 'pending',
+    otpHmac,
+    clicked: false,
+    submittedOtp: null,
+    attestation: null,
+    createdAtMs: now,
+    expiresAtMs: now + input.ttlSec * 1000,
+  });
+
+  const approvalUrl = `${input.approvalBaseUrl.replace(/\/$/, '')}/${approvalId}`;
+  await input.sendEmail({
+    to: input.to,
+    subject: 'Approval requested',
+    text: `${input.summary}\n\nReview and approve: ${approvalUrl}\n\nThis request expires in ${Math.round(input.ttlSec / 60)} minutes. If you did not initiate it, ignore this email.`,
+  });
+
+  return { approvalId, otp: otp || undefined, approvalUrl };
+}
+
+/** Out-of-TEE recorder used by the approval page (flows). It can never produce
+ *  an approval — only the in-TEE `checkApproval` validates + signs. */
+export async function recordSubmission(
+  store: ApprovalStore,
+  approvalId: string,
+  opts: { clicked: boolean; submittedOtp?: string | null },
+): Promise<void> {
+  await store.recordSubmission(approvalId, opts.clicked, opts.submittedOtp ?? null);
+}
+
+export interface CheckApprovalInput {
+  store: ApprovalStore;
+  signingKey: string | Uint8Array;
+  approvalId: string;
+  nowMs?: number;
+}
+
+export interface CheckApprovalResult {
+  approved: boolean;
+  /** 'pending' | 'approved' | 'denied' | 'expired' | 'replayed' */
+  status: string;
+  attestation?: string;
+}
+
+/**
+ * Validate the human action against the TEE-keyed OTP HMAC and, if valid, mint
+ * + persist + return the signed attestation. Single-use via the store's atomic
+ * `finalizeConsume` (fails closed if it lost the race).
+ */
+export async function checkApproval(input: CheckApprovalInput): Promise<CheckApprovalResult> {
+  const row = await input.store.load(input.approvalId);
+  if (!row) return { approved: false, status: 'pending' };
+  if (row.status === 'denied') return { approved: false, status: 'denied' };
+  if (row.status === 'consumed') {
+    // Already spent: return the prior attestation, but the caller must treat a
+    // second consume as a replay at the execution layer (request_hash → nonce).
+    return { approved: false, status: 'replayed', attestation: row.attestation ?? undefined };
+  }
+  const now = nowMsOf(input.nowMs);
+  if (now >= row.expiresAtMs) return { approved: false, status: 'expired' };
+  if (!row.clicked) return { approved: false, status: 'pending' };
+
+  if (row.assurance === 'L2') {
+    const otpKey = deriveOtpKey(input.signingKey);
+    const submitted = row.submittedOtp ?? '';
+    if (!submitted || !timingSafeEqualHex(otpHmacHex(otpKey, input.approvalId, submitted), row.otpHmac)) {
+      return { approved: false, status: 'pending' };
+    }
+  }
+
+  const payload: AttestationPayload = {
+    schema: 'email-approval-v1',
+    approval_id: row.approvalId,
+    approver: row.approver,
+    assurance: row.assurance,
+    request_hash: row.requestHash,
+    status: 'approved',
+    approved_at_ms: now,
+    expires_at_ms: row.expiresAtMs,
+  };
+  const payloadStr = serializePayload(payload);
+  const envelope: AttestationEnvelope = {
+    v: 'email-approval-v1',
+    alg: 'secp256k1-sha256',
+    payload: payloadStr,
+    sig: signPayload(payloadStr, input.signingKey),
+  };
+  const attestation = JSON.stringify(envelope);
+
+  const won = await input.store.finalizeConsume(input.approvalId, attestation);
+  if (!won) return { approved: false, status: 'replayed' };
+  return { approved: true, status: 'approved', attestation };
+}
+
+export class ApprovalVerifyError extends Error {}
+
+export interface VerifyApprovalInput {
+  attestation: string;
+  approvalId: string;
+  /** Operation the consuming action is about to perform. Must match the bound
+   *  hash; if the action expects a bound approval it MUST pass non-empty. */
+  expectedRequestHash: string;
+  /** SEC1 pubkey hex of the approval action's signing key (pin this). */
+  signerPubKeyHex: string;
+  nowMs?: number;
+}
+
+/**
+ * Mirror of the runtime's `verify_approval_attestation`, in action JS (still
+ * in-TEE). Every failure is terminal — an approval that cannot prove THIS
+ * operation reports an error, never `approved`.
+ */
+export function verifyApproval(input: VerifyApprovalInput): AttestationPayload {
+  let envelope: AttestationEnvelope;
+  try {
+    envelope = JSON.parse(input.attestation) as AttestationEnvelope;
+  } catch {
+    throw new ApprovalVerifyError('malformed attestation');
+  }
+  if (envelope.v !== 'email-approval-v1' || envelope.alg !== 'secp256k1-sha256') {
+    throw new ApprovalVerifyError(`unsupported attestation version/alg: ${envelope.v}/${envelope.alg}`);
+  }
+  if (!verifyPayloadSig(envelope.payload, envelope.sig, input.signerPubKeyHex)) {
+    throw new ApprovalVerifyError('attestation signature verification FAILED');
+  }
+  let payload: AttestationPayload;
+  try {
+    payload = JSON.parse(envelope.payload) as AttestationPayload;
+  } catch {
+    throw new ApprovalVerifyError('malformed attestation payload');
+  }
+  if (payload.schema !== 'email-approval-v1') {
+    throw new ApprovalVerifyError(`unexpected payload schema: ${payload.schema}`);
+  }
+  if (payload.approval_id !== input.approvalId) {
+    throw new ApprovalVerifyError('attestation is for a different approvalId');
+  }
+  if (payload.status !== 'approved') {
+    throw new ApprovalVerifyError(`attestation status is '${payload.status}', not 'approved'`);
+  }
+  if (payload.request_hash !== input.expectedRequestHash) {
+    throw new ApprovalVerifyError(
+      payload.request_hash === ''
+        ? 'attestation is unbound (no operation hash) but this action expects a bound approval — refusing'
+        : 'attestation does not match the expected operation (requestHash mismatch)',
+    );
+  }
+  if (nowMsOf(input.nowMs) >= payload.expires_at_ms) {
+    throw new ApprovalVerifyError('attestation has expired');
+  }
+  return payload;
+}
+
+export { publicKeyHex };

--- a/lit-approvals/src/crypto.ts
+++ b/lit-approvals/src/crypto.ts
@@ -1,0 +1,93 @@
+/**
+ * Crypto primitives for the approval primitive. Runs inside the Lit Actions
+ * runtime: no Node `crypto`, no `Buffer` — only @noble/* (bundled).
+ *
+ * One CID-bound TEE key (the approval action's `getLitActionPrivateKey()`)
+ * powers two things, domain-separated:
+ *   - the OTP HMAC key (so a store adversary can't brute-force the 6-digit OTP)
+ *   - the secp256k1 attestation signing key (its pubkey is what consuming
+ *     actions pin to verify approvals)
+ */
+
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+export function sha256Hex(payload: string): string {
+  return bytesToHex(sha256(utf8ToBytes(payload)));
+}
+
+function toKeyBytes(privateKey: string | Uint8Array): Uint8Array {
+  if (privateKey instanceof Uint8Array) return privateKey;
+  return hexToBytes(privateKey.trim().replace(/^0x/, '').toLowerCase());
+}
+
+/** Domain-separated subkey from the action's signing key. Keeps the OTP HMAC
+ *  key distinct from the signing scalar even though both come from one CID key. */
+export function deriveOtpKey(signingKey: string | Uint8Array): Uint8Array {
+  return hmac(sha256, toKeyBytes(signingKey), utf8ToBytes('lit-approvals/otp-hmac/v1'));
+}
+
+export function otpHmacHex(otpKey: Uint8Array, approvalId: string, otp: string): string {
+  return bytesToHex(hmac(sha256, otpKey, utf8ToBytes(`${approvalId}:${otp}`)));
+}
+
+/** Length-safe constant-time-ish hex comparison. */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** secp256k1 ECDSA over sha256(payloadBytes), compact 64-byte sig as hex.
+ *  Matches the runtime verifier's `secp256k1-sha256`. */
+export function signPayload(payload: string, signingKey: string | Uint8Array): string {
+  const msgHash = sha256(utf8ToBytes(payload));
+  const sig = secp256k1.sign(msgHash, toKeyBytes(signingKey));
+  return bytesToHex(sig.toCompactRawBytes());
+}
+
+export function verifyPayloadSig(payload: string, sigHex: string, pubKeyHex: string): boolean {
+  try {
+    const msgHash = sha256(utf8ToBytes(payload));
+    return secp256k1.verify(hexToBytes(sigHex), msgHash, hexToBytes(pubKeyHex.replace(/^0x/, '')));
+  } catch {
+    return false;
+  }
+}
+
+/** SEC1-compressed pubkey hex for the signing key — pin this in consuming
+ *  actions (the analog of the old LIT_APPROVAL_ATTESTATION_PUBKEY). */
+export function publicKeyHex(signingKey: string | Uint8Array, compressed = true): string {
+  return bytesToHex(secp256k1.getPublicKey(toKeyBytes(signingKey), compressed));
+}
+
+/** Randomness seam — inject `randomBytes` (default: crypto.getRandomValues).
+ *  Throws rather than silently degrading to weak randomness for security
+ *  material (OTP, approvalId). */
+export type RandomBytes = (n: number) => Uint8Array;
+
+export const defaultRandomBytes: RandomBytes = (n: number) => {
+  const g = (globalThis as { crypto?: { getRandomValues?: (b: Uint8Array) => Uint8Array } }).crypto;
+  if (!g?.getRandomValues) {
+    throw new Error('lit-approvals: no CSPRNG (crypto.getRandomValues) — inject randomBytes');
+  }
+  const bytes = new Uint8Array(n);
+  g.getRandomValues(bytes);
+  return bytes;
+};
+
+export function genApprovalId(randomBytes: RandomBytes): string {
+  return bytesToHex(randomBytes(16));
+}
+
+/** Uniform 6-digit OTP via rejection sampling (no modulo bias). */
+export function genOtp(randomBytes: RandomBytes): string {
+  for (;;) {
+    const b = randomBytes(4);
+    const n = ((b[0]! << 24) | (b[1]! << 16) | (b[2]! << 8) | b[3]!) >>> 0;
+    if (n < 4_000_000_000) return String(n % 1_000_000).padStart(6, '0');
+  }
+}

--- a/lit-approvals/src/index.ts
+++ b/lit-approvals/src/index.ts
@@ -1,0 +1,42 @@
+export const VERSION = '0.1.0';
+
+export {
+  requestApproval,
+  recordSubmission,
+  checkApproval,
+  verifyApproval,
+  ApprovalVerifyError,
+  publicKeyHex,
+} from './approvals';
+export type {
+  RequestApprovalInput,
+  RequestApprovalResult,
+  CheckApprovalInput,
+  CheckApprovalResult,
+  VerifyApprovalInput,
+} from './approvals';
+
+export { neonStore, neonHttpQuery, SCHEMA_SQL } from './store';
+export type { NeonQuery } from './store';
+
+export {
+  sha256Hex,
+  deriveOtpKey,
+  otpHmacHex,
+  signPayload,
+  verifyPayloadSig,
+  genApprovalId,
+  genOtp,
+  defaultRandomBytes,
+} from './crypto';
+export type { RandomBytes } from './crypto';
+
+export type {
+  Assurance,
+  RowStatus,
+  ApprovalRow,
+  ApprovalStore,
+  AttestationPayload,
+  AttestationEnvelope,
+  FetchLike,
+} from './types';

--- a/lit-approvals/src/store.ts
+++ b/lit-approvals/src/store.ts
@@ -1,0 +1,115 @@
+/**
+ * Neon-backed `ApprovalStore` over the serverless SQL-over-HTTP endpoint
+ * (`fetch`, no TCP — works inside the action runtime). The store is UNTRUSTED:
+ * correctness never depends on it being honest (see README). It provides
+ * shared state that survives horizontal scaling and ping-pong deploys, which
+ * the v1 in-memory store could not.
+ *
+ * NOTE: the exact Neon HTTP wire shape must be validated against live Neon on
+ * the dev deploy — the seam below (`NeonQuery`) is the tested interface; the
+ * `neonHttpQuery` transport is best-effort until that check.
+ */
+
+import type { ApprovalRow, ApprovalStore, FetchLike, RowStatus, Assurance } from './types';
+
+/** Minimal executor: run a parameterized statement, get rows back. */
+export type NeonQuery = (sql: string, params: unknown[]) => Promise<Record<string, unknown>[]>;
+
+export const SCHEMA_SQL = `
+create table if not exists lit_approvals (
+  approval_id    text primary key,
+  approver       text not null,
+  assurance      text not null check (assurance in ('L1','L2')),
+  request_hash   text not null default '',
+  status         text not null default 'pending',
+  otp_hmac       text not null default '',
+  clicked        boolean not null default false,
+  submitted_otp  text,
+  attestation    text,
+  created_at_ms  bigint not null,
+  expires_at_ms  bigint not null
+);
+`;
+
+function rowFromDb(r: Record<string, unknown>): ApprovalRow {
+  return {
+    approvalId: String(r.approval_id),
+    approver: String(r.approver),
+    assurance: String(r.assurance) as Assurance,
+    requestHash: String(r.request_hash ?? ''),
+    status: String(r.status) as RowStatus,
+    otpHmac: String(r.otp_hmac ?? ''),
+    clicked: r.clicked === true || r.clicked === 't' || r.clicked === 'true',
+    submittedOtp: r.submitted_otp == null ? null : String(r.submitted_otp),
+    attestation: r.attestation == null ? null : String(r.attestation),
+    createdAtMs: Number(r.created_at_ms),
+    expiresAtMs: Number(r.expires_at_ms),
+  };
+}
+
+export function neonStore(query: NeonQuery): ApprovalStore {
+  return {
+    async insertPending(row: ApprovalRow): Promise<void> {
+      await query(
+        `insert into lit_approvals
+           (approval_id, approver, assurance, request_hash, status, otp_hmac,
+            clicked, submitted_otp, attestation, created_at_ms, expires_at_ms)
+         values ($1,$2,$3,$4,'pending',$5,false,null,null,$6,$7)`,
+        [row.approvalId, row.approver, row.assurance, row.requestHash, row.otpHmac, row.createdAtMs, row.expiresAtMs],
+      );
+    },
+    async load(approvalId: string): Promise<ApprovalRow | null> {
+      const rows = await query(`select * from lit_approvals where approval_id = $1`, [approvalId]);
+      return rows[0] ? rowFromDb(rows[0]) : null;
+    },
+    async recordSubmission(approvalId, clicked, submittedOtp): Promise<void> {
+      await query(
+        `update lit_approvals set clicked = $2, submitted_otp = $3
+           where approval_id = $1 and status = 'pending'`,
+        [approvalId, clicked, submittedOtp],
+      );
+    },
+    async finalizeConsume(approvalId, attestation): Promise<boolean> {
+      // Atomic single-use: only the row still 'pending' transitions. Note an
+      // adversary with DB write can roll this back — true anti-replay lives at
+      // the execution layer (request_hash bound to a chain nonce / order id).
+      const rows = await query(
+        `update lit_approvals set status = 'consumed', attestation = $2
+           where approval_id = $1 and status = 'pending'
+         returning approval_id`,
+        [approvalId, attestation],
+      );
+      return rows.length === 1;
+    },
+    async markDenied(approvalId): Promise<void> {
+      await query(`update lit_approvals set status = 'denied' where approval_id = $1 and status = 'pending'`, [approvalId]);
+    },
+  };
+}
+
+/**
+ * Best-effort Neon serverless SQL-over-HTTP transport. The connection string
+ * is a full-access credential — seal it (do NOT pass it as a plaintext action
+ * param). Validate the exact header/response shape against live Neon before GA.
+ */
+export function neonHttpQuery(connectionString: string, fetchImpl: FetchLike): NeonQuery {
+  const host = connectionString.replace(/^postgres(ql)?:\/\//, '').split('@')[1]?.split('/')[0]?.split('?')[0];
+  if (!host) throw new Error('lit-approvals: cannot parse host from Neon connection string');
+  const endpoint = `https://${host}/sql`;
+  return async (sql, params) => {
+    const res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Neon-Connection-String': connectionString,
+        'Neon-Raw-Text-Output': 'false',
+        'Neon-Array-Mode': 'false',
+      },
+      body: JSON.stringify({ query: sql, params }),
+    });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`lit-approvals: Neon HTTP ${res.status}: ${text.slice(0, 200)}`);
+    const parsed = JSON.parse(text) as { rows?: Record<string, unknown>[] };
+    return parsed.rows ?? [];
+  };
+}

--- a/lit-approvals/src/types.ts
+++ b/lit-approvals/src/types.ts
@@ -1,0 +1,69 @@
+export type Assurance = 'L1' | 'L2';
+
+/** DB row status. Distinct from the *attestation* payload status (which is
+ *  always 'approved' when present). `consumed` is the single-use terminal. */
+export type RowStatus = 'pending' | 'consumed' | 'denied' | 'expired';
+
+export type FetchLike = (url: string, init?: Record<string, unknown>) => Promise<{
+  status: number;
+  ok: boolean;
+  text(): Promise<string>;
+}>;
+
+/** A pending approval as persisted in the untrusted shared store. Nothing here
+ *  is trusted for integrity: forgery is prevented by the signature the runtime
+ *  verifies, and OTP confidentiality by `otpHmac` being keyed with a TEE-held
+ *  key. See README "Threat model". */
+export interface ApprovalRow {
+  approvalId: string;
+  approver: string;
+  assurance: Assurance;
+  /** Operation binding. Empty = unbound (L1 notification grade). */
+  requestHash: string;
+  status: RowStatus;
+  /** HMAC(otpKey, `${approvalId}:${otp}`) — otpKey is derived in-TEE, never
+   *  stored. A store adversary can't reverse this to recover the 6-digit OTP. */
+  otpHmac: string;
+  /** Set by the (untrusted) approval page when the human acts. */
+  clicked: boolean;
+  submittedOtp: string | null;
+  /** Signed `email-approval-v1` envelope, written once on consume. */
+  attestation: string | null;
+  createdAtMs: number;
+  expiresAtMs: number;
+}
+
+/** The shared-store seam. The Neon implementation is one impl; tests use an
+ *  in-memory one. Integrity does NOT depend on this store being honest. */
+export interface ApprovalStore {
+  insertPending(row: ApprovalRow): Promise<void>;
+  load(approvalId: string): Promise<ApprovalRow | null>;
+  /** Called from the untrusted approval page (flows) when the human acts. */
+  recordSubmission(approvalId: string, clicked: boolean, submittedOtp: string | null): Promise<void>;
+  /** Atomic single-use guard: set status=consumed + store attestation ONLY if
+   *  the row is still `pending`. Returns false if it lost the race / already
+   *  consumed — the caller then fails closed. */
+  finalizeConsume(approvalId: string, attestation: string): Promise<boolean>;
+  markDenied(approvalId: string): Promise<void>;
+}
+
+/** The exact object that is JSON-serialized and signed. Field set + snake_case
+ *  keys match the runtime verifier (`ApprovalAttestationPayload`) so the same
+ *  attestation verifies in the Rust op or in action JS. */
+export interface AttestationPayload {
+  schema: 'email-approval-v1';
+  approval_id: string;
+  approver: string;
+  assurance: Assurance;
+  request_hash: string;
+  status: 'approved';
+  approved_at_ms: number;
+  expires_at_ms: number;
+}
+
+export interface AttestationEnvelope {
+  v: 'email-approval-v1';
+  alg: 'secp256k1-sha256';
+  payload: string;
+  sig: string;
+}

--- a/lit-approvals/test/crypto.test.ts
+++ b/lit-approvals/test/crypto.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { sha256Hex, genOtp, deriveOtpKey, otpHmacHex, publicKeyHex, signPayload, verifyPayloadSig } from '../src/crypto';
+import { seededRandom } from './memstore';
+
+describe('crypto primitives', () => {
+  it('sha256Hex matches the known vector for "abc"', () => {
+    expect(sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('genOtp returns a uniform 6-digit string', () => {
+    const rand = seededRandom(42);
+    for (let i = 0; i < 100; i++) expect(genOtp(rand)).toMatch(/^\d{6}$/);
+  });
+
+  it('otpKey is domain-separated and deterministic for a given signing key', () => {
+    const k1 = deriveOtpKey('11'.repeat(32));
+    const k2 = deriveOtpKey('11'.repeat(32));
+    const k3 = deriveOtpKey('22'.repeat(32));
+    expect(Buffer.from(k1)).toEqual(Buffer.from(k2));
+    expect(Buffer.from(k1)).not.toEqual(Buffer.from(k3));
+  });
+
+  it('otpHmac binds the approvalId (same OTP, different id → different hmac)', () => {
+    const key = deriveOtpKey('11'.repeat(32));
+    expect(otpHmacHex(key, 'a', '123456')).not.toBe(otpHmacHex(key, 'b', '123456'));
+  });
+
+  it('sign/verify round-trips and rejects a tampered payload', () => {
+    const key = '33'.repeat(32);
+    const pub = publicKeyHex(key);
+    const sig = signPayload('hello', key);
+    expect(verifyPayloadSig('hello', sig, pub)).toBe(true);
+    expect(verifyPayloadSig('hell0', sig, pub)).toBe(false);
+  });
+});

--- a/lit-approvals/test/flow.test.ts
+++ b/lit-approvals/test/flow.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import {
+  requestApproval,
+  recordSubmission,
+  checkApproval,
+  verifyApproval,
+  publicKeyHex,
+  ApprovalVerifyError,
+} from '../src/approvals';
+import { sha256Hex, signPayload } from '../src/crypto';
+import { memStore, seededRandom } from './memstore';
+
+// A fixed 32-byte signing key standing in for getLitActionPrivateKey().
+const SIGNING_KEY = '11'.repeat(32);
+const PUB = publicKeyHex(SIGNING_KEY);
+const T0 = 1_700_000_000_000;
+
+function noopEmail() {
+  const sent: { to: string; subject: string; text: string }[] = [];
+  return { sent, send: async (m: { to: string; subject: string; text: string }) => void sent.push(m) };
+}
+
+async function l2Request(store = memStore(), requestHash = sha256Hex('move 0.1 BTC to 0xabc|nonce42'), seed = 7) {
+  const email = noopEmail();
+  const res = await requestApproval({
+    store,
+    signingKey: SIGNING_KEY,
+    to: 'user@example.com',
+    summary: 'Sweep 0.1 BTC to cold storage',
+    assurance: 'L2',
+    ttlSec: 600,
+    requestHash,
+    approvalBaseUrl: 'https://flows.example/approvals',
+    sendEmail: email.send,
+    nowMs: T0,
+    randomBytes: seededRandom(seed),
+  });
+  return { store, res, requestHash, email };
+}
+
+describe('happy path (L2)', () => {
+  it('request → human OTP submit → check signs an attestation that verifies', async () => {
+    const { store, res, requestHash } = await l2Request();
+    expect(res.otp).toMatch(/^\d{6}$/);
+    expect(res.approvalUrl).toContain(res.approvalId);
+
+    // human acts on the (untrusted) page
+    await recordSubmission(store, res.approvalId, { clicked: true, submittedOtp: res.otp });
+
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(checked.approved).toBe(true);
+    expect(checked.attestation).toBeTruthy();
+
+    const payload = verifyApproval({
+      attestation: checked.attestation!,
+      approvalId: res.approvalId,
+      expectedRequestHash: requestHash,
+      signerPubKeyHex: PUB,
+      nowMs: T0 + 2000,
+    });
+    expect(payload.status).toBe('approved');
+    expect(payload.request_hash).toBe(requestHash);
+  });
+
+  it('emails a notification with the link, never the OTP', async () => {
+    const { res, email } = await l2Request();
+    expect(email.sent).toHaveLength(1);
+    expect(email.sent[0]!.text).toContain(res.approvalUrl);
+    expect(email.sent[0]!.text).not.toContain(res.otp!);
+  });
+});
+
+describe('operation binding', () => {
+  it('rejects a valid attestation replayed for a DIFFERENT operation', async () => {
+    const { store, res } = await l2Request();
+    await recordSubmission(store, res.approvalId, { clicked: true, submittedOtp: res.otp });
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(() =>
+      verifyApproval({
+        attestation: checked.attestation!,
+        approvalId: res.approvalId,
+        expectedRequestHash: sha256Hex('move 5 BTC to 0xEVIL'),
+        signerPubKeyHex: PUB,
+        nowMs: T0 + 2000,
+      }),
+    ).toThrow(/does not match the expected operation/);
+  });
+
+  it('refuses an unbound (L1) approval where a bound one is expected', async () => {
+    const store = memStore();
+    const email = noopEmail();
+    const res = await requestApproval({
+      store, signingKey: SIGNING_KEY, to: 'u@e.com', summary: 'run report',
+      assurance: 'L1', ttlSec: 600, approvalBaseUrl: 'https://flows.example/approvals',
+      sendEmail: email.send, nowMs: T0, randomBytes: seededRandom(3),
+    });
+    await recordSubmission(store, res.approvalId, { clicked: true });
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(checked.approved).toBe(true); // L1 link-click approves
+    expect(() =>
+      verifyApproval({
+        attestation: checked.attestation!, approvalId: res.approvalId,
+        expectedRequestHash: sha256Hex('move funds'), signerPubKeyHex: PUB, nowMs: T0 + 2000,
+      }),
+    ).toThrow(/unbound/);
+  });
+
+  it('requires a requestHash for L2 at request time', async () => {
+    await expect(
+      requestApproval({
+        store: memStore(), signingKey: SIGNING_KEY, to: 'u@e.com', summary: 's',
+        assurance: 'L2', ttlSec: 600, approvalBaseUrl: 'https://flows.example/approvals',
+        sendEmail: noopEmail().send, nowMs: T0, randomBytes: seededRandom(1),
+      }),
+    ).rejects.toThrow(/requires a requestHash/);
+  });
+});
+
+describe('OTP step-up', () => {
+  it('does not approve on a wrong OTP', async () => {
+    const { store, res } = await l2Request();
+    await recordSubmission(store, res.approvalId, { clicked: true, submittedOtp: '000000' });
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(checked.approved).toBe(false);
+    expect(checked.attestation).toBeUndefined();
+  });
+
+  it('does not approve on click without an OTP (L2)', async () => {
+    const { store, res } = await l2Request();
+    await recordSubmission(store, res.approvalId, { clicked: true });
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(checked.approved).toBe(false);
+  });
+});
+
+describe('malicious store admin (the whole point)', () => {
+  it('cannot forge an approval by writing status/attestation directly', async () => {
+    const { store, res, requestHash } = await l2Request();
+    // Adversary with full DB write sets the row "approved" and injects junk.
+    const row = store.rows.get(res.approvalId)!;
+    row.status = 'pending';
+    row.clicked = true;
+    row.submittedOtp = '000000'; // they don't know the real OTP
+    row.attestation = JSON.stringify({ v: 'email-approval-v1', alg: 'secp256k1-sha256', payload: '{}', sig: '00'.repeat(64) });
+
+    // The legit check still won't approve (OTP HMAC mismatch — they lack otpKey).
+    const checked = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(checked.approved).toBe(false);
+
+    // And the consuming verifier rejects any attestation they fabricate.
+    expect(() =>
+      verifyApproval({
+        attestation: row.attestation!, approvalId: res.approvalId,
+        expectedRequestHash: requestHash, signerPubKeyHex: PUB, nowMs: T0 + 1000,
+      }),
+    ).toThrow(ApprovalVerifyError);
+  });
+
+  it('ciphertext/attestation substitution: a valid attestation for a different approval is rejected', async () => {
+    const a = await l2Request(undefined, sha256Hex('op-A'), 7);
+    await recordSubmission(a.store, a.res.approvalId, { clicked: true, submittedOtp: a.res.otp });
+    const goodA = await checkApproval({ store: a.store, signingKey: SIGNING_KEY, approvalId: a.res.approvalId, nowMs: T0 + 1000 });
+
+    // Adversary drops attestation A onto a fresh pending approval B (distinct id).
+    const b = await l2Request(undefined, sha256Hex('op-B'), 99);
+    expect(() =>
+      verifyApproval({
+        attestation: goodA.attestation!, approvalId: b.res.approvalId,
+        expectedRequestHash: b.requestHash, signerPubKeyHex: PUB, nowMs: T0 + 1000,
+      }),
+    ).toThrow(/different approvalId/);
+  });
+});
+
+describe('single-use + expiry', () => {
+  it('consumes once; a second check reports replayed, not approved', async () => {
+    const { store, res } = await l2Request();
+    await recordSubmission(store, res.approvalId, { clicked: true, submittedOtp: res.otp });
+    const first = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1000 });
+    expect(first.approved).toBe(true);
+    const second = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 1100 });
+    expect(second.approved).toBe(false);
+    expect(second.status).toBe('replayed');
+  });
+
+  it('rejects an expired pending approval, and an expired attestation', async () => {
+    const { store, res, requestHash } = await l2Request();
+    await recordSubmission(store, res.approvalId, { clicked: true, submittedOtp: res.otp });
+    const late = await checkApproval({ store, signingKey: SIGNING_KEY, approvalId: res.approvalId, nowMs: T0 + 10_000_000 });
+    expect(late.approved).toBe(false);
+    expect(late.status).toBe('expired');
+
+    // And even a genuine attestation fails verification past its expiry.
+    const store2 = memStore();
+    const r2 = await l2Request(store2, requestHash);
+    await recordSubmission(store2, r2.res.approvalId, { clicked: true, submittedOtp: r2.res.otp });
+    const ok = await checkApproval({ store: store2, signingKey: SIGNING_KEY, approvalId: r2.res.approvalId, nowMs: T0 + 1000 });
+    expect(() =>
+      verifyApproval({
+        attestation: ok.attestation!, approvalId: r2.res.approvalId,
+        expectedRequestHash: requestHash, signerPubKeyHex: PUB, nowMs: T0 + 10_000_000,
+      }),
+    ).toThrow(/expired/);
+  });
+});
+
+describe('signer key isolation', () => {
+  it('an attestation signed by a DIFFERENT key does not verify against the pinned pubkey', async () => {
+    const { res, requestHash } = await l2Request();
+    // A malicious sibling action forges its OWN well-formed attestation, signed
+    // with its own CID-bound key (which is NOT the approval action's key).
+    const payload = JSON.stringify({
+      schema: 'email-approval-v1', approval_id: res.approvalId, approver: 'user@example.com',
+      assurance: 'L2', request_hash: requestHash, status: 'approved',
+      approved_at_ms: T0, expires_at_ms: T0 + 600_000,
+    });
+    const forged = JSON.stringify({
+      v: 'email-approval-v1', alg: 'secp256k1-sha256', payload,
+      sig: signPayload(payload, '22'.repeat(32)),
+    });
+    expect(() =>
+      verifyApproval({
+        attestation: forged, approvalId: res.approvalId,
+        expectedRequestHash: requestHash, signerPubKeyHex: PUB, nowMs: T0 + 2000,
+      }),
+    ).toThrow(/signature verification FAILED/);
+  });
+});

--- a/lit-approvals/test/memstore.ts
+++ b/lit-approvals/test/memstore.ts
@@ -1,0 +1,48 @@
+import type { ApprovalRow, ApprovalStore } from '../src/types';
+
+/** In-memory ApprovalStore for tests. Also lets a test play the role of a
+ *  malicious store admin by mutating `rows` directly. */
+export function memStore(): ApprovalStore & { rows: Map<string, ApprovalRow> } {
+  const rows = new Map<string, ApprovalRow>();
+  return {
+    rows,
+    async insertPending(row) {
+      rows.set(row.approvalId, { ...row });
+    },
+    async load(id) {
+      const r = rows.get(id);
+      return r ? { ...r } : null;
+    },
+    async recordSubmission(id, clicked, submittedOtp) {
+      const r = rows.get(id);
+      if (r && r.status === 'pending') {
+        r.clicked = clicked;
+        r.submittedOtp = submittedOtp;
+      }
+    },
+    async finalizeConsume(id, attestation) {
+      const r = rows.get(id);
+      if (!r || r.status !== 'pending') return false;
+      r.status = 'consumed';
+      r.attestation = attestation;
+      return true;
+    },
+    async markDenied(id) {
+      const r = rows.get(id);
+      if (r && r.status === 'pending') r.status = 'denied';
+    },
+  };
+}
+
+/** Deterministic, NON-cryptographic randomBytes for tests (counter-seeded). */
+export function seededRandom(seed = 1): (n: number) => Uint8Array {
+  let s = seed >>> 0;
+  return (n: number) => {
+    const out = new Uint8Array(n);
+    for (let i = 0; i < n; i++) {
+      s = (s * 1664525 + 1013904223) >>> 0;
+      out[i] = s & 0xff;
+    }
+    return out;
+  };
+}

--- a/lit-approvals/tsconfig.json
+++ b/lit-approvals/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/lit-approvals/vitest.config.ts
+++ b/lit-approvals/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What

Implements plan **D6.1**: moves the email-approval primitive **off** lit-api-server's in-memory `ApprovalService` and **into action logic** backed by an **untrusted shared store** (Neon over HTTP). This fixes the v1 bug where pending approvals were dropped on every horizontal scale-out / ping-pong deploy — the store now survives both, and the runtime never holds approval state.

Architecture (per the agreed design — lit-api-server fully out of approvals, page on the flows frontend, email sent from the action):

```
phase 1  approval ACTION (in-TEE)   requestApproval()  → id+OTP, write pending row to Neon, email link
   ↓
human    approval PAGE (flows)      recordSubmission() → record click + typed OTP  (cannot approve)
   ↓
phase 2  approval ACTION (in-TEE)   checkApproval()    → verify OTP vs TEE-keyed HMAC, SIGN attestation, consume
   ↓
consume  consuming ACTION (in-TEE)  verifyApproval()   → signature + approvalId + request_hash + expiry
```

One CID-bound key (`getLitActionPrivateKey()`) powers both the OTP HMAC (domain-separated) and the secp256k1 attestation signature — **no service holds a signing key** (this also resolves the v1 "service can forge" trust-boundary follow-up). The attestation format is unchanged (`email-approval-v1` / `secp256k1-sha256`), so it still verifies in the existing runtime op *or* in action JS.

## Why this is safe with an untrusted DB

Assume the adversary can **read + write every Neon row**. Encoded as tests (17 passing):

- **Cannot forge** — approval is proven by the signature; a fabricated row fails `verifyApproval` (they lack the key).
- **Cannot substitute** a real attestation onto another operation/approval — `approvalId` + `request_hash` are signed. *(This is why naïve encrypt-and-compare was rejected: encryption ≠ authentication.)*
- **Cannot brute-force the OTP** — only `HMAC(otpKey, id:otp)` is stored; `otpKey` is TEE-derived, never persisted.
- **Can only deny / DoS** — availability, not integrity.

Single-use is atomic on consume but **rollback-able by a DB admin**, so true anti-replay is pushed to the **execution-layer idempotency key** (bind `request_hash` to a chain nonce / venue `clientOrderId`). Documented in the README.

## Verification

`lit-approvals` in isolation: **17 unit tests pass** (the threat model *is* the test suite — forgery, substitution, OTP, binding, single-use, expiry, signer isolation), `npm run typecheck` clean, `npm run build` → ~90 KB IIFE + ESM.

## Status: stage 1 of N (draft)

This PR is **only the foundation library** + Neon schema. Deliberately separate, reviewable follow-ups:

1. **Remove** `ApprovalService` + the remote `sendEmail`/`requestEmailApproval`/`checkEmailApproval` ops from lit-api-server and the runtime (they become unused once actions own the flow).
2. **flows PR**: add the `/approvals/<id>` page that calls `recordSubmission` (writes click/OTP to Neon).
3. **Wire** the `cex-sweep-with-email-approval` example to the new action flow.
4. **Validate** the `neonHttpQuery` transport against live Neon on the dev deploy (the tested seam is the `NeonQuery` executor; the HTTP wire shape is best-effort until then).

Stacked on #483 (`feat/lit-venues-layer`) since it builds on the D6.1 plan note and the current ApprovalService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)