### PR TITLE
Add Lit Action primitives example

### DIFF
--- a/examples/chipotle-primitives/README.md
+++ b/examples/chipotle-primitives/README.md
@@ -1,0 +1,144 @@
+# chipotle-primitives
+
+A catalog of reusable Lit Action primitives, implemented as composable helpers
+on top of **audited libraries** rather than hand-rolled crypto:
+
+- [`micro-eth-signer@0.19.0`](https://github.com/paulmillr/micro-eth-signer) (Paul Miller) — `addr`, `eip191Signer`, `Transaction`, the ABI coder, wei math
+- [`@noble/hashes@1.4.0`](https://github.com/paulmillr/noble-hashes) (Paul Miller) — keccak-256, hex/byte utilities
+
+Everything here is glue around those plus the `Lit.Actions.*` host API and the
+Deno globals `fetch` / `crypto`. No bespoke secp256k1, no bespoke ABI encoder.
+
+## Files (grouped by concern)
+
+| Module | Primitives |
+| --- | --- |
+| `lit-action-core.js` | `keccak256`, `keccak256Utf8`, `arrayify`, `abiEncode`, `GateError`, `deny` (shared base; imports the npm libs) |
+| `lit-action-rpc.js` | `rpc`, `assertAllowedRpc`, `assertChainId`, `requireConfirmations` |
+| `lit-action-onchain.js` | `readContract`, `readAndValidateLog`, `sendEth`, `bindToOnchainOrder` |
+| `lit-action-gating.js` | `gateEthBalance`, `gateErc20Balance`, `gateNftOwnership`, `gateTimeWindow`, `gateSanctions`, `gateAuthToken`, `requireCallerSignature`, `requirePkpAllowed`, `combineGates` |
+| `lit-action-signing.js` | `signWithPkp`, `signWithAction`, `buildAuthDigest`, `signDigest`, `recoverSigner`, `getActionAddress` |
+| `lit-action-secrets.js` | `sealToVault`, `openFromVault`, `withSecret`, `assembleSecretRpcUrl` |
+| `lit-action-oracles.js` | `requireStrictAgreement`, `medianWithSpreadCheck`, `signedPriceFeed`, `aiConsensus` |
+| `lit-action-replay.js` | `newNonce`, `withDeadline`, `assertNotExpired` |
+| `lit-action-primitives.js` | barrel — re-exports all of the above |
+
+See [`uses.md`](./uses.md) for a per-function description and a "when to use it"
+example for every primitive.
+
+## The one rule
+
+Anything that defines the **trust boundary** — host whitelists, min-source
+counts, spread caps, allowed addresses, base RPC URLs, oracle addresses — must
+be **hardcoded in the action source**, never read from `js_params`. The
+whitelist is part of the action code, so changing it changes the IPFS CID and
+therefore the action-derived signer address. That is the property that makes the
+gate trustworthy. Caller-supplied policy is theater.
+
+These primitives take thresholds as **arguments**; the action that imports them
+passes hardcoded constants. Do not forward a `policy` object straight out of
+`js_params` into them.
+
+## Denials fail closed
+
+Gates **throw** `GateError` on denial; they never return a soft "denied" object.
+Your `main` catches and translates:
+
+```js
+import * as P from "./lit-action-primitives.js";
+
+// Trust boundary — hardcoded in THIS file. Editing it changes the CID + signer.
+const POLICY = {
+  rpc: {
+    84532: { hostRegex: /^base-sepolia\.g\.alchemy\.com$/i, minConfirmations: 2 },
+  },
+};
+const OWNER = "0xYourBoundOwner";
+
+async function main({ chainId, rpcUrl, token, to, amount, nonce, deadline, signature }) {
+  try {
+    P.assertAllowedRpc({ chainId, rpcUrl, policy: POLICY.rpc });
+    await P.assertChainId({ rpcUrl, expectedChainId: chainId });
+    P.assertNotExpired({ deadline });
+
+    // Caller must sign a message carrying nonce + deadline (replay safety).
+    const message = `withdraw\n${token}\n${to}\n${amount}\n${nonce}\n${deadline}`;
+    P.requireCallerSignature({ message, signature, allowedAddress: OWNER });
+
+    // Sign the exact tuple the verifying contract re-derives with ecrecover.
+    const { signature: authSig, signer, digest } = await P.signDigest({
+      types: ["address", "address", "uint256", "bytes32", "uint256", "uint256"],
+      values: [token, to, amount, nonce, deadline, chainId],
+      useAction: true,
+    });
+
+    return Lit.Actions.setResponse({
+      response: JSON.stringify({ authorized: true, authSig, signer, digest }),
+    });
+  } catch (e) {
+    return Lit.Actions.setResponse({
+      response: JSON.stringify({ authorized: false, reason: e.message }),
+    });
+  }
+}
+```
+
+## Value-type conventions for `abiEncode` / `signDigest`
+
+`abiEncode(types, values)` feeds micro-eth-signer's ABI coder, which (via
+micro-packed) is stricter than ethers about JS types. The wrapper coerces the
+common cases for you:
+
+- `uint*` / `int*` — pass `number`, `bigint`, or decimal `string`; coerced with `BigInt`.
+- `address` — pass a `0x`-hex string.
+- `bytes` / `bytesN` — pass a `0x`-hex string (converted to bytes) or a `Uint8Array`.
+- `bool` — pass a boolean.
+- `string` — pass a string.
+
+The output bytes are the bare head/tail tuple encoding (selector stripped), so
+`keccak256(abiEncode(...))` matches `keccak256(abi.encode(...))` on-chain.
+
+## Consuming this module from an action
+
+These files use **relative imports between each other** (`./lit-action-core.js`
+etc.). The Lit Action runtime loads ES modules from jsDelivr by bare,
+version-pinned specifier (see the existing `examples/solana-signer` action) and
+does **not** resolve local relative imports. So the split set must be combined
+before deploy. Pick one of:
+
+1. **Bundle at deploy.** Bundle `lit-action-primitives.js` (or just the concerns
+   you use) into your action with a build step, the way
+   `examples/mpc-signing-frost` runs `npm run build:action` to inline its glue.
+   The relative imports resolve at bundle time; the npm (`micro-eth-signer`,
+   `@noble/*`) imports stay as runtime jsDelivr specifiers.
+2. **Vendor it.** Copy the functions you use directly into your action file
+   (collapsing the relative imports). Simplest; what most existing examples do
+   (each inlines its own `rpcCall` / `ethCall`).
+3. **Publish + pin.** Publish this package to npm and import a concern the same
+   way the examples import `@noble/*`:
+   `import * as P from "chipotle-primitives@x.y.z";`.
+
+## Verify import resolution in the live runtime
+
+The single most important thing to smoke-test: that every pinned specifier
+resolves in **your** runtime. Run an action that imports this module and calls
+`Lit.Actions.showImportDetails()` — it logs every resolved module URL and its
+SHA-384. Confirm in particular:
+
+- `micro-eth-signer@0.19.0` (root) resolves with its `@noble@2.2.0` +
+  `micro-packed` deps bundled.
+- `micro-eth-signer@0.19.0/advanced/abi.js` (the ABI subpath) resolves. If it
+  does not, try the `/+esm` form (`micro-eth-signer@0.19.0/advanced/abi.js/+esm`)
+  or vendor `createContract` in.
+- `@noble/hashes@1.4.0/sha3/+esm` and `.../utils/+esm` resolve (this is the form
+  already proven in `examples/solana-signer`).
+
+`ethers` v5 is also available as a runtime global if you ever need a fallback
+for the ABI coder; the rest of this module does not depend on it.
+
+## Source files in `ext/js` vs this module
+
+This module lives under `examples/`, not in `lit-actions/ext/js/`, so the
+ASCII-only snapshot constraint does not strictly apply — but the file is kept
+ASCII-only anyway. If you ever move it into the runtime snapshot, keep it ASCII
+(use `\uXXXX` escapes for any non-ASCII).

--- a/examples/chipotle-primitives/lit-action-core.js
+++ b/examples/chipotle-primitives/lit-action-core.js
@@ -69,7 +69,7 @@ function coerceAbiValue(type, v) {
  * `defaultAbiCoder.encode(types, values)`. Implemented by building a synthetic
  * function fragment, encoding through micro-eth-signer's audited ABI coder, and
  * stripping the 4-byte selector -- so the bytes are the bare head/tail tuple
- * encoding a Solidity contract re-derives with `abi.decode`.
+ * encoding a Solidity contract re-derives with `abi.encode`.
  *
  * @param {string[]} types e.g. ["address","uint256","bytes32"]
  * @param {any[]} values   integers as number|bigint|string, address/bytes as 0x-hex

--- a/examples/chipotle-primitives/lit-action-core.js
+++ b/examples/chipotle-primitives/lit-action-core.js
@@ -1,0 +1,104 @@
+// lit-action-core.js
+//
+// Shared low-level helpers used across the other lit-action-* modules: keccak,
+// ABI tuple coding, hex<->bytes, and the GateError / deny() denial convention.
+//
+// We deliberately do not hand-roll crypto or ABI encoding. Everything here is
+// glue around audited libraries from Paul Miller (paulmillr): micro-eth-signer
+// (ABI coder, wei math, hex coder) and @noble/hashes (keccak-256, byte utils).
+//
+// See README.md for the trust-boundary rule and for how the bare, version-pinned
+// jsDelivr import specifiers below are resolved by the Lit Action runtime.
+
+import { ethHex } from "micro-eth-signer@0.19.0";
+import { createContract } from "micro-eth-signer@0.19.0/advanced/abi.js";
+import { keccak_256 } from "@noble/hashes@1.4.0/sha3/+esm";
+import {
+  bytesToHex,
+  hexToBytes,
+  utf8ToBytes,
+} from "@noble/hashes@1.4.0/utils/+esm";
+
+// Re-export the audited byte utils so sibling modules import them from one place.
+export { bytesToHex, hexToBytes, utf8ToBytes };
+
+// Denials are thrown, never returned. Gates fail closed: the first thrown
+// GateError aborts the action, and the caller's `main` is expected to catch and
+// translate it into `{ authorized: false, reason }`.
+export class GateError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "GateError";
+  }
+}
+
+export const deny = (reason) => {
+  throw new GateError(reason);
+};
+
+/** keccak-256 of raw bytes, returned as a 0x-prefixed hex string. */
+export function keccak256(bytes) {
+  return "0x" + bytesToHex(keccak_256(bytes));
+}
+
+/** keccak-256 of a UTF-8 string (e.g. an event signature or question text). */
+export function keccak256Utf8(text) {
+  return keccak256(utf8ToBytes(text));
+}
+
+/** 0x-hex string -> Uint8Array (ethers `arrayify` equivalent). */
+export function arrayify(hex) {
+  return ethHex.decode(hex);
+}
+
+// Coerce a single JS value to what micro-eth-signer's ABI coder (micro-packed)
+// expects for `type`: bigint for integers, 0x-hex string for address, raw bytes
+// for bytesN/bytes, boolean for bool, string otherwise.
+function coerceAbiValue(type, v) {
+  if (/^u?int\d*$/.test(type)) return BigInt(v);
+  if (type === "address") return typeof v === "string" ? v : ethHex.encode(v);
+  if (/^bytes\d*$/.test(type)) {
+    return typeof v === "string" ? hexToBytes(v.replace(/^0x/, "")) : v;
+  }
+  if (type === "bool") return Boolean(v);
+  return v;
+}
+
+/**
+ * ABI-encode an arbitrary tuple of solidity types + values, matching ethers'
+ * `defaultAbiCoder.encode(types, values)`. Implemented by building a synthetic
+ * function fragment, encoding through micro-eth-signer's audited ABI coder, and
+ * stripping the 4-byte selector -- so the bytes are the bare head/tail tuple
+ * encoding a Solidity contract re-derives with `abi.decode`.
+ *
+ * @param {string[]} types e.g. ["address","uint256","bytes32"]
+ * @param {any[]} values   integers as number|bigint|string, address/bytes as 0x-hex
+ * @returns {Uint8Array}
+ */
+export function abiEncode(types, values) {
+  if (types.length !== values.length) {
+    throw new Error("abiEncode: types/values length mismatch");
+  }
+  const inputs = types.map((type, i) => ({ name: `a${i}`, type }));
+  const c = createContract([
+    { type: "function", name: "f", inputs, outputs: [] },
+  ]);
+  const arg = {};
+  inputs.forEach((inp, i) => {
+    arg[inp.name] = coerceAbiValue(inp.type, values[i]);
+  });
+  // encodeInput returns selector(4) || abi.encode(tuple); drop the selector.
+  return c.f.encodeInput(arg).slice(4);
+}
+
+/**
+ * First value out of a decodeOutput result (single-return coders give the bare
+ * value; multi-return give a named object).
+ */
+export function firstValue(decoded) {
+  if (decoded && typeof decoded === "object" && !Array.isArray(decoded)) {
+    const vals = Object.values(decoded);
+    return vals.length === 1 ? vals[0] : decoded;
+  }
+  return decoded;
+}

--- a/examples/chipotle-primitives/lit-action-gating.js
+++ b/examples/chipotle-primitives/lit-action-gating.js
@@ -1,0 +1,127 @@
+// lit-action-gating.js
+//
+// Gating / access control. Every gate FAILS CLOSED by throwing GateError; the
+// importing action catches and translates into { authorized: false, reason }.
+// Thresholds are arguments the action HARDCODES (trust-boundary rule in README).
+
+import { addr, eip191Signer } from "micro-eth-signer@0.19.0";
+import { deny } from "./lit-action-core.js";
+import { rpc } from "./lit-action-rpc.js";
+import { ethCallContract, ERC20, ERC1155, SANCTIONS } from "./lit-action-onchain.js";
+
+// Chainalysis on-chain sanctions oracle (Ethereum mainnet). Hardcoded here so
+// the screened set is fixed by the action's CID, not by the caller.
+export const CHAINALYSIS_SANCTIONS_ORACLE =
+  "0x40C57923924B5c5c5455c48D93317139ADDaC8fb";
+
+/** Deny unless native balance >= minWei. */
+export async function gateEthBalance({ address, minWei, rpcUrl }) {
+  const bal = BigInt(await rpc(rpcUrl, "eth_getBalance", [address, "latest"]));
+  if (bal < BigInt(minWei)) deny(`balance ${bal} < required ${minWei}`);
+  return bal;
+}
+
+/** Deny unless ERC-20 balanceOf(holder) >= minAmount. */
+export async function gateErc20Balance({ holder, token, minAmount, rpcUrl }) {
+  const bal = BigInt(await ethCallContract(rpcUrl, token, ERC20, "balanceOf", { o: holder }));
+  if (bal < BigInt(minAmount)) deny(`token balance ${bal} < required ${minAmount}`);
+  return bal;
+}
+
+/**
+ * Deny unless the holder owns the NFT. ERC-721: balanceOf(holder) > 0. ERC-1155:
+ * pass `tokenId` and we check balanceOf(holder, tokenId) > 0.
+ */
+export async function gateNftOwnership({ holder, nftContract, rpcUrl, tokenId }) {
+  const bal =
+    tokenId === undefined
+      ? BigInt(await ethCallContract(rpcUrl, nftContract, ERC20, "balanceOf", { o: holder }))
+      : BigInt(await ethCallContract(rpcUrl, nftContract, ERC1155, "balanceOf", { o: holder, id: BigInt(tokenId) }));
+  if (bal <= 0n) deny(`holder ${holder} owns none of ${nftContract}`);
+  return bal;
+}
+
+/** Reject outside the inclusive [startUnix, endUnix] window. */
+export function gateTimeWindow({ startUnix, endUnix }) {
+  const now = Math.floor(Date.now() / 1000);
+  if (now < startUnix) deny(`window not open yet (${startUnix - now}s to go)`);
+  if (now > endUnix) deny(`window closed (${now - endUnix}s ago)`);
+  return now;
+}
+
+/**
+ * Staticcall the Chainalysis sanctions oracle on a hostname-pinned mainnet RPC
+ * and deny if the address is sanctioned. `screeningRpcUrl` must already be
+ * pinned by the caller (see assertAllowedRpc).
+ */
+export async function gateSanctions({ address, screeningRpcUrl }) {
+  const sanctioned = await ethCallContract(
+    screeningRpcUrl,
+    CHAINALYSIS_SANCTIONS_ORACLE,
+    SANCTIONS,
+    "isSanctioned",
+    { a: address },
+  );
+  if (sanctioned) deny(`address ${address} is on the sanctions list`);
+  return false;
+}
+
+/** POST to an auth service and require { valid: true }. */
+export async function gateAuthToken({ token, verifyUrl }) {
+  const res = await fetch(verifyUrl, {
+    method: "POST",
+    redirect: "error",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+  if (!res.ok) deny(`auth service -> HTTP ${res.status}`);
+  const body = await res.json();
+  if (body.valid !== true) deny("auth token rejected");
+  return true;
+}
+
+/**
+ * Recover the signer of an EIP-191 message and require it to equal
+ * `allowedAddress`. The message MUST carry a nonce/deadline for replay
+ * protection (the caller builds that into the message text). Returns the
+ * recovered address.
+ */
+export function requireCallerSignature({ message, signature, allowedAddress }) {
+  let recovered;
+  try {
+    recovered = eip191Signer.recoverPublicKey(signature, message);
+  } catch (e) {
+    deny(`signature did not recover: ${e.message}`);
+  }
+  if (recovered.toLowerCase() !== allowedAddress.toLowerCase()) {
+    deny(`unauthorized: signer ${recovered} != allowed ${allowedAddress}`);
+  }
+  return recovered;
+}
+
+/**
+ * Case-insensitive allowlist check for a PKP address. Relies on the gateway
+ * having already proven PKP ownership. `allowedPkp` may be a string or array.
+ */
+export function requirePkpAllowed({ pkpAddress, allowedPkp }) {
+  const allow = (Array.isArray(allowedPkp) ? allowedPkp : [allowedPkp]).map((a) =>
+    a.toLowerCase(),
+  );
+  if (!allow.includes(pkpAddress.toLowerCase())) {
+    deny(`pkp ${pkpAddress} not in allowlist`);
+  }
+  return true;
+}
+
+/**
+ * Run several gate thunks in order and fail closed on the first denial. Since
+ * gating is just code, AND/OR composition is free -- compose your own OR by
+ * try/catching individual gates. Returns the array of gate results.
+ */
+export async function combineGates(gateFns) {
+  const results = [];
+  for (const fn of gateFns) {
+    results.push(await fn());
+  }
+  return results;
+}

--- a/examples/chipotle-primitives/lit-action-gating.js
+++ b/examples/chipotle-primitives/lit-action-gating.js
@@ -11,7 +11,7 @@ import { ethCallContract, ERC20, ERC1155, SANCTIONS } from "./lit-action-onchain
 
 // Chainalysis on-chain sanctions oracle (Ethereum mainnet). Hardcoded here so
 // the screened set is fixed by the action's CID, not by the caller.
-export const CHAINALYSIS_SANCTIONS_ORACLE =
+const CHAINALYSIS_SANCTIONS_ORACLE =
   "0x40C57923924B5c5c5455c48D93317139ADDaC8fb";
 
 /** Deny unless native balance >= minWei. */

--- a/examples/chipotle-primitives/lit-action-onchain.js
+++ b/examples/chipotle-primitives/lit-action-onchain.js
@@ -1,0 +1,179 @@
+// lit-action-onchain.js
+//
+// On-chain read / write. View calls, receipt/log validation, native transfers
+// from a PKP wallet, and the solver-vault recipient-binding pattern. Built on
+// micro-eth-signer's ABI coder + Transaction and the hardened `rpc` helper.
+
+import { addr, ethHex, weieth, Transaction } from "micro-eth-signer@0.19.0";
+import { createContract } from "micro-eth-signer@0.19.0/advanced/abi.js";
+import { deny, firstValue } from "./lit-action-core.js";
+import { rpc } from "./lit-action-rpc.js";
+
+// Minimal contracts reused by the gating module.
+export const ERC20 = createContract([
+  { type: "function", name: "balanceOf", inputs: [{ name: "o", type: "address" }], outputs: [{ type: "uint256" }] },
+]);
+export const ERC1155 = createContract([
+  { type: "function", name: "balanceOf", inputs: [{ name: "o", type: "address" }, { name: "id", type: "uint256" }], outputs: [{ type: "uint256" }] },
+]);
+export const SANCTIONS = createContract([
+  { type: "function", name: "isSanctioned", inputs: [{ name: "a", type: "address" }], outputs: [{ type: "bool" }] },
+]);
+
+function normalizeContractArgs(arg, inputs) {
+  if (arg === undefined) return arg;
+  if (!inputs) {
+    if (Array.isArray(arg) && arg.length === 1) return arg[0];
+    if (arg && typeof arg === "object" && !(arg instanceof Uint8Array)) {
+      const keys = Object.keys(arg);
+      if (keys.length === 1) return arg[keys[0]];
+    }
+    return arg;
+  }
+  const ins = inputs;
+  if (ins.length === 0) return arg;
+  if (ins.length === 1) {
+    if (Array.isArray(arg)) return arg[0];
+    if (arg && typeof arg === "object" && !(arg instanceof Uint8Array)) {
+      const keys = Object.keys(arg);
+      if (keys.length === 1) return arg[keys[0]];
+    }
+    return arg;
+  }
+  if (Array.isArray(arg) && ins.every((inp) => inp.name)) {
+    return Object.fromEntries(ins.map((inp, i) => [inp.name, arg[i]]));
+  }
+  return arg;
+}
+
+/** eth_call a single method on a pre-built `createContract` instance. */
+export async function ethCallContract(rpcUrl, address, contract, method, arg, inputs) {
+  const data = ethHex.encode(contract[method].encodeInput(normalizeContractArgs(arg, inputs)));
+  const result = await rpc(rpcUrl, "eth_call", [{ to: address, data }, "latest"]);
+  if (!result || result === "0x") {
+    throw new Error(`${method} -> empty result (wrong address or chain?)`);
+  }
+  return firstValue(contract[method].decodeOutput(ethHex.decode(result)));
+}
+
+/**
+ * eth_call view helper. `abi` is JSON ABI fragments; `args` is either a named
+ * object or a positional array matching `method`'s inputs.
+ * @returns the decoded output (bare value for single-return functions).
+ */
+export async function readContract({ rpcUrl, address, abi, method, args }) {
+  const fragment = abi.find((f) => f.type === "function" && f.name === method);
+  if (!fragment) throw new Error(`readContract: method not in ABI: ${method}`);
+  return ethCallContract(
+    rpcUrl,
+    address,
+    createContract(abi),
+    method,
+    args,
+    fragment.inputs || [],
+  );
+}
+
+/**
+ * Fetch a receipt, confirm it succeeded, and confirm the log at `logIndex` came
+ * from `expectedContract` and carries `expectedTopic` as topics[0]. Returns the
+ * matched log so the caller can decode topics/data.
+ */
+export async function readAndValidateLog({
+  rpcUrl,
+  txHash,
+  logIndex,
+  expectedContract,
+  expectedTopic,
+}) {
+  const receipt = await rpc(rpcUrl, "eth_getTransactionReceipt", [txHash]);
+  if (!receipt) deny(`no receipt for ${txHash} (unmined or unknown)`);
+  if (receipt.status !== "0x1") deny(`tx ${txHash} did not succeed`);
+  const log = (receipt.logs || []).find(
+    (l) => Number(l.logIndex) === Number(logIndex),
+  );
+  if (!log) deny(`no log at index ${logIndex}`);
+  if (addr.addChecksum(log.address) !== addr.addChecksum(expectedContract)) {
+    deny(`log emitted by ${log.address}, expected ${expectedContract}`);
+  }
+  if ((log.topics[0] || "").toLowerCase() !== expectedTopic.toLowerCase()) {
+    deny(`log topic ${log.topics[0]} != expected ${expectedTopic}`);
+  }
+  return log;
+}
+
+/**
+ * Build/sign/broadcast a native ETH transfer from a PKP wallet (PKP must be
+ * funded). Fees are derived from eth_gasPrice (maxFee = 2x gasPrice). Returns
+ * the broadcast tx hash. EIP-1559 typed transaction via micro-eth-signer.
+ */
+export async function sendEth({ pkpId, to, amountEth, chainId, rpcUrl }) {
+  const key = await Lit.Actions.getPrivateKey({ pkpId });
+  const from = addr.fromPrivateKey(key);
+  const [nonceHex, gasPriceHex] = await Promise.all([
+    rpc(rpcUrl, "eth_getTransactionCount", [from, "pending"]),
+    rpc(rpcUrl, "eth_gasPrice", []),
+  ]);
+  const gasPrice = BigInt(gasPriceHex);
+  const tx = Transaction.prepare({
+    to,
+    value: weieth.decode(String(amountEth)),
+    nonce: BigInt(nonceHex),
+    maxPriorityFeePerGas: gasPrice,
+    maxFeePerGas: gasPrice * 2n,
+    gasLimit: 21000n,
+    chainId: BigInt(chainId),
+  });
+  const signed = tx.signBy(key);
+  const raw = signed.toHex();
+  const txHash = await rpc(rpcUrl, "eth_sendRawTransaction", [raw]);
+  return { txHash, from, to, amountEth };
+}
+
+/**
+ * The solver-vault pattern. Reconstruct a fill from a PINNED settlement source
+ * and require the caller-supplied recipient/token/amount to match what the
+ * order actually says. Never trust the caller's claimed amounts.
+ *
+ * `orderAbi` defaults to a common `getOrder(bytes32) -> (recipient, token,
+ * amount, exists)` shape; override for your settlement contract.
+ */
+export async function bindToOnchainOrder({
+  rpcUrl,
+  settlementContract,
+  depositId,
+  requested,
+  orderAbi,
+}) {
+  const abi = orderAbi || [
+    {
+      type: "function",
+      name: "getOrder",
+      inputs: [{ name: "id", type: "bytes32" }],
+      outputs: [
+        { name: "recipient", type: "address" },
+        { name: "token", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "exists", type: "bool" },
+      ],
+    },
+  ];
+  const order = await readContract({
+    rpcUrl,
+    address: settlementContract,
+    abi,
+    method: "getOrder",
+    args: { id: depositId },
+  });
+  if (!order.exists) deny(`no order for depositId ${depositId}`);
+  if (addr.addChecksum(requested.recipient) !== addr.addChecksum(order.recipient)) {
+    deny(`recipient ${requested.recipient} != order recipient ${order.recipient}`);
+  }
+  if (addr.addChecksum(requested.token) !== addr.addChecksum(order.token)) {
+    deny(`token ${requested.token} != order token ${order.token}`);
+  }
+  if (BigInt(requested.amount) > BigInt(order.amount)) {
+    deny(`amount ${requested.amount} exceeds order amount ${order.amount}`);
+  }
+  return order;
+}

--- a/examples/chipotle-primitives/lit-action-oracles.js
+++ b/examples/chipotle-primitives/lit-action-oracles.js
@@ -1,0 +1,101 @@
+// lit-action-oracles.js
+//
+// Consensus & oracles. Strict byte-for-byte agreement for discrete facts, median
+// + spread check for continuous values, a signed price feed, and categorical
+// LLM consensus. All deny (fail closed) when agreement is not reached.
+
+import { deny, keccak256Utf8 } from "./lit-action-core.js";
+import { signDigest } from "./lit-action-signing.js";
+
+/**
+ * For discrete facts (sanctioned y/n, event presence). Fetch each source via
+ * `fetchSource(source)`, require at least `minSources` successes, and deny
+ * unless they all agree byte-for-byte (deep-equal via JSON). Returns the agreed
+ * value.
+ */
+export async function requireStrictAgreement({ sources, fetchSource, minSources }) {
+  const settled = await Promise.allSettled(sources.map((s) => fetchSource(s)));
+  const ok = settled.filter((r) => r.status === "fulfilled").map((r) => r.value);
+  if (ok.length < minSources) {
+    deny(`only ${ok.length} sources responded, need ${minSources}`);
+  }
+  const canonical = JSON.stringify(ok[0]);
+  if (!ok.every((v) => JSON.stringify(v) === canonical)) {
+    deny("sources disagree");
+  }
+  return ok[0];
+}
+
+/**
+ * For continuous values. Take the median of `observations` (bigint fixed-point
+ * recommended) and reject if (max-min)/median exceeds `maxSpreadBps`. Requires
+ * at least `minSources` observations. Returns the median.
+ */
+export function medianWithSpreadCheck({ observations, minSources, maxSpreadBps }) {
+  const obs = observations.map((o) => BigInt(o)).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  if (obs.length < minSources) {
+    deny(`only ${obs.length} observations, need ${minSources}`);
+  }
+  const mid = obs.length >> 1;
+  const median = obs.length % 2 ? obs[mid] : (obs[mid - 1] + obs[mid]) / 2n;
+  if (median === 0n) deny("median is zero");
+  const spreadBps = ((obs[obs.length - 1] - obs[0]) * 10000n) / median;
+  if (spreadBps > BigInt(maxSpreadBps)) {
+    deny(`spread ${spreadBps}bps exceeds cap ${maxSpreadBps}bps`);
+  }
+  return median;
+}
+
+// Decimal string -> integer fixed-point with `decimals` places, using BigInt
+// throughout. "65000.12", 18 -> 65000120000000000000000n
+function toFixedPoint(decimalStr, decimals) {
+  const [whole, frac = ""] = String(decimalStr).split(".");
+  const fracPadded = (frac + "0".repeat(decimals)).slice(0, decimals);
+  return BigInt(whole + fracPadded);
+}
+
+/**
+ * Fetch N exchange prices, median-with-spread-check them, scale to fixed-point
+ * via BigInt (NOT Math.round -- avoids float overflow at 18 decimals), and sign
+ * the result with the action key. `sources` is an array of async fns returning
+ * a decimal price string (e.g. "65000.12"). Returns { price, median, signature,
+ * signer, digest, assetId }.
+ */
+export async function signedPriceFeed({ asset, sources, decimals, registry, deadline }) {
+  const prices = await Promise.all(sources.map((fetchPrice) => fetchPrice()));
+  const scaled = prices.map((p) => toFixedPoint(p, decimals));
+  const median = medianWithSpreadCheck({
+    observations: scaled,
+    minSources: sources.length,
+    maxSpreadBps: 100n,
+  });
+  const assetId = keccak256Utf8(asset);
+  const { signature, signer, digest } = await signDigest({
+    types: ["address", "bytes32", "uint256", "uint8", "uint256"],
+    values: [registry, assetId, median, decimals, deadline],
+    useAction: true,
+  });
+  return { price: median.toString(), median, signature, signer, digest, assetId };
+}
+
+/**
+ * Strict agreement across LLM providers for a categorical YES/NO/UNCLEAR answer.
+ * `providers` is an array of async fns returning one of those strings. Binds
+ * questionId = keccak256(questionText) so the prompt can't be swapped under the
+ * answer. Returns { questionId, answer, agreed } when >= minAgreement providers
+ * give the same answer; otherwise denies.
+ */
+export async function aiConsensus({ question, providers, minAgreement }) {
+  const questionId = keccak256Utf8(question);
+  const settled = await Promise.allSettled(providers.map((p) => p()));
+  const votes = settled
+    .filter((r) => r.status === "fulfilled")
+    .map((r) => String(r.value).toUpperCase())
+    .filter((v) => v === "YES" || v === "NO" || v === "UNCLEAR");
+  const tally = votes.reduce((m, v) => ((m[v] = (m[v] || 0) + 1), m), {});
+  const [answer, count] = Object.entries(tally).sort((a, b) => b[1] - a[1])[0] || [];
+  if (!answer || count < minAgreement) {
+    deny(`no ${minAgreement}-way agreement (tally ${JSON.stringify(tally)})`);
+  }
+  return { questionId, answer, agreed: count };
+}

--- a/examples/chipotle-primitives/lit-action-oracles.js
+++ b/examples/chipotle-primitives/lit-action-oracles.js
@@ -7,6 +7,32 @@
 import { deny, keccak256Utf8 } from "./lit-action-core.js";
 import { signDigest } from "./lit-action-signing.js";
 
+function requireNonEmptyArray(name, value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    deny(`${name} must be a non-empty array`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(name, value, max) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    deny(`${name} must be an integer >= 1`);
+  }
+  if (max !== undefined && n > max) {
+    deny(`${name} ${n} exceeds available count ${max}`);
+  }
+  return n;
+}
+
+function requireUint8(name, value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0 || n > 255) {
+    deny(`${name} must be an integer between 0 and 255`);
+  }
+  return n;
+}
+
 /**
  * For discrete facts (sanctioned y/n, event presence). Fetch each source via
  * `fetchSource(source)`, require at least `minSources` successes, and deny
@@ -14,10 +40,13 @@ import { signDigest } from "./lit-action-signing.js";
  * value.
  */
 export async function requireStrictAgreement({ sources, fetchSource, minSources }) {
-  const settled = await Promise.allSettled(sources.map((s) => fetchSource(s)));
+  const src = requireNonEmptyArray("sources", sources);
+  if (typeof fetchSource !== "function") deny("fetchSource must be a function");
+  const min = requirePositiveInteger("minSources", minSources, src.length);
+  const settled = await Promise.allSettled(src.map((s) => fetchSource(s)));
   const ok = settled.filter((r) => r.status === "fulfilled").map((r) => r.value);
-  if (ok.length < minSources) {
-    deny(`only ${ok.length} sources responded, need ${minSources}`);
+  if (ok.length < min) {
+    deny(`only ${ok.length} sources responded, need ${min}`);
   }
   const canonical = JSON.stringify(ok[0]);
   if (!ok.every((v) => JSON.stringify(v) === canonical)) {
@@ -32,15 +61,24 @@ export async function requireStrictAgreement({ sources, fetchSource, minSources 
  * at least `minSources` observations. Returns the median.
  */
 export function medianWithSpreadCheck({ observations, minSources, maxSpreadBps }) {
-  const obs = observations.map((o) => BigInt(o)).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-  if (obs.length < minSources) {
-    deny(`only ${obs.length} observations, need ${minSources}`);
+  const raw = requireNonEmptyArray("observations", observations);
+  const min = requirePositiveInteger("minSources", minSources, raw.length);
+  let maxSpread;
+  try {
+    maxSpread = BigInt(maxSpreadBps);
+  } catch {
+    deny("maxSpreadBps must be an integer");
+  }
+  if (maxSpread < 0n) deny("maxSpreadBps must be non-negative");
+  const obs = raw.map((o) => BigInt(o)).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  if (obs.length < min) {
+    deny(`only ${obs.length} observations, need ${min}`);
   }
   const mid = obs.length >> 1;
   const median = obs.length % 2 ? obs[mid] : (obs[mid - 1] + obs[mid]) / 2n;
   if (median === 0n) deny("median is zero");
   const spreadBps = ((obs[obs.length - 1] - obs[0]) * 10000n) / median;
-  if (spreadBps > BigInt(maxSpreadBps)) {
+  if (spreadBps > maxSpread) {
     deny(`spread ${spreadBps}bps exceeds cap ${maxSpreadBps}bps`);
   }
   return median;
@@ -58,24 +96,29 @@ function toFixedPoint(decimalStr, decimals) {
  * Fetch N exchange prices, median-with-spread-check them, scale to fixed-point
  * via BigInt (NOT Math.round -- avoids float overflow at 18 decimals), and sign
  * the result with the action key. `sources` is an array of async fns returning
- * a decimal price string (e.g. "65000.12"). Returns { price, median, signature,
- * signer, digest, assetId }.
+ * a decimal price string (e.g. "65000.12"). Returns JSON-safe price/median
+ * strings plus { signature, signer, digest, assetId }.
  */
 export async function signedPriceFeed({ asset, sources, decimals, registry, deadline }) {
-  const prices = await Promise.all(sources.map((fetchPrice) => fetchPrice()));
-  const scaled = prices.map((p) => toFixedPoint(p, decimals));
+  const src = requireNonEmptyArray("sources", sources);
+  if (!src.every((fetchPrice) => typeof fetchPrice === "function")) {
+    deny("sources must be functions");
+  }
+  const dec = requireUint8("decimals", decimals);
+  const prices = await Promise.all(src.map((fetchPrice) => fetchPrice()));
+  const scaled = prices.map((p) => toFixedPoint(p, dec));
   const median = medianWithSpreadCheck({
     observations: scaled,
-    minSources: sources.length,
+    minSources: src.length,
     maxSpreadBps: 100n,
   });
   const assetId = keccak256Utf8(asset);
   const { signature, signer, digest } = await signDigest({
     types: ["address", "bytes32", "uint256", "uint8", "uint256"],
-    values: [registry, assetId, median, decimals, deadline],
+    values: [registry, assetId, median, dec, deadline],
     useAction: true,
   });
-  return { price: median.toString(), median, signature, signer, digest, assetId };
+  return { price: median.toString(), median: median.toString(), signature, signer, digest, assetId };
 }
 
 /**
@@ -86,16 +129,19 @@ export async function signedPriceFeed({ asset, sources, decimals, registry, dead
  * give the same answer; otherwise denies.
  */
 export async function aiConsensus({ question, providers, minAgreement }) {
+  const prov = requireNonEmptyArray("providers", providers);
+  if (!prov.every((p) => typeof p === "function")) deny("providers must be functions");
+  const min = requirePositiveInteger("minAgreement", minAgreement, prov.length);
   const questionId = keccak256Utf8(question);
-  const settled = await Promise.allSettled(providers.map((p) => p()));
+  const settled = await Promise.allSettled(prov.map((p) => p()));
   const votes = settled
     .filter((r) => r.status === "fulfilled")
     .map((r) => String(r.value).toUpperCase())
     .filter((v) => v === "YES" || v === "NO" || v === "UNCLEAR");
   const tally = votes.reduce((m, v) => ((m[v] = (m[v] || 0) + 1), m), {});
   const [answer, count] = Object.entries(tally).sort((a, b) => b[1] - a[1])[0] || [];
-  if (!answer || count < minAgreement) {
-    deny(`no ${minAgreement}-way agreement (tally ${JSON.stringify(tally)})`);
+  if (!answer || count < min) {
+    deny(`no ${min}-way agreement (tally ${JSON.stringify(tally)})`);
   }
   return { questionId, answer, agreed: count };
 }

--- a/examples/chipotle-primitives/lit-action-primitives.js
+++ b/examples/chipotle-primitives/lit-action-primitives.js
@@ -1,0 +1,23 @@
+// lit-action-primitives.js
+//
+// Barrel module: re-exports every lit-action-* primitive so an action can pull
+// the whole catalog with one import.
+//
+//   import * as P from "./lit-action-primitives.js";
+//   P.assertAllowedRpc(...); P.signDigest(...);
+//
+// Or import a single concern directly, e.g.
+//   import { gateEthBalance, combineGates } from "./lit-action-gating.js";
+//
+// NOTE: these modules use relative imports between each other, which the Lit
+// Action runtime does not resolve on its own -- bundle them (or vendor the set)
+// before deploy. See README.md > "Consuming this module from an action".
+
+export * from "./lit-action-core.js";     // keccak256, abiEncode, arrayify, GateError, deny
+export * from "./lit-action-rpc.js";      // rpc, assertAllowedRpc, assertChainId, requireConfirmations
+export * from "./lit-action-onchain.js";  // readContract, readAndValidateLog, sendEth, bindToOnchainOrder
+export * from "./lit-action-gating.js";   // gate*, requireCallerSignature, requirePkpAllowed, combineGates
+export * from "./lit-action-signing.js";  // signWithPkp, signWithAction, buildAuthDigest, signDigest, recoverSigner, getActionAddress
+export * from "./lit-action-secrets.js";  // sealToVault, openFromVault, withSecret, assembleSecretRpcUrl
+export * from "./lit-action-oracles.js";  // requireStrictAgreement, medianWithSpreadCheck, signedPriceFeed, aiConsensus
+export * from "./lit-action-replay.js";   // newNonce, withDeadline, assertNotExpired

--- a/examples/chipotle-primitives/lit-action-primitives.js
+++ b/examples/chipotle-primitives/lit-action-primitives.js
@@ -13,11 +13,59 @@
 // Action runtime does not resolve on its own -- bundle them (or vendor the set)
 // before deploy. See README.md > "Consuming this module from an action".
 
-export * from "./lit-action-core.js";     // keccak256, abiEncode, arrayify, GateError, deny
-export * from "./lit-action-rpc.js";      // rpc, assertAllowedRpc, assertChainId, requireConfirmations
-export * from "./lit-action-onchain.js";  // readContract, readAndValidateLog, sendEth, bindToOnchainOrder
-export * from "./lit-action-gating.js";   // gate*, requireCallerSignature, requirePkpAllowed, combineGates
-export * from "./lit-action-signing.js";  // signWithPkp, signWithAction, buildAuthDigest, signDigest, recoverSigner, getActionAddress
-export * from "./lit-action-secrets.js";  // sealToVault, openFromVault, withSecret, assembleSecretRpcUrl
-export * from "./lit-action-oracles.js";  // requireStrictAgreement, medianWithSpreadCheck, signedPriceFeed, aiConsensus
-export * from "./lit-action-replay.js";   // newNonce, withDeadline, assertNotExpired
+export {
+  keccak256,
+  keccak256Utf8,
+  arrayify,
+  abiEncode,
+  GateError,
+  deny,
+} from "./lit-action-core.js";
+export {
+  rpc,
+  assertAllowedRpc,
+  assertChainId,
+  requireConfirmations,
+} from "./lit-action-rpc.js";
+export {
+  readContract,
+  readAndValidateLog,
+  sendEth,
+  bindToOnchainOrder,
+} from "./lit-action-onchain.js";
+export {
+  gateEthBalance,
+  gateErc20Balance,
+  gateNftOwnership,
+  gateTimeWindow,
+  gateSanctions,
+  gateAuthToken,
+  requireCallerSignature,
+  requirePkpAllowed,
+  combineGates,
+} from "./lit-action-gating.js";
+export {
+  signWithPkp,
+  signWithAction,
+  buildAuthDigest,
+  signDigest,
+  recoverSigner,
+  getActionAddress,
+} from "./lit-action-signing.js";
+export {
+  sealToVault,
+  openFromVault,
+  withSecret,
+  assembleSecretRpcUrl,
+} from "./lit-action-secrets.js";
+export {
+  requireStrictAgreement,
+  medianWithSpreadCheck,
+  signedPriceFeed,
+  aiConsensus,
+} from "./lit-action-oracles.js";
+export {
+  newNonce,
+  withDeadline,
+  assertNotExpired,
+} from "./lit-action-replay.js";

--- a/examples/chipotle-primitives/lit-action-replay.js
+++ b/examples/chipotle-primitives/lit-action-replay.js
@@ -1,0 +1,25 @@
+// lit-action-replay.js
+//
+// Authorization-tuple helpers (replay safety). Generate the nonce + deadline you
+// fold into every signed digest, and reject stale authorizations before signing.
+
+import { deny, bytesToHex } from "./lit-action-core.js";
+
+/** Cryptographically random 32-byte nonce as a 0x-hex string (Web Crypto). */
+export function newNonce() {
+  const b = new Uint8Array(32);
+  crypto.getRandomValues(b);
+  return "0x" + bytesToHex(b);
+}
+
+/** Unix-seconds deadline `seconds` into the future. Fold into every digest. */
+export function withDeadline(seconds) {
+  return Math.floor(Date.now() / 1000) + seconds;
+}
+
+/** Reject a stale authorization before signing. Returns the seconds remaining. */
+export function assertNotExpired({ deadline }) {
+  const now = Math.floor(Date.now() / 1000);
+  if (now > Number(deadline)) deny(`authorization expired ${now - deadline}s ago`);
+  return Number(deadline) - now;
+}

--- a/examples/chipotle-primitives/lit-action-replay.js
+++ b/examples/chipotle-primitives/lit-action-replay.js
@@ -14,12 +14,18 @@ export function newNonce() {
 
 /** Unix-seconds deadline `seconds` into the future. Fold into every digest. */
 export function withDeadline(seconds) {
-  return Math.floor(Date.now() / 1000) + seconds;
+  const n = Number(seconds);
+  if (!Number.isInteger(n) || n < 0) {
+    deny("deadline offset must be a non-negative integer");
+  }
+  return Math.floor(Date.now() / 1000) + n;
 }
 
 /** Reject a stale authorization before signing. Returns the seconds remaining. */
 export function assertNotExpired({ deadline }) {
+  const d = Number(deadline);
+  if (!Number.isInteger(d)) deny("deadline must be a unix-seconds integer");
   const now = Math.floor(Date.now() / 1000);
-  if (now > Number(deadline)) deny(`authorization expired ${now - deadline}s ago`);
-  return Number(deadline) - now;
+  if (now > d) deny(`authorization expired ${now - d}s ago`);
+  return d - now;
 }

--- a/examples/chipotle-primitives/lit-action-rpc.js
+++ b/examples/chipotle-primitives/lit-action-rpc.js
@@ -1,0 +1,66 @@
+// lit-action-rpc.js
+//
+// RPC trust anchors & chain safety. A caller can pass any rpcUrl in js_params,
+// so the host must be pinned against the action's HARDCODED policy (see the
+// trust-boundary rule in README.md). `policy` is the action's constant map,
+// never js_params.
+
+import { deny } from "./lit-action-core.js";
+
+/**
+ * Hardened JSON-RPC POST. `redirect: "error"` closes the open-redirect-after-pin
+ * hole (a pinned host that 30x-redirects to an attacker). Throws on HTTP error
+ * and on JSON-RPC error.
+ */
+export async function rpc(url, method, params = []) {
+  const res = await fetch(url, {
+    method: "POST",
+    redirect: "error",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!res.ok) throw new Error(`rpc ${method} -> HTTP ${res.status}`);
+  const body = await res.json();
+  if (body.error) throw new Error(`rpc ${method} -> ${body.error.message}`);
+  return body.result;
+}
+
+/**
+ * Require https + a hostname that matches the per-chain policy, and return that
+ * per-chain policy (e.g. { hostRegex, minConfirmations }). `policy` must be the
+ * action's HARDCODED map, never js_params.
+ */
+export function assertAllowedRpc({ chainId, rpcUrl, policy }) {
+  const chainPolicy = policy && policy[chainId];
+  if (!chainPolicy) deny(`no RPC policy for chainId ${chainId}`);
+  let u;
+  try {
+    u = new URL(rpcUrl);
+  } catch {
+    deny("rpcUrl is not a valid URL");
+  }
+  if (u.protocol !== "https:") deny(`rpcUrl must be https, got ${u.protocol}`);
+  if (!chainPolicy.hostRegex.test(u.hostname)) {
+    deny(`rpc host not whitelisted: ${u.hostname}`);
+  }
+  return chainPolicy;
+}
+
+/** Cross-check eth_chainId. Only meaningful AFTER the hostname pin. */
+export async function assertChainId({ rpcUrl, expectedChainId }) {
+  const got = Number(await rpc(rpcUrl, "eth_chainId", []));
+  if (got !== Number(expectedChainId)) {
+    deny(`rpc chainId ${got} != expected ${expectedChainId}`);
+  }
+  return got;
+}
+
+/** Reorg defense: don't sign until the source block is buried `minConf` deep. */
+export async function requireConfirmations({ rpcUrl, blockNumber, minConf }) {
+  const head = Number(await rpc(rpcUrl, "eth_blockNumber", []));
+  const confirmations = head - Number(blockNumber) + 1;
+  if (confirmations < minConf) {
+    deny(`only ${confirmations} confirmations, need ${minConf}`);
+  }
+  return confirmations;
+}

--- a/examples/chipotle-primitives/lit-action-secrets.js
+++ b/examples/chipotle-primitives/lit-action-secrets.js
@@ -1,0 +1,34 @@
+// lit-action-secrets.js
+//
+// Encryption / secrets (PKP-as-vault). Thin wrappers over Lit.Actions.Encrypt /
+// Decrypt, plus a decrypt-use-discard helper so a plaintext secret only lives
+// inside the TEE for the lifetime of a callback.
+
+/** AES-encrypt plaintext to a PKP; store the ciphertext anywhere. */
+export async function sealToVault({ pkpId, plaintext }) {
+  return Lit.Actions.Encrypt({ pkpId, message: plaintext });
+}
+
+/** Decrypt ciphertext sealed to a PKP. Gate this behind your access logic. */
+export async function openFromVault({ pkpId, ciphertext }) {
+  return Lit.Actions.Decrypt({ pkpId, ciphertext });
+}
+
+/**
+ * Decrypt-use-discard wrapper: the secret only exists in plaintext inside the
+ * TEE for the lifetime of `fn`. Returns whatever `fn` returns.
+ */
+export async function withSecret({ pkpId, ciphertext }, fn) {
+  const secret = await Lit.Actions.Decrypt({ pkpId, ciphertext });
+  return fn(secret);
+}
+
+/**
+ * Decrypt the secret portion of a provider URL in-TEE and append it to a
+ * HARDCODED baseUrl, so the target chain/host stays verifiable from the source.
+ * `baseUrl` must come from action constants, never js_params.
+ */
+export async function assembleSecretRpcUrl({ pkpId, encryptedKey, baseUrl }) {
+  const key = await Lit.Actions.Decrypt({ pkpId, ciphertext: encryptedKey });
+  return `${baseUrl}${key}`;
+}

--- a/examples/chipotle-primitives/lit-action-signing.js
+++ b/examples/chipotle-primitives/lit-action-signing.js
@@ -1,0 +1,64 @@
+// lit-action-signing.js
+//
+// Signing & action identity. EIP-191 personal-sign with either a PKP wallet key
+// or the action's CID-derived key, plus the authorization-digest builder that
+// every authorization primitive is built on. Uses micro-eth-signer's
+// eip191Signer (signatures are 0x{r}{s}{v}, v in 27/28 -- ecrecover-compatible).
+
+import { addr, eip191Signer } from "micro-eth-signer@0.19.0";
+import { keccak256, abiEncode, arrayify } from "./lit-action-core.js";
+
+/**
+ * EIP-191 personal-sign of `message` (string or bytes) with a PKP wallet key.
+ * Returns { signature, signer }.
+ */
+export async function signWithPkp({ pkpId, message }) {
+  const key = await Lit.Actions.getPrivateKey({ pkpId });
+  return { signature: eip191Signer.sign(message, key), signer: addr.fromPrivateKey(key) };
+}
+
+/**
+ * EIP-191 personal-sign of `message` with the action's CID-derived key
+ * (immutable-proof identity). Returns { signature, signer }.
+ */
+export async function signWithAction({ message }) {
+  const key = await Lit.Actions.getLitActionPrivateKey();
+  return { signature: eip191Signer.sign(message, key), signer: addr.fromPrivateKey(key) };
+}
+
+/**
+ * Build the ready-to-sign authorization digest: abi.encode(types, values) ->
+ * keccak256 -> arrayify. Returns { digest (0x hex), digestBytes (Uint8Array) }.
+ * This is the exact tuple your verifying contract re-derives before ecrecover.
+ */
+export function buildAuthDigest({ types, values }) {
+  const digest = keccak256(abiEncode(types, values));
+  return { digest, digestBytes: arrayify(digest) };
+}
+
+/**
+ * buildAuthDigest + EIP-191 sign in one call -- the core of every authorization
+ * primitive. Signs with the action key (useAction, default) or a PKP key.
+ * Returns { signature, signer, digest }.
+ */
+export async function signDigest({ types, values, useAction = true, pkpId }) {
+  const { digest, digestBytes } = buildAuthDigest({ types, values });
+  const key = useAction
+    ? await Lit.Actions.getLitActionPrivateKey()
+    : await Lit.Actions.getPrivateKey({ pkpId });
+  return {
+    signature: eip191Signer.sign(digestBytes, key),
+    signer: addr.fromPrivateKey(key),
+    digest,
+  };
+}
+
+/** Recover the EIP-191 signer address of (message, signature). */
+export function recoverSigner({ message, signature }) {
+  return eip191Signer.recoverPublicKey(signature, message);
+}
+
+/** Derive a sibling action's wallet address from its IPFS CID. */
+export async function getActionAddress({ ipfsId }) {
+  return Lit.Actions.getLitActionWalletAddress({ ipfsId });
+}

--- a/examples/chipotle-primitives/package.json
+++ b/examples/chipotle-primitives/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chipotle-primitives",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Reusable Lit Action primitives (gating, signing, RPC safety, oracles, secrets) built on audited libraries from Paul Miller -- micro-eth-signer and @noble/hashes. Import into any Lit Action.",
+  "dependencies": {
+    "micro-eth-signer": "0.19.0",
+    "@noble/hashes": "1.4.0"
+  }
+}

--- a/examples/chipotle-primitives/uses.md
+++ b/examples/chipotle-primitives/uses.md
@@ -1,0 +1,258 @@
+# Primitive reference — what each function does and when to use it
+
+Every function below lives in one of the `lit-action-*` modules and is also
+re-exported from `lit-action-primitives.js`. Gates and asserts **fail closed**
+(they throw `GateError`); your `main` catches and returns
+`{ authorized: false, reason }`. Reads and signers return values.
+
+Reminder: anything that defines the trust boundary (host regexes, min-source
+counts, spread caps, allowed addresses, base URLs) is passed in as an argument
+that **the action source hardcodes** — never forwarded from `js_params`.
+
+---
+
+## `lit-action-core.js` — hashing, ABI, denial base
+
+### `keccak256(bytes) -> 0xhex`
+keccak-256 of raw bytes (`@noble/hashes`), returned 0x-prefixed.
+**Use when** you need a raw hash — e.g. hashing packed bytes you already built,
+or computing an event-topic to match in `readAndValidateLog`.
+
+### `keccak256Utf8(text) -> 0xhex`
+keccak-256 of a UTF-8 string.
+**Use when** binding an identifier to text so it can't be swapped — e.g.
+`questionId = keccak256Utf8(questionText)` in an oracle, or an event signature
+hash like `keccak256Utf8("Transfer(address,address,uint256)")`.
+
+### `arrayify(0xhex) -> Uint8Array`
+0x-hex to bytes (ethers `arrayify` equivalent).
+**Use when** you have a digest as hex and need the byte form to feed a signer.
+
+### `abiEncode(types, values) -> Uint8Array`
+ABI-encodes a tuple exactly like `abi.encode(...)` on-chain (audited coder,
+selector stripped).
+**Use when** building the preimage a contract will re-derive — almost always via
+`buildAuthDigest`/`signDigest` rather than directly. Pass ints as
+number/bigint/string, address/bytes as 0x-hex (see README value-type table).
+
+### `GateError` / `deny(reason)`
+The throw-to-deny convention.
+**Use when** writing your own gate: call `deny("why")` to fail closed; catch
+`GateError` (or any `Error`) in `main`.
+
+---
+
+## `lit-action-rpc.js` — RPC trust anchors & chain safety
+
+### `rpc(url, method, params) -> result`
+Hardened JSON-RPC POST with `redirect: "error"` (closes the
+open-redirect-after-pin hole) that throws on HTTP/RPC error.
+**Use when** making any raw JSON-RPC call. Prefer this over a bare `fetch` so a
+pinned host that 30x-redirects to an attacker is rejected.
+
+### `assertAllowedRpc({ chainId, rpcUrl, policy }) -> chainPolicy`
+Requires https + a hostname matching the per-chain `policy`, and returns that
+chain's policy (e.g. `{ hostRegex, minConfirmations }`).
+**Use when** an action accepts an `rpcUrl` from the caller. Run this first — it
+pins the node so subsequent reads are trustworthy. `policy` is your hardcoded
+map.
+
+### `assertChainId({ rpcUrl, expectedChainId }) -> number`
+Cross-checks `eth_chainId` against what you expect.
+**Use when** you've pinned the host and want defense-in-depth that the node is
+actually serving the chain you think (e.g. before signing a chain-scoped
+authorization).
+
+### `requireConfirmations({ rpcUrl, blockNumber, minConf }) -> number`
+Reorg defense — fails unless the source block is buried `minConf` deep.
+**Use when** signing off an on-chain event (a deposit, a fill, a settlement):
+don't authorize until the triggering tx can't be reorged out.
+
+---
+
+## `lit-action-onchain.js` — reads & writes
+
+### `readContract({ rpcUrl, address, abi, method, args }) -> decoded`
+Generic `eth_call` view helper; decodes via JSON ABI fragments.
+**Use when** reading any contract view function — balances, config flags, order
+structs. `args` is a named object or positional array.
+
+### `readAndValidateLog({ rpcUrl, txHash, logIndex, expectedContract, expectedTopic }) -> log`
+Fetches a receipt, confirms it succeeded, and confirms the log at `logIndex`
+came from the expected contract and event signature.
+**Use when** an action reacts to a specific on-chain event and must prove that
+event really happened from the right source before acting (e.g. cross-chain
+"mint on B because burn happened on A").
+
+### `sendEth({ pkpId, to, amountEth, chainId, rpcUrl }) -> { txHash, ... }`
+Builds/signs/broadcasts a native transfer from a PKP wallet (EIP-1559, fees from
+`eth_gasPrice`).
+**Use when** the action itself must move native funds — e.g. a funded PKP
+relayer paying out, refunding gas, or sweeping.
+
+### `bindToOnchainOrder({ rpcUrl, settlementContract, depositId, requested, orderAbi }) -> order`
+Reconstructs an order from a pinned settlement contract and requires the
+caller's recipient/token/amount to match what the order actually says.
+**Use when** a bot/solver asks you to authorize a payout. This is the kill shot
+for exfiltration — the bot can claim any recipient in `js_params`, but the order
+on-chain says who really gets paid.
+
+---
+
+## `lit-action-gating.js` — access control (fail closed)
+
+### `gateEthBalance({ address, minWei, rpcUrl })`
+Denies unless native balance ≥ `minWei`.
+**Use when** token-gating on ETH holdings (e.g. "must hold ≥ 0.1 ETH to use this
+action").
+
+### `gateErc20Balance({ holder, token, minAmount, rpcUrl })`
+Denies unless ERC-20 `balanceOf(holder)` ≥ `minAmount`.
+**Use when** gating on a fungible token balance — membership tiers, staking
+minimums, fee-token checks.
+
+### `gateNftOwnership({ holder, nftContract, rpcUrl, tokenId })`
+Denies unless the holder owns the NFT (ERC-721 `balanceOf > 0`, or ERC-1155
+`balanceOf(holder, tokenId) > 0` when `tokenId` is given).
+**Use when** gating behind an NFT membership/pass.
+
+### `gateTimeWindow({ startUnix, endUnix })`
+Rejects outside the inclusive time window.
+**Use when** an action should only run during a sale, an auction, a claim
+period, or after a vesting cliff.
+
+### `gateSanctions({ address, screeningRpcUrl })`
+Staticcalls the hardcoded Chainalysis oracle on a pinned mainnet RPC; denies if
+the address is sanctioned.
+**Use when** compliance requires screening a counterparty before signing a
+transfer or payout.
+
+### `gateAuthToken({ token, verifyUrl })`
+POSTs the token to your auth service and requires `{ valid: true }`.
+**Use when** access depends on an off-chain system (a logged-in session, a
+subscription, an API entitlement).
+
+### `requireCallerSignature({ message, signature, allowedAddress }) -> recovered`
+Recovers the EIP-191 signer and requires it to equal `allowedAddress`.
+**Use when** only a specific owner may trigger an action. The `message` must
+carry a nonce + deadline (see `newNonce` / `withDeadline`) for replay safety.
+
+### `requirePkpAllowed({ pkpAddress, allowedPkp })`
+Case-insensitive allowlist check for a PKP address.
+**Use when** restricting an action to one or more known PKPs (the gateway has
+already proven PKP ownership; this just enforces the allowlist).
+
+### `combineGates([...gateFns]) -> results[]`
+Runs gate thunks in order, failing closed on the first denial.
+**Use when** an action needs several conditions AND-ed together:
+`await combineGates([() => gateSanctions(...), () => gateErc20Balance(...)])`.
+For OR logic, try/catch individual gates.
+
+---
+
+## `lit-action-signing.js` — signing & action identity
+
+### `signWithPkp({ pkpId, message }) -> { signature, signer }`
+EIP-191 personal-sign with a PKP wallet key (account/user identity).
+**Use when** the signature should be attributable to a user's PKP wallet rather
+than to the action code.
+
+### `signWithAction({ message }) -> { signature, signer }`
+EIP-191 personal-sign with the action's CID-derived key.
+**Use when** the signature must prove "this exact code approved this." A contract
+pins the action's derived address; editing the action changes the CID and the
+signer, so the approval can't be forged by modified code.
+
+### `buildAuthDigest({ types, values }) -> { digest, digestBytes }`
+`abi.encode -> keccak256 -> arrayify`, the exact tuple your verifying contract
+re-derives before `ecrecover`.
+**Use when** you want the digest without signing yet (e.g. to log it, or to sign
+with a custom key path).
+
+### `signDigest({ types, values, useAction, pkpId }) -> { signature, signer, digest }`
+`buildAuthDigest` + sign in one call — the core of every authorization
+primitive.
+**Use when** producing the signature a contract will verify: encode the same
+tuple the contract checks (`token, recipient, amount, nonce, deadline, vault,
+chainId`, etc.) and sign it. Default signs with the action key; set
+`useAction: false` + `pkpId` for a PKP.
+
+### `recoverSigner({ message, signature }) -> address`
+Recovers the EIP-191 signer address.
+**Use when** verifying a signature you received and you want the address back
+(e.g. to look it up), rather than just asserting equality.
+
+### `getActionAddress({ ipfsId }) -> address`
+Derives a sibling action's wallet address from its IPFS CID.
+**Use when** wiring two actions together — e.g. pinning a price-oracle action's
+address into a consumer contract's constructor.
+
+---
+
+## `lit-action-secrets.js` — PKP-as-vault
+
+### `sealToVault({ pkpId, plaintext }) -> ciphertext`
+Encrypts plaintext to a PKP; store the ciphertext anywhere.
+**Use when** provisioning a secret (an API key, a webhook URL) that only this
+PKP context can later decrypt.
+
+### `openFromVault({ pkpId, ciphertext }) -> plaintext`
+Decrypts ciphertext sealed to a PKP.
+**Use when** you need the secret and have already passed your access gates.
+
+### `withSecret({ pkpId, ciphertext }, async (secret) => {...}) -> result`
+Decrypt-use-discard: the plaintext only exists for the callback's lifetime.
+**Use when** using a secret for a single operation (one signed API request) and
+you want to minimize how long it sits in memory.
+
+### `assembleSecretRpcUrl({ pkpId, encryptedKey, baseUrl }) -> url`
+Decrypts the key portion in-TEE and appends it to a hardcoded `baseUrl`.
+**Use when** an RPC/provider URL embeds a secret API key but the host/chain must
+stay verifiable — keep `baseUrl` in source, encrypt only the key.
+
+---
+
+## `lit-action-oracles.js` — consensus & oracles
+
+### `requireStrictAgreement({ sources, fetchSource, minSources }) -> value`
+Fetches each source, requires ≥ `minSources` successes, and denies unless they
+agree byte-for-byte.
+**Use when** the fact is discrete and must be unanimous — "is this address
+sanctioned?", "did this event occur?". Disagreement should block, not average.
+
+### `medianWithSpreadCheck({ observations, minSources, maxSpreadBps }) -> median`
+Median of the observations; denies if `(max-min)/median` exceeds the cap. BigInt
+throughout.
+**Use when** aggregating continuous values (prices, rates) and you want a manipulation
+guard — a single rogue feed can't drag the result if the spread blows the cap.
+
+### `signedPriceFeed({ asset, sources, decimals, registry, deadline }) -> { price, signature, ... }`
+Fetches N prices, median-with-spread-check, BigInt fixed-point scaling, then
+signs the result.
+**Use when** publishing an attestable price on-chain — the consumer contract
+verifies the signature against the action's pinned address.
+
+### `aiConsensus({ question, providers, minAgreement }) -> { questionId, answer, agreed }`
+Polls LLM providers for a categorical YES/NO/UNCLEAR and requires `minAgreement`
+to concur; binds `questionId = keccak256(question)`.
+**Use when** resolving a subjective/real-world question (a prediction market,
+content moderation) where you want multiple models to agree before acting.
+
+---
+
+## `lit-action-replay.js` — replay safety
+
+### `newNonce() -> 0xhex`
+Random 32-byte nonce (Web Crypto).
+**Use when** issuing an authorization — fold the nonce into the signed digest so
+the same signature can't be replayed (the contract tracks used nonces).
+
+### `withDeadline(seconds) -> unixSeconds`
+A deadline `seconds` in the future.
+**Use when** issuing an authorization that should expire — fold it into the
+digest and have the contract reject past it.
+
+### `assertNotExpired({ deadline })`
+Rejects a stale authorization before signing.
+**Use when** an action re-signs or acts on a caller-supplied deadline — bail
+early if it's already past instead of producing a useless signature.


### PR DESCRIPTION
Adds a new chipotle-primitives example package with reusable Lit Action helpers for RPC pinning, gating, signing, on-chain reads, secrets, replay protection, and oracle consensus. Documents the trust-boundary rule, runtime import constraints, and per-function usage guidance. Includes a package manifest pinning micro-eth-signer and @noble/hashes for the primitives.