### PR TITLE
docs(billing): document sovereign-mode billing split (CPL-267)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -138,19 +138,34 @@
 
 **Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
 
+## Completed
+
 ## CPL-267 Sovereign Mode: Billing bypass documentation
 
 **What:** Admin writes in sovereign mode bypass Stripe billing guards (user's wallet pays gas directly to chain). Lit Action execution still charges via Stripe. Document this split explicitly in SDK + billing page.
 
 **Why:** Billing logic is per-op today (see `stripe::` in lit-api-server); sovereign admin writes never hit those guards. Accounting split must be visible to ops and support, otherwise conversion-to-sovereign looks like "billing broken."
 
-**How to fix:** Add note to `billing.md` or equivalent. Add sovereign-mode label to Stripe dashboard for per-account identification.
+**Done (2026-06-25):** Documented the split in three places —
+`docs/management/pricing.mdx` (new "Billing in ChainSecured (sovereign) mode"
+section + billing-identity note), `docs/management/account_modes.mdx` (split
+the Billing table row, added a "How billing splits in ChainSecured mode"
+subsection with an ops/support `<Note>`), and `lit-api-server/README.md`
+(billing-model paragraph). The docs explain why a freshly-converted sovereign
+account can show zero Stripe charges and how ops can confirm a sovereign
+account via the on-chain `managed` flag.
+
+**Remaining (ops, not code):** Tagging sovereign customers in the Stripe
+dashboard (`mode: sovereign` metadata) is documented as a recommended ops
+convenience but not auto-applied — the Stripe customer is created lazily with
+only `metadata.wallet_address` and doesn't know the on-chain mode at creation
+time. Wiring an automatic label would require a contract read at customer
+creation plus a metadata update on conversion (touches `lit-billing-core`);
+deferred as it exceeds this P3 doc scope.
 
 **Priority:** P3
 
 **Added:** 2026-04-21 via `/plan-eng-review` on branch feature/cpl-267-self-sovereign-mode
-
-## Completed
 ## Monitor: Keyboard Shortcuts
 - **What:** Add keyboard shortcuts to the Lit Node Monitor: R to refresh, F to fund all critical, S to toggle settings panel.
 - **Why:** Operators use this tool daily. Keyboard shortcuts reduce friction for the most common actions.

--- a/docs/management/account_modes.mdx
+++ b/docs/management/account_modes.mdx
@@ -36,12 +36,50 @@ actions, registering PKPs, minting usage keys, etc.
 | Auditability             | Server logs + on-chain events                         | On-chain events only; every change is wallet-signed  |
 | Dashboard surface        | Same management UI                                    | Same management UI; writes prompt the wallet         |
 | Lit Action execution     | Usage API key in `X-Api-Key`                          | Usage API key in `X-Api-Key` (minted from contract)  |
-| Billing                  | Stripe credits on the account                         | Stripe credits on the account (same flow)            |
+| Billing — admin writes   | Stripe credits ($0.01/call)                           | **Not** billed via Stripe — you pay gas on-chain     |
+| Billing — Lit Actions    | Stripe credits ($0.01/sec)                            | Stripe credits ($0.01/sec) — identical to API mode   |
 
 In the SDK and contracts, ChainSecured mode is the `sovereign` mode
 (`mode: 'sovereign'`); earlier material called it *self-sovereign*. Same
 thing — wallet ownership of the account on Base, with no required server
 round-trip for admin writes.
+
+### How billing splits in ChainSecured mode
+
+This is the one place the two modes diverge on billing, and it surprises
+people: **admin writes and Lit Action execution are billed on different
+rails.**
+
+- **Admin writes** (create group, add action, mint usage key, ...) in
+  ChainSecured mode are wallet-signed transactions you submit directly to
+  the `AccountConfig` contract. They never pass through the server's
+  metered HTTP endpoint, so they never hit the Stripe credit guard. You
+  pay the **Base gas** for each write from your connected wallet, and
+  **nothing is charged to Stripe** — there is no `$0.01` management charge.
+- **Lit Action execution** is unchanged. Runs are still metered at
+  `$0.01/second` against your Stripe credit balance, exactly as in API
+  mode, because execution goes through the server regardless of who owns
+  the account.
+
+In API mode both halves are billed to Stripe — admin writes at `$0.01`
+each (the server relays the tx and covers gas) and execution at
+`$0.01/second`. Converting to ChainSecured moves only the admin-write half
+off Stripe and onto your wallet's gas; the execution half is untouched.
+
+<Note>
+**For ops and support:** after a customer converts to ChainSecured, their
+Stripe activity drops to *Lit Action execution only* — admin writes stop
+appearing in Stripe entirely. This is expected, not "billing broken." A
+freshly-converted account that only does admin writes (and no executions)
+can legitimately show **zero** Stripe charges. The Stripe credit balance
+itself is preserved across conversion (see
+[Converting an API account to ChainSecured](#converting-an-api-account-to-chainsecured)).
+To confirm an account is sovereign, take the Stripe customer's
+`metadata.wallet_address` and read the account's on-chain `managed` flag
+(`managed = false` ⇒ ChainSecured). A recommended ops convenience is to
+tag such customers in the Stripe dashboard (e.g. a `mode: sovereign`
+metadata field) so they're filterable without an on-chain lookup.
+</Note>
 
 ## When to pick which
 

--- a/docs/management/pricing.mdx
+++ b/docs/management/pricing.mdx
@@ -90,3 +90,20 @@ If a call is made when your balance is exhausted, the API returns a `402 Payment
 ## Billing Identity
 
 Your billing account is tied to the **wallet address derived from your account API key**. This wallet address is used as the Stripe customer identifier. If you provide an email address when creating your account, it is forwarded to Stripe for your customer record and for payment receipts.
+
+In **ChainSecured (sovereign) mode** there is no account API key — billing is tied to the account's **billing wallet** instead. This wallet is fixed at account creation and preserved across conversion to ChainSecured and across ownership transfers, so your Stripe credit balance follows the account even as the admin wallet rotates.
+
+---
+
+## Billing in ChainSecured (sovereign) mode
+
+[ChainSecured mode](/management/account_modes) splits billing across two rails, and the split is worth calling out explicitly:
+
+| What you do | API mode | ChainSecured (sovereign) mode |
+|---|---|---|
+| Admin write (create group, add action, mint usage key, ...) | $0.01 credit charged via Stripe; the server relays the tx and covers gas | **Not charged to Stripe.** You sign and submit the tx yourself and pay **Base gas** from your connected wallet |
+| Lit Action execution | $0.01/second via Stripe | $0.01/second via Stripe — **identical to API mode** |
+
+In other words, converting to ChainSecured moves only the **admin-write** half of billing off Stripe (onto your wallet's gas). Lit Action **execution** is metered against your Stripe credit balance in both modes, because execution always runs through the server. A ChainSecured account that performs admin writes but no executions can legitimately show **zero** Stripe charges — admin-write gas is paid on-chain and never reaches Stripe.
+
+This is the expected behavior, not a billing fault: there is no `$0.01` management charge for sovereign admin writes because those writes never pass through the server's metered endpoint.

--- a/lit-api-server/README.md
+++ b/lit-api-server/README.md
@@ -67,6 +67,13 @@ nothing is charged. Error semantics: invalid key → 401, insufficient credits �
 402 (body states amount needed and how to fund), billing infra down → 503. See
 the [Errors reference](https://developer.litprotocol.com/management/errors).
 
+ChainSecured (sovereign) accounts split this: admin writes are wallet-signed
+contract calls that never reach the metered HTTP endpoints, so the
+`BilledManagementApiKey` guard never fires and the $0.01 management charge is
+*not* applied (the user pays Base gas instead). Lit Action execution still
+flows through `BilledLitActionApiKey` and bills $0.01/second exactly as in API
+mode. See [API Mode vs ChainSecured Mode](https://developer.litprotocol.com/management/account_modes#how-billing-splits-in-chainsecured-mode).
+
 ## OpenAPI
 
 The spec is generated from the route definitions:


### PR DESCRIPTION
## Summary

Documents the billing split for ChainSecured (sovereign) mode so ops and support don't read a freshly-converted account's dropped Stripe activity as "billing broken." In sovereign mode, admin writes are wallet-signed contract calls that bypass the Stripe management-charge guard (`BilledManagementApiKey`) — the user pays Base gas directly — while Lit Action execution still bills $0.01/sec via Stripe exactly as in API mode.

Changes (docs only):
- **`docs/management/pricing.mdx`** — new "Billing in ChainSecured (sovereign) mode" section with a per-rail comparison table, plus a billing-identity note that sovereign billing is tied to the preserved billing wallet.
- **`docs/management/account_modes.mdx`** — split the misleading single "Billing" table row into separate admin-writes and Lit-Actions rows, and added a "How billing splits in ChainSecured mode" subsection with an ops/support note.
- **`lit-api-server/README.md`** — note the split in the billing-model section, referencing the guard names.
- **`TODOS.md`** — moved CPL-267 to Completed with a done/remaining breakdown.

One item is deliberately left to ops: auto-tagging sovereign customers in the Stripe dashboard is documented as a recommended manual convenience rather than implemented, since the Stripe customer is created lazily with only `metadata.wallet_address` and wiring an automatic `mode: sovereign` label would require a contract read at customer creation plus a metadata update on conversion (touches `lit-billing-core`), out of scope for this P3 doc task.

## Test plan
- [x] Documentation-only change — no code paths modified, nothing to test beyond the docs build.
- [x] Internal anchor `#how-billing-splits-in-chainsecured-mode` matches the new heading; cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)