### PR TITLE
docs: document EIP-1271 smart-contract-wallet auth (Safe, ZeroDev)

### DIFF
--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -228,12 +228,17 @@ the server's api\_payer signs the on-chain conversion on their behalf.
    key.
 2. Open the account dropdown and click **Convert to ChainSecured**.
    Confirm the irreversible-action prompt.
-3. **Connect the wallet** that will become the new admin. **EOA only —
-   the server verifies the EIP-712 signature via plain ECDSA `recover()`
-   and does not yet validate ERC-1271 contract-account signatures**, so
-   Safes and other contract wallets are not supported in this flow today.
-   The dashboard prompts a chain switch if your wallet isn't on the chain
-   reported by `GET /get_node_chain_config`.
+3. **Connect the wallet** that will become the new admin. Both EOAs and
+   smart-contract wallets (a Gnosis Safe, a ZeroDev/Kernel account, etc.)
+   are supported. You pass the **same** request shape either way — the
+   server first attempts standard ECDSA recovery, and if the signature
+   doesn't recover to the claimed address it treats that address as a
+   contract and verifies the signature via an on-chain ERC-1271
+   `isValidSignature(digest, signature)` call on the chain reported by
+   `GET /get_node_chain_config` (Base). The contract wallet must already
+   be **deployed** on that chain — counterfactual (ERC-6492) wallets are
+   not supported. The dashboard prompts a chain switch if your wallet
+   isn't on that chain.
 4. **Sign the EIP-712 ownership-transfer typed data.** The dashboard
    composes a typed-data envelope with `primaryType: "ConvertAccount"` —
    wallet UIs surface it as a labelled struct (`address`, `issuedAt`)

--- a/docs/management/api_direct.mdx
+++ b/docs/management/api_direct.mdx
@@ -347,6 +347,13 @@ The canonical typed-data shape (must match exactly — field declaration order i
 
 The server enforces a ±5-minute window on `issuedAt` as the only replay protection — no nonce store. Worst-case replay on the unauthenticated mint endpoints just produces an extra unattached PKP (compute cost only — see each endpoint below for specifics).
 
+**EOA and smart-contract wallets use identical parameters.** Every flow above (and the `X-Wallet-Auth` billing header) accepts both, with no extra field or flag to set — you always post the same `{ typed_data, signature }` (the `message.address` is your wallet address either way). The server first tries standard 65-byte ECDSA recovery; if the signature doesn't recover to the claimed `address`, it treats that address as a contract and verifies on-chain via ERC-1271 `isValidSignature(digest, signature)` on the domain's chain. Two value-level differences for the contract-wallet (e.g. Gnosis Safe, ZeroDev/Kernel) path:
+
+- `signature` is whatever the wallet produces — not necessarily a 65-byte ECDSA tuple. It may be longer (a Safe is roughly 65 bytes per owner plus overhead); the hard cap is 4 KiB.
+- The contract wallet must already be **deployed** on the domain's chain. Counterfactual (ERC-6492) wallets are not supported.
+
+The `"0x<65-byte hex>"` signatures shown in the request examples below are the EOA case; substitute your contract wallet's signature bytes for the ERC-1271 path.
+
 #### `POST /create_wallet_with_signature`
 
 Mints a PKP via DStack MPC after verifying a wallet-ownership signature. Used by `createWallet` in ChainSecured mode; the response is then passed to the on-chain `registerWalletDerivation` call (signed by the same wallet) to register the PKP to the account.


### PR DESCRIPTION
## What

EIP-1271 smart-contract-wallet signature support is fully merged into `main`:

- **#473** `feat(chainsecured)` (merged 2026-06-10) — accepts Safe/contract-wallet sigs across `create_wallet`, `add_usage_api_key`, and `convert_to_chain_secured_account`.
- **#517** `feat(billing)` (merged 2026-06-22) — accepts EIP-1271 sigs on the `X-Wallet-Auth` billing header (`BillingAuth`).

But the docs lagged: `account_modes.mdx` still told users the convert-to-ChainSecured flow was **EOA only** and that "Safes and other contract wallets are not supported in this flow today" — which #473 made false.

## Changes

- **`account_modes.mdx`** — replace the stale "EOA only / does not yet validate ERC-1271" caveat in step 3 of the convert flow with an accurate description: same request shape for EOA and contract wallets, server falls back to an on-chain `isValidSignature` call, contract must already be deployed (no ERC-6492).
- **`api_direct.mdx`** — add a note to the EIP-712 envelope section clarifying that **EOA and smart-contract wallets use identical parameters** (no flag/extra field), the server auto-detects EOA vs ERC-1271, and contract signatures may exceed 65 bytes (4 KiB cap).

## Why this matters

Answers the common integration question directly — there are no different params for a Safe/ZeroDev wallet; you post the same `{ typed_data, signature }` and the server picks the verification path. The only value-level differences are the signature bytes and that the contract must be deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)