### PR TITLE
chore(k6-soak): log billing wallet address at setup

### DIFF
--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -220,6 +220,7 @@ export function setup(): SoakSetupData {
       });
       created.push({ usageApiKey: acc.usageApiKey, pkpId: acc.walletAddress });
     }
+    logBillingWallets(created);
     return created;
   }
 
@@ -245,7 +246,22 @@ export function setup(): SoakSetupData {
     ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
     accounts.push({ usageApiKey: account.usageApiKey, pkpId: account.walletAddress });
   }
+  logBillingWallets(accounts);
   return accounts;
+}
+
+/**
+ * Log the billing wallet address(es) the run will use. These are public 0x
+ * addresses (never the API keys) — they match the Stripe customer's
+ * `metadata.wallet_address`, so you can find the customer and grant credits
+ * when a prod run runs out of money. Printed at setup so it's at the top of
+ * the run log.
+ */
+function logBillingWallets(accounts: SoakAccountData[]): void {
+  const wallets = accounts.map((a) => a.pkpId).join(", ");
+  console.log(
+    `soak: billing wallet address(es) in use (fund the Stripe customer whose metadata.wallet_address matches one of these): ${wallets}`,
+  );
 }
 
 export function encryptDecrypt(setupData: SoakSetupData) {


### PR DESCRIPTION
When a prod soak runs out of credits, you need the account's billing wallet to find its Stripe customer (`metadata.wallet_address`) and grant credits. This prints the public wallet address(es) the run will use at setup, so it's right at the top of the run log instead of having to pull it from the `K6_ACCOUNTS_PROD_JSON` secret. Logs only the public `0x` address — never the API keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)