### PR TITLE
ci(k6): provision Node on self-hosted runner for load-test summary

### DIFF
--- a/.github/workflows/k6-loadtest.yml
+++ b/.github/workflows/k6-loadtest.yml
@@ -158,6 +158,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The self-hosted runner doesn't have node on PATH; the summary step
+      # (scripts/k6-loadtest-github-summary.mjs) needs it. setup-node also
+      # provisions npm for any future tooling.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install k6
         uses: grafana/setup-k6-action@v1
 


### PR DESCRIPTION
The "Post k6 load test summary" step in the k6 Load Test workflow runs `scripts/k6-loadtest-github-summary.mjs`, but the `self-hosted` runner has no `node` on `PATH`, so the step failed with `node: command not found` (exit 127). This adds an `actions/setup-node@v4` step after checkout, pinned to Node 22 to match the sibling `k6-client-check.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)