### PR TITLE
ci(stripe): nightly Stripe usage digest to Slack

### DIFF
--- a/.github/workflows/stripe-report-nightly.yml
+++ b/.github/workflows/stripe-report-nightly.yml
@@ -1,0 +1,91 @@
+# Nightly Stripe usage digest → Slack.
+#
+# Runs the `stripe_report` CLI against the LIVE Stripe account, then posts a
+# top-spenders summary (per-customer charges over the window) to the Slack
+# incoming webhook in $SLACK_WEBHOOK_URL.
+#
+# Schedule: 08:00 UTC daily = midnight PST (01:00 during PDT — GitHub cron is
+# UTC and does not follow daylight saving). Also runnable on demand via
+# "Run workflow" with a custom window.
+#
+# Required repo secrets:
+#   STRIPE_SECRET_KEY      - Stripe live secret key
+#   STRIPE_PUBLISHABLE_KEY - Stripe live publishable key
+#   SLACK_WEBHOOK_URL      - Slack incoming webhook URL
+
+name: Stripe usage report (nightly → Slack)
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Window size in days"
+        required: false
+        default: "7"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stripe-report-nightly
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Generate + post Stripe usage
+    runs-on: self-hosted
+    env:
+      DAYS: ${{ github.event.inputs.days || '7' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Self-hosted runners persist state between runs; ensure a clean tree.
+      - name: Reset workspace to HEAD
+        run: git checkout HEAD -- .
+
+      # lit-api-server pulls in lit-actions (libsqlite3 + bindgen/libclang) and
+      # lit-actions-grpc (protobuf build script). Retry on apt lock contention.
+      - name: Install system dependencies
+        run: |
+          for i in 1 2 3 4 5; do
+            sudo apt-get update -qq && \
+            sudo apt-get install -y libsqlite3-dev libclang-dev protobuf-compiler && break
+            echo "apt lock held, waiting 10s (attempt $i/5)..."
+            sleep 10
+          done
+
+      - uses: dtolnay/rust-toolchain@1.91
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Generate usage report (CSV)
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+        run: |
+          bash scripts/stripe_report.sh \
+            --days "$DAYS" \
+            --csv-only \
+            --out "${{ github.workspace }}/stripe-report"
+
+      - name: Post digest to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          node scripts/stripe-report-slack.mjs \
+            "${{ github.workspace }}/stripe-report.csv" \
+            --days "$DAYS"
+
+      # Keep the raw CSV around for 30 days for ad-hoc digging.
+      - name: Upload CSV artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stripe-report-csv
+          path: ${{ github.workspace }}/stripe-report.csv
+          if-no-files-found: ignore
+          retention-days: 30

--- a/scripts/stripe-report-slack.mjs
+++ b/scripts/stripe-report-slack.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Post a Stripe usage digest to Slack from a stripe_report CSV.
+//
+// Reads the CSV produced by `cargo run --bin stripe_report` (columns:
+// date,customer_id,wallet_address,email,charges_count,charges_cents,credits_cents),
+// aggregates per customer across the whole window, and POSTs a top-spenders
+// summary to the Slack incoming webhook in $SLACK_WEBHOOK_URL.
+//
+// Usage:
+//   SLACK_WEBHOOK_URL=https://hooks.slack.com/...  \
+//   node scripts/stripe-report-slack.mjs <report.csv> [--days N] [--top N] [--dry-run]
+//
+// --dry-run prints the payload to stdout instead of posting (no webhook needed).
+
+import { readFileSync } from "node:fs";
+
+function parseArgs(argv) {
+  const args = { csv: null, days: null, top: 15, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--days") args.days = Number(argv[++i]);
+    else if (a === "--top") args.top = Number(argv[++i]);
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (!a.startsWith("--") && args.csv === null) args.csv = a;
+    else throw new Error(`unexpected argument: ${a}`);
+  }
+  if (!args.csv) throw new Error("usage: stripe-report-slack.mjs <report.csv> [--days N] [--top N] [--dry-run]");
+  if (args.days !== null && !Number.isFinite(args.days)) throw new Error("--days must be a number");
+  if (!Number.isFinite(args.top) || args.top < 1) throw new Error("--top must be a positive number");
+  return args;
+}
+
+// Minimal RFC-4180 CSV parser: handles quoted fields with embedded commas,
+// quotes ("" escape), and newlines. Returns an array of row arrays.
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else field += c;
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ",") {
+      row.push(field); field = "";
+    } else if (c === "\n") {
+      row.push(field); field = ""; rows.push(row); row = [];
+    } else if (c === "\r") {
+      // swallow; \n handles the row break
+    } else field += c;
+  }
+  // flush trailing field/row if the file didn't end on a newline
+  if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+  return rows;
+}
+
+function centsToUsd(cents) {
+  const neg = cents < 0;
+  const v = Math.abs(cents);
+  const s = `$${Math.floor(v / 100)}.${String(v % 100).padStart(2, "0")}`;
+  return neg ? `-${s}` : s;
+}
+
+// A leading 0x wallet shown compact: 0x1234…abcd
+function shortWallet(w) {
+  if (!w || !w.startsWith("0x") || w.length < 12) return w || "";
+  return `${w.slice(0, 6)}…${w.slice(-4)}`;
+}
+
+function aggregate(rows) {
+  const header = rows[0] || [];
+  const idx = Object.fromEntries(header.map((h, i) => [h.trim(), i]));
+  for (const col of ["customer_id", "charges_count", "charges_cents"]) {
+    if (idx[col] === undefined) throw new Error(`CSV missing expected column: ${col}`);
+  }
+  const byCustomer = new Map();
+  const dates = new Set();
+  for (const r of rows.slice(1)) {
+    if (r.length === 1 && r[0] === "") continue; // blank line
+    const id = r[idx.customer_id];
+    if (!id) continue;
+    const date = r[idx.date];
+    if (date) dates.add(date);
+    const cents = Number(r[idx.charges_cents] || 0);
+    const count = Number(r[idx.charges_count] || 0);
+    const cur = byCustomer.get(id) || {
+      id,
+      wallet: r[idx.wallet_address] || "",
+      email: r[idx.email] || "",
+      cents: 0,
+      count: 0,
+    };
+    cur.cents += cents;
+    cur.count += count;
+    if (!cur.wallet && r[idx.wallet_address]) cur.wallet = r[idx.wallet_address];
+    if (!cur.email && r[idx.email]) cur.email = r[idx.email];
+    byCustomer.set(id, cur);
+  }
+  const customers = [...byCustomer.values()]
+    .filter((c) => c.cents !== 0 || c.count !== 0)
+    .sort((a, b) => b.cents - a.cents || b.count - a.count);
+  const totalCents = customers.reduce((s, c) => s + c.cents, 0);
+  const totalCount = customers.reduce((s, c) => s + c.count, 0);
+  const sortedDates = [...dates].sort();
+  return {
+    customers,
+    totalCents,
+    totalCount,
+    firstDate: sortedDates[0] || null,
+    lastDate: sortedDates[sortedDates.length - 1] || null,
+  };
+}
+
+function buildMessage(agg, { days, top }) {
+  const window = days ? `last ${days} day${days === 1 ? "" : "s"}` : "window";
+  const range = agg.firstDate ? ` (${agg.firstDate} → ${agg.lastDate} UTC)` : "";
+  const lines = [];
+  lines.push(`*📊 Stripe usage — ${window}*${range}`);
+
+  if (agg.customers.length === 0) {
+    lines.push("");
+    lines.push("_No billable usage recorded in this window._");
+    return lines.join("\n");
+  }
+
+  lines.push(
+    `*${centsToUsd(agg.totalCents)}* across *${agg.totalCount}* call${agg.totalCount === 1 ? "" : "s"} ` +
+      `from *${agg.customers.length}* customer${agg.customers.length === 1 ? "" : "s"}`,
+  );
+  lines.push("");
+
+  const shown = agg.customers.slice(0, top);
+  shown.forEach((c, i) => {
+    const wallet = shortWallet(c.wallet);
+    const label = wallet ? `\`${wallet}\`` : `\`${c.id}\``;
+    const email = c.email ? ` (${c.email})` : "";
+    lines.push(
+      `${i + 1}. ${label}${email} — ${centsToUsd(c.cents)} · ${c.count} call${c.count === 1 ? "" : "s"}`,
+    );
+  });
+
+  const remaining = agg.customers.length - shown.length;
+  if (remaining > 0) {
+    const restCents = agg.customers.slice(top).reduce((s, c) => s + c.cents, 0);
+    lines.push(`_…and ${remaining} more (${centsToUsd(restCents)})_`);
+  }
+  return lines.join("\n");
+}
+
+async function post(webhook, text) {
+  const res = await fetch(webhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  const body = await res.text();
+  if (!res.ok || body !== "ok") {
+    throw new Error(`Slack webhook returned ${res.status}: ${body}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const csv = readFileSync(args.csv, "utf8");
+  const rows = parseCsv(csv);
+  const agg = aggregate(rows);
+  const text = buildMessage(agg, { days: args.days, top: args.top });
+
+  if (args.dryRun) {
+    console.log(text);
+    return;
+  }
+  const webhook = process.env.SLACK_WEBHOOK_URL;
+  if (!webhook) throw new Error("SLACK_WEBHOOK_URL is not set");
+  await post(webhook, text);
+  console.error(`Posted Stripe usage digest to Slack (${agg.customers.length} customers, ${centsToUsd(agg.totalCents)}).`);
+}
+
+main().catch((e) => {
+  console.error(`error: ${e.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a nightly GitHub Actions job that runs the existing `stripe_report` CLI against the **live** Stripe account and posts a per-customer **top-spenders digest** to Slack — so we can see who's actually using the network without hand-running the report.

The GCP `service_request{url_path="/core/v1/lit_action"}` metric carries no caller identity, so it can't be sliced by customer. The billing path (api key → on-chain billing wallet → Stripe customer) is the only place caller identity exists, and `stripe_report` already aggregates it — this just automates + delivers it.

## How

- **`.github/workflows/stripe-report-nightly.yml`** — `schedule` at `0 8 * * *` (midnight PST / 1am PDT; GitHub cron is UTC and doesn't follow DST) + `workflow_dispatch` with a custom `days` window. Builds & runs `stripe_report --csv-only`, posts via the script, archives the CSV as a 30-day artifact.
- **`scripts/stripe-report-slack.mjs`** — parses the report CSV (RFC-4180 parser handles quoted emails with commas), aggregates charges per customer over the window, and POSTs a ranked summary to `$SLACK_WEBHOOK_URL`. Handles empty windows and top-N truncation.

## Secrets

- Reuses existing `STRIPE_SECRET_KEY` / `STRIPE_PUBLISHABLE_KEY` (live).
- New `SLACK_WEBHOOK_URL` secret added to the repo.

## Testing

- Slack-posting half tested end-to-end against the real webhook (formatting, CSV quoting, empty-window, top-N truncation).
- `stripe_report` itself is already built/verified by the existing Rust CI.
- Triggered a manual `workflow_dispatch` run to validate the full report → Slack path (see checks).

## Notes

- Caveat: `charges_count` ≈ activity, not exact request count — a long-running lit_action bills in 5s flushes, so one request can produce multiple charges. `charges_cents` (= seconds of compute) is the truer usage signal.
- Scheduled runs only fire once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)