### PR TITLE
docs(todos): resolve CPL-267 orphan-key GC as won't-fix

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -96,9 +96,9 @@
 
 **Resolution (2026-06-25): WON'T FIX — premise invalid.** The orphan-key-growth concern doesn't match the architecture:
 
-- **Keys are derived on demand, never stored.** `dstack::v1::get_client_key(path)` → `dstack::get_key` (`lit-api-server/src/dstack/v1/dstack.rs:111`) deterministically derives a key from the TEE root key + path. Nothing is persisted per key, so no TEE state accumulates. The dstack SDK exposes only `get_quote`/`get_info`/`get_key` — there is no delete/revoke, so there is nothing to GC.
-- **The server keeps no record of prepared wallets.** `create_wallet_with_signature` (`src/core/account_management.rs:196`) generates a random derivation path, derives the key, returns `wallet_address` + `derivation_path` to the user, and persists nothing.
-- **An orphan wallet is unreachable and untraceable.** Signing re-derives the path exclusively from on-chain `getWalletDerivation` (`src/accounts/mod.rs:477`); without `registerWalletDerivation` the server can't find the path and use fails with 401 (`src/auth_resolver.rs:95`).
+- **Keys are derived on demand, never stored.** `dstack::v1::get_client_key(derivation_path)` → `dstack::get_key` (`lit-api-server/src/dstack/v1/dstack.rs:111`) deterministically derives a key from the TEE root key + path. Nothing is persisted per key, so no TEE state accumulates. The dstack SDK exposes only `get_quote`/`get_info`/`get_key` — there is no delete/revoke, so there is nothing to GC.
+- **The server keeps no record of prepared wallets.** `create_wallet_with_signature` (`lit-api-server/src/core/account_management.rs:196`) generates a random derivation path, derives the key, returns `wallet_address` + `derivation_path` to the user, and persists nothing.
+- **An orphan wallet is unreachable and untraceable.** Signing re-derives the path exclusively from on-chain `getWalletDerivation` (`lit-api-server/src/accounts/mod.rs:477`); without `registerWalletDerivation` the server can't find the path and use fails with 401 (`lit-api-server/src/auth_resolver.rs:95`).
 
 Implementing the proposed fix would *create* net-new persistent state that doesn't exist today (the opposite of bounding growth) and would have nothing meaningful to delete. The existing design already has the property this ticket wanted. If observability is desired later, scope it as a create-vs-register conversion metric — not a key GC.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -116,6 +116,14 @@
 
 **Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
 
+**Resolution (2026-06-25): WON'T FIX — premise invalid.** The orphan-key-growth concern doesn't match the architecture:
+
+- **Keys are derived on demand, never stored.** `dstack::v1::get_client_key(path)` → `dstack::get_key` (`lit-api-server/src/dstack/v1/dstack.rs:111`) deterministically derives a key from the TEE root key + path. Nothing is persisted per key, so no TEE state accumulates. The dstack SDK exposes only `get_quote`/`get_info`/`get_key` — there is no delete/revoke, so there is nothing to GC.
+- **The server keeps no record of prepared wallets.** `create_wallet_with_signature` (`src/core/account_management.rs:196`) generates a random derivation path, derives the key, returns `wallet_address` + `derivation_path` to the user, and persists nothing.
+- **An orphan wallet is unreachable and untraceable.** Signing re-derives the path exclusively from on-chain `getWalletDerivation` (`src/accounts/mod.rs:477`); without `registerWalletDerivation` the server can't find the path and use fails with 401 (`src/auth_resolver.rs:95`).
+
+Implementing the proposed fix would *create* net-new persistent state that doesn't exist today (the opposite of bounding growth) and would have nothing meaningful to delete. The existing design already has the property this ticket wanted. If observability is desired later, scope it as a create-vs-register conversion metric — not a key GC.
+
 ## CPL-267 Sovereign Mode: Document cache staleness window
 
 **What:** SDK + dashboard docs should state: "After a sovereign-mode write, reads on other server instances may show stale data for up to N seconds (polling interval)."


### PR DESCRIPTION
Marks the **CPL-267 "GC orphan prepared wallet keys"** TODO as WON'T FIX, because the orphan-key-growth premise doesn't match the dstack architecture: wallet keys are derived on demand and never stored, the server keeps no record of prepared wallets, and an unregistered wallet is unreachable since signing re-derives the path exclusively from on-chain `getWalletDerivation`. Implementing the proposed GC would *create* net-new persistent state and have nothing meaningful to delete. The resolution block cites the relevant code (`dstack/v1/dstack.rs:111`, `core/account_management.rs:196`, `accounts/mod.rs:477`, `auth_resolver.rs:95`) and notes that a create-vs-register conversion metric is the right scope if observability is wanted later. Docs-only change to `TODOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)