### PR TITLE
fix(dashboard): guard confirmDelete against concurrent _confirmResolve leak

### DIFF
--- a/lit-static/dapps/dashboard/ui-utils.js
+++ b/lit-static/dapps/dashboard/ui-utils.js
@@ -151,6 +151,13 @@ export function initModalClose() {
 let _confirmResolve = null;
 
 export function confirmDelete(message, opts) {
+  // Guard against a concurrent call clobbering an in-flight dialog. There is a
+  // single confirm overlay, so a second dialog can't be shown anyway; resolving
+  // the loser as `false` (the safe default for a destructive action) avoids
+  // overwriting _confirmResolve and silently leaking the first caller's promise.
+  if (_confirmResolve) {
+    return Promise.resolve(false);
+  }
   return new Promise((resolve) => {
     _confirmResolve = resolve;
     const overlay = document.getElementById('confirm-overlay');


### PR DESCRIPTION
Guards `confirmDelete()` in `ui-utils.js` against a concurrent-call promise leak: a second call previously overwrote the module-level `_confirmResolve` before the first resolved, leaving the first caller's `await confirmDelete(...)` hanging forever. Since there is a single confirm overlay (only one dialog can ever be shown), an in-flight dialog is now left intact and the losing call resolves as `false` — the safe default for a destructive action. Pre-existing bug found by adversarial review during PR1 ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)