### PR TITLE
fix(ci): install AWS CLI v2 via official installer in rollback-on-failure (PEP 668)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -601,10 +601,11 @@ jobs:
           # pre-installed aws is reused; --update keeps it idempotent across reruns
           # on a persistent self-hosted $HOME.
           if ! command -v aws >/dev/null 2>&1; then
-            curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-            unzip -q -o /tmp/awscliv2.zip -d /tmp
-            /tmp/aws/install --update --install-dir "$HOME/.local/aws-cli" --bin-dir "$HOME/.local/bin"
-            rm -rf /tmp/awscliv2.zip /tmp/aws
+            tmp=$(mktemp -d)
+            trap 'rm -rf "$tmp"' EXIT
+            curl -fsSL --retry 3 "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$tmp/awscliv2.zip"
+            unzip -q "$tmp/awscliv2.zip" -d "$tmp"
+            "$tmp/aws/install" --update --install-dir "$HOME/.local/aws-cli" --bin-dir "$HOME/.local/bin"
           fi
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Roll the domain back to the previous instance, stop the bad one

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -582,7 +582,17 @@ jobs:
       - name: Install Phala CLI + AWS CLI
         run: |
           npm install -g phala
-          command -v aws >/dev/null 2>&1 || python3 -m pip install --quiet --user awscli
+          # AWS CLI v2 via the official installer (no Python dependency). The old
+          # `pip install --user awscli` fails on the runner's externally-managed
+          # Python (PEP 668: "externally-managed-environment"). Guarded so a
+          # pre-installed aws is reused; --update keeps it idempotent across reruns
+          # on a persistent self-hosted $HOME.
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q -o /tmp/awscliv2.zip -d /tmp
+            /tmp/aws/install --update --install-dir "$HOME/.local/aws-cli" --bin-dir "$HOME/.local/bin"
+            rm -rf /tmp/awscliv2.zip /tmp/aws
+          fi
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Roll the domain back to the previous instance, stop the bad one
         env:


### PR DESCRIPTION
## What

The `rollback-on-failure` job in `deploy-staging.yml` installed the AWS CLI with:

```bash
command -v aws >/dev/null 2>&1 || python3 -m pip install --quiet --user awscli
```

On the self-hosted runner's now-externally-managed Python this is refused under [PEP 668](https://peps.python.org/pep-0668/):

```
error: externally-managed-environment
× This environment is externally managed
hint: See PEP 668 for the detailed specification.
##[error]Process completed with exit code 1
```

`--user` doesn't help — `~/.local/site-packages` is still on the system interpreter's path, so PEP 668 blocks it too. The job exits 1 **at the install step**, before reaching the actual rollback logic (Route 53 CNAME flip + stopping the bad CVM), so staging auto-rollback silently no-ops.

## Why it surfaced now

The bug was latent since the step was written. It only executed for the first time when the new k6 loadtest gate (#506) failed and triggered `rollback-on-failure` in [run 27774379917](https://github.com/LIT-Protocol/chipotle/actions/runs/27774379917). (The loadtest gate itself is being addressed separately in #507 — this PR is independent and only fixes the broken rollback bootstrap.)

## Fix

Install AWS CLI **v2 via the official zip installer** — no Python dependency, so PEP 668 doesn't apply:

- Keeps the `command -v aws` guard so a pre-installed CLI is reused.
- `--update` makes re-runs idempotent on a persistent self-hosted `$HOME`.
- `unzip -o` overwrites any stale extraction.
- `$HOME/.local/bin` is still appended to `GITHUB_PATH`, unchanged.

All three subcommands the rollback uses — `sts assume-role`, `route53 list-hosted-zones-by-name`, `route53 change-resource-record-sets` — are available in AWS CLI v2.

## Verification

- YAML validated.
- Hard to trigger naturally (requires a post-deploy gate to fail in ping-pong mode). The install logic can be validated directly on the runner: run the `curl … awscli-exe-linux-x86_64.zip` + `/tmp/aws/install --update …` sequence and confirm `aws --version` resolves with no PEP 668 error. End-to-end confirmation comes on the next real rollback — the job should now reach the "Roll the domain back" step instead of dying at install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)