### PR TITLE
feat(monitor): add R/F/S keyboard shortcuts for operators

### DIFF
--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -920,7 +920,8 @@ function isTypingTarget(target) {
 // never collide with browser shortcuts like Ctrl+R / Cmd+S; we bail out the
 // moment a modifier is held, a field is focused, or a modal dialog is open.
 document.addEventListener('keydown', (e) => {
-  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+  if (e.repeat) return;
   if (isTypingTarget(e.target)) return;
   if (document.querySelector('dialog[open]')) return;
 

--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -907,6 +907,40 @@ document.addEventListener('keydown', (e) => {
   toggleAccordion(header.parentElement);
 });
 
+/* ═══ Global keyboard shortcuts ══════════════════════════════════════════════ */
+
+// True when the user is typing into a field — single-key shortcuts must not fire.
+function isTypingTarget(target) {
+  if (!target) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
+}
+
+// Single-key operator shortcuts. Deliberately bare keys (no modifiers) so they
+// never collide with browser shortcuts like Ctrl+R / Cmd+S; we bail out the
+// moment a modifier is held, a field is focused, or a modal dialog is open.
+document.addEventListener('keydown', (e) => {
+  if (e.ctrlKey || e.metaKey || e.altKey) return;
+  if (isTypingTarget(e.target)) return;
+  if (document.querySelector('dialog[open]')) return;
+
+  switch (e.key.toLowerCase()) {
+    case 'r': // Refresh all data
+      e.preventDefault();
+      el('btn-refresh-all')?.click();
+      break;
+    case 'f': // Fund all critical payers — wire up once the fund-all-critical
+      // action lands (Phase 1/2 payer safety console). No-ops safely until then.
+      e.preventDefault();
+      el('btn-fund-all-critical')?.click();
+      break;
+    case 's': // Toggle the settings (thresholds) panel
+      e.preventDefault();
+      el('btn-toggle-settings')?.click();
+      break;
+  }
+});
+
 /* ═══ Settings panel ═════════════════════════════════════════════════════════ */
 
 el('btn-toggle-settings')?.addEventListener('click', () => {

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -385,7 +385,7 @@
         </select>
       </div>
       <div class="refresh-controls">
-        <button type="button" id="btn-refresh-all" style="margin-top: 0; padding: 0.4rem 0.9rem; font-size: 0.85rem;">Refresh</button>
+        <button type="button" id="btn-refresh-all" title="Refresh all data (R)" style="margin-top: 0; padding: 0.4rem 0.9rem; font-size: 0.85rem;">Refresh</button>
         <span id="refresh-countdown" class="countdown">30s</span>
       </div>
     </div>
@@ -427,7 +427,7 @@
             </div>
             <div id="api-payers-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
 
-            <button type="button" class="settings-toggle" id="btn-toggle-settings">&#9881; Thresholds</button>
+            <button type="button" class="settings-toggle" id="btn-toggle-settings" title="Toggle settings panel (S)">&#9881; Thresholds</button>
             <div id="settings-panel" class="settings-panel">
               <div class="settings-row">
                 <label for="threshold-warning">Warning</label>


### PR DESCRIPTION
## Summary
Adds single-key keyboard shortcuts to the Lit Node Monitor for the most common daily operator actions:
- **R** — refresh all data (clicks `btn-refresh-all`)
- **S** — toggle the settings/thresholds panel (clicks `btn-toggle-settings`)
- **F** — fund all critical payers (wired to `btn-fund-all-critical`)

Shortcuts only fire when no input/select/textarea is focused, no modifier is held (so Ctrl+R / Cmd+S are never intercepted), and no modal dialog is open. Added "(R)" / "(S)" tooltips to the Refresh and Thresholds buttons for discoverability.

## Note on the F shortcut
There is no "fund all critical" button or action in the monitor yet — it depends on the Phase 1/2 payer safety console work that hasn't shipped. The **F** binding is in place and correctly guarded, but it targets `btn-fund-all-critical` with optional chaining, so it safely no-ops until that button exists. When the fund-all-critical feature lands, give its button `id="btn-fund-all-critical"` and F works with zero further changes (a comment in `app.js` marks the spot).

## Test plan
- [x] `node --check app.js` passes
- [ ] Manual smoke test: press R (refreshes), S (toggles panel); confirm neither fires while focused in a threshold input or with the wallet dialog open

🤖 Generated with [Claude Code](https://claude.com/claude-code)