### PR TITLE
Add k6 load test run summary

### DIFF
--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -214,6 +214,11 @@ jobs:
           set -o pipefail
           k6 run "${{ steps.spec.outputs.path }}" 2>&1 | tee "k6-loadtest-${{ inputs.test }}.log"
 
+      - name: Post k6 load test summary
+        if: ${{ always() }}
+        continue-on-error: true
+        run: node scripts/k6-loadtest-github-summary.mjs soak-summary.json "${{ inputs.test }}"
+
       - name: Upload k6 summary
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/k6/loadtest/README.md
+++ b/k6/loadtest/README.md
@@ -131,7 +131,7 @@ baseline must not let a regression pass green. The absolute ceilings
 (`SOAK_P95_ENCRYPT_MS` 350 / `SOAK_P95_ECDSA_MS` 700) apply only when no baseline
 is requested (local / measurement runs).
 
-Each run also uploads `soak-summary.json` (per-scenario p50/p95/p99/avg/max +
+Each run also uploads `soak-summary.json` (per-scenario p50/p95/p99/avg/min/max +
 check & failure rates) as a build artifact — the same shape the baseline takes.
 
 ### Refreshing the baseline — `update-soak-baseline.sh`

--- a/k6/loadtest/soak.spec.ts
+++ b/k6/loadtest/soak.spec.ts
@@ -445,6 +445,7 @@ function trend(data: any, sub: string) {
   const v = data?.metrics?.[sub]?.values;
   if (!v) return null;
   return {
+    min: v["min"],
     p50: v["med"],
     p95: v["p(95)"],
     p99: v["p(99)"],

--- a/lit-actions/Cargo.lock
+++ b/lit-actions/Cargo.lock
@@ -3839,7 +3839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6244,9 +6244,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -7728,9 +7728,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -8393,7 +8393,7 @@ dependencies = [
  "errno 0.3.13",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9978,7 +9978,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/lit-api-server/Cargo.lock
+++ b/lit-api-server/Cargo.lock
@@ -5855,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/lit-core/Cargo.lock
+++ b/lit-core/Cargo.lock
@@ -2529,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",

--- a/scripts/k6-loadtest-github-summary.mjs
+++ b/scripts/k6-loadtest-github-summary.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const [summaryPath = "soak-summary.json", testName = "loadtest"] =
+  process.argv.slice(2);
+const outputPath = process.env.GITHUB_STEP_SUMMARY;
+
+function appendMarkdown(markdown) {
+  if (outputPath) {
+    fs.appendFileSync(outputPath, markdown);
+    return;
+  }
+  process.stdout.write(markdown);
+}
+
+function formatMs(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  return `${Number(value.toFixed(2))}ms`;
+}
+
+function formatPercent(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  return `${Number((value * 100).toFixed(2))}%`;
+}
+
+function inlineCode(value) {
+  if (value === null || value === undefined || value === "") {
+    return "`n/a`";
+  }
+  return `\`${String(value).replaceAll("`", "'")}\``;
+}
+
+function scenarioLabel(name) {
+  return `\`${name.replaceAll("`", "'")}\``;
+}
+
+if (!fs.existsSync(summaryPath)) {
+  appendMarkdown(
+    [
+      "## k6 Load Test Summary",
+      "",
+      `**Test:** ${inlineCode(testName)}`,
+      "",
+      `${inlineCode(summaryPath)} was not produced, so no soak latency table is available. Check the k6 log artifact for the full run output.`,
+      "",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+let summary;
+try {
+  summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+} catch (error) {
+  appendMarkdown(
+    [
+      "## k6 Load Test Summary",
+      "",
+      `**Test:** ${inlineCode(testName)}`,
+      "",
+      `Could not parse ${inlineCode(summaryPath)}: ${error.message}`,
+      "",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+const scenarios = Object.entries(summary.scenarios ?? {}).filter(
+  ([, values]) => values && typeof values === "object",
+);
+
+const lines = [
+  "## k6 Load Test Summary",
+  "",
+  `**Test:** ${inlineCode(testName)}`,
+  `**Base URL:** ${inlineCode(summary.base_url)}`,
+  `**Correlation ID:** ${inlineCode(summary.correlation_id)}`,
+  "",
+];
+
+if (scenarios.length > 0) {
+  lines.push(
+    "| Scenario | avg | min | med | max | p95 | p99 |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+  );
+
+  for (const [name, values] of scenarios) {
+    lines.push(
+      `| ${scenarioLabel(name)} | ${formatMs(values.avg)} | ${formatMs(
+        values.min,
+      )} | ${formatMs(values.p50)} | ${formatMs(values.max)} | ${formatMs(
+        values.p95,
+      )} | ${formatMs(values.p99)} |`,
+    );
+  }
+} else {
+  lines.push("No per-scenario soak latency metrics were captured.");
+}
+
+lines.push(
+  "",
+  "| Run metric | Value |",
+  "| --- | ---: |",
+  `| checks rate | ${formatPercent(summary.checks_rate)} |`,
+  `| HTTP request failure rate | ${formatPercent(summary.http_req_failed_rate)} |`,
+  "",
+);
+
+appendMarkdown(lines.join("\n"));


### PR DESCRIPTION
Adds a best-effort k6 load test summary step that writes soak latency metrics into the GitHub Actions run summary. The formatter renders avg/min/med/max/p95/p99 per scenario from soak-summary.json, plus checks and HTTP failure rates, so deploy-staging and manual load-test runs expose the key numbers without digging through logs. Also bumps vulnerable Rust transitive lockfile entries: quinn-proto to 0.11.15 across affected workspaces and memmap2 to 0.9.11 in lit-actions, fixing the Rust CI advisory failure. Validation: rendered the k6 formatter against k6/baselines/soak.next.json, parsed the workflow YAML, ran git diff --check, cargo metadata --locked for updated Rust workspaces, and cargo deny advisories/sources for the affected workspaces.