### PR TITLE
fix(dashboard): register auth-ready callback after init* wiring

### DIFF
--- a/lit-static/dapps/dashboard/app.js
+++ b/lit-static/dapps/dashboard/app.js
@@ -276,7 +276,7 @@ function refreshChangeOwnershipVisibility() {
 
 // ----- Auth ready callback -----
 
-setOnAuthReady(() => {
+function onAuthReady() {
   updateStatCards();
   preloadAllTables();
   updateUsageKeyOverrideUI();
@@ -284,7 +284,7 @@ setOnAuthReady(() => {
   refreshChangeOwnershipVisibility();
   updateChainSecuredRpcUrlUI();
   handleBillingReturn();
-});
+}
 
 // ----- Init -----
 
@@ -322,6 +322,16 @@ function init() {
   initUsageKeyOverride();
   initChainSecuredRpc();
   initAbout();
+
+  // Register the auth-ready callback only after every init* call above has
+  // attached its button listeners. Registering at module-eval time let
+  // initLogin()'s synchronous updateAuthUI() (auth.js) fire _onAuthReady
+  // mid-init for already-logged-in sessions — before button-disable wiring
+  // ran, leaving a brief duplicate-click window. Because initLogin() already
+  // ran (and skipped the then-null callback), trigger the flow once here for
+  // sessions restored from a previous visit.
+  setOnAuthReady(onAuthReady);
+  if (isAuthenticated()) onAuthReady();
 }
 
 init();


### PR DESCRIPTION
The dashboard registered its auth-ready callback (`setOnAuthReady`) at module-eval time, so `initLogin()`'s synchronous `updateAuthUI()` fired `_onAuthReady` mid-init for already-logged-in sessions — before `initWallets`/`initGroups`/`initActions`/`initKeys` had attached their button-disable listeners, leaving a brief duplicate-click window. This moves registration to the end of `init()`, after all `init*` wiring runs. Because `initLogin()` already executed (and skipped the then-null callback), the flow is also triggered once for sessions restored from a previous visit, preserving table preloading for returning users. Fresh logins still fire normally via `updateAuthUI()` since `init()` has completed by then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)