### PR TITLE
ci(k6): switch perf gate from spike to low-VU soak (latency regression gate)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -463,21 +463,30 @@ jobs:
     with:
       api_root_url: ${{ needs.wait-for-api-available.outputs.api_root_url }}
 
-  # Performance regression gate. Runs a load test against the freshly-deployed
+  # Latency regression gate. Runs a low-VU soak against the freshly-deployed
   # (cold) instance on its OWN direct URL (not the public domain). Note the cold
   # box auto-claims the public domain at boot — before this gate runs — so a bad
   # build may already be serving public traffic by now; this gate does NOT
   # prevent that. What it does: a load-test failure blocks confirm-cutover and
   # triggers rollback-on-failure below, which flips the public domain back to the
   # still-running old instance. So it's detect-and-roll-back, not prevent-go-live.
-  # `spike` is the fast variant (~2–3 min); heavier soak/breakpoint runs are
-  # available via k6-loadtest.yml dispatch.
+  #
+  # Why soak (low VU) and not spike: spike (25 VUs of real crypto) saturates the
+  # small staging box and trips lit-api-server's CPU load-shedding guard (429s),
+  # which measures the failure cliff, not latency — and the fast 429s actually
+  # mask "got slower" regressions. A low-VU soak stays under the shed threshold
+  # so per-endpoint p95 reflects the code path. SCENARIO=soak drops the spec's
+  # ramp_* scenarios. The p95 ceilings live in soak.spec.ts (interim absolute
+  # bounds; Phase 2 swaps them for run-over-run deltas vs a baseline).
   k6-loadtest:
     needs: [wait-for-api-available, k6-correctness]
     uses: ./.github/workflows/k6-loadtest.yml
     with:
       api_root_url: ${{ needs.wait-for-api-available.outputs.api_root_url }}
-      test: spike
+      test: soak
+      vus: '2'
+      duration: 3m
+      scenario: soak
 
   # ───────────────────────── Zero-downtime cutover (ping-pong) ─────────────────────────
   # The cold CVM's dstack-ingress auto-claims the public domain on boot (as soon

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -487,6 +487,10 @@ jobs:
       vus: '2'
       duration: 3m
       scenario: soak
+      # Create ephemeral accounts against the freshly-deployed box rather than
+      # relying on the pre-seeded pool, which may not exist on this instance and
+      # would 401 → false rollback.
+      create_accounts: 'true'
 
   # ───────────────────────── Zero-downtime cutover (ping-pong) ─────────────────────────
   # The cold CVM's dstack-ingress auto-claims the public domain on boot (as soon

--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ''
+      scenario:
+        description: "Soak-only: restrict to a scenario group ('soak' or 'ramp'). Empty = all. The gate uses 'soak' to drop the ramp_* scenarios."
+        required: false
+        type: string
+        default: ''
     secrets:
       accounts_json:
         description: "Raw JSON content for pre-funded accounts file (written to a temp file at runtime)"
@@ -96,6 +101,15 @@ on:
         required: false
         type: string
         default: ''
+      scenario:
+        description: "Soak-only: restrict to a scenario group ('soak' or 'ramp'). Empty = all scenarios."
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - soak
+          - ramp
       accounts_file:
         description: "Optional accounts file override, relative to the k6/ dir (e.g. ./data/accounts.next.json)"
         required: false
@@ -156,6 +170,7 @@ jobs:
           SOAK_DURATION: ${{ inputs.duration }}
           BPT_STEP_DURATION: ${{ inputs.duration }}
           BPT_STEPS: ${{ inputs.steps }}
+          SCENARIO: ${{ inputs.scenario }}
         # pipefail keeps k6's exit code (the threshold gate) while teeing the
         # full summary — incl. p50/p95/p99 + check rates — to an artifact.
         run: |

--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: string
         default: ''
+      create_accounts:
+        description: "Soak-only: create ephemeral accounts in setup instead of using the pre-seeded pool. The gate sets 'true' so it doesn't depend on the pool existing on a freshly-deployed box."
+        required: false
+        type: string
+        default: ''
     secrets:
       accounts_json:
         description: "Raw JSON content for pre-funded accounts file (written to a temp file at runtime)"
@@ -110,6 +115,14 @@ on:
           - ''
           - soak
           - ramp
+      create_accounts:
+        description: "Soak-only: create ephemeral accounts in setup instead of using the pre-seeded pool"
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - 'true'
       accounts_file:
         description: "Optional accounts file override, relative to the k6/ dir (e.g. ./data/accounts.next.json)"
         required: false
@@ -171,6 +184,7 @@ jobs:
           BPT_STEP_DURATION: ${{ inputs.duration }}
           BPT_STEPS: ${{ inputs.steps }}
           SCENARIO: ${{ inputs.scenario }}
+          SOAK_CREATE_ACCOUNTS: ${{ inputs.create_accounts }}
         # pipefail keeps k6's exit code (the threshold gate) while teeing the
         # full summary — incl. p50/p95/p99 + check rates — to an artifact.
         run: |

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -48,6 +48,16 @@ import { ensureAccountCredits } from "../stripe.ts";
 const SOAK_DURATION = __ENV.SOAK_DURATION || "30m";
 const SOAK_VUS = parseInt(__ENV.SOAK_VUS || "3", 10);
 
+// Interim per-endpoint p95 latency ceilings (ms) for the deploy gate.
+// Coarse absolute ceilings at ~3x the observed low-load baseline on staging
+// (encrypt/decrypt ~106ms p95, ecdsa-sign ~274ms p95) — enough to catch gross
+// "we made this endpoint a lot slower" regressions without false-failing on
+// normal jitter. Phase 2 replaces these with run-over-run deltas vs a stored
+// baseline. Overridable via env so manual/endurance soaks at higher VU (where
+// latency legitimately rises) don't trip them.
+const SOAK_P95_ENCRYPT_MS = __ENV.SOAK_P95_ENCRYPT_MS || "350";
+const SOAK_P95_ECDSA_MS = __ENV.SOAK_P95_ECDSA_MS || "700";
+
 // Stages: 2min ramp-up, (duration - 4min) steady, 2min ramp-down
 const RAMP_UP = "2m";
 const RAMP_DOWN = "2m";
@@ -130,8 +140,16 @@ export const options = {
   thresholds: {
     http_req_duration: ["p(99)<15000"],
     checks: ["rate>=0.95"],
-    "http_req_duration{scenario:soak_encrypt_decrypt}": ["p(99)<15000"],
-    "http_req_duration{scenario:soak_ecdsa_sign}": ["p(99)<15000"],
+    // soak_* carry the interim per-endpoint p95 regression ceilings (the gate
+    // runs SCENARIO=soak); keep the loose p99 "didn't fall over" bound too.
+    "http_req_duration{scenario:soak_encrypt_decrypt}": [
+      `p(95)<${SOAK_P95_ENCRYPT_MS}`,
+      "p(99)<15000",
+    ],
+    "http_req_duration{scenario:soak_ecdsa_sign}": [
+      `p(95)<${SOAK_P95_ECDSA_MS}`,
+      "p(99)<15000",
+    ],
     "http_req_duration{scenario:ramp_encrypt_decrypt}": ["p(99)<15000"],
     "http_req_duration{scenario:ramp_ecdsa_sign}": ["p(99)<15000"],
   },

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -120,39 +120,62 @@ const allScenarios = {
   },
 };
 
-const SCENARIO = __ENV.SCENARIO;
-const scenarios =
-  SCENARIO === "soak"
+// Fail loud on a typo'd SCENARIO rather than silently running every scenario
+// (which would re-enable the heavier ramp_* load on a gate that wanted soak).
+const SCENARIO = __ENV.SCENARIO || "";
+if (SCENARIO !== "" && SCENARIO !== "soak" && SCENARIO !== "ramp") {
+  throw new Error(
+    `Invalid SCENARIO="${SCENARIO}"; expected "soak", "ramp", or empty (run all).`,
+  );
+}
+const runSoak = SCENARIO === "" || SCENARIO === "soak";
+const runRamp = SCENARIO === "" || SCENARIO === "ramp";
+
+const scenarios = {
+  ...(runSoak
     ? {
         soak_encrypt_decrypt: allScenarios.soak_encrypt_decrypt,
         soak_ecdsa_sign: allScenarios.soak_ecdsa_sign,
       }
-    : SCENARIO === "ramp"
-      ? {
-          ramp_encrypt_decrypt: allScenarios.ramp_encrypt_decrypt,
-          ramp_ecdsa_sign: allScenarios.ramp_ecdsa_sign,
-        }
-      : allScenarios;
+    : {}),
+  ...(runRamp
+    ? {
+        ramp_encrypt_decrypt: allScenarios.ramp_encrypt_decrypt,
+        ramp_ecdsa_sign: allScenarios.ramp_ecdsa_sign,
+      }
+    : {}),
+};
+
+// Build thresholds only for the scenarios that actually run. Defining a
+// threshold over a submetric that receives zero samples (e.g. ramp_* when
+// SCENARIO=soak) is at best misleading and, on some k6 versions, fails the run
+// outright — which would break the gate every time. Keep them in lockstep with
+// `scenarios` above.
+const thresholds: Record<string, string[]> = {
+  http_req_duration: ["p(99)<15000"],
+  checks: ["rate>=0.95"],
+};
+if (runSoak) {
+  // soak_* carry the interim per-endpoint p95 regression ceilings (the gate
+  // runs SCENARIO=soak); keep the loose p99 "didn't fall over" bound too.
+  thresholds["http_req_duration{scenario:soak_encrypt_decrypt}"] = [
+    `p(95)<${SOAK_P95_ENCRYPT_MS}`,
+    "p(99)<15000",
+  ];
+  thresholds["http_req_duration{scenario:soak_ecdsa_sign}"] = [
+    `p(95)<${SOAK_P95_ECDSA_MS}`,
+    "p(99)<15000",
+  ];
+}
+if (runRamp) {
+  thresholds["http_req_duration{scenario:ramp_encrypt_decrypt}"] = ["p(99)<15000"];
+  thresholds["http_req_duration{scenario:ramp_ecdsa_sign}"] = ["p(99)<15000"];
+}
 
 export const options = {
   scenarios,
-  setupTimeout: "3m", // 8 accounts × 2 API calls each; ~6s/call → ~96s min; 3m allows for slow responses
-  thresholds: {
-    http_req_duration: ["p(99)<15000"],
-    checks: ["rate>=0.95"],
-    // soak_* carry the interim per-endpoint p95 regression ceilings (the gate
-    // runs SCENARIO=soak); keep the loose p99 "didn't fall over" bound too.
-    "http_req_duration{scenario:soak_encrypt_decrypt}": [
-      `p(95)<${SOAK_P95_ENCRYPT_MS}`,
-      "p(99)<15000",
-    ],
-    "http_req_duration{scenario:soak_ecdsa_sign}": [
-      `p(95)<${SOAK_P95_ECDSA_MS}`,
-      "p(99)<15000",
-    ],
-    "http_req_duration{scenario:ramp_encrypt_decrypt}": ["p(99)<15000"],
-    "http_req_duration{scenario:ramp_ecdsa_sign}": ["p(99)<15000"],
-  },
+  setupTimeout: "3m", // accounts × 2 API calls each; ~6s/call; 3m allows for slow responses
+  thresholds,
 };
 
 export interface SoakAccountData {
@@ -163,16 +186,23 @@ export interface SoakAccountData {
 export type SoakSetupData = SoakAccountData[];
 
 export function setup(): SoakSetupData {
-  const maxVus = Math.max(SOAK_VUS, RAMP_MAX_VUS);
-  if (PRECREATED_ACCOUNTS.length < maxVus) {
+  // Only provision/fund accounts for the scenarios that actually run. k6 gives
+  // each concurrent VU a globally-unique __VU, so the pool must cover the SUM of
+  // the running scenarios' peak VUs (soak peaks at SOAK_VUS total across its two
+  // scenarios; ramp peaks at RAMP_MAX_VUS). With SCENARIO=soak,SOAK_VUS=2 this is
+  // 2 — not 8 — so a soak-only gate doesn't demand or fund ramp accounts it never
+  // uses (which would waste Stripe top-ups and fail if the pool is < 8).
+  const requiredAccounts =
+    (runSoak ? SOAK_VUS : 0) + (runRamp ? RAMP_MAX_VUS : 0);
+  if (PRECREATED_ACCOUNTS.length < requiredAccounts) {
     throw new Error(
-      `Not enough pre-created accounts for soak test: need ${maxVus}, found ${PRECREATED_ACCOUNTS.length}. Run accounts.seed.spec.ts with a higher ACCOUNTS_COUNT.`,
+      `Not enough pre-created accounts for soak test: need ${requiredAccounts}, found ${PRECREATED_ACCOUNTS.length}. Run accounts.seed.spec.ts with a higher ACCOUNTS_COUNT.`,
     );
   }
 
   const accounts: SoakAccountData[] = [];
   const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
-  for (let i = 0; i < maxVus; i++) {
+  for (let i = 0; i < requiredAccounts; i++) {
     const account = PRECREATED_ACCOUNTS[i];
     ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
     accounts.push({ usageApiKey: account.usageApiKey, pkpId: account.walletAddress });

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -34,14 +34,14 @@
  */
 import { checkAndLog, assertOk, warnOnHttpFailures } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";
-import { PRECREATED_ACCOUNTS } from "../setup.ts";
+import { PRECREATED_ACCOUNTS, createAccountAndUsageKey } from "../setup.ts";
 import { sleep } from "k6";
 import {
   ECDSA_SIGN_CODE,
   ENCRYPT_CODE,
   DECRYPT_CODE,
 } from "../LitActionCode/index.ts";
-import { BASE_URL, COMMON_PARAMS } from "../defaults.ts";
+import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "../defaults.ts";
 import { ensureAccountCredits } from "../stripe.ts";
 
 // Parse duration: "1h", "30m", "10m" etc.
@@ -57,6 +57,15 @@ const SOAK_VUS = parseInt(__ENV.SOAK_VUS || "3", 10);
 // latency legitimately rises) don't trip them.
 const SOAK_P95_ENCRYPT_MS = __ENV.SOAK_P95_ENCRYPT_MS || "350";
 const SOAK_P95_ECDSA_MS = __ENV.SOAK_P95_ECDSA_MS || "700";
+
+// Gate mode: create ephemeral accounts in setup() instead of reading the
+// pre-seeded pool. The deploy gate runs against a freshly-deployed (possibly
+// cold) instance that may not have the committed pool's accounts — relying on
+// the pool there produces spurious 401s ("key not recognized") and a false
+// rollback. Creating accounts against the actual target box is robust. Default
+// off so manual/endurance soaks keep reusing the cheap pre-seeded pool.
+const SOAK_CREATE_ACCOUNTS =
+  (__ENV.SOAK_CREATE_ACCOUNTS || "").toLowerCase() === "true";
 
 // Stages: 2min ramp-up, (duration - 4min) steady, 2min ramp-down
 const RAMP_UP = "2m";
@@ -194,9 +203,28 @@ export function setup(): SoakSetupData {
   // uses (which would waste Stripe top-ups and fail if the pool is < 8).
   const requiredAccounts =
     (runSoak ? SOAK_VUS : 0) + (runRamp ? RAMP_MAX_VUS : 0);
+
+  // Gate path: create fresh accounts against the actual target box so the run
+  // never depends on a pre-seeded pool existing on that instance.
+  // createAccountAndUsageKey already funds the account via ensureAccountCredits.
+  if (SOAK_CREATE_ACCOUNTS) {
+    const created: SoakAccountData[] = [];
+    for (let i = 0; i < requiredAccounts; i++) {
+      const acc = createAccountAndUsageKey({
+        accountName: `k6-soak-${K6_RUN_ID}-${i}`,
+        accountDescription: "ephemeral k6 soak gate account",
+        usageKeyName: `k6-soak-usage-${K6_RUN_ID}-${i}`,
+        usageKeyDescription: "ephemeral k6 soak gate usage key",
+        setupContext: "soak",
+      });
+      created.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
+    }
+    return created;
+  }
+
   if (PRECREATED_ACCOUNTS.length < requiredAccounts) {
     throw new Error(
-      `Not enough pre-created accounts for soak test: need ${requiredAccounts}, found ${PRECREATED_ACCOUNTS.length}. Run accounts.seed.spec.ts with a higher ACCOUNTS_COUNT.`,
+      `Not enough pre-created accounts for soak test: need ${requiredAccounts}, found ${PRECREATED_ACCOUNTS.length}. Run accounts.seed.spec.ts with a higher ACCOUNTS_COUNT, or set SOAK_CREATE_ACCOUNTS=true to create ephemeral accounts.`,
     );
   }
 

--- a/plans/k6-perf-regression-gate.md
+++ b/plans/k6-perf-regression-gate.md
@@ -1,6 +1,6 @@
 # Gate releases on k6 load tests (perf regression gate)
 
-**Status:** Phase 1 shipped (PR #506, branch `glitch003/ci-perf-tests-k6`). Phases 2–3 not started.
+**Status:** Phase 1 shipped (PR #506). Gate vehicle switched spike → low-VU soak after a live test (see §3.1). Phase 2 not started.
 **Scope:** Turn the existing k6 load tests (`k6/loadtest/{spike,soak,breakpoint}.spec.ts`) from manual-only tools into an automated perf-regression gate on the staging deploy, then into real run-over-run regression detection. Dedicated idle servers are earmarked as the stable load-generation / baseline hardware.
 
 ---
@@ -32,6 +32,25 @@ Stop perf regressions from shipping. Today the load tests only run by hand (`jus
 
 **Known limitation (by design for P1):** the gate is detect-and-roll-back. The cold box auto-claims the public domain at container boot, so a bad build can briefly serve public traffic before the gate fails and `rollback-on-failure` flips DNS back.
 
+### 3.1 Gate vehicle: spike → low-VU soak (chosen after a live test)
+
+The first dispatch ran `test: spike` (25 VUs of real crypto) against next and got a flood of HTTP 429s. Root cause: that load saturates the small `tdx.small` box and trips lit-api-server's CPU load-shedding guard (`cpu_overload.rs`, sheds at load>2×cpu or CPU PSI>50%). Spike measures the *failure cliff*, not latency — and worse, the shed 429s return instantly, which would *lower* measured latency and **mask** "got slower" regressions. So spike is the wrong vehicle for "we made this endpoint a lot slower."
+
+Switched the gate to a **low-VU soak** (`test: soak`, `vus: 2`, `duration: 3m`, `scenario: soak`). A 2-VU soak with soak's 2–4s think time runs at ~2 req/s — well under the shed threshold — so per-endpoint p95 reflects the code path, not contention. `SCENARIO=soak` (new `k6-loadtest.yml` input) drops the spec's `ramp_*` scenarios (one of which spins a hot no-op VU on the runner).
+
+**Verified clean on next (run 27782975924):** 0 shedding 429s, `http_req_failed 0.00%`, `checks 100%`. First baseline numbers (low-load p95):
+
+| Endpoint | avg | p95 | max |
+|---|---|---|---|
+| `soak_encrypt_decrypt` | 99 ms | **106 ms** | 207 ms |
+| `soak_ecdsa_sign` | 249 ms | **274 ms** | 322 ms |
+
+`soak_*` and `ramp_*` agreed within a few ms → reproducible signal.
+
+**Interim absolute ceilings (in `soak.spec.ts`, env-overridable):** `SOAK_P95_ENCRYPT_MS=350`, `SOAK_P95_ECDSA_MS=700` (~3× baseline). Catches gross regressions without false-failing on jitter; Phase 2 replaces with deltas.
+
+**Open knob:** the soak scenario's hardcoded 2m ramp-up/down makes the gate ~7 min. If that's too slow per deploy, trim the ramps (→ ~4 min) or run on a dedicated box (Phase 3).
+
 ---
 
 ## 4. Phase 2 — real regression detection (TODO)
@@ -43,8 +62,8 @@ The headline goal: gate on a **delta vs the last green release**, not just absol
 - Comparison step in CI: fail if e.g. `p95 > 1.2× baseline` for the last green release.
 
 **Folded-in from the Codex adversarial review of PR #506:**
-- **#4 — tighten the deploy gate thresholds.** Spike's `checks>=0.8` / `p99<30s` lets a degraded build (up to 20% failed assertions) pass and go live. Phase 2's delta gate is the real fix; also revisit the absolute floor for the cutover gate specifically.
-- **#2 — reduce time-to-rollback.** `k6-loadtest` in `rollback-on-failure`'s `needs` means rollback can't start until the ~3-min spike finishes, even if an earlier independent gate (e.g. `verify-attestation`) already failed. Decouple fast-fail rollback from the slow load-test gate so a bad-but-live box is pulled back ASAP. (Pre-existing pattern — `k6-smoke`/`k6-correctness` already do this — but worth fixing while we're here.)
+- **#4 — gate thresholds.** Partially addressed: the gate is now low-VU soak with interim per-endpoint p95 ceilings (§3.1), not the loose spike `checks>=0.8`/`p99<30s`. The real fix is still the delta gate above — replace the absolute `SOAK_P95_*_MS` ceilings with run-over-run deltas vs the last green release.
+- **#2 — reduce time-to-rollback.** `k6-loadtest` in `rollback-on-failure`'s `needs` means rollback can't start until the ~7-min soak finishes, even if an earlier independent gate (e.g. `verify-attestation`) already failed. Decouple fast-fail rollback from the slow load-test gate so a bad-but-live box is pulled back ASAP. (Pre-existing pattern — `k6-smoke`/`k6-correctness` already do this — but worth fixing while we're here.)
 
 ---
 

--- a/plans/k6-perf-regression-gate.md
+++ b/plans/k6-perf-regression-gate.md
@@ -49,6 +49,8 @@ Switched the gate to a **low-VU soak** (`test: soak`, `vus: 2`, `duration: 3m`, 
 
 **Interim absolute ceilings (in `soak.spec.ts`, env-overridable):** `SOAK_P95_ENCRYPT_MS=350`, `SOAK_P95_ECDSA_MS=700` (~3× baseline). Catches gross regressions without false-failing on jitter; Phase 2 replaces with deltas.
 
+**Account provenance (fixed):** a validation run failed with 401 "key not recognized" — the committed `accounts.next.json` keys didn't resolve on the instance serving at that moment (they resolved fine ~15 min later). A gate that runs against a freshly-deployed / cold instance can't depend on a pre-seeded pool existing there. Fix: `SOAK_CREATE_ACCOUNTS=true` (new `create_accounts` workflow input, set by the gate) makes `soak.spec.ts` create ephemeral accounts via `createAccountAndUsageKey` against the actual target box in `setup()`, like the correctness specs do. Manual runs default to the pre-seeded pool. **Open question (possible prod concern, not yet investigated):** why valid accounts stopped resolving — is account/API-key state per-instance and not replicated across the ping-pong pair (→ real users 401 after cutover), or just cutover-timing? See [[pingpong-deploy-cvm-name-param]].
+
 **Open knob:** the soak scenario's hardcoded 2m ramp-up/down makes the gate ~7 min. If that's too slow per deploy, trim the ramps (→ ~4 min) or run on a dedicated box (Phase 3).
 
 ---


### PR DESCRIPTION
Follow-up to #506. The first dispatched spike run against next got a flood of HTTP 429s: 25 VUs of real crypto saturate the small `tdx.small` box and trip lit-api-server's CPU load-shedding guard, so spike measures the failure cliff rather than latency — and the instant 429s would actually *mask* "we made this endpoint slower" regressions. This swaps the deploy gate to a **low-VU soak** (`vus: 2`, `duration: 3m`, `scenario: soak`), which a live run confirmed stays under the shed threshold (0 shedding 429s, 100% checks) with stable per-endpoint p95 (encrypt/decrypt ~106ms, ecdsa-sign ~274ms). Adds a `scenario` input to `k6-loadtest.yml` to drop the spec's `ramp_*` scenarios, and interim env-overridable p95 ceilings in `soak.spec.ts` (`SOAK_P95_ENCRYPT_MS=350`, `SOAK_P95_ECDSA_MS=700`, ~3× baseline) — to be replaced by run-over-run deltas in Phase 2. The plan doc records the decision, baseline numbers, and the ~7-min runtime knob (trim soak's 2m ramps if too slow per deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)