### PR TITLE
fix(k6-correctness): select accounts.next.json on main, not accounts.dev.json

### DIFF
--- a/.github/workflows/k6-correctness.yml
+++ b/.github/workflows/k6-correctness.yml
@@ -37,7 +37,9 @@ jobs:
   correctness:
     runs-on: self-hosted
     env:
-      K6_ACCOUNTS_FILE: ${{ inputs.accounts_file || (github.ref_name == 'next' && './data/accounts.next.json' || './data/accounts.dev.json') }}
+      # `main` is the deploy branch and targets chipotle-next (test.chipotle.litprotocol.com);
+      # the legacy `next` branch is retired. chipotle-dev is deprecated.
+      K6_ACCOUNTS_FILE: ${{ inputs.accounts_file || (github.ref_name == 'main' && './data/accounts.next.json' || './data/accounts.dev.json') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The `k6-correctness` job fails on every staging deploy with 401s:

```
401 | API key not recognized — it does not resolve to any account.
```

(e.g. [run 27712288500](https://github.com/LIT-Protocol/chipotle/actions/runs/27712288500))

## Root cause

`k6-correctness.yml` still selected its accounts file off the **retired `next` branch**:

```yaml
github.ref_name == 'next' && './data/accounts.next.json' || './data/accounts.dev.json'
```

Deploys run on `main`, so this fell through to `accounts.dev.json` — whose API keys are not registered on the `chipotle-next` instance → 401 on every check → job fails (and `rollback-on-failure` fires).

`k6-smoke` was already fixed for this in `cdcc34ec` ("select accounts.next.json on main, not accounts.dev.json"), but the same fix was never applied to `k6-correctness`. That's why smoke passed and correctness failed in the same run.

## Fix

Mirror the smoke fix — select `accounts.next.json` when on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)