### PR TITLE
ci(k6): add opt-in prod soak latency-baseline to manual prod test

### DIFF
--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -59,6 +59,16 @@ on:
         required: false
         type: string
         default: ''
+      p95_encrypt_ms:
+        description: "Soak-only: override encrypt/decrypt p95 ceiling (ms). Empty = spec default (350). Set high for a measurement run that shouldn't gate."
+        required: false
+        type: string
+        default: ''
+      p95_ecdsa_ms:
+        description: "Soak-only: override ecdsa-sign p95 ceiling (ms). Empty = spec default (700)."
+        required: false
+        type: string
+        default: ''
     secrets:
       accounts_json:
         description: "Raw JSON content for pre-funded accounts file (written to a temp file at runtime)"
@@ -185,6 +195,8 @@ jobs:
           BPT_STEPS: ${{ inputs.steps }}
           SCENARIO: ${{ inputs.scenario }}
           SOAK_CREATE_ACCOUNTS: ${{ inputs.create_accounts }}
+          SOAK_P95_ENCRYPT_MS: ${{ inputs.p95_encrypt_ms }}
+          SOAK_P95_ECDSA_MS: ${{ inputs.p95_ecdsa_ms }}
         # pipefail keeps k6's exit code (the threshold gate) while teeing the
         # full summary — incl. p50/p95/p99 + check rates — to an artifact.
         run: |

--- a/.github/workflows/manual_k6-prod-test.yml
+++ b/.github/workflows/manual_k6-prod-test.yml
@@ -1,11 +1,27 @@
 # Manually run k6 smoke + correctness tests against production.
 # Does NOT trigger a deployment — only runs the test suite against the live prod API
 # using pre-funded accounts from the K6_ACCOUNTS_PROD_JSON secret.
+#
+# Set run_soak=true to also capture a low-VU soak latency baseline against prod
+# (e.g. before/after a release to eyeball regressions until Phase 2 deltas land).
+# The soak uses the SAME pre-funded prod pool — NOT create_accounts, which can't
+# fund accounts in prod (top-ups are test-mode only).
 
 name: "k6 Prod Test (manual)"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_soak:
+        description: "Also run a low-VU soak latency baseline (spends real Stripe credits on the pre-funded prod accounts)"
+        required: false
+        type: boolean
+        default: false
+      soak_duration:
+        description: "Soak steady-state duration (longer = steadier p95; adds ~4m ramps + cost)"
+        required: false
+        type: string
+        default: '5m'
 
 jobs:
   k6-smoke:
@@ -22,5 +38,27 @@ jobs:
     with:
       api_root_url: https://${{ vars.DOMAIN_PROD }}/core/v1
       env: prod
+    secrets:
+      accounts_json: ${{ secrets.K6_ACCOUNTS_PROD_JSON }}
+
+  # Opt-in (run_soak=true) prod latency baseline. Runs AFTER correctness so the
+  # cheap checks validate the box first and their traffic doesn't skew the p95.
+  # Uses the pre-funded prod pool (NOT create_accounts — prod can't fund test
+  # accounts). p95 ceilings overridden very high: this is a MEASUREMENT run, so
+  # read the per-endpoint p95 in the summary; it should not gate on prod latency
+  # that differs from the staging-tuned defaults.
+  k6-soak-baseline:
+    if: ${{ inputs.run_soak }}
+    needs: [k6-correctness]
+    uses: ./.github/workflows/k6-loadtest.yml
+    with:
+      api_root_url: https://${{ vars.DOMAIN_PROD }}/core/v1
+      env: prod
+      test: soak
+      vus: '2'
+      duration: ${{ inputs.soak_duration }}
+      scenario: soak
+      p95_encrypt_ms: '100000'
+      p95_ecdsa_ms: '100000'
     secrets:
       accounts_json: ${{ secrets.K6_ACCOUNTS_PROD_JSON }}


### PR DESCRIPTION
Adds an opt-in low-VU soak latency baseline to the manual prod test, so you can click-run it before/after a release to eyeball regressions until Phase 2 delta-gating lands. It reuses the existing pre-funded `K6_ACCOUNTS_PROD_JSON` pool — **not** `create_accounts`, which can't fund accounts in prod (top-ups are test-mode only). Trigger via Actions → "k6 Prod Test (manual)" → `run_soak: true` (optionally set `soak_duration`); the soak runs after smoke+correctness so the box is validated first and its traffic doesn't skew the p95. The new `p95_encrypt_ms`/`p95_ecdsa_ms` inputs on `k6-loadtest.yml` let this measurement run disable the staging-tuned ceilings (set to 100000) so it reports prod p95s without gating on them. Spends real Stripe credits on the prod accounts (~a few dollars); read the per-endpoint p95 in the run summary and compare before vs after the prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)