### PR TITLE
feat(lit-payments): auto-fund API payer gas wallets + low-balance alerts

### DIFF
--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -53,6 +53,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.6",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
 name = "alloy-dyn-abi"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +181,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "borsh",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +280,60 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
@@ -94,7 +349,7 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -104,9 +359,48 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
- "secp256k1",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -115,8 +409,87 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -128,6 +501,37 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -150,10 +554,11 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -168,12 +573,14 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
  "macro-string",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -198,6 +605,82 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.13.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -493,6 +976,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +1098,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,12 +1176,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -642,6 +1209,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +1234,25 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -865,6 +1469,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1675,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -1056,6 +1716,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1261,6 +1922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1941,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1365,6 +2033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "generator"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,8 +2069,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1406,9 +2082,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1463,7 +2141,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1482,12 +2160,24 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1498,6 +2188,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1752,6 +2453,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +2565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2609,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1949,6 +2691,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2771,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2",
 ]
 
@@ -2073,7 +2875,7 @@ dependencies = [
  "async-trait",
  "base64_light",
  "hex",
- "reqwest",
+ "reqwest 0.12.28",
  "rocket",
  "serde",
  "serde_json",
@@ -2085,6 +2887,7 @@ dependencies = [
 name = "lit-payments"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-dyn-abi",
  "alloy-primitives",
  "alloy-serde",
@@ -2099,7 +2902,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "rocket",
  "rocket_cors",
  "serde",
@@ -2151,6 +2954,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
@@ -2343,6 +3161,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,10 +3362,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -2689,6 +3568,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +3659,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -2902,6 +3838,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,7 +3922,7 @@ dependencies = [
  "either",
  "figment",
  "futures",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "multer",
@@ -2981,7 +3954,7 @@ checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
 dependencies = [
  "devise",
  "glob",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "rocket_http",
@@ -3018,7 +3991,7 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "hyper 0.14.32",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "pear",
@@ -3137,6 +4110,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -3145,13 +4119,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3159,6 +4173,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3189,12 +4204,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3219,8 +4267,21 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -3231,7 +4292,16 @@ checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.9.4",
- "secp256k1-sys",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3355,6 +4425,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +4569,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,7 +4669,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -3748,6 +4876,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,6 +5058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +5179,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4066,7 +5231,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -4080,7 +5245,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.3",
@@ -4344,6 +5509,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4389,6 +5555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -4502,7 +5678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4515,8 +5691,22 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver 1.0.28",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4530,6 +5720,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,12 +5749,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4783,7 +6036,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4814,7 +6067,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4833,7 +6086,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",

--- a/lit-payments/Cargo.toml
+++ b/lit-payments/Cargo.toml
@@ -9,6 +9,15 @@ license = "Apache-2.0"
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.22"
+# Provider + local-signer stack for the gas funder (broadcasts plain ETH
+# value transfers to top up the lit-api-server payer pool). Mirrors the
+# feature set lit-api-server uses on the same alloy 1.x line.
+alloy = { version = "1.0", features = [
+    "network",
+    "providers",
+    "rpc-types",
+    "signer-local",
+] }
 alloy-dyn-abi = "1.0"
 alloy-primitives = "1.0"
 alloy-serde = "1.0"

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -212,9 +212,10 @@ LIT_ACCOUNTS_CONTRACT_ADDRESS=0x...  # same value as lit-api-server NodeConfig.t
 # GAS_FUNDER_DAILY_CAP_WEI=50000000000000000    # 0.05   ETH — rolling 24h ceiling
 # GAS_FUNDER_HOTWALLET_MIN_WEI=20000000000000000 # 0.02  ETH — "reload me" alert below this
 # GAS_FUNDER_ENABLED=true                # flip on once observe mode looks right
-# GAS_FUNDER_CHAIN_ID=8453               # default Base mainnet
+# GAS_FUNDER_CHAIN_ID=8453               # default Base mainnet; verified against the RPC before any send
 # GAS_FUNDER_INTERVAL_SECS=900           # default 15m
 # GAS_FUNDER_INCLUDE_ADMIN=true          # also monitor/fund the admin payer
+# GAS_FUNDER_ALLOWED_RECIPIENTS=0xabc...,0xdef...  # optional: only ever fund these (defense vs spoofed get_api_payers)
 ```
 
 ## LITKEY browser payment claim flow
@@ -287,10 +288,21 @@ automated funder + alerter. Code: `src/gas_funder/`.
   resolved addresses, thresholds, and tick logs before it can move funds.
 - **ACTIVE** (`GAS_FUNDER_ENABLED=true`): actually sends top-ups.
 
-**Safety rails.** Per-tx ceiling + rolling-24h ceiling; a `pending` row is
-written *before* each send (single instance + await-receipt ⇒ sequential
-nonces, no double-spend on restart); the hot wallet is checked to cover the
-whole round before any send. Routine top-ups are **silent** (info logs only).
+**Safety rails.**
+- Per-tx ceiling + rolling-24h ceiling (DB-summed). Cap reads **fail closed** —
+  if the ledger can't be read, the tick funds nothing.
+- **Singleton advisory lock** (`pg_try_advisory_lock`) so a Railway deploy
+  overlap or stray second process can't run two funders against one budget.
+- Each send records `pending` → stamps the tx hash + `broadcast` **before**
+  awaiting the receipt, so a receipt timeout/RPC error never "forgets" money in
+  the mempool and re-sends it. The receipt wait is **bounded** (a stuck tx can't
+  freeze the loop), and a recipient with an in-flight/recent top-up is skipped.
+- Optional `GAS_FUNDER_ALLOWED_RECIPIENTS` allowlist: since `get_api_payers` is
+  unauthenticated, when set the funder only sends to allowlisted addresses and
+  alerts on any unexpected payer (spoof/MITM detection).
+- Before any send in ACTIVE mode it verifies the RPC's chain id matches
+  `GAS_FUNDER_CHAIN_ID` and that the hot wallet can cover the whole round.
+- Routine top-ups are **silent** (info logs only).
 
 **Alerts** (email via Resend, to `GAS_FUNDER_ALERT_EMAIL`, deduped by a
 cooldown): hot-wallet-low **"reload me"** (the one wallet a human watches),
@@ -395,6 +407,9 @@ GAS_FUNDER_HIGH_WATER_WEI=5000000000000000      # 0.005  ETH
 GAS_FUNDER_MAX_TX_WEI=5000000000000000          # 0.005  ETH per tx
 GAS_FUNDER_DAILY_CAP_WEI=50000000000000000      # 0.05   ETH per rolling 24h
 GAS_FUNDER_HOTWALLET_MIN_WEI=20000000000000000  # 0.02   ETH — "reload me" alert
+# Optional but recommended: restrict sends to a known set of addresses, so a
+# spoofed/MITM get_api_payers response can't redirect funds.
+# GAS_FUNDER_ALLOWED_RECIPIENTS=0xabc...,0xdef...
 # Start WITHOUT GAS_FUNDER_ENABLED (observe mode: alerts only). Once the
 # tick logs and emails look right, set GAS_FUNDER_ENABLED=true to send.
 # GAS_FUNDER_ENABLED=true

--- a/lit-payments/README.md
+++ b/lit-payments/README.md
@@ -199,6 +199,22 @@ LIT_ACCOUNTS_CONTRACT_ADDRESS=0x...  # same value as lit-api-server NodeConfig.t
 # wallet-sig or API-key verification).
 # LIT_API_SERVER_BASE_URL=http://localhost:8000
 # LIT_INTERNAL_SHARED_SECRET=$(openssl rand -base64 32)
+
+# Optional — gas funder (see "Gas funder" section below). Off entirely
+# unless GAS_FUNDER_PRIVATE_KEY is set. Leave GAS_FUNDER_ENABLED unset to
+# run in OBSERVE mode (alerts only, no on-chain sends).
+# GAS_FUNDER_PRIVATE_KEY=0x...           # dedicated low-value hot wallet
+# GAS_FUNDER_ALERT_EMAIL=you@litprotocol.com
+# GAS_FUNDER_RPC_URL=https://base-mainnet.g.alchemy.com/v2/...   # falls back to ALCHEMY_HTTPS_URL
+# GAS_FUNDER_LOW_WATER_WEI=500000000000000      # 0.0005 ETH — top up below this
+# GAS_FUNDER_HIGH_WATER_WEI=5000000000000000    # 0.005  ETH — top up to this
+# GAS_FUNDER_MAX_TX_WEI=5000000000000000        # 0.005  ETH — per-tx ceiling
+# GAS_FUNDER_DAILY_CAP_WEI=50000000000000000    # 0.05   ETH — rolling 24h ceiling
+# GAS_FUNDER_HOTWALLET_MIN_WEI=20000000000000000 # 0.02  ETH — "reload me" alert below this
+# GAS_FUNDER_ENABLED=true                # flip on once observe mode looks right
+# GAS_FUNDER_CHAIN_ID=8453               # default Base mainnet
+# GAS_FUNDER_INTERVAL_SECS=900           # default 15m
+# GAS_FUNDER_INCLUDE_ADMIN=true          # also monitor/fund the admin payer
 ```
 
 ## LITKEY browser payment claim flow
@@ -240,6 +256,53 @@ cargo run
 Visit <http://localhost:8000/login>, enter `chris@litprotocol.com` (or
 whatever's seeded in `migrations/20260518000002_seed_operators.sql`),
 check your inbox, click the link.
+
+## Gas funder
+
+Keeps the lit-api-server **API payer pool** topped up so on-chain writes
+(`new_account`, etc.) never fail with `insufficient funds for gas`.
+
+**Why it's needed.** lit-api-server signs writes from a pool of payer wallets
+whose keys live in the dstack TEE. Pool signer-selection is round-robin and
+**not balance-aware**, so a single drained wallet causes intermittent 500s.
+The in-TEE admin payer only rebalances on pool *resize*, never continuously,
+and nothing alerts on low balances. lit-payments runs out of the TEE hot path
+(Railway, single instance, already polling), so it's the natural home for an
+automated funder + alerter. Code: `src/gas_funder/`.
+
+**What it does each tick** (`GAS_FUNDER_INTERVAL_SECS`, default 15m):
+
+1. Fetches the **live** payer set from lit-api-server
+   (`GET /core/v1/get_api_payers`, plus `get_admin_api_payer` when
+   `GAS_FUNDER_INCLUDE_ADMIN`). The pool rotates, so it's re-read every tick.
+2. Reads each balance on-chain.
+3. Tops up any payer below `LOW_WATER` up to `HIGH_WATER`, clamped by
+   `MAX_TX` per send and a rolling-24h `DAILY_CAP` (summed from
+   `gas_funding_events`).
+
+**Modes.** Off entirely unless `GAS_FUNDER_PRIVATE_KEY` is set. With it set:
+
+- **OBSERVE** (default — `GAS_FUNDER_ENABLED` unset/false): reads balances and
+  emails alerts, but broadcasts **nothing**. Deploy here first to verify the
+  resolved addresses, thresholds, and tick logs before it can move funds.
+- **ACTIVE** (`GAS_FUNDER_ENABLED=true`): actually sends top-ups.
+
+**Safety rails.** Per-tx ceiling + rolling-24h ceiling; a `pending` row is
+written *before* each send (single instance + await-receipt ⇒ sequential
+nonces, no double-spend on restart); the hot wallet is checked to cover the
+whole round before any send. Routine top-ups are **silent** (info logs only).
+
+**Alerts** (email via Resend, to `GAS_FUNDER_ALERT_EMAIL`, deduped by a
+cooldown): hot-wallet-low **"reload me"** (the one wallet a human watches),
+send failure, hot wallet can't cover the round, and daily cap reached while
+payers are still low. In OBSERVE mode it also emails what it *would* have sent.
+
+**Custody note.** This puts a spendable key on Railway, outside the TEE. Treat
+it as a **gas tank**: dedicate a fresh key, keep its balance small, and let the
+"reload me" alert bound the loss if it's ever compromised.
+
+See the env vars in [Local development](#2-set-env-vars) and
+[Set service variables](#3-set-service-variables).
 
 ## Deploy to Railway
 
@@ -318,6 +381,23 @@ Optional operator caps if you want non-default values:
 ```sh
 MAX_GRANT_CENTS=2000
 MAX_DAILY_PER_OPERATOR_CENTS=10000
+```
+
+Optional gas funder (see [Gas funder](#gas-funder)). Off unless
+`GAS_FUNDER_PRIVATE_KEY` is set:
+
+```sh
+GAS_FUNDER_PRIVATE_KEY=0x...                    # dedicated low-value hot wallet
+GAS_FUNDER_ALERT_EMAIL=you@litprotocol.com
+GAS_FUNDER_RPC_URL=https://base-mainnet.g.alchemy.com/v2/...  # falls back to ALCHEMY_HTTPS_URL
+GAS_FUNDER_LOW_WATER_WEI=500000000000000        # 0.0005 ETH
+GAS_FUNDER_HIGH_WATER_WEI=5000000000000000      # 0.005  ETH
+GAS_FUNDER_MAX_TX_WEI=5000000000000000          # 0.005  ETH per tx
+GAS_FUNDER_DAILY_CAP_WEI=50000000000000000      # 0.05   ETH per rolling 24h
+GAS_FUNDER_HOTWALLET_MIN_WEI=20000000000000000  # 0.02   ETH — "reload me" alert
+# Start WITHOUT GAS_FUNDER_ENABLED (observe mode: alerts only). Once the
+# tick logs and emails look right, set GAS_FUNDER_ENABLED=true to send.
+# GAS_FUNDER_ENABLED=true
 ```
 
 Generate secrets locally and paste the values into Railway:

--- a/lit-payments/migrations/20260623000001_gas_funder.sql
+++ b/lit-payments/migrations/20260623000001_gas_funder.sql
@@ -24,26 +24,33 @@ CREATE TABLE gas_funding_events (
     chain_id            BIGINT      NOT NULL,
     -- 0x-lowercased recipient (an API payer pool wallet or the admin payer).
     recipient           TEXT        NOT NULL,
-    -- Amount sent, in wei. NUMERIC holds the full 256-bit range; we bind/read
-    -- it as a base-10 string (U256) to avoid lossy float conversions.
-    amount_wei          NUMERIC     NOT NULL CHECK (amount_wei > 0),
+    -- Amount sent, in wei. NUMERIC(78,0) is integer-only (scale 0) and bounds
+    -- the precision to U256's max 78 decimal digits, so a malformed/fractional
+    -- row can't poison the cap sum. Bound/read as a base-10 string (U256) to
+    -- avoid lossy float conversions.
+    amount_wei          NUMERIC(78, 0) NOT NULL CHECK (amount_wei > 0),
     -- Recipient balance observed just before the send, for the audit trail.
-    balance_before_wei  NUMERIC,
+    balance_before_wei  NUMERIC(78, 0),
     tx_hash             TEXT,
-    -- 'pending' (recorded, not yet confirmed) | 'sent' (receipt, status 1)
-    -- | 'failed' (send error / revert / receipt error).
-    status              TEXT        NOT NULL CHECK (status IN ('pending', 'sent', 'failed')),
+    -- 'pending'   recorded, not yet broadcast
+    -- 'broadcast' accepted by the RPC (tx_hash set), receipt not yet observed
+    -- 'sent'      receipt with status 1
+    -- 'failed'    send error / revert (nothing of value moved)
+    -- Only 'failed' is excluded from the rolling cap; 'pending'/'broadcast'
+    -- count so in-flight money is never refunded and re-sent.
+    status              TEXT        NOT NULL
+                          CHECK (status IN ('pending', 'broadcast', 'sent', 'failed')),
     error               TEXT
 );
 
 -- Rolling-window sum for the daily cap query (created_at > now() - 24h).
 CREATE INDEX gas_funding_events_created_at_idx ON gas_funding_events (created_at DESC);
 
--- Small partial index to find interrupted sends (status='pending' that never
--- transitioned) for the stale-pending warning.
-CREATE INDEX gas_funding_events_pending_idx
-    ON gas_funding_events (created_at)
-    WHERE status = 'pending';
+-- Partial index to find interrupted/unconfirmed sends (still 'pending' or
+-- 'broadcast') for the stale-pending warning and the recent-funding guard.
+CREATE INDEX gas_funding_events_inflight_idx
+    ON gas_funding_events (recipient, created_at)
+    WHERE status IN ('pending', 'broadcast');
 
 -- One row per alert kind/key, holding the last time we emailed it. The
 -- funder upserts here under a cooldown so a persistently-low wallet emails

--- a/lit-payments/migrations/20260623000001_gas_funder.sql
+++ b/lit-payments/migrations/20260623000001_gas_funder.sql
@@ -1,0 +1,54 @@
+-- Gas funder: keep the lit-api-server API payer pool topped up.
+--
+-- lit-api-server signs `new_account` (and other write) transactions from a
+-- pool of payer wallets whose keys live inside the dstack TEE. The pool's
+-- signer selection is NOT balance-aware: a drained payer is still handed
+-- requests, and the on-chain `newAccount` then reverts with
+-- `insufficient funds for gas`. There is no in-TEE continuous top-up — the
+-- admin payer only rebalances on pool *resize*.
+--
+-- lit-payments runs out of the TEE hot path (Railway, single instance,
+-- already polling), so it carries a small hot wallet that tops up any payer
+-- below a low-water mark, up to a high-water target. These two tables are the
+-- audit ledger (which also backs the rolling 24h spend cap) and the alert
+-- de-dupe state. See `src/gas_funder/`.
+
+-- One row per attempted funding transaction. `status='pending'` is written
+-- BEFORE broadcast so a crash mid-send is conservatively counted against the
+-- daily cap (errs toward NOT over-funding) and surfaces as a stale-pending
+-- warning rather than silently double-spending on restart.
+CREATE TABLE gas_funding_events (
+    id                  BIGSERIAL   PRIMARY KEY,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    chain_id            BIGINT      NOT NULL,
+    -- 0x-lowercased recipient (an API payer pool wallet or the admin payer).
+    recipient           TEXT        NOT NULL,
+    -- Amount sent, in wei. NUMERIC holds the full 256-bit range; we bind/read
+    -- it as a base-10 string (U256) to avoid lossy float conversions.
+    amount_wei          NUMERIC     NOT NULL CHECK (amount_wei > 0),
+    -- Recipient balance observed just before the send, for the audit trail.
+    balance_before_wei  NUMERIC,
+    tx_hash             TEXT,
+    -- 'pending' (recorded, not yet confirmed) | 'sent' (receipt, status 1)
+    -- | 'failed' (send error / revert / receipt error).
+    status              TEXT        NOT NULL CHECK (status IN ('pending', 'sent', 'failed')),
+    error               TEXT
+);
+
+-- Rolling-window sum for the daily cap query (created_at > now() - 24h).
+CREATE INDEX gas_funding_events_created_at_idx ON gas_funding_events (created_at DESC);
+
+-- Small partial index to find interrupted sends (status='pending' that never
+-- transitioned) for the stale-pending warning.
+CREATE INDEX gas_funding_events_pending_idx
+    ON gas_funding_events (created_at)
+    WHERE status = 'pending';
+
+-- One row per alert kind/key, holding the last time we emailed it. The
+-- funder upserts here under a cooldown so a persistently-low wallet emails
+-- once per cooldown window instead of on every poll tick.
+CREATE TABLE gas_funder_alerts (
+    alert_key     TEXT        PRIMARY KEY,
+    last_sent_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/lit-payments/src/auto_topup/reconciler_tests.rs
+++ b/lit-payments/src/auto_topup/reconciler_tests.rs
@@ -55,6 +55,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 60,
         cors_allowed_origins: vec!["http://localhost".to_string()],
+        gas_funder: None,
     }
 }
 

--- a/lit-payments/src/auto_topup/webhook/handler_tests.rs
+++ b/lit-payments/src/auto_topup/webhook/handler_tests.rs
@@ -83,6 +83,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         stripe_webhook_secret: WEBHOOK_SECRET.into(),
         reconciler_interval_secs: 900,
         cors_allowed_origins: vec!["http://localhost".to_string()],
+        gas_funder: None,
     }
 }
 

--- a/lit-payments/src/billing/auto_topup_config_tests.rs
+++ b/lit-payments/src/billing/auto_topup_config_tests.rs
@@ -75,6 +75,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
         cors_allowed_origins: vec!["http://localhost".to_string()],
+        gas_funder: None,
     }
 }
 

--- a/lit-payments/src/billing/sca_resume_tests.rs
+++ b/lit-payments/src/billing/sca_resume_tests.rs
@@ -53,6 +53,7 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
         cors_allowed_origins: vec!["http://localhost".to_string()],
+        gas_funder: None,
     }
 }
 

--- a/lit-payments/src/billing/setup_intent_tests.rs
+++ b/lit-payments/src/billing/setup_intent_tests.rs
@@ -61,6 +61,7 @@ fn test_config(stripe_secret_key: String) -> Config {
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
         cors_allowed_origins: vec!["http://localhost".to_string()],
+        gas_funder: None,
     }
 }
 

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -149,6 +149,13 @@ pub struct GasFunderConfig {
     /// Also monitor/fund the admin payer (`get_admin_api_payer`) alongside the
     /// pool. `GAS_FUNDER_INCLUDE_ADMIN` (default true).
     pub include_admin: bool,
+    /// Optional recipient allowlist. `get_api_payers` is fetched over
+    /// unauthenticated HTTP, so a spoofed/MITM/misconfigured response could
+    /// name attacker addresses. When set, the funder will ONLY send to
+    /// addresses that are in BOTH the fetched payer set and this list, and
+    /// alerts on any fetched payer not on it. `GAS_FUNDER_ALLOWED_RECIPIENTS`
+    /// (comma-separated 0x addresses); unset = no allowlist (rely on caps).
+    pub allowed_recipients: Option<Vec<Address>>,
 }
 
 impl std::fmt::Debug for GasFunderConfig {
@@ -167,6 +174,7 @@ impl std::fmt::Debug for GasFunderConfig {
             .field("interval_secs", &self.interval_secs)
             .field("alert_email", &self.alert_email)
             .field("include_admin", &self.include_admin)
+            .field("allowed_recipients", &self.allowed_recipients)
             .finish()
     }
 }
@@ -267,7 +275,34 @@ fn parse_gas_funder_config() -> Result<Option<GasFunderConfig>> {
         interval_secs: optional_i64("GAS_FUNDER_INTERVAL_SECS", 900)?.max(30) as u64,
         alert_email: required("GAS_FUNDER_ALERT_EMAIL")?,
         include_admin: optional_bool("GAS_FUNDER_INCLUDE_ADMIN", true),
+        allowed_recipients: parse_allowed_recipients()?,
     }))
+}
+
+/// Parse the optional `GAS_FUNDER_ALLOWED_RECIPIENTS` allowlist (comma-separated
+/// 0x addresses). `None` when unset; an `Err` if set but any entry is not a
+/// valid address (fail loud rather than silently dropping a guard entry).
+fn parse_allowed_recipients() -> Result<Option<Vec<Address>>> {
+    let Some(raw) = optional_trimmed("GAS_FUNDER_ALLOWED_RECIPIENTS") else {
+        return Ok(None);
+    };
+    let mut out = Vec::new();
+    for entry in raw.split(',') {
+        let e = entry.trim();
+        if e.is_empty() {
+            continue;
+        }
+        let addr = Address::from_str(e).with_context(|| {
+            format!("GAS_FUNDER_ALLOWED_RECIPIENTS contains a non-address entry: {e:?}")
+        })?;
+        if !out.contains(&addr) {
+            out.push(addr);
+        }
+    }
+    if out.is_empty() {
+        anyhow::bail!("GAS_FUNDER_ALLOWED_RECIPIENTS is set but contains no valid addresses");
+    }
+    Ok(Some(out))
 }
 
 /// Parse a required base-10 wei amount into a `U256`. (A `0x`-prefixed value

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -5,7 +5,9 @@
 
 use std::str::FromStr;
 
-use alloy_primitives::Address;
+use alloy::signers::Signer;
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::{Address, B256, U256};
 use anyhow::{Context, Result};
 use lit_billing_core::on_chain::OnChainBillingResolver;
 
@@ -99,6 +101,74 @@ pub struct Config {
     /// `allow_credentials: true` that's CSRF-on-tap. Now exact-match
     /// only; misconfigured deployments fail loudly.
     pub cors_allowed_origins: Vec<String>,
+    /// Optional gas funder. `Some` only when `GAS_FUNDER_PRIVATE_KEY` is set;
+    /// otherwise the feature is off and the background loop never starts. See
+    /// [`GasFunderConfig`] and `src/gas_funder/`.
+    pub gas_funder: Option<GasFunderConfig>,
+}
+
+/// Configuration for the API-payer gas funder (see `src/gas_funder/`).
+///
+/// Loaded only when `GAS_FUNDER_PRIVATE_KEY` is present; when present, every
+/// money-affecting threshold is *required* (no silent defaults). All `_wei`
+/// fields are absolute amounts in wei — e.g. `0.005 ETH` is
+/// `5000000000000000`.
+#[derive(Clone)]
+pub struct GasFunderConfig {
+    /// Master switch. `false` (default) = OBSERVE mode: balances are checked
+    /// and low-balance / "reload me" alerts are emailed, but NO funding
+    /// transactions are broadcast. Set `GAS_FUNDER_ENABLED=true` to actually
+    /// send. Lets a deploy run in alert-only mode first to verify wiring,
+    /// addresses and thresholds before it can move funds.
+    pub enabled: bool,
+    /// The hot wallet that pays out top-ups. Derived from
+    /// `GAS_FUNDER_PRIVATE_KEY`; never logged (see the `Debug` impl).
+    pub signer: PrivateKeySigner,
+    /// JSON-RPC endpoint for the payer chain. `GAS_FUNDER_RPC_URL`, falling
+    /// back to `ALCHEMY_HTTPS_URL`.
+    pub rpc_url: String,
+    /// Chain id the payers live on. `GAS_FUNDER_CHAIN_ID` (default Base 8453).
+    pub chain_id: u64,
+    /// Below this balance a payer is topped up. `GAS_FUNDER_LOW_WATER_WEI`.
+    pub low_water_wei: U256,
+    /// Top-ups bring a payer up to this target. `GAS_FUNDER_HIGH_WATER_WEI`
+    /// (must be > low-water).
+    pub high_water_wei: U256,
+    /// Hard ceiling on any single top-up. `GAS_FUNDER_MAX_TX_WEI`.
+    pub max_tx_wei: U256,
+    /// Hard ceiling on total funding broadcast per rolling 24h.
+    /// `GAS_FUNDER_DAILY_CAP_WEI`.
+    pub daily_cap_wei: U256,
+    /// Email a "reload me" alert when the hot wallet itself drops below this.
+    /// `GAS_FUNDER_HOTWALLET_MIN_WEI`.
+    pub hotwallet_min_wei: U256,
+    /// Seconds between funder ticks. `GAS_FUNDER_INTERVAL_SECS` (default 900).
+    pub interval_secs: u64,
+    /// Recipient for all funder alert emails. `GAS_FUNDER_ALERT_EMAIL`.
+    pub alert_email: String,
+    /// Also monitor/fund the admin payer (`get_admin_api_payer`) alongside the
+    /// pool. `GAS_FUNDER_INCLUDE_ADMIN` (default true).
+    pub include_admin: bool,
+}
+
+impl std::fmt::Debug for GasFunderConfig {
+    /// Redacts the private key (prints only the derived hot-wallet address).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GasFunderConfig")
+            .field("enabled", &self.enabled)
+            .field("hot_wallet", &self.signer.address())
+            .field("rpc_url", &self.rpc_url)
+            .field("chain_id", &self.chain_id)
+            .field("low_water_wei", &self.low_water_wei)
+            .field("high_water_wei", &self.high_water_wei)
+            .field("max_tx_wei", &self.max_tx_wei)
+            .field("daily_cap_wei", &self.daily_cap_wei)
+            .field("hotwallet_min_wei", &self.hotwallet_min_wei)
+            .field("interval_secs", &self.interval_secs)
+            .field("alert_email", &self.alert_email)
+            .field("include_admin", &self.include_admin)
+            .finish()
+    }
 }
 
 impl Config {
@@ -129,7 +199,94 @@ impl Config {
             stripe_webhook_secret: required("STRIPE_WEBHOOK_SECRET")?,
             reconciler_interval_secs: optional_i64("RECONCILER_INTERVAL_SECS", 900)?,
             cors_allowed_origins,
+            gas_funder: parse_gas_funder_config()?,
         })
+    }
+}
+
+/// Parse the optional gas funder config. Returns `None` (feature off) unless
+/// `GAS_FUNDER_PRIVATE_KEY` is set; once it is, every other field is required
+/// so a misconfigured funder fails loudly at boot rather than silently
+/// no-op'ing (or worse, sending the wrong amounts).
+fn parse_gas_funder_config() -> Result<Option<GasFunderConfig>> {
+    let Some(raw_key) = optional_trimmed("GAS_FUNDER_PRIVATE_KEY") else {
+        return Ok(None);
+    };
+
+    let chain_id = optional_i64("GAS_FUNDER_CHAIN_ID", chain::BASE_CHAIN_ID)?;
+    if chain_id <= 0 {
+        anyhow::bail!("GAS_FUNDER_CHAIN_ID must be a positive integer; got {chain_id}");
+    }
+    let chain_id = chain_id as u64;
+
+    let key_hex = raw_key.strip_prefix("0x").unwrap_or(&raw_key);
+    let key_bytes = hex::decode(key_hex)
+        .context("GAS_FUNDER_PRIVATE_KEY must be a hex-encoded 32-byte private key")?;
+    if key_bytes.len() != 32 {
+        anyhow::bail!(
+            "GAS_FUNDER_PRIVATE_KEY must decode to 32 bytes; got {}",
+            key_bytes.len()
+        );
+    }
+    let signer = PrivateKeySigner::from_bytes(&B256::from_slice(&key_bytes))
+        .context("GAS_FUNDER_PRIVATE_KEY is not a valid secp256k1 private key")?
+        .with_chain_id(Some(chain_id));
+
+    let rpc_url = optional_trimmed("GAS_FUNDER_RPC_URL")
+        .or_else(|| optional_trimmed("ALCHEMY_HTTPS_URL"))
+        .context(
+            "GAS_FUNDER_RPC_URL (or ALCHEMY_HTTPS_URL) is required when GAS_FUNDER_PRIVATE_KEY is set",
+        )?;
+
+    let low_water_wei = required_u256_wei("GAS_FUNDER_LOW_WATER_WEI")?;
+    let high_water_wei = required_u256_wei("GAS_FUNDER_HIGH_WATER_WEI")?;
+    let max_tx_wei = required_u256_wei("GAS_FUNDER_MAX_TX_WEI")?;
+    let daily_cap_wei = required_u256_wei("GAS_FUNDER_DAILY_CAP_WEI")?;
+    let hotwallet_min_wei = required_u256_wei("GAS_FUNDER_HOTWALLET_MIN_WEI")?;
+
+    if high_water_wei <= low_water_wei {
+        anyhow::bail!("GAS_FUNDER_HIGH_WATER_WEI must be greater than GAS_FUNDER_LOW_WATER_WEI");
+    }
+    if max_tx_wei.is_zero() {
+        anyhow::bail!("GAS_FUNDER_MAX_TX_WEI must be greater than 0");
+    }
+    if daily_cap_wei.is_zero() {
+        anyhow::bail!("GAS_FUNDER_DAILY_CAP_WEI must be greater than 0");
+    }
+
+    Ok(Some(GasFunderConfig {
+        enabled: optional_bool("GAS_FUNDER_ENABLED", false),
+        signer,
+        rpc_url,
+        chain_id,
+        low_water_wei,
+        high_water_wei,
+        max_tx_wei,
+        daily_cap_wei,
+        hotwallet_min_wei,
+        interval_secs: optional_i64("GAS_FUNDER_INTERVAL_SECS", 900)?.max(30) as u64,
+        alert_email: required("GAS_FUNDER_ALERT_EMAIL")?,
+        include_admin: optional_bool("GAS_FUNDER_INCLUDE_ADMIN", true),
+    }))
+}
+
+/// Parse a required base-10 wei amount into a `U256`. (A `0x`-prefixed value
+/// is accepted as hex, but env values are expected to be decimal wei.)
+fn required_u256_wei(name: &str) -> Result<U256> {
+    let raw = required(name)?;
+    U256::from_str(raw.trim())
+        .with_context(|| format!("{name} must be a base-10 wei integer; got {raw:?}"))
+}
+
+/// Parse a boolean env var. Truthy: `1`, `true`, `yes`, `on` (case-insensitive).
+/// Anything else present is false; absent returns `default`.
+fn optional_bool(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => default,
     }
 }
 

--- a/lit-payments/src/gas_funder/db.rs
+++ b/lit-payments/src/gas_funder/db.rs
@@ -9,11 +9,52 @@
 use alloy_primitives::U256;
 use anyhow::{Context, Result};
 use sqlx::PgPool;
+use sqlx::pool::PoolConnection;
+use sqlx::postgres::Postgres;
 use std::str::FromStr;
 
+/// Postgres session advisory-lock key for the funder singleton. Guards against
+/// two funder processes running concurrently (e.g. during a Railway deploy
+/// overlap, where the new instance boots and fires its first tick before the
+/// old one is torn down) — `numReplicas: 1` does not cover that window.
+const GAS_FUNDER_LOCK_KEY: i64 = 7_766_980_010_001;
+
+/// Try to take the funder's singleton advisory lock on a dedicated pooled
+/// connection. Returns the held connection on success (caller MUST pass it to
+/// [`release_lock`] when done), or `None` if another process holds it.
+///
+/// The lock is a *session* lock bound to this connection, so the connection is
+/// held for the whole tick and explicitly unlocked before being returned to
+/// the pool — dropping it without unlocking would strand the lock on a pooled
+/// backend.
+pub async fn try_acquire_lock(pool: &PgPool) -> Result<Option<PoolConnection<Postgres>>> {
+    let mut conn = pool
+        .acquire()
+        .await
+        .context("acquiring connection for funder advisory lock")?;
+    let got: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+        .bind(GAS_FUNDER_LOCK_KEY)
+        .fetch_one(&mut *conn)
+        .await
+        .context("pg_try_advisory_lock")?;
+    if got { Ok(Some(conn)) } else { Ok(None) }
+}
+
+/// Release the funder advisory lock and return the connection to the pool.
+pub async fn release_lock(mut conn: PoolConnection<Postgres>) {
+    if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
+        .bind(GAS_FUNDER_LOCK_KEY)
+        .execute(&mut *conn)
+        .await
+    {
+        tracing::warn!("gas_funder: failed to release advisory lock: {e}");
+    }
+}
+
 /// Sum of all non-failed funding amounts in the last 24h for `chain_id`.
-/// Backs the rolling daily spend cap. `pending` rows are included so an
-/// interrupted send still consumes budget (conservative).
+/// Backs the rolling daily spend cap. `pending` and `broadcast` rows are
+/// included so an interrupted or unconfirmed send still consumes budget
+/// (fail-closed: we never refund budget for money that may be in flight).
 pub async fn funded_last_24h(pool: &PgPool, chain_id: i64) -> Result<U256> {
     let total: String = sqlx::query_scalar(
         "SELECT COALESCE(SUM(amount_wei), 0)::text
@@ -54,6 +95,52 @@ pub async fn insert_pending(
     Ok(id)
 }
 
+/// Record that the transaction was accepted by the RPC (broadcast) and stamp
+/// its hash, BEFORE we wait for the receipt. This is the critical fail-closed
+/// step: if the subsequent receipt wait times out or errors, the row stays
+/// `broadcast` (still counted against the cap) and carries the hash, so we
+/// never "forget" money already in the mempool and re-send it.
+pub async fn mark_broadcast(pool: &PgPool, id: i64, tx_hash: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE gas_funding_events
+            SET status = 'broadcast', tx_hash = $2, updated_at = now()
+          WHERE id = $1",
+    )
+    .bind(id)
+    .bind(tx_hash)
+    .execute(pool)
+    .await
+    .context("mark gas funding event broadcast")?;
+    Ok(())
+}
+
+/// True if `recipient` already has a non-failed funding row within
+/// `within_secs`. Used to skip re-funding a wallet whose previous top-up is
+/// still in flight (or just landed), preventing a double-send when a tx is
+/// slow to mine.
+pub async fn funded_recipient_recently(
+    pool: &PgPool,
+    chain_id: i64,
+    recipient: &str,
+    within_secs: i64,
+) -> Result<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM gas_funding_events
+             WHERE chain_id = $1
+               AND recipient = $2
+               AND status <> 'failed'
+               AND created_at > now() - ($3 || ' seconds')::interval)",
+    )
+    .bind(chain_id)
+    .bind(recipient)
+    .bind(within_secs.to_string())
+    .fetch_one(pool)
+    .await
+    .context("checking recent funding for recipient")?;
+    Ok(exists)
+}
+
 pub async fn mark_sent(pool: &PgPool, id: i64, tx_hash: &str) -> Result<()> {
     sqlx::query(
         "UPDATE gas_funding_events
@@ -82,14 +169,15 @@ pub async fn mark_failed(pool: &PgPool, id: i64, error: &str) -> Result<()> {
     Ok(())
 }
 
-/// Count `pending` rows older than `older_than_secs` — these are sends that
-/// were recorded but never transitioned (a crash between insert and receipt).
-/// Surfaced as a warning; never auto-retried (that could double-spend).
+/// Count unresolved rows (`pending` recorded-but-not-broadcast, or `broadcast`
+/// awaiting a receipt we never observed) older than `older_than_secs`. These
+/// are interrupted/unconfirmed sends. Surfaced as a warning; never auto-retried
+/// (that could double-spend).
 pub async fn count_stale_pending(pool: &PgPool, older_than_secs: i64) -> Result<i64> {
     let n: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
            FROM gas_funding_events
-          WHERE status = 'pending'
+          WHERE status IN ('pending', 'broadcast')
             AND created_at < now() - ($1 || ' seconds')::interval",
     )
     .bind(older_than_secs.to_string())
@@ -120,4 +208,16 @@ pub async fn should_alert(pool: &PgPool, key: &str, cooldown_secs: i64) -> Resul
     .await
     .context("gas funder alert cooldown upsert")?;
     Ok(acquired.is_some())
+}
+
+/// Clear an alert's cooldown so it can fire again on the next tick. Called when
+/// the email send fails *after* `should_alert` already stamped the cooldown, so
+/// a failed notification doesn't silence the alert for the whole window.
+pub async fn reset_alert(pool: &PgPool, key: &str) -> Result<()> {
+    sqlx::query("DELETE FROM gas_funder_alerts WHERE alert_key = $1")
+        .bind(key)
+        .execute(pool)
+        .await
+        .context("resetting gas funder alert cooldown")?;
+    Ok(())
 }

--- a/lit-payments/src/gas_funder/db.rs
+++ b/lit-payments/src/gas_funder/db.rs
@@ -1,0 +1,123 @@
+//! Postgres helpers for the gas funder.
+//!
+//! Wei amounts are stored in NUMERIC columns and crossed the sqlx boundary as
+//! base-10 strings (cast `$n::numeric` on write, `::text` on read) so we never
+//! round a 256-bit value through an `f64`. The 24h cap sum and the alert
+//! cooldown both run as single statements — the funder loop is single-instance
+//! (Railway `numReplicas: 1`), so there's no cross-replica race to guard.
+
+use alloy_primitives::U256;
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+use std::str::FromStr;
+
+/// Sum of all non-failed funding amounts in the last 24h for `chain_id`.
+/// Backs the rolling daily spend cap. `pending` rows are included so an
+/// interrupted send still consumes budget (conservative).
+pub async fn funded_last_24h(pool: &PgPool, chain_id: i64) -> Result<U256> {
+    let total: String = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(amount_wei), 0)::text
+           FROM gas_funding_events
+          WHERE chain_id = $1
+            AND status <> 'failed'
+            AND created_at > now() - interval '24 hours'",
+    )
+    .bind(chain_id)
+    .fetch_one(pool)
+    .await
+    .context("summing 24h gas funding")?;
+    U256::from_str(total.trim()).with_context(|| format!("parsing 24h funding sum {total:?}"))
+}
+
+/// Record an intended send as `pending` BEFORE broadcasting. Returns the row
+/// id so the caller can transition it to `sent`/`failed`.
+pub async fn insert_pending(
+    pool: &PgPool,
+    chain_id: i64,
+    recipient: &str,
+    amount_wei: &str,
+    balance_before_wei: &str,
+) -> Result<i64> {
+    let id = sqlx::query_scalar::<_, i64>(
+        "INSERT INTO gas_funding_events
+            (chain_id, recipient, amount_wei, balance_before_wei, status)
+         VALUES ($1, $2, $3::numeric, $4::numeric, 'pending')
+         RETURNING id",
+    )
+    .bind(chain_id)
+    .bind(recipient)
+    .bind(amount_wei)
+    .bind(balance_before_wei)
+    .fetch_one(pool)
+    .await
+    .context("insert pending gas funding event")?;
+    Ok(id)
+}
+
+pub async fn mark_sent(pool: &PgPool, id: i64, tx_hash: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE gas_funding_events
+            SET status = 'sent', tx_hash = $2, updated_at = now()
+          WHERE id = $1",
+    )
+    .bind(id)
+    .bind(tx_hash)
+    .execute(pool)
+    .await
+    .context("mark gas funding event sent")?;
+    Ok(())
+}
+
+pub async fn mark_failed(pool: &PgPool, id: i64, error: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE gas_funding_events
+            SET status = 'failed', error = $2, updated_at = now()
+          WHERE id = $1",
+    )
+    .bind(id)
+    .bind(error)
+    .execute(pool)
+    .await
+    .context("mark gas funding event failed")?;
+    Ok(())
+}
+
+/// Count `pending` rows older than `older_than_secs` — these are sends that
+/// were recorded but never transitioned (a crash between insert and receipt).
+/// Surfaced as a warning; never auto-retried (that could double-spend).
+pub async fn count_stale_pending(pool: &PgPool, older_than_secs: i64) -> Result<i64> {
+    let n: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+           FROM gas_funding_events
+          WHERE status = 'pending'
+            AND created_at < now() - ($1 || ' seconds')::interval",
+    )
+    .bind(older_than_secs.to_string())
+    .fetch_one(pool)
+    .await
+    .context("count stale pending gas funding events")?;
+    Ok(n)
+}
+
+/// Acquire the right to send the alert keyed by `key`, respecting a cooldown.
+///
+/// Returns `true` if no alert for this key has been sent within
+/// `cooldown_secs` (and stamps `now()`), `false` if it's still cooling down.
+/// The decision and the stamp happen in one upsert so repeated ticks can't
+/// both pass.
+pub async fn should_alert(pool: &PgPool, key: &str, cooldown_secs: i64) -> Result<bool> {
+    let acquired: Option<String> = sqlx::query_scalar(
+        "INSERT INTO gas_funder_alerts (alert_key, last_sent_at)
+         VALUES ($1, now())
+         ON CONFLICT (alert_key) DO UPDATE
+            SET last_sent_at = now()
+          WHERE gas_funder_alerts.last_sent_at < now() - ($2 || ' seconds')::interval
+         RETURNING alert_key",
+    )
+    .bind(key)
+    .bind(cooldown_secs.to_string())
+    .fetch_optional(pool)
+    .await
+    .context("gas funder alert cooldown upsert")?;
+    Ok(acquired.is_some())
+}

--- a/lit-payments/src/gas_funder/mod.rs
+++ b/lit-payments/src/gas_funder/mod.rs
@@ -598,9 +598,9 @@ async fn execute_topup(
         }
         // Leave the row `broadcast` (budget retained, hash recorded) — do NOT
         // mark failed; the funds may well have landed.
-        Ok(Err(e)) => anyhow::bail!(
-            "receipt error for {tx_hash} (left in-flight, budget retained): {e}"
-        ),
+        Ok(Err(e)) => {
+            anyhow::bail!("receipt error for {tx_hash} (left in-flight, budget retained): {e}")
+        }
         Err(_) => anyhow::bail!(
             "receipt timeout for {tx_hash} after {RECEIPT_TIMEOUT:?} (left in-flight, budget retained)"
         ),
@@ -735,7 +735,9 @@ async fn maybe_alert(
                 // The cooldown was already stamped; clear it so a failed send
                 // doesn't silence this alert for the whole window.
                 if let Err(e2) = db::reset_alert(pool, key).await {
-                    tracing::warn!("gas_funder: could not reset alert '{key}' after send failure: {e2}");
+                    tracing::warn!(
+                        "gas_funder: could not reset alert '{key}' after send failure: {e2}"
+                    );
                 }
             }
         }
@@ -797,14 +799,26 @@ mod tests {
             (addr(1), wei("100")), // at low-water
             (addr(2), wei("200")), // above
         ];
-        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("1000"), wei("100000"));
+        let plan = decide_topups(
+            &balances,
+            wei("100"),
+            wei("500"),
+            wei("1000"),
+            wei("100000"),
+        );
         assert!(plan.is_empty());
     }
 
     #[test]
     fn tops_low_payer_up_to_high_water() {
         let balances = vec![(addr(1), wei("30"))];
-        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("1000"), wei("100000"));
+        let plan = decide_topups(
+            &balances,
+            wei("100"),
+            wei("500"),
+            wei("1000"),
+            wei("100000"),
+        );
         assert_eq!(plan.len(), 1);
         assert_eq!(plan[0].recipient, addr(1));
         assert_eq!(plan[0].amount_wei, wei("470")); // 500 - 30

--- a/lit-payments/src/gas_funder/mod.rs
+++ b/lit-payments/src/gas_funder/mod.rs
@@ -46,12 +46,21 @@ const HOTWALLET_ALERT_COOLDOWN_SECS: i64 = 6 * 3600;
 const FAILURE_ALERT_COOLDOWN_SECS: i64 = 3600;
 /// Cooldown for the OBSERVE-mode "would have funded" email.
 const OBSERVE_ALERT_COOLDOWN_SECS: i64 = 6 * 3600;
-/// A `pending` funding row older than this is flagged as a possible
-/// interrupted send (never auto-retried — that could double-spend).
+/// A `pending`/`broadcast` funding row older than this is flagged as a possible
+/// interrupted/unconfirmed send (never auto-retried — that could double-spend).
 const STALE_PENDING_SECS: i64 = 600;
 /// Gas units assumed for a plain value transfer when sizing the hot-wallet
 /// coverage reserve.
 const VALUE_TRANSFER_GAS: u64 = 21_000;
+/// Max time to wait for a funding tx receipt before giving up on confirmation.
+/// On timeout the row stays `broadcast` (counted against the cap) so the funds
+/// are never re-sent; the next tick's recent-funding guard also skips it.
+const RECEIPT_TIMEOUT: Duration = Duration::from_secs(120);
+/// Skip re-funding a recipient that already has a non-failed funding row within
+/// this window — prevents a double-send when a prior top-up is slow to mine.
+const INFLIGHT_GRACE_SECS: i64 = 900;
+/// Cooldown for the admin-payer-unreachable and spoofed-payer alerts.
+const STRUCTURAL_ALERT_COOLDOWN_SECS: i64 = 6 * 3600;
 
 /// Spawn the background funder loop. No-op (logs once) when the funder is not
 /// configured. Returns immediately; the loop runs for the process lifetime.
@@ -85,10 +94,30 @@ pub fn spawn(config: Config, pool: PgPool, mailer: Mailer) {
     });
 }
 
-/// One funder pass: read balances, decide top-ups, alert, and (in ACTIVE
-/// mode) fund. Errors from individual sends are caught and alerted; only
-/// setup failures (RPC/payer-list unreachable) bubble up to the caller.
+/// One funder pass, guarded by a singleton advisory lock so a deploy overlap
+/// or stray second process can't run two funders against the same budget.
 async fn run_once(
+    config: &Config,
+    funder: &GasFunderConfig,
+    pool: &PgPool,
+    mailer: &Mailer,
+) -> Result<()> {
+    let Some(lock) = db::try_acquire_lock(pool).await? else {
+        tracing::warn!("gas_funder: another instance holds the funder lock; skipping tick");
+        return Ok(());
+    };
+    // Run the body and ALWAYS release the lock, regardless of how it returns,
+    // so the session lock isn't stranded on the pooled connection.
+    let result = run_locked(config, funder, pool, mailer).await;
+    db::release_lock(lock).await;
+    result
+}
+
+/// The funder body, run while holding the advisory lock: read balances, decide
+/// top-ups, alert, and (in ACTIVE mode) fund. Errors from individual sends are
+/// caught and alerted; only setup failures (RPC/payer-list unreachable) bubble
+/// up to the caller.
+async fn run_locked(
     config: &Config,
     funder: &GasFunderConfig,
     pool: &PgPool,
@@ -111,11 +140,57 @@ async fn run_once(
         .await
         .context("reading hot wallet balance")?;
 
-    let payers = fetch_payers(config, funder)
+    let (fetched_payers, admin_failed) = fetch_payers(config, funder)
         .await
         .context("fetching API payer set")?;
+    if admin_failed {
+        let body = format!(
+            "gas_funder could not fetch the admin payer from {}/core/v1/get_admin_api_payer, \
+             so the admin payer is NOT being monitored or funded this round.",
+            config.lit_api_server_base_url,
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "admin_payer_unreachable",
+            STRUCTURAL_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder could not reach the admin payer",
+            &body,
+        )
+        .await;
+    }
+
+    // Defense-in-depth for the unauthenticated get_api_payers source: if an
+    // allowlist is configured, only ever consider addresses on it, and alert on
+    // any fetched payer that isn't (a spoofed/MITM/misconfigured response).
+    let (payers, rejected) = apply_allowlist(&fetched_payers, funder.allowed_recipients.as_deref());
+    if !rejected.is_empty() {
+        let body = format!(
+            "gas_funder received {} payer address(es) NOT on GAS_FUNDER_ALLOWED_RECIPIENTS \
+             from {}/core/v1/get_api_payers — possible spoofed/misconfigured response. They \
+             were ignored (not funded):\n\n{}",
+            rejected.len(),
+            config.lit_api_server_base_url,
+            rejected
+                .iter()
+                .map(|a| format!("  {}", format_address(*a)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "payer_not_allowlisted",
+            STRUCTURAL_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder saw a non-allowlisted payer address",
+            &body,
+        )
+        .await;
+    }
     if payers.is_empty() {
-        tracing::warn!("gas_funder: get_api_payers returned no addresses; nothing to do");
+        tracing::warn!("gas_funder: no fundable payer addresses this tick; nothing to do");
         return Ok(());
     }
 
@@ -128,9 +203,29 @@ async fn run_once(
         balances.push((*addr, bal));
     }
 
-    let funded_24h = db::funded_last_24h(pool, funder.chain_id as i64)
-        .await
-        .unwrap_or(U256::ZERO);
+    // Fail CLOSED on the cap ledger: if we can't read 24h spend, don't fund —
+    // an `unwrap_or(0)` here would silently re-authorize a full daily cap.
+    let funded_24h = match db::funded_last_24h(pool, funder.chain_id as i64).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("gas_funder: cannot read 24h cap ledger; skipping funding: {e:?}");
+            let body = format!(
+                "gas_funder could not read its rolling-24h spend ledger, so it is skipping \
+                 funding this tick (fail-closed). Error: {e}"
+            );
+            maybe_alert(
+                pool,
+                mailer,
+                funder,
+                "cap_ledger_unreadable",
+                FAILURE_ALERT_COOLDOWN_SECS,
+                "[lit-payments] Gas funder cap ledger unreadable — funding paused",
+                &body,
+            )
+            .await;
+            return Ok(());
+        }
+    };
     let remaining_budget = funder.daily_cap_wei.saturating_sub(funded_24h);
 
     let low_count = balances
@@ -240,12 +335,49 @@ async fn run_once(
         return Ok(());
     }
 
+    // ACTIVE: verify the RPC actually serves the chain we think it does before
+    // we move real ETH — a wrong GAS_FUNDER_RPC_URL / GAS_FUNDER_CHAIN_ID would
+    // otherwise send funds on the wrong chain.
+    match provider.get_chain_id().await {
+        Ok(cid) if cid == funder.chain_id => {}
+        Ok(cid) => {
+            let body = format!(
+                "gas_funder RPC chain id mismatch: the RPC reports chain {cid} but \
+                 GAS_FUNDER_CHAIN_ID is {}. Refusing to send to avoid wrong-chain transfers.",
+                funder.chain_id,
+            );
+            maybe_alert(
+                pool,
+                mailer,
+                funder,
+                "chain_id_mismatch",
+                FAILURE_ALERT_COOLDOWN_SECS,
+                "[lit-payments] Gas funder RPC chain id mismatch — funding paused",
+                &body,
+            )
+            .await;
+            return Ok(());
+        }
+        Err(e) => {
+            tracing::error!("gas_funder: could not read RPC chain id; skipping: {e:?}");
+            return Ok(());
+        }
+    }
+
     // ACTIVE: make sure the hot wallet can physically cover the plan + gas
     // before we start broadcasting, so we don't get a half-funded round.
     let total_planned = plan
         .iter()
         .fold(U256::ZERO, |acc, p| acc.saturating_add(p.amount_wei));
-    let gas_price = U256::from(provider.get_gas_price().await.unwrap_or_default());
+    // Fail CLOSED on gas price: a zero fallback would size the reserve at 0 and
+    // start a round the hot wallet can't actually complete.
+    let gas_price = match provider.get_gas_price().await {
+        Ok(g) => U256::from(g),
+        Err(e) => {
+            tracing::error!("gas_funder: could not read gas price; skipping round: {e:?}");
+            return Ok(());
+        }
+    };
     // 2x headroom over the nominal value-transfer gas, per planned send.
     let gas_reserve = gas_price
         .saturating_mul(U256::from(VALUE_TRANSFER_GAS))
@@ -279,6 +411,34 @@ async fn run_once(
 
     let mut failures: Vec<String> = Vec::new();
     for planned in &plan {
+        // Skip a recipient that already has an in-flight / recently-landed
+        // top-up — guards against double-funding when a prior tx is slow to
+        // mine and the balance still reads low.
+        match db::funded_recipient_recently(
+            pool,
+            funder.chain_id as i64,
+            &format_address(planned.recipient),
+            INFLIGHT_GRACE_SECS,
+        )
+        .await
+        {
+            Ok(true) => {
+                tracing::info!(
+                    recipient = %format_address(planned.recipient),
+                    "gas_funder: skipping — recent/in-flight funding within {INFLIGHT_GRACE_SECS}s"
+                );
+                continue;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                // Can't prove there's no in-flight send → fail closed, skip it.
+                tracing::error!(
+                    recipient = %format_address(planned.recipient),
+                    "gas_funder: recent-funding check failed; skipping recipient: {e:?}"
+                );
+                continue;
+            }
+        }
         match execute_topup(&provider, funder, pool, planned).await {
             Ok(tx_hash) => tracing::info!(
                 recipient = %format_address(planned.recipient),
@@ -374,8 +534,16 @@ pub fn decide_topups(
     plan
 }
 
-/// Record a `pending` row, broadcast the transfer, await the receipt, then
-/// transition the row to `sent`/`failed`. Returns the tx hash on success.
+/// Record a `pending` row, broadcast, stamp the tx hash + `broadcast` state
+/// BEFORE waiting, then bounded-wait for the receipt.
+///
+/// Fail-closed money handling:
+/// - `send_transaction` errored (nothing broadcast) → `failed`, budget refunded.
+/// - broadcast OK → hash recorded as `broadcast` (counts against the cap) before
+///   any await, so a later timeout/error can't make us re-send.
+/// - receipt status 1 → `sent`; on-chain revert → `failed`.
+/// - receipt timeout or RPC error → row stays `broadcast` (budget retained); we
+///   return Err so it's alerted, but the funds are NOT re-sent.
 async fn execute_topup(
     provider: &DynProvider,
     funder: &GasFunderConfig,
@@ -400,28 +568,42 @@ async fn execute_topup(
         ..Default::default()
     };
 
-    match provider.send_transaction(req).await {
-        Ok(pending) => match pending.get_receipt().await {
-            Ok(receipt) => {
-                let tx_hash = format!("{:#x}", receipt.transaction_hash);
-                if receipt.status() {
-                    db::mark_sent(pool, id, &tx_hash).await?;
-                    Ok(tx_hash)
-                } else {
-                    let msg = format!("transaction reverted on-chain: {tx_hash}");
-                    db::mark_failed(pool, id, &msg).await?;
-                    anyhow::bail!("{msg}")
-                }
-            }
-            Err(e) => {
-                db::mark_failed(pool, id, &format!("receipt error: {e}")).await?;
-                Err(anyhow::Error::from(e).context("awaiting funding tx receipt"))
-            }
-        },
+    let pending = match provider.send_transaction(req).await {
+        Ok(p) => p,
         Err(e) => {
+            // Nothing left the node — safe to mark failed and refund budget.
             db::mark_failed(pool, id, &format!("send error: {e}")).await?;
-            Err(anyhow::Error::from(e).context("broadcasting funding tx"))
+            return Err(anyhow::Error::from(e).context("broadcasting funding tx"));
         }
+    };
+
+    // Broadcast accepted. Persist the hash + `broadcast` state NOW, before the
+    // receipt wait, so an interrupted confirmation can never lose track of money
+    // already in the mempool.
+    let tx_hash = format!("{:#x}", pending.tx_hash());
+    db::mark_broadcast(pool, id, &tx_hash)
+        .await
+        .context("recording broadcast funding event")?;
+
+    match tokio::time::timeout(RECEIPT_TIMEOUT, pending.get_receipt()).await {
+        Ok(Ok(receipt)) => {
+            if receipt.status() {
+                db::mark_sent(pool, id, &tx_hash).await?;
+                Ok(tx_hash)
+            } else {
+                // A reverted transfer moved no value; safe to mark failed.
+                db::mark_failed(pool, id, &format!("reverted on-chain: {tx_hash}")).await?;
+                anyhow::bail!("funding tx reverted on-chain: {tx_hash}")
+            }
+        }
+        // Leave the row `broadcast` (budget retained, hash recorded) — do NOT
+        // mark failed; the funds may well have landed.
+        Ok(Err(e)) => anyhow::bail!(
+            "receipt error for {tx_hash} (left in-flight, budget retained): {e}"
+        ),
+        Err(_) => anyhow::bail!(
+            "receipt timeout for {tx_hash} after {RECEIPT_TIMEOUT:?} (left in-flight, budget retained)"
+        ),
     }
 }
 
@@ -440,7 +622,11 @@ fn build_provider(funder: &GasFunderConfig) -> Result<DynProvider> {
 
 /// Fetch the live API payer set from lit-api-server (and the admin payer when
 /// `include_admin`). These are public, unauthenticated read endpoints.
-async fn fetch_payers(config: &Config, funder: &GasFunderConfig) -> Result<Vec<Address>> {
+///
+/// Returns `(payers, admin_fetch_failed)`. `admin_fetch_failed` is true only
+/// when `include_admin` is set and the admin endpoint errored — surfaced as an
+/// alert by the caller so the admin payer isn't silently dropped from coverage.
+async fn fetch_payers(config: &Config, funder: &GasFunderConfig) -> Result<(Vec<Address>, bool)> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
@@ -470,15 +656,43 @@ async fn fetch_payers(config: &Config, funder: &GasFunderConfig) -> Result<Vec<A
         }
     }
 
+    let mut admin_failed = false;
     if funder.include_admin {
         match fetch_admin_payer(&client, base).await {
             Ok(Some(addr)) if !out.contains(&addr) => out.push(addr),
             Ok(_) => {}
-            Err(e) => tracing::warn!("gas_funder: could not fetch admin payer (skipping): {e}"),
+            Err(e) => {
+                tracing::warn!("gas_funder: could not fetch admin payer (skipping): {e}");
+                admin_failed = true;
+            }
         }
     }
 
-    Ok(out)
+    Ok((out, admin_failed))
+}
+
+/// Restrict the fetched payer set to the configured allowlist. Returns
+/// `(allowed, rejected)`. With no allowlist, everything is allowed and
+/// `rejected` is empty. Pure — unit-tested.
+fn apply_allowlist(
+    fetched: &[Address],
+    allowlist: Option<&[Address]>,
+) -> (Vec<Address>, Vec<Address>) {
+    match allowlist {
+        None => (fetched.to_vec(), Vec::new()),
+        Some(allow) => {
+            let mut allowed = Vec::new();
+            let mut rejected = Vec::new();
+            for &a in fetched {
+                if allow.contains(&a) {
+                    allowed.push(a);
+                } else {
+                    rejected.push(a);
+                }
+            }
+            (allowed, rejected)
+        }
+    }
 }
 
 async fn fetch_admin_payer(client: &reqwest::Client, base: &str) -> Result<Option<Address>> {
@@ -518,6 +732,11 @@ async fn maybe_alert(
             let html = format!("<pre>{}</pre>", html_escape(body));
             if let Err(e) = mailer.send(&funder.alert_email, subject, &html, body).await {
                 tracing::warn!("gas_funder: alert email '{key}' failed to send: {e}");
+                // The cooldown was already stamped; clear it so a failed send
+                // doesn't silence this alert for the whole window.
+                if let Err(e2) = db::reset_alert(pool, key).await {
+                    tracing::warn!("gas_funder: could not reset alert '{key}' after send failure: {e2}");
+                }
             }
         }
         Ok(false) => {
@@ -622,5 +841,31 @@ mod tests {
     #[test]
     fn html_escape_neutralizes_markup() {
         assert_eq!(html_escape("a & b < c > d"), "a &amp; b &lt; c &gt; d");
+    }
+
+    #[test]
+    fn allowlist_none_allows_everything() {
+        let fetched = vec![addr(1), addr(2)];
+        let (allowed, rejected) = apply_allowlist(&fetched, None);
+        assert_eq!(allowed, fetched);
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn allowlist_partitions_fetched_into_allowed_and_rejected() {
+        let fetched = vec![addr(1), addr(2), addr(3)];
+        let allow = vec![addr(1), addr(3), addr(9)]; // 9 not fetched; ignored
+        let (allowed, rejected) = apply_allowlist(&fetched, Some(&allow));
+        assert_eq!(allowed, vec![addr(1), addr(3)]);
+        assert_eq!(rejected, vec![addr(2)]); // attacker-injected / unexpected
+    }
+
+    #[test]
+    fn allowlist_rejects_all_when_none_match() {
+        let fetched = vec![addr(7), addr(8)];
+        let allow = vec![addr(1)];
+        let (allowed, rejected) = apply_allowlist(&fetched, Some(&allow));
+        assert!(allowed.is_empty());
+        assert_eq!(rejected, fetched);
     }
 }

--- a/lit-payments/src/gas_funder/mod.rs
+++ b/lit-payments/src/gas_funder/mod.rs
@@ -1,0 +1,626 @@
+//! API-payer gas funder.
+//!
+//! Keeps the lit-api-server payer pool topped up so `new_account` (and other
+//! on-chain writes) never fail with `insufficient funds for gas`.
+//!
+//! Background: lit-api-server signs writes from a pool of payer wallets whose
+//! keys live in the dstack TEE. Pool signer-selection is round-robin and *not*
+//! balance-aware, so a single drained wallet causes intermittent 500s. The
+//! in-TEE admin payer only rebalances on pool *resize*, never continuously.
+//! lit-payments runs out of the TEE hot path (Railway, single instance), so it
+//! carries a small hot wallet and tops payers up on a schedule.
+//!
+//! ## Modes
+//! - OBSERVE (`GAS_FUNDER_ENABLED` unset/false): read balances, email
+//!   alerts, broadcast nothing. Safe first deploy.
+//! - ACTIVE (`GAS_FUNDER_ENABLED=true`): top up any payer below low-water up
+//!   to high-water, subject to a per-tx cap and a rolling 24h cap.
+//!
+//! ## Safety rails
+//! - Funds the *live* `get_api_payers` set each tick (the pool rotates).
+//! - Per-tx ceiling + rolling-24h ceiling (DB-summed); a bug/compromise can't
+//!   drain the hot wallet in one tick.
+//! - Records a `pending` row BEFORE each send; single-instance + await-receipt
+//!   makes nonces sequential and avoids double-spend on restart.
+//! - "Reload me" email when the hot wallet itself runs low (the one wallet a
+//!   human watches); routine successful top-ups are silent (info logs only).
+
+mod db;
+
+use std::time::Duration;
+
+use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use alloy_primitives::{Address, TxKind, U256};
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+use tokio::time as tokio_time;
+
+use crate::chain::format_address;
+use crate::config::{Config, GasFunderConfig};
+use crate::mail::Mailer;
+
+/// Cooldown for the "hot wallet low — reload me" email.
+const HOTWALLET_ALERT_COOLDOWN_SECS: i64 = 6 * 3600;
+/// Cooldown for failure / cap-reached / can't-cover alerts.
+const FAILURE_ALERT_COOLDOWN_SECS: i64 = 3600;
+/// Cooldown for the OBSERVE-mode "would have funded" email.
+const OBSERVE_ALERT_COOLDOWN_SECS: i64 = 6 * 3600;
+/// A `pending` funding row older than this is flagged as a possible
+/// interrupted send (never auto-retried — that could double-spend).
+const STALE_PENDING_SECS: i64 = 600;
+/// Gas units assumed for a plain value transfer when sizing the hot-wallet
+/// coverage reserve.
+const VALUE_TRANSFER_GAS: u64 = 21_000;
+
+/// Spawn the background funder loop. No-op (logs once) when the funder is not
+/// configured. Returns immediately; the loop runs for the process lifetime.
+pub fn spawn(config: Config, pool: PgPool, mailer: Mailer) {
+    let Some(funder) = config.gas_funder.clone() else {
+        tracing::info!("gas_funder: not configured (GAS_FUNDER_PRIVATE_KEY unset); skipping");
+        return;
+    };
+    let interval_secs = funder.interval_secs.max(30);
+    tracing::info!(
+        mode = if funder.enabled { "ACTIVE" } else { "OBSERVE" },
+        chain_id = funder.chain_id,
+        interval_secs,
+        hot_wallet = %format_address(funder.signer.address()),
+        include_admin = funder.include_admin,
+        "gas_funder: starting ({})",
+        if funder.enabled {
+            "will broadcast funding txns"
+        } else {
+            "alerts only, no sends"
+        }
+    );
+    tokio::spawn(async move {
+        let mut ticker = tokio_time::interval(Duration::from_secs(interval_secs));
+        loop {
+            ticker.tick().await;
+            if let Err(e) = run_once(&config, &funder, &pool, &mailer).await {
+                tracing::warn!("gas_funder tick failed: {e:?}");
+            }
+        }
+    });
+}
+
+/// One funder pass: read balances, decide top-ups, alert, and (in ACTIVE
+/// mode) fund. Errors from individual sends are caught and alerted; only
+/// setup failures (RPC/payer-list unreachable) bubble up to the caller.
+async fn run_once(
+    config: &Config,
+    funder: &GasFunderConfig,
+    pool: &PgPool,
+    mailer: &Mailer,
+) -> Result<()> {
+    if let Ok(n) = db::count_stale_pending(pool, STALE_PENDING_SECS).await
+        && n > 0
+    {
+        tracing::warn!(
+            "gas_funder: {n} pending funding event(s) older than {STALE_PENDING_SECS}s — \
+             possible interrupted send; not auto-retried (inspect gas_funding_events)"
+        );
+    }
+
+    let provider = build_provider(funder)?;
+
+    let hot_addr = funder.signer.address();
+    let hot_balance = provider
+        .get_balance(hot_addr)
+        .await
+        .context("reading hot wallet balance")?;
+
+    let payers = fetch_payers(config, funder)
+        .await
+        .context("fetching API payer set")?;
+    if payers.is_empty() {
+        tracing::warn!("gas_funder: get_api_payers returned no addresses; nothing to do");
+        return Ok(());
+    }
+
+    let mut balances: Vec<(Address, U256)> = Vec::with_capacity(payers.len());
+    for addr in &payers {
+        let bal = provider
+            .get_balance(*addr)
+            .await
+            .with_context(|| format!("reading balance of {}", format_address(*addr)))?;
+        balances.push((*addr, bal));
+    }
+
+    let funded_24h = db::funded_last_24h(pool, funder.chain_id as i64)
+        .await
+        .unwrap_or(U256::ZERO);
+    let remaining_budget = funder.daily_cap_wei.saturating_sub(funded_24h);
+
+    let low_count = balances
+        .iter()
+        .filter(|(_, b)| *b < funder.low_water_wei)
+        .count();
+
+    tracing::info!(
+        mode = if funder.enabled { "ACTIVE" } else { "OBSERVE" },
+        hot_wallet = %format_address(hot_addr),
+        hot_balance_wei = %hot_balance,
+        payers = payers.len(),
+        below_low_water = low_count,
+        funded_24h_wei = %funded_24h,
+        remaining_budget_wei = %remaining_budget,
+        "gas_funder: tick"
+    );
+
+    // "Reload me" — the one wallet a human watches. Independent of whether any
+    // payer is low right now.
+    if hot_balance < funder.hotwallet_min_wei {
+        let body = format!(
+            "The gas funder hot wallet is running low.\n\n\
+             Hot wallet : {}\n\
+             Balance    : {} wei\n\
+             Reload at  : {} wei (GAS_FUNDER_HOTWALLET_MIN_WEI)\n\n\
+             Reload it so it can keep topping up the lit-api-server API payer wallets.",
+            format_address(hot_addr),
+            hot_balance,
+            funder.hotwallet_min_wei,
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "hotwallet_low",
+            HOTWALLET_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder hot wallet low — reload needed",
+            &body,
+        )
+        .await;
+    }
+
+    if low_count == 0 {
+        return Ok(());
+    }
+
+    // Payers are low but the rolling cap is spent — alert and stop. (Checked
+    // before planning because decide_topups would otherwise return an empty
+    // plan and we'd say nothing.)
+    if remaining_budget.is_zero() {
+        let body = format!(
+            "The gas funder hit its rolling 24h cap ({} wei) but {} payer wallet(s) are still \
+             below low-water ({} wei):\n\n{}\n\nRaise GAS_FUNDER_DAILY_CAP_WEI or investigate \
+             unusually fast gas burn.",
+            funder.daily_cap_wei,
+            low_count,
+            funder.low_water_wei,
+            format_low_list(&balances, funder.low_water_wei),
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "daily_cap_reached",
+            FAILURE_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder daily cap reached — payers still low",
+            &body,
+        )
+        .await;
+        return Ok(());
+    }
+
+    let plan = decide_topups(
+        &balances,
+        funder.low_water_wei,
+        funder.high_water_wei,
+        funder.max_tx_wei,
+        remaining_budget,
+    );
+    if plan.is_empty() {
+        return Ok(());
+    }
+
+    // OBSERVE mode: report what we WOULD do, broadcast nothing.
+    if !funder.enabled {
+        let body = format!(
+            "gas_funder is in OBSERVE mode (GAS_FUNDER_ENABLED is not true), so the following \
+             top-ups were NOT sent:\n\n{}\n\nSet GAS_FUNDER_ENABLED=true to enable automatic \
+             funding.",
+            format_plan(&plan),
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "observe_would_fund",
+            OBSERVE_ALERT_COOLDOWN_SECS,
+            "[lit-payments] API payer wallets low (gas funder in observe mode)",
+            &body,
+        )
+        .await;
+        tracing::info!(
+            planned = plan.len(),
+            "gas_funder: OBSERVE mode — top-ups planned but not sent"
+        );
+        return Ok(());
+    }
+
+    // ACTIVE: make sure the hot wallet can physically cover the plan + gas
+    // before we start broadcasting, so we don't get a half-funded round.
+    let total_planned = plan
+        .iter()
+        .fold(U256::ZERO, |acc, p| acc.saturating_add(p.amount_wei));
+    let gas_price = U256::from(provider.get_gas_price().await.unwrap_or_default());
+    // 2x headroom over the nominal value-transfer gas, per planned send.
+    let gas_reserve = gas_price
+        .saturating_mul(U256::from(VALUE_TRANSFER_GAS))
+        .saturating_mul(U256::from(plan.len() as u64))
+        .saturating_mul(U256::from(2u64));
+    if hot_balance < total_planned.saturating_add(gas_reserve) {
+        let body = format!(
+            "The gas funder hot wallet cannot cover this round's planned top-ups.\n\n\
+             Hot wallet     : {}\n\
+             Balance        : {} wei\n\
+             Planned total  : {} wei\n\
+             Gas reserve    : ~{} wei\n\n\
+             Reload the hot wallet. No funding txns were sent this round.",
+            format_address(hot_addr),
+            hot_balance,
+            total_planned,
+            gas_reserve,
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "hotwallet_insufficient",
+            FAILURE_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder hot wallet cannot cover planned top-ups",
+            &body,
+        )
+        .await;
+        return Ok(());
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    for planned in &plan {
+        match execute_topup(&provider, funder, pool, planned).await {
+            Ok(tx_hash) => tracing::info!(
+                recipient = %format_address(planned.recipient),
+                amount_wei = %planned.amount_wei,
+                tx_hash = %tx_hash,
+                "gas_funder: funded payer"
+            ),
+            Err(e) => {
+                tracing::error!(
+                    recipient = %format_address(planned.recipient),
+                    amount_wei = %planned.amount_wei,
+                    "gas_funder: funding failed: {e:?}"
+                );
+                failures.push(format!(
+                    "  {} (+{} wei): {e}",
+                    format_address(planned.recipient),
+                    planned.amount_wei
+                ));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        let body = format!(
+            "gas_funder failed to fund {} payer wallet(s) this round:\n\n{}",
+            failures.len(),
+            failures.join("\n"),
+        );
+        maybe_alert(
+            pool,
+            mailer,
+            funder,
+            "fund_failed",
+            FAILURE_ALERT_COOLDOWN_SECS,
+            "[lit-payments] Gas funder failed to fund payer(s)",
+            &body,
+        )
+        .await;
+    }
+
+    Ok(())
+}
+
+/// A single planned top-up: send `amount_wei` to `recipient` (whose current
+/// balance is `balance_wei`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedTopup {
+    pub recipient: Address,
+    pub amount_wei: U256,
+    pub balance_wei: U256,
+}
+
+/// Decide which payers to top up and by how much. Pure: no chain or DB access,
+/// so it's exhaustively unit-testable.
+///
+/// For each payer below `low_water`, plan to bring it up to `high_water`,
+/// clamped by the per-tx ceiling `max_tx` and the `remaining_budget` (the
+/// rolling-24h cap minus what's already been spent). Budget is consumed
+/// greedily in iteration order; once exhausted, remaining low payers are left
+/// for a future tick.
+pub fn decide_topups(
+    balances: &[(Address, U256)],
+    low_water: U256,
+    high_water: U256,
+    max_tx: U256,
+    mut remaining_budget: U256,
+) -> Vec<PlannedTopup> {
+    let mut plan = Vec::new();
+    for &(recipient, balance) in balances {
+        if balance >= low_water {
+            continue;
+        }
+        let mut amount = high_water.saturating_sub(balance);
+        if amount > max_tx {
+            amount = max_tx;
+        }
+        if amount > remaining_budget {
+            amount = remaining_budget;
+        }
+        if amount.is_zero() {
+            continue;
+        }
+        plan.push(PlannedTopup {
+            recipient,
+            amount_wei: amount,
+            balance_wei: balance,
+        });
+        remaining_budget = remaining_budget.saturating_sub(amount);
+        if remaining_budget.is_zero() {
+            break;
+        }
+    }
+    plan
+}
+
+/// Record a `pending` row, broadcast the transfer, await the receipt, then
+/// transition the row to `sent`/`failed`. Returns the tx hash on success.
+async fn execute_topup(
+    provider: &DynProvider,
+    funder: &GasFunderConfig,
+    pool: &PgPool,
+    planned: &PlannedTopup,
+) -> Result<String> {
+    let recipient = format_address(planned.recipient);
+    let id = db::insert_pending(
+        pool,
+        funder.chain_id as i64,
+        &recipient,
+        &planned.amount_wei.to_string(),
+        &planned.balance_wei.to_string(),
+    )
+    .await
+    .context("recording pending funding event")?;
+
+    let req = TransactionRequest {
+        to: Some(TxKind::Call(planned.recipient)),
+        value: Some(planned.amount_wei),
+        chain_id: Some(funder.chain_id),
+        ..Default::default()
+    };
+
+    match provider.send_transaction(req).await {
+        Ok(pending) => match pending.get_receipt().await {
+            Ok(receipt) => {
+                let tx_hash = format!("{:#x}", receipt.transaction_hash);
+                if receipt.status() {
+                    db::mark_sent(pool, id, &tx_hash).await?;
+                    Ok(tx_hash)
+                } else {
+                    let msg = format!("transaction reverted on-chain: {tx_hash}");
+                    db::mark_failed(pool, id, &msg).await?;
+                    anyhow::bail!("{msg}")
+                }
+            }
+            Err(e) => {
+                db::mark_failed(pool, id, &format!("receipt error: {e}")).await?;
+                Err(anyhow::Error::from(e).context("awaiting funding tx receipt"))
+            }
+        },
+        Err(e) => {
+            db::mark_failed(pool, id, &format!("send error: {e}")).await?;
+            Err(anyhow::Error::from(e).context("broadcasting funding tx"))
+        }
+    }
+}
+
+/// Build a wallet-backed provider for the funder's chain. The default fillers
+/// (nonce, gas, fee, chain-id) handle everything a plain value transfer needs.
+fn build_provider(funder: &GasFunderConfig) -> Result<DynProvider> {
+    let url: reqwest::Url = funder
+        .rpc_url
+        .parse()
+        .context("GAS_FUNDER_RPC_URL is not a valid URL")?;
+    Ok(ProviderBuilder::new()
+        .wallet(funder.signer.clone())
+        .connect_http(url)
+        .erased())
+}
+
+/// Fetch the live API payer set from lit-api-server (and the admin payer when
+/// `include_admin`). These are public, unauthenticated read endpoints.
+async fn fetch_payers(config: &Config, funder: &GasFunderConfig) -> Result<Vec<Address>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("building payer-list HTTP client")?;
+
+    let base = &config.lit_api_server_base_url;
+    let payers_url = format!("{base}/core/v1/get_api_payers");
+    let payer_strings: Vec<String> = client
+        .get(&payers_url)
+        .send()
+        .await
+        .context("GET get_api_payers")?
+        .error_for_status()
+        .context("get_api_payers returned non-success")?
+        .json()
+        .await
+        .context("decoding get_api_payers response")?;
+
+    let mut out = Vec::with_capacity(payer_strings.len() + 1);
+    for p in payer_strings {
+        let addr = p
+            .trim()
+            .parse::<Address>()
+            .with_context(|| format!("get_api_payers returned a non-address entry: {p:?}"))?;
+        if !out.contains(&addr) {
+            out.push(addr);
+        }
+    }
+
+    if funder.include_admin {
+        match fetch_admin_payer(&client, base).await {
+            Ok(Some(addr)) if !out.contains(&addr) => out.push(addr),
+            Ok(_) => {}
+            Err(e) => tracing::warn!("gas_funder: could not fetch admin payer (skipping): {e}"),
+        }
+    }
+
+    Ok(out)
+}
+
+async fn fetch_admin_payer(client: &reqwest::Client, base: &str) -> Result<Option<Address>> {
+    let url = format!("{base}/core/v1/get_admin_api_payer");
+    let raw: String = client
+        .get(&url)
+        .send()
+        .await
+        .context("GET get_admin_api_payer")?
+        .error_for_status()
+        .context("get_admin_api_payer returned non-success")?
+        .json()
+        .await
+        .context("decoding get_admin_api_payer response")?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(trimmed.parse::<Address>().with_context(|| {
+        format!("get_admin_api_payer returned a non-address: {raw:?}")
+    })?))
+}
+
+/// Send an alert email if its cooldown has elapsed. Failures to send are
+/// logged, never propagated — alerting must not break the funder loop.
+async fn maybe_alert(
+    pool: &PgPool,
+    mailer: &Mailer,
+    funder: &GasFunderConfig,
+    key: &str,
+    cooldown_secs: i64,
+    subject: &str,
+    body: &str,
+) {
+    match db::should_alert(pool, key, cooldown_secs).await {
+        Ok(true) => {
+            let html = format!("<pre>{}</pre>", html_escape(body));
+            if let Err(e) = mailer.send(&funder.alert_email, subject, &html, body).await {
+                tracing::warn!("gas_funder: alert email '{key}' failed to send: {e}");
+            }
+        }
+        Ok(false) => {
+            tracing::info!("gas_funder: alert '{key}' suppressed (within cooldown)");
+        }
+        Err(e) => tracing::warn!("gas_funder: alert cooldown check for '{key}' failed: {e}"),
+    }
+}
+
+fn format_plan(plan: &[PlannedTopup]) -> String {
+    plan.iter()
+        .map(|p| {
+            format!(
+                "  {} : balance {} wei  ->  send +{} wei",
+                format_address(p.recipient),
+                p.balance_wei,
+                p.amount_wei
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_low_list(balances: &[(Address, U256)], low_water: U256) -> String {
+    balances
+        .iter()
+        .filter(|(_, b)| *b < low_water)
+        .map(|(a, b)| format!("  {} : {} wei", format_address(*a), b))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Minimal HTML escaping for the alert body (we wrap it in `<pre>`).
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn addr(n: u8) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[19] = n;
+        Address::from(bytes)
+    }
+
+    fn wei(s: &str) -> U256 {
+        U256::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn skips_payers_at_or_above_low_water() {
+        let balances = vec![
+            (addr(1), wei("100")), // at low-water
+            (addr(2), wei("200")), // above
+        ];
+        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("1000"), wei("100000"));
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn tops_low_payer_up_to_high_water() {
+        let balances = vec![(addr(1), wei("30"))];
+        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("1000"), wei("100000"));
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].recipient, addr(1));
+        assert_eq!(plan[0].amount_wei, wei("470")); // 500 - 30
+    }
+
+    #[test]
+    fn clamps_topup_to_max_tx() {
+        let balances = vec![(addr(1), wei("0"))];
+        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("250"), wei("100000"));
+        assert_eq!(plan[0].amount_wei, wei("250")); // capped by max_tx
+    }
+
+    #[test]
+    fn clamps_to_remaining_budget_and_stops_when_exhausted() {
+        let balances = vec![
+            (addr(1), wei("0")),
+            (addr(2), wei("0")),
+            (addr(3), wei("0")),
+        ];
+        // Each wants 500, max_tx 500, but only 700 budget remains.
+        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("500"), wei("700"));
+        assert_eq!(plan.len(), 2);
+        assert_eq!(plan[0].amount_wei, wei("500"));
+        assert_eq!(plan[1].amount_wei, wei("200")); // remainder of the budget
+    }
+
+    #[test]
+    fn zero_remaining_budget_plans_nothing() {
+        let balances = vec![(addr(1), wei("0"))];
+        let plan = decide_topups(&balances, wei("100"), wei("500"), wei("500"), U256::ZERO);
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn html_escape_neutralizes_markup() {
+        assert_eq!(html_escape("a & b < c > d"), "a &amp; b &lt; c &gt; d");
+    }
+}

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -9,6 +9,7 @@ pub mod billing;
 pub mod chain;
 pub mod config;
 pub mod db;
+pub mod gas_funder;
 pub mod internal;
 pub mod mail;
 pub mod portal;

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -47,6 +47,9 @@ async fn rocket() -> _ {
     rate::spawn_rate_poller(pool.clone());
     let per_customer_mutex = PerCustomerMutex::new();
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
+    // Keep the lit-api-server API payer pool topped up (no-op unless
+    // GAS_FUNDER_PRIVATE_KEY is configured). Runs out of the TEE hot path.
+    lit_payments::gas_funder::spawn(cfg.clone(), pool.clone(), mailer.clone());
 
     // Codex P1 (Phase 8): exact-match CORS allowlist driven by
     // `cors_allowed_origins`. The prior config used


### PR DESCRIPTION
lit-api-server signs on-chain writes (`new_account`, etc.) from a TEE-held payer pool whose round-robin signer selection isn't balance-aware, so a single drained wallet causes intermittent `insufficient funds for gas` 500s — and nothing tops the wallets up between pool resizes or alerts when they run low. This adds a gas funder to lit-payments (out of the TEE hot path, single Railway instance, already polling): each tick it reads the live `get_api_payers` set, tops any payer below low-water up to high-water — bounded by per-tx and rolling-24h caps — and emails alerts via the existing Resend mailer. It's off unless `GAS_FUNDER_PRIVATE_KEY` is set and defaults to OBSERVE mode (alerts only, no sends) until `GAS_FUNDER_ENABLED=true`, with a `pending`-row-before-send ledger that keeps restarts double-spend-safe. The new env vars and the custody tradeoff (a spendable key on Railway — keep it small, bounded by the "reload me" alert) are documented in the README, and `cargo build`/`clippy` are clean with the `decide_topups`/escape unit tests passing (6/6). The large `Cargo.lock` growth is just the alloy provider/signer stack that lit-api-server already depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
