### PR TITLE
feat(k6): phase 2 — delta perf gate vs committed baseline

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -491,6 +491,11 @@ jobs:
       # relying on the pre-seeded pool, which may not exist on this instance and
       # would 401 → false rollback.
       create_accounts: 'true'
+      # Phase 2: fail on a p95 regression vs the committed baseline (delta gate)
+      # rather than the staging-tuned absolute ceilings. Path is relative to
+      # k6/loadtest/ (where the spec's open() resolves from). Refresh the
+      # baseline with k6/update-soak-baseline.sh.
+      baseline_file: ../baselines/soak.next.json
 
   # ───────────────────────── Zero-downtime cutover (ping-pong) ─────────────────────────
   # The cold CVM's dstack-ingress auto-claims the public domain on boot (as soon

--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -69,6 +69,11 @@ on:
         required: false
         type: string
         default: ''
+      baseline_file:
+        description: "Soak-only: path to a committed baseline summary, relative to k6/loadtest/ (e.g. ../baselines/soak.next.json). When set, the gate fails on a p95 regression vs that baseline (max(baseline*1.3, baseline+50ms)) instead of the absolute ceilings."
+        required: false
+        type: string
+        default: ''
     secrets:
       accounts_json:
         description: "Raw JSON content for pre-funded accounts file (written to a temp file at runtime)"
@@ -197,6 +202,7 @@ jobs:
           SOAK_CREATE_ACCOUNTS: ${{ inputs.create_accounts }}
           SOAK_P95_ENCRYPT_MS: ${{ inputs.p95_encrypt_ms }}
           SOAK_P95_ECDSA_MS: ${{ inputs.p95_ecdsa_ms }}
+          SOAK_BASELINE_FILE: ${{ inputs.baseline_file }}
         # pipefail keeps k6's exit code (the threshold gate) while teeing the
         # full summary — incl. p50/p95/p99 + check rates — to an artifact.
         run: |
@@ -208,7 +214,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: k6-loadtest-${{ inputs.test }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: k6-loadtest-${{ inputs.test }}.log
+          path: |
+            k6-loadtest-${{ inputs.test }}.log
+            soak-summary.json
           if-no-files-found: ignore
 
       - name: Clean up accounts file

--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -138,6 +138,11 @@ on:
         options:
           - ''
           - 'true'
+      baseline_file:
+        description: "Soak-only: committed baseline summary path, relative to k6/loadtest/ (e.g. ../baselines/soak.next.json). Set to gate on a p95 regression vs that baseline."
+        required: false
+        type: string
+        default: ''
       accounts_file:
         description: "Optional accounts file override, relative to the k6/ dir (e.g. ./data/accounts.next.json)"
         required: false

--- a/k6/baselines/soak.next.json
+++ b/k6/baselines/soak.next.json
@@ -1,0 +1,12 @@
+{
+  "env": "next",
+  "base_url": "https://test.chipotle.litprotocol.com/core/v1",
+  "generated_at": "2026-06-18",
+  "note": "Staging (next) soak latency baseline for the deploy perf gate. p95/p50/etc. in ms. The gate fails a deploy if a run's p95 exceeds max(baseline*1.3, baseline+50ms) per endpoint. Regenerate with k6/update-soak-baseline.sh and commit via PR when perf legitimately changes (e.g. got substantially faster). p99/max were not captured for the seed run; the script fills them on the next refresh.",
+  "scenarios": {
+    "soak_encrypt_decrypt": { "p50": 103, "p95": 112, "p99": null, "avg": 104, "max": 198 },
+    "soak_ecdsa_sign": { "p50": 252, "p95": 274, "p99": null, "avg": 254, "max": null }
+  },
+  "checks_rate": 1,
+  "http_req_failed_rate": 0
+}

--- a/k6/loadtest/README.md
+++ b/k6/loadtest/README.md
@@ -88,3 +88,86 @@ BASE_URL=http://localhost:8000/core/v1 k6 run k6/loadtest/breakpoint.spec.ts
 | `BPT_MAX_VUS`      | `30`    | Maximum/peak VUs for the test                 |
 | `BPT_STEP_DURATION`| `2m`    | Duration for each load step                   |
 | `BPT_STEPS`        | *none*  | Optional comma-separated list of VU levels    |
+
+---
+
+## Performance regression gate (soak) + baseline
+
+Staging deploys are gated on a **low-VU soak** that fails the deploy if an
+endpoint got meaningfully slower. The gate runs in
+`.github/workflows/deploy-staging.yml` (via the reusable `k6-loadtest.yml`)
+against the freshly-deployed instance, after smoke + correctness and before the
+ping-pong cutover. A failure blocks cutover and triggers `rollback-on-failure`.
+
+Why soak and not spike: 25-VU spikes saturate the small staging box and trip the
+API's CPU load-shedding (429s), which measures the failure cliff, not latency —
+and the fast 429s would *mask* a regression. A 2-VU soak stays under that
+threshold so per-endpoint p95 reflects the code path.
+
+### How the gate decides pass/fail
+
+The gate compares the run's per-endpoint **p95** against a **committed baseline**
+(`k6/baselines/soak.next.json` — a saved run summary). For each endpoint it
+fails if:
+
+```
+p95 > max(baseline_p95 * (1 + SOAK_P95_TOLERANCE), baseline_p95 + SOAK_P95_FLOOR_MS)
+```
+
+Defaults: `SOAK_P95_TOLERANCE=0.30` (30%) and `SOAK_P95_FLOOR_MS=50`. The floor
+keeps the ~60–130-sample p95 noise from false-failing on tiny absolute moves.
+With the seeded baseline (encrypt p95 ~112ms, ecdsa ~274ms) the gate trips at
+roughly encrypt > 162ms / ecdsa > 356ms.
+
+Anchoring on a *committed* baseline (not the previous run) is deliberate: it
+catches **cumulative** drift. Comparing only to the last run would let a steady
+few-percent-per-release creep pass forever and compound.
+
+If no baseline is provided (`SOAK_BASELINE_FILE` unset), the gate falls back to
+the coarse absolute ceilings `SOAK_P95_ENCRYPT_MS` (350) / `SOAK_P95_ECDSA_MS`
+(700).
+
+Each run also uploads `soak-summary.json` (per-scenario p50/p95/p99/avg/max +
+check & failure rates) as a build artifact — the same shape the baseline takes.
+
+### Refreshing the baseline — `update-soak-baseline.sh`
+
+Baseline updates are a **manual** operation. When perf legitimately changes (e.g.
+a release made things substantially faster, so the old ceiling is needlessly
+loose), regenerate and commit the baseline:
+
+```bash
+# Requires k6 installed locally. Runs a measurement soak against staging
+# (creates its own test-mode-funded accounts) and writes the new baseline.
+k6/update-soak-baseline.sh                  # network=next, 5m steady (~9m total)
+DURATION=10m k6/update-soak-baseline.sh     # longer run → steadier p95
+NETWORK=next BASE_URL=https://… k6/update-soak-baseline.sh
+
+# Then review the numbers and commit via PR:
+git add k6/baselines/soak.next.json
+git commit -m "chore(k6): refresh soak baseline"
+```
+
+The script is a pure measurement run — it deliberately does **not** load a
+baseline, so it never gates itself; it just measures and writes
+`k6/baselines/soak.<network>.json`. Review the new p95s before committing (a PR
+makes baseline changes reviewable, which is the point).
+
+### Relevant environment variables
+
+| Variable               | Default | Description                                                        |
+|------------------------|---------|--------------------------------------------------------------------|
+| `SOAK_VUS`             | `3`     | Total soak VUs (the gate uses `2`)                                 |
+| `SOAK_DURATION`        | `30m`   | Steady-state duration (the gate uses `3m`)                         |
+| `SCENARIO`             | *all*   | `soak` (the gate) runs only the steady scenarios; drops `ramp_*`   |
+| `SOAK_CREATE_ACCOUNTS` | `false` | `true` → create ephemeral accounts in setup vs the pre-seeded pool |
+| `SOAK_BASELINE_FILE`   | *none*  | Path (relative to `k6/loadtest/`) to a baseline summary to gate on |
+| `SOAK_P95_TOLERANCE`   | `0.30`  | Allowed fractional p95 growth vs baseline                          |
+| `SOAK_P95_FLOOR_MS`    | `50`    | Absolute p95 cushion added on top of the tolerance                 |
+| `SOAK_P95_ENCRYPT_MS`  | `350`   | Absolute encrypt/decrypt p95 ceiling (fallback when no baseline)   |
+| `SOAK_P95_ECDSA_MS`    | `700`   | Absolute ecdsa-sign p95 ceiling (fallback when no baseline)        |
+
+> Prod baseline: `manual_k6-prod-test.yml` can run the same soak against prod
+> (`run_soak: true`) as a manual before/after-release latency check. It uses the
+> pre-funded `K6_ACCOUNTS_PROD_JSON` pool and high p95 overrides (measurement
+> only, not gated). See the project plan in `plans/k6-perf-regression-gate.md`.

--- a/k6/loadtest/README.md
+++ b/k6/loadtest/README.md
@@ -123,9 +123,13 @@ Anchoring on a *committed* baseline (not the previous run) is deliberate: it
 catches **cumulative** drift. Comparing only to the last run would let a steady
 few-percent-per-release creep pass forever and compound.
 
-If no baseline is provided (`SOAK_BASELINE_FILE` unset), the gate falls back to
-the coarse absolute ceilings `SOAK_P95_ENCRYPT_MS` (350) / `SOAK_P95_ECDSA_MS`
-(700).
+**Fail-closed:** when a baseline IS requested (`SOAK_BASELINE_FILE` set, as the
+deploy gate does), the run errors red if the baseline can't be opened, isn't
+valid JSON, has no positive p95 for a running endpoint, or the tolerance/floor
+are invalid. It never silently downgrades to the absolute ceilings — a broken
+baseline must not let a regression pass green. The absolute ceilings
+(`SOAK_P95_ENCRYPT_MS` 350 / `SOAK_P95_ECDSA_MS` 700) apply only when no baseline
+is requested (local / measurement runs).
 
 Each run also uploads `soak-summary.json` (per-scenario p50/p95/p99/avg/max +
 check & failure rates) as a build artifact — the same shape the baseline takes.
@@ -162,7 +166,7 @@ makes baseline changes reviewable, which is the point).
 | `SCENARIO`             | *all*   | `soak` (the gate) runs only the steady scenarios; drops `ramp_*`   |
 | `SOAK_CREATE_ACCOUNTS` | `false` | `true` → create ephemeral accounts in setup vs the pre-seeded pool |
 | `SOAK_BASELINE_FILE`   | *none*  | Path (relative to `k6/loadtest/`) to a baseline summary to gate on |
-| `SOAK_P95_TOLERANCE`   | `0.30`  | Allowed fractional p95 growth vs baseline                          |
+| `SOAK_P95_TOLERANCE`   | `0.30`  | Allowed p95 growth vs baseline, as a **fraction** (0.30 = 30%, not 30) |
 | `SOAK_P95_FLOOR_MS`    | `50`    | Absolute p95 cushion added on top of the tolerance                 |
 | `SOAK_P95_ENCRYPT_MS`  | `350`   | Absolute encrypt/decrypt p95 ceiling (fallback when no baseline)   |
 | `SOAK_P95_ECDSA_MS`    | `700`   | Absolute ecdsa-sign p95 ceiling (fallback when no baseline)        |

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -66,39 +66,72 @@ const SOAK_P95_ECDSA_MS = __ENV.SOAK_P95_ECDSA_MS || "700";
 const SOAK_P95_TOLERANCE = parseFloat(__ENV.SOAK_P95_TOLERANCE || "0.30");
 const SOAK_P95_FLOOR_MS = parseFloat(__ENV.SOAK_P95_FLOOR_MS || "50");
 
-// Optional committed baseline. open() resolves relative to THIS spec's dir
-// (k6/loadtest/), so the gate passes e.g. "../baselines/soak.next.json".
-// Absent/unreadable → null → absolute fallback ceilings above.
+// Committed baseline. When SOAK_BASELINE_FILE is set the gate runs in baseline
+// mode and FAILS CLOSED: any problem loading the baseline, an invalid
+// tolerance/floor, or a missing/non-positive p95 for a running endpoint throws
+// at init so the run errors red. It never silently downgrades to the loose
+// absolute ceilings — that would let a real regression pass green. When unset
+// (local / measurement runs) we use the absolute SOAK_P95_*_MS ceilings.
+// open() resolves relative to THIS spec's dir (k6/loadtest/), so the gate
+// passes e.g. "../baselines/soak.next.json".
 const SOAK_BASELINE_FILE = __ENV.SOAK_BASELINE_FILE || "";
+const baselineMode = SOAK_BASELINE_FILE !== "";
 // deno-lint-ignore no-explicit-any
 let soakBaseline: any = null;
-if (SOAK_BASELINE_FILE) {
+if (baselineMode) {
+  let raw: string;
   try {
-    soakBaseline = JSON.parse(open(SOAK_BASELINE_FILE) as string);
+    raw = open(SOAK_BASELINE_FILE) as string;
   } catch (e) {
-    console.warn(
-      `soak: could not load baseline ${SOAK_BASELINE_FILE} (${String(
+    throw new Error(
+      `soak: SOAK_BASELINE_FILE="${SOAK_BASELINE_FILE}" could not be opened (${String(
         (e as Error).message ?? e,
-      )}); using absolute p95 ceilings`,
+      )}). The gate fails closed — fix the path (relative to k6/loadtest/) or unset it.`,
+    );
+  }
+  try {
+    soakBaseline = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `soak: baseline ${SOAK_BASELINE_FILE} is not valid JSON (${String(
+        (e as Error).message ?? e,
+      )}).`,
+    );
+  }
+  if (!Number.isFinite(SOAK_P95_TOLERANCE) || SOAK_P95_TOLERANCE < 0) {
+    throw new Error(
+      `soak: SOAK_P95_TOLERANCE must be a non-negative number — a fraction, e.g. 0.30 = 30% (not 30); got "${__ENV.SOAK_P95_TOLERANCE}".`,
+    );
+  }
+  if (!Number.isFinite(SOAK_P95_FLOOR_MS) || SOAK_P95_FLOOR_MS < 0) {
+    throw new Error(
+      `soak: SOAK_P95_FLOOR_MS must be a non-negative number of ms; got "${__ENV.SOAK_P95_FLOOR_MS}".`,
     );
   }
 }
 
-// p95 ceiling (ms, as a string for the k6 threshold) for an endpoint:
-// baseline-derived delta if we have a baseline p95, else the absolute fallback.
+// p95 ceiling (ms string for the k6 threshold) for an endpoint. In baseline
+// mode it is derived from the baseline p95 and throws if that p95 is absent or
+// non-positive (fail closed). Without a baseline it returns the absolute
+// fallback ceiling.
 function p95Ceiling(scenario: string, absoluteMs: string): string {
+  if (!baselineMode) return absoluteMs;
   const base = soakBaseline?.scenarios?.[scenario]?.p95;
-  if (typeof base === "number" && base > 0) {
-    const ceil = Math.max(
-      base * (1 + SOAK_P95_TOLERANCE),
-      base + SOAK_P95_FLOOR_MS,
+  if (typeof base !== "number" || !(base > 0)) {
+    throw new Error(
+      `soak: baseline ${SOAK_BASELINE_FILE} has no valid p95 for "${scenario}" (got ${JSON.stringify(
+        base,
+      )}). The gate fails closed — regenerate the baseline with k6/update-soak-baseline.sh.`,
     );
-    console.log(
-      `soak: ${scenario} p95 ceiling ${ceil.toFixed(0)}ms (baseline ${base}ms +${(SOAK_P95_TOLERANCE * 100).toFixed(0)}%/+${SOAK_P95_FLOOR_MS}ms)`,
-    );
-    return String(ceil);
   }
-  return absoluteMs;
+  const ceil = Math.max(
+    base * (1 + SOAK_P95_TOLERANCE),
+    base + SOAK_P95_FLOOR_MS,
+  );
+  console.log(
+    `soak: ${scenario} p95 ceiling ${ceil.toFixed(0)}ms (baseline ${base}ms +${(SOAK_P95_TOLERANCE * 100).toFixed(0)}%/+${SOAK_P95_FLOOR_MS}ms)`,
+  );
+  return String(ceil);
 }
 
 // Gate mode: create ephemeral accounts in setup() instead of reading the

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -32,7 +32,7 @@
  *   SOAK_DURATION  - Total test duration for soak scenario (default: 30m)
  *   SOAK_VUS       - Virtual users for soak scenario (default: 3)
  */
-import { checkAndLog, assertOk, warnOnHttpFailures } from "../helpers.ts";
+import { checkAndLog, assertOk } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";
 import { PRECREATED_ACCOUNTS, createAccountAndUsageKey } from "../setup.ts";
 import { sleep } from "k6";
@@ -43,20 +43,63 @@ import {
 } from "../LitActionCode/index.ts";
 import { BASE_URL, COMMON_PARAMS, K6_RUN_ID } from "../defaults.ts";
 import { ensureAccountCredits } from "../stripe.ts";
+// @ts-ignore – remote JS lib, no type declarations
+import { textSummary } from "https://jslib.k6.io/k6-summary/0.1.0/index.js";
 
 // Parse duration: "1h", "30m", "10m" etc.
 const SOAK_DURATION = __ENV.SOAK_DURATION || "30m";
 const SOAK_VUS = parseInt(__ENV.SOAK_VUS || "3", 10);
 
-// Interim per-endpoint p95 latency ceilings (ms) for the deploy gate.
-// Coarse absolute ceilings at ~3x the observed low-load baseline on staging
-// (encrypt/decrypt ~106ms p95, ecdsa-sign ~274ms p95) — enough to catch gross
-// "we made this endpoint a lot slower" regressions without false-failing on
-// normal jitter. Phase 2 replaces these with run-over-run deltas vs a stored
-// baseline. Overridable via env so manual/endurance soaks at higher VU (where
-// latency legitimately rises) don't trip them.
+// Per-endpoint p95 latency ceilings (ms) for the deploy perf gate.
+//
+// When a committed baseline is provided (SOAK_BASELINE_FILE — a previously-saved
+// soak summary), the ceiling for each endpoint is DERIVED from that baseline's
+// p95: fail if this run is more than SOAK_P95_TOLERANCE over it, with a
+// SOAK_P95_FLOOR_MS absolute cushion so small-sample jitter doesn't false-fail.
+// Without a baseline (local runs, or before one is committed) we fall back to
+// these coarse absolute ceilings. All overridable via env.
 const SOAK_P95_ENCRYPT_MS = __ENV.SOAK_P95_ENCRYPT_MS || "350";
 const SOAK_P95_ECDSA_MS = __ENV.SOAK_P95_ECDSA_MS || "700";
+
+// Regression tolerance vs the baseline: fail if p95 > max(baseline*(1+tol),
+// baseline + floor).
+const SOAK_P95_TOLERANCE = parseFloat(__ENV.SOAK_P95_TOLERANCE || "0.30");
+const SOAK_P95_FLOOR_MS = parseFloat(__ENV.SOAK_P95_FLOOR_MS || "50");
+
+// Optional committed baseline. open() resolves relative to THIS spec's dir
+// (k6/loadtest/), so the gate passes e.g. "../baselines/soak.next.json".
+// Absent/unreadable → null → absolute fallback ceilings above.
+const SOAK_BASELINE_FILE = __ENV.SOAK_BASELINE_FILE || "";
+// deno-lint-ignore no-explicit-any
+let soakBaseline: any = null;
+if (SOAK_BASELINE_FILE) {
+  try {
+    soakBaseline = JSON.parse(open(SOAK_BASELINE_FILE) as string);
+  } catch (e) {
+    console.warn(
+      `soak: could not load baseline ${SOAK_BASELINE_FILE} (${String(
+        (e as Error).message ?? e,
+      )}); using absolute p95 ceilings`,
+    );
+  }
+}
+
+// p95 ceiling (ms, as a string for the k6 threshold) for an endpoint:
+// baseline-derived delta if we have a baseline p95, else the absolute fallback.
+function p95Ceiling(scenario: string, absoluteMs: string): string {
+  const base = soakBaseline?.scenarios?.[scenario]?.p95;
+  if (typeof base === "number" && base > 0) {
+    const ceil = Math.max(
+      base * (1 + SOAK_P95_TOLERANCE),
+      base + SOAK_P95_FLOOR_MS,
+    );
+    console.log(
+      `soak: ${scenario} p95 ceiling ${ceil.toFixed(0)}ms (baseline ${base}ms +${(SOAK_P95_TOLERANCE * 100).toFixed(0)}%/+${SOAK_P95_FLOOR_MS}ms)`,
+    );
+    return String(ceil);
+  }
+  return absoluteMs;
+}
 
 // Gate mode: create ephemeral accounts in setup() instead of reading the
 // pre-seeded pool. The deploy gate runs against a freshly-deployed (possibly
@@ -168,11 +211,11 @@ if (runSoak) {
   // soak_* carry the interim per-endpoint p95 regression ceilings (the gate
   // runs SCENARIO=soak); keep the loose p99 "didn't fall over" bound too.
   thresholds["http_req_duration{scenario:soak_encrypt_decrypt}"] = [
-    `p(95)<${SOAK_P95_ENCRYPT_MS}`,
+    `p(95)<${p95Ceiling("soak_encrypt_decrypt", SOAK_P95_ENCRYPT_MS)}`,
     "p(99)<15000",
   ];
   thresholds["http_req_duration{scenario:soak_ecdsa_sign}"] = [
-    `p(95)<${SOAK_P95_ECDSA_MS}`,
+    `p(95)<${p95Ceiling("soak_ecdsa_sign", SOAK_P95_ECDSA_MS)}`,
     "p(99)<15000",
   ];
 }
@@ -184,6 +227,8 @@ if (runRamp) {
 export const options = {
   scenarios,
   setupTimeout: "3m", // accounts × 2 API calls each; ~6s/call; 3m allows for slow responses
+  // Include p(99) so the JSON summary / baseline captures it (default stats omit it).
+  summaryTrendStats: ["avg", "min", "med", "max", "p(95)", "p(99)"],
   thresholds,
 };
 
@@ -361,4 +406,54 @@ export function ecdsaSign(setupData: SoakSetupData) {
   sleep(2 + Math.random() * 2);
 }
 
-export const handleSummary = warnOnHttpFailures;
+/** Extract the trend stats for a (sub)metric, null-safe. */
+// deno-lint-ignore no-explicit-any
+function trend(data: any, sub: string) {
+  const v = data?.metrics?.[sub]?.values;
+  if (!v) return null;
+  return {
+    p50: v["med"],
+    p95: v["p(95)"],
+    p99: v["p(99)"],
+    avg: v["avg"],
+    max: v["max"],
+  };
+}
+
+/**
+ * Write a machine-readable summary (soak-summary.json) alongside the text
+ * summary. This file is BOTH the per-run artifact for the gate's regression
+ * comparison and the exact shape the committed baseline takes — so
+ * update-soak-baseline.sh just saves this file as the baseline. Keeps the
+ * HTTP-failure warning from the old warnOnHttpFailures.
+ */
+// deno-lint-ignore no-explicit-any
+export function handleSummary(data: any): Record<string, string> {
+  const summary = {
+    env: __ENV.K6_ENV || "",
+    base_url: BASE_URL,
+    correlation_id: K6_RUN_ID,
+    generated_at: new Date().toISOString(),
+    scenarios: {
+      soak_encrypt_decrypt: trend(
+        data,
+        "http_req_duration{scenario:soak_encrypt_decrypt}",
+      ),
+      soak_ecdsa_sign: trend(data, "http_req_duration{scenario:soak_ecdsa_sign}"),
+    },
+    checks_rate: data?.metrics?.checks?.values?.rate ?? null,
+    http_req_failed_rate: data?.metrics?.http_req_failed?.values?.rate ?? null,
+  };
+
+  const failed = data?.metrics?.http_req_failed;
+  if (failed && failed.values?.rate > 0) {
+    console.warn(
+      `\n⚠ WARNING: ${(failed.values.rate * 100).toFixed(1)}% of HTTP requests failed\n`,
+    );
+  }
+
+  return {
+    stdout: textSummary(data, { indent: " ", enableColors: true }),
+    "soak-summary.json": JSON.stringify(summary, null, 2),
+  };
+}

--- a/k6/update-soak-baseline.sh
+++ b/k6/update-soak-baseline.sh
@@ -36,6 +36,15 @@ echo "  duration: ${DURATION} steady (+~4m ramp up/down)"
 echo "  accounts: ephemeral, created + test-mode-funded for this run"
 echo
 
+command -v python3 >/dev/null 2>&1 || {
+  echo "error: python3 is required to validate the measured summary before writing the baseline." >&2
+  exit 1
+}
+
+# No SOAK_BASELINE_FILE → not baseline mode, so the spec uses absolute ceilings.
+# Set them sky-high so this measurement run genuinely never gates itself on
+# latency (otherwise a legitimately-slower run would exit non-zero under set -e
+# before we capture the numbers).
 K6_CORRELATION_ID="baseline-$(date +%s)" \
 SOAK_CREATE_ACCOUNTS=true \
 SCENARIO=soak \
@@ -43,6 +52,8 @@ SOAK_VUS=2 \
 SOAK_DURATION="$DURATION" \
 BASE_URL="$BASE_URL" \
 K6_ENV=staging \
+SOAK_P95_ENCRYPT_MS=100000 \
+SOAK_P95_ECDSA_MS=100000 \
   k6 run loadtest/soak.spec.ts
 
 [ -f soak-summary.json ] || {
@@ -50,7 +61,43 @@ K6_ENV=staging \
   exit 1
 }
 
+# Validate the measurement before baking it into the gate's baseline: a degraded
+# or partial run (failed checks, HTTP failures, or a null/zero p95 from a
+# zero-sample scenario) must NOT become the accepted ceiling. Warn if it's
+# meaningfully slower than the current baseline, since you normally refresh to
+# TIGHTEN, not loosen.
 mkdir -p baselines
+python3 - "soak-summary.json" "$OUT" <<'PY'
+import json, os, sys
+new = json.load(open(sys.argv[1]))
+problems = []
+if new.get("checks_rate") != 1:
+    problems.append(f"checks_rate={new.get('checks_rate')} (want 1.0)")
+if new.get("http_req_failed_rate") not in (0, 0.0):
+    problems.append(f"http_req_failed_rate={new.get('http_req_failed_rate')} (want 0)")
+for name in ("soak_encrypt_decrypt", "soak_ecdsa_sign"):
+    sc = (new.get("scenarios") or {}).get(name)
+    p95 = sc.get("p95") if isinstance(sc, dict) else None
+    if not isinstance(p95, (int, float)) or isinstance(p95, bool) or p95 <= 0:
+        problems.append(f"{name}.p95={p95!r} (want a positive number)")
+if problems:
+    sys.stderr.write("error: measurement run was not clean — baseline NOT written:\n")
+    for p in problems:
+        sys.stderr.write(f"  - {p}\n")
+    sys.exit(1)
+cur_path = sys.argv[2]
+if os.path.exists(cur_path):
+    cur = json.load(open(cur_path))
+    for name in ("soak_encrypt_decrypt", "soak_ecdsa_sign"):
+        old = ((cur.get("scenarios") or {}).get(name) or {}).get("p95")
+        nw = new["scenarios"][name]["p95"]
+        if isinstance(old, (int, float)) and not isinstance(old, bool) and nw > old * 1.1:
+            sys.stderr.write(
+                f"WARNING: {name} p95 {nw:.0f}ms is >10% slower than the current "
+                f"baseline {old:.0f}ms — refreshes usually TIGHTEN. Double-check before committing.\n"
+            )
+PY
+
 mv soak-summary.json "$OUT"
 
 echo

--- a/k6/update-soak-baseline.sh
+++ b/k6/update-soak-baseline.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regenerate the soak latency baseline used by the deploy perf gate.
+#
+# Runs the soak test against staging (creating its own ephemeral, test-mode-
+# funded accounts via SOAK_CREATE_ACCOUNTS) and saves the per-endpoint p95
+# summary to k6/baselines/soak.<network>.json. This is a MANUAL operation: run
+# it when perf legitimately changes (e.g. a release made things substantially
+# faster), eyeball the numbers, and commit the updated baseline in a PR. The
+# deploy gate compares every staging deploy against the committed baseline.
+#
+# It is a MEASUREMENT run — it deliberately does NOT set SOAK_BASELINE_FILE, so
+# it never gates itself; it just measures and writes the result.
+#
+# Requires: k6 installed locally (https://grafana.com/docs/k6/latest/set-up/install-k6/).
+#
+# Usage (from anywhere):
+#   k6/update-soak-baseline.sh                  # network=next, 5m steady
+#   DURATION=10m k6/update-soak-baseline.sh     # longer run → steadier p95
+#   NETWORK=next BASE_URL=https://… k6/update-soak-baseline.sh
+set -euo pipefail
+cd "$(dirname "$0")" # → k6/
+
+NETWORK="${NETWORK:-next}"
+DURATION="${DURATION:-5m}"
+BASE_URL="${BASE_URL:-https://test.chipotle.litprotocol.com/core/v1}"
+OUT="baselines/soak.${NETWORK}.json"
+
+command -v k6 >/dev/null 2>&1 || {
+  echo "error: k6 not found — install it: https://grafana.com/docs/k6/latest/set-up/install-k6/" >&2
+  exit 1
+}
+
+echo "Measuring soak baseline → ${OUT}"
+echo "  target:   ${BASE_URL}"
+echo "  duration: ${DURATION} steady (+~4m ramp up/down)"
+echo "  accounts: ephemeral, created + test-mode-funded for this run"
+echo
+
+K6_CORRELATION_ID="baseline-$(date +%s)" \
+SOAK_CREATE_ACCOUNTS=true \
+SCENARIO=soak \
+SOAK_VUS=2 \
+SOAK_DURATION="$DURATION" \
+BASE_URL="$BASE_URL" \
+K6_ENV=staging \
+  k6 run loadtest/soak.spec.ts
+
+[ -f soak-summary.json ] || {
+  echo "error: soak-summary.json was not produced — the run likely failed before the summary." >&2
+  exit 1
+}
+
+mkdir -p baselines
+mv soak-summary.json "$OUT"
+
+echo
+echo "Wrote ${OUT}:"
+cat "$OUT"
+echo
+echo "Next: review the p95 numbers, then commit them:"
+echo "  git add k6/${OUT} && git commit -m 'chore(k6): refresh soak baseline' && open a PR"

--- a/plans/k6-perf-regression-gate.md
+++ b/plans/k6-perf-regression-gate.md
@@ -1,6 +1,6 @@
 # Gate releases on k6 load tests (perf regression gate)
 
-**Status:** Phase 1 shipped (PR #506). Gate vehicle switched spike → low-VU soak after a live test (see §3.1). Phase 2 not started.
+**Status:** Phase 1 shipped (PR #506). Gate vehicle switched spike → low-VU soak after a live test (see §3.1). Phase 2 (delta gate vs committed baseline) shipped (see §4). Phase 3 not started.
 **Scope:** Turn the existing k6 load tests (`k6/loadtest/{spike,soak,breakpoint}.spec.ts`) from manual-only tools into an automated perf-regression gate on the staging deploy, then into real run-over-run regression detection. Dedicated idle servers are earmarked as the stable load-generation / baseline hardware.
 
 ---
@@ -55,17 +55,18 @@ Switched the gate to a **low-VU soak** (`test: soak`, `vus: 2`, `duration: 3m`, 
 
 ---
 
-## 4. Phase 2 — real regression detection (TODO)
+## 4. Phase 2 — delta gate vs committed baseline ✅ SHIPPED
 
-The headline goal: gate on a **delta vs the last green release**, not just absolute thresholds.
+Gate on a **delta vs a committed baseline**, not absolute thresholds. Baseline is anchored in a committed file (not the last artifact) so cumulative drift is caught, and refreshed manually.
 
-- Add a `handleSummary` that writes structured JSON (replace/augment `warnOnHttpFailures`).
-- Persist each run's key metrics (p50/p95/p99 per scenario, check rate). Simplest: committed JSON or a bucket. Better: k6 → Prometheus remote-write → Grafana on the idle servers (native k6 Prometheus output) for dashboards + history.
-- Comparison step in CI: fail if e.g. `p95 > 1.2× baseline` for the last green release.
+- **Structured JSON output.** `soak.spec.ts` `handleSummary` now writes `soak-summary.json` (per-scenario p50/p95/p99/avg/max + check & failure rates). `summaryTrendStats` extended to include p(99). This file is both the per-run artifact and the exact shape the baseline takes.
+- **Committed baseline:** `k6/baselines/soak.next.json` (a saved summary). The deploy gate passes `baseline_file: ../baselines/soak.next.json` (path is relative to `k6/loadtest/` — where the spec's `open()` resolves).
+- **Delta gate (in-spec, reuses k6 thresholds).** When `SOAK_BASELINE_FILE` is set, each endpoint's p95 threshold is derived: `p95 < max(baseline*(1+SOAK_P95_TOLERANCE), baseline + SOAK_P95_FLOOR_MS)` (defaults 0.30 / 50ms — the floor stops ~60-130-sample jitter from false-failing). k6's exit code = the gate, so it flows through the existing cutover-block + rollback plumbing with no new job. No baseline / unreadable → falls back to the absolute `SOAK_P95_*_MS` ceilings.
+- **Manual baseline refresh:** `k6/update-soak-baseline.sh` runs a measurement soak against staging (create_accounts, no baseline → doesn't gate itself) and writes `k6/baselines/soak.next.json`. Run it + commit via PR when perf legitimately changes (e.g. got substantially faster). Per the decision: baseline updates are a deliberate manual op, not automated.
 
-**Folded-in from the Codex adversarial review of PR #506:**
-- **#4 — gate thresholds.** Partially addressed: the gate is now low-VU soak with interim per-endpoint p95 ceilings (§3.1), not the loose spike `checks>=0.8`/`p99<30s`. The real fix is still the delta gate above — replace the absolute `SOAK_P95_*_MS` ceilings with run-over-run deltas vs the last green release.
-- **#2 — reduce time-to-rollback.** `k6-loadtest` in `rollback-on-failure`'s `needs` means rollback can't start until the ~7-min soak finishes, even if an earlier independent gate (e.g. `verify-attestation`) already failed. Decouple fast-fail rollback from the slow load-test gate so a bad-but-live box is pulled back ASAP. (Pre-existing pattern — `k6-smoke`/`k6-correctness` already do this — but worth fixing while we're here.)
+**Folded-in Codex findings:** #4 (loose thresholds) — resolved: the gate is now a baseline-relative delta. #2 (time-to-rollback: rollback waits the full ~7-min soak even if an earlier gate failed) — **still open**, deferred to a fast-fail-decoupling change.
+
+**Not done (optional):** prod baseline gating (the manual prod soak still just measures with high ceilings); k6→Prometheus/Grafana history (the committed file + per-run artifacts suffice for the gate).
 
 ---
 


### PR DESCRIPTION
Phase 2 of the k6 perf gate (plan: `plans/k6-perf-regression-gate.md`). Replaces the soak gate's staging-tuned absolute p95 ceilings with a **regression gate vs a committed baseline**, so cumulative drift is caught — not just "worse than the last run."

**How it works:** `soak.spec.ts`'s `handleSummary` now writes a structured `soak-summary.json` (per-scenario p50/p95/p99/avg/max + check/failure rates). When `SOAK_BASELINE_FILE` is set, each endpoint's p95 threshold is derived from the committed baseline: `p95 < max(baseline*1.3, baseline+50ms)` (the +50ms floor absorbs small-sample jitter). k6's exit code is the gate, so it reuses the existing cutover-block + rollback plumbing — no new CI job. No/unreadable baseline → falls back to the absolute ceilings.

- `k6/baselines/soak.next.json` — committed staging baseline (a saved summary), seeded from the clean validation run (encrypt p95 112ms, ecdsa 274ms).
- `k6/update-soak-baseline.sh` — **manual** baseline refresh: runs a measurement soak against staging (creates its own accounts, no baseline so it doesn't gate itself) and writes the baseline file for review + commit.
- `k6-loadtest.yml` — `baseline_file` input (call + dispatch) → `SOAK_BASELINE_FILE`; uploads `soak-summary.json`.
- `deploy-staging.yml` — gate passes `baseline_file: ../baselines/soak.next.json`.
- `k6/loadtest/README.md` — documents the gate, baseline, and refresh script.

Why committed-file over last-run-artifact: comparing only to the previous run lets a steady few-percent-per-release creep pass forever and compound; a fixed anchor catches it until deliberately re-blessed. Per-run `soak-summary.json` is still uploaded for history.

Validated live on staging with `baseline_file` set (run 27798192925).

🤖 Generated with [Claude Code](https://claude.com/claude-code)