### PR TITLE
feat(payments): enterprise net-30 committed-use billing

### DIFF
--- a/lit-billing-core/src/invoice.rs
+++ b/lit-billing-core/src/invoice.rs
@@ -1,0 +1,97 @@
+//! Stripe invoicing primitives.
+//!
+//! Used by the enterprise committed-use billing job in `lit-payments`: create a
+//! *draft* invoice on the invoice customer, attach line items, and (later, when
+//! we drop the human-in-the-loop step) finalize + send it.
+//!
+//! Invoices are created with `collection_method = send_invoice` and
+//! `days_until_due = 30` (net-30), and `auto_advance = false` so they stay as a
+//! reviewable **draft** until explicitly finalized — either by a human in the
+//! Stripe dashboard (v1) or by [`finalize_and_send`] (future). All POSTs take an
+//! idempotency key so retries can't create duplicate invoices or line items.
+
+use anyhow::Result;
+
+use crate::client::StripeClient;
+
+/// Create a **draft** invoice for `customer_id` (net-30, send-invoice
+/// collection). Returns the Stripe invoice id (`in_…`).
+///
+/// `pending_invoice_items_behavior=exclude` means this invoice does NOT sweep in
+/// the customer's other floating invoice items — only the items we explicitly
+/// attach via [`add_invoice_item`] with this invoice id land on it.
+pub async fn create_draft_invoice(
+    client: &StripeClient,
+    customer_id: &str,
+    days_until_due: i64,
+    description: &str,
+    idempotency_key: &str,
+) -> Result<String> {
+    let days_str = days_until_due.to_string();
+    let params = [
+        ("customer", customer_id),
+        ("collection_method", "send_invoice"),
+        ("days_until_due", days_str.as_str()),
+        // Keep it a reviewable draft; do not auto-finalize on a schedule.
+        ("auto_advance", "false"),
+        ("pending_invoice_items_behavior", "exclude"),
+        ("description", description),
+    ];
+    let resp = client
+        .post_with_idempotency("invoices", &params, idempotency_key)
+        .await?;
+    let id = resp
+        .body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe: missing invoice id"))?
+        .to_string();
+    Ok(id)
+}
+
+/// Attach a single line item (`amount_cents`, USD) to draft `invoice_id` for
+/// `customer_id`. Returns the invoice-item id (`ii_…`). Stripe rejects a
+/// zero-amount item, so callers must skip items whose amount is 0.
+pub async fn add_invoice_item(
+    client: &StripeClient,
+    customer_id: &str,
+    invoice_id: &str,
+    amount_cents: i64,
+    description: &str,
+    idempotency_key: &str,
+) -> Result<String> {
+    let amount_str = amount_cents.to_string();
+    let params = [
+        ("customer", customer_id),
+        ("invoice", invoice_id),
+        ("amount", amount_str.as_str()),
+        ("currency", "usd"),
+        ("description", description),
+    ];
+    let resp = client
+        .post_with_idempotency("invoiceitems", &params, idempotency_key)
+        .await?;
+    let id = resp
+        .body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Stripe: missing invoiceitem id"))?
+        .to_string();
+    Ok(id)
+}
+
+/// Finalize a draft invoice and send it to the customer (net-30). NOT used in
+/// v1 — invoices are sent manually from the dashboard after review — but kept
+/// here so the future "drop the human" switch is a one-line call. Finalizing
+/// auto-sends because the invoice uses `collection_method = send_invoice`.
+pub async fn finalize_and_send(
+    client: &StripeClient,
+    invoice_id: &str,
+    idempotency_key: &str,
+) -> Result<()> {
+    let path = format!("invoices/{invoice_id}/finalize");
+    client
+        .post_with_idempotency(&path, &[("auto_advance", "true")], idempotency_key)
+        .await?;
+    Ok(())
+}

--- a/lit-billing-core/src/lib.rs
+++ b/lit-billing-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`StripeClient`] — credentials + HTTP plumbing, no caching.
 //! - [`customer`] — wallet ↔ Stripe customer lookup, email updates.
 //! - [`balance`] — credit-balance reads.
+//! - [`invoice`] — draft-invoice + line-item creation (enterprise billing).
 //! - [`reporting`] — pagination helpers + per-day aggregation for the
 //!   `stripe_report` binary.
 //! - [`format`] — pure helpers (`cents_to_display`, `unix_to_utc_date`).
@@ -24,6 +25,7 @@ pub mod customer;
 pub mod eip712;
 pub mod format;
 pub mod http;
+pub mod invoice;
 pub mod on_chain;
 pub mod reporting;
 

--- a/lit-payments/migrations/20260623000001_enterprise_billing.sql
+++ b/lit-payments/migrations/20260623000001_enterprise_billing.sql
@@ -49,8 +49,17 @@ CREATE TABLE enterprise_accounts (
     -- has been written; gates the onboarding step so it never double-grants.
     baseline_balance_txn_id               TEXT,
     baseline_granted_at                   TIMESTAMPTZ,
+    -- Window-start for the baseline credit, stamped BEFORE the Stripe write so a
+    -- crash between the write and recording success is recoverable within
+    -- Stripe's idempotency window — and refused (not double-credited) past it.
+    baseline_attempted_at                 TIMESTAMPTZ,
     created_at                            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at                            TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at                            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Payer and invoice customers are deliberately DIFFERENT Stripe customers.
+    CONSTRAINT enterprise_accounts_distinct_customers
+        CHECK (payer_customer_id <> invoice_customer_id),
+    CONSTRAINT enterprise_accounts_term_order
+        CHECK (term_start IS NULL OR term_end IS NULL OR term_start <= term_end)
 );
 
 CREATE TABLE enterprise_invoices (
@@ -66,16 +75,16 @@ CREATE TABLE enterprise_invoices (
     committed_period         TEXT        NOT NULL,
     -- Snapshot, frozen at first attempt so resume/retry never recomputes from a
     -- balance that the regrant has since changed.
-    consumed_units           BIGINT      NOT NULL,
-    included_units           BIGINT      NOT NULL,
-    overage_units            BIGINT      NOT NULL,
-    committed_fee_cents      BIGINT      NOT NULL,
-    overage_cents            BIGINT      NOT NULL,
-    total_cents              BIGINT      NOT NULL,
+    consumed_units           BIGINT      NOT NULL CHECK (consumed_units >= 0),
+    included_units           BIGINT      NOT NULL CHECK (included_units >= 0),
+    overage_units            BIGINT      NOT NULL CHECK (overage_units >= 0),
+    committed_fee_cents      BIGINT      NOT NULL CHECK (committed_fee_cents >= 0),
+    overage_cents            BIGINT      NOT NULL CHECK (overage_cents >= 0),
+    total_cents              BIGINT      NOT NULL CHECK (total_cents >= 0),
     stripe_invoice_id        TEXT,
     regrant_balance_txn_id   TEXT,
-    -- pending | draft | sent | paid | error | manual
-    status                   TEXT        NOT NULL DEFAULT 'pending',
+    status                   TEXT        NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'draft', 'sent', 'paid', 'error', 'manual')),
     notified_at              TIMESTAMPTZ,
     created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -111,6 +120,13 @@ INSERT INTO enterprise_accounts (
 -- June 2026 committed fee was invoiced MANUALLY. Record it so the billing job's
 -- first generated invoice is the July anchor (July advance + June arrears
 -- overage) rather than re-billing June's committed fee.
+--
+-- NOTE on the window columns: this is the FIRST invoice, which is committed-fee
+-- in advance only (there is no prior cycle to meter), so period_start/period_end
+-- here are the committed cycle it paid for (2026-06-17 → 2026-07-17). Generated
+-- rows differ by design: their period_start/period_end is the ARREARS window
+-- (previous_anchor → anchor) that the overage line covers. consumed/overage are
+-- 0 because nothing was metered for this seed.
 INSERT INTO enterprise_invoices (
     enterprise_account_id, period_key, period_start, period_end, committed_period,
     consumed_units, included_units, overage_units,

--- a/lit-payments/migrations/20260623000001_enterprise_billing.sql
+++ b/lit-payments/migrations/20260623000001_enterprise_billing.sql
@@ -1,0 +1,124 @@
+-- Enterprise committed-use billing (prepaid allotment + arrears overage).
+--
+-- See plans/enterprise-committed-billing.md. One row per committed-use customer
+-- in `enterprise_accounts`; one row per generated invoice in `enterprise_invoices`
+-- (also the per-period idempotency gate for the billing job).
+--
+-- Metering model: the payer Stripe customer is debited at the standard $0.01/unit
+-- rate by lit-api-server (1 cent == 1 unit). The billing job keeps the payer's
+-- credit topped to `target_credit_cents` with exactly ONE regrant per cycle, so
+-- consumption for the cycle == target_credit_cents + balance_at_billing_time
+-- (balance is negative when credit is available). No usage ledger, no Stripe
+-- transaction listing. This identity only holds if the monthly regrant (and the
+-- one-time baseline grant) are the ONLY credits on the payer account — so the
+-- payer account must NOT have auto-topup enabled and must not receive manual
+-- portal grants.
+
+CREATE TABLE enterprise_accounts (
+    id                                    BIGSERIAL   PRIMARY KEY,
+    name                                  TEXT        NOT NULL,
+    -- Stripe customer that consumes service on Chipotle and receives the
+    -- credit buffer (regrants). Unique: one enterprise profile per payer.
+    payer_customer_id                     TEXT        NOT NULL UNIQUE,
+    -- Stripe customer that receives the invoice — deliberately a DIFFERENT
+    -- customer from the payer.
+    invoice_customer_id                   TEXT        NOT NULL,
+    -- Flat committed fee billed monthly in advance (e.g. 900000 = $9,000).
+    committed_fee_cents                   BIGINT      NOT NULL CHECK (committed_fee_cents >= 0),
+    -- Included allotment per cycle, in units (1 unit == 1 cent of $0.01-rate
+    -- charges == ~1 compute second). e.g. 3_000_000.
+    included_units                        BIGINT      NOT NULL CHECK (included_units >= 0),
+    -- Overage price per unit, in hundredths of a cent, to keep integer math
+    -- exact. $0.0025/unit == 25 hundredths-of-a-cent.
+    overage_rate_hundredths_cent_per_unit BIGINT      NOT NULL CHECK (overage_rate_hundredths_cent_per_unit >= 0),
+    -- Credit buffer target the payer account is kept topped up to (e.g.
+    -- 50_000_000 = $500k). Must dwarf a cycle's burn so they never run dry.
+    target_credit_cents                   BIGINT      NOT NULL CHECK (target_credit_cents > 0),
+    -- Day of month the invoice is issued / the cycle rolls. 1..=28 to dodge
+    -- short-month edge cases.
+    billing_anchor_day                    INT         NOT NULL CHECK (billing_anchor_day BETWEEN 1 AND 28),
+    -- Where the human-review breakdown email is sent.
+    notify_email                          TEXT        NOT NULL,
+    -- v1 = false: create a DRAFT invoice + email for manual send. Flip to true
+    -- to finalize+send automatically (future).
+    auto_send                             BOOLEAN     NOT NULL DEFAULT false,
+    active                                BOOLEAN     NOT NULL DEFAULT true,
+    term_start                            DATE,
+    term_end                              DATE,
+    -- One-time buffer establishment. Set once the initial top-to-target credit
+    -- has been written; gates the onboarding step so it never double-grants.
+    baseline_balance_txn_id               TEXT,
+    baseline_granted_at                   TIMESTAMPTZ,
+    created_at                            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE enterprise_invoices (
+    id                       BIGSERIAL   PRIMARY KEY,
+    enterprise_account_id    BIGINT      NOT NULL REFERENCES enterprise_accounts(id),
+    -- Anchor month the invoice is issued in, 'YYYY-MM'. One invoice per account
+    -- per period — the idempotency gate for the billing job.
+    period_key               TEXT        NOT NULL,
+    -- Arrears window the overage is measured over (previous anchor → this anchor).
+    period_start             DATE        NOT NULL,
+    period_end               DATE        NOT NULL,
+    -- Human label for the advance cycle the committed fee covers.
+    committed_period         TEXT        NOT NULL,
+    -- Snapshot, frozen at first attempt so resume/retry never recomputes from a
+    -- balance that the regrant has since changed.
+    consumed_units           BIGINT      NOT NULL,
+    included_units           BIGINT      NOT NULL,
+    overage_units            BIGINT      NOT NULL,
+    committed_fee_cents      BIGINT      NOT NULL,
+    overage_cents            BIGINT      NOT NULL,
+    total_cents              BIGINT      NOT NULL,
+    stripe_invoice_id        TEXT,
+    regrant_balance_txn_id   TEXT,
+    -- pending | draft | sent | paid | error | manual
+    status                   TEXT        NOT NULL DEFAULT 'pending',
+    notified_at              TIMESTAMPTZ,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (enterprise_account_id, period_key)
+);
+
+CREATE INDEX enterprise_invoices_account_period_idx
+    ON enterprise_invoices (enterprise_account_id, period_key);
+
+-- Seed the first committed-use customer: Uneven Labs, Inc.
+-- (contract signed 2026-06-17; see plans/enterprise-committed-billing.md).
+INSERT INTO enterprise_accounts (
+    name, payer_customer_id, invoice_customer_id,
+    committed_fee_cents, included_units, overage_rate_hundredths_cent_per_unit,
+    target_credit_cents, billing_anchor_day, notify_email,
+    auto_send, active, term_start, term_end
+) VALUES (
+    'Uneven Labs, Inc.',
+    'cus_UXvHcFlfhR6rc5',   -- payer (engineering@unevenlabs.com)
+    'cus_UiVuFoABiqcMs5',   -- invoice (accounting@unevenlabs.com)
+    900000,                 -- $9,000/mo committed
+    3000000,                -- 3,000,000 unit allotment
+    25,                     -- $0.0025/unit overage
+    50000000,               -- $500k credit buffer target
+    17,                     -- anchor on the 17th (effective date)
+    'chris@litprotocol.com',
+    false,                  -- draft + email for manual send (v1)
+    true,
+    '2026-06-17',
+    '2027-06-17'
+);
+
+-- June 2026 committed fee was invoiced MANUALLY. Record it so the billing job's
+-- first generated invoice is the July anchor (July advance + June arrears
+-- overage) rather than re-billing June's committed fee.
+INSERT INTO enterprise_invoices (
+    enterprise_account_id, period_key, period_start, period_end, committed_period,
+    consumed_units, included_units, overage_units,
+    committed_fee_cents, overage_cents, total_cents, status
+)
+SELECT
+    id, '2026-06', DATE '2026-06-17', DATE '2026-07-17', '2026-06-17 → 2026-07-17',
+    0, included_units, 0,
+    committed_fee_cents, 0, committed_fee_cents, 'manual'
+FROM enterprise_accounts
+WHERE payer_customer_id = 'cus_UXvHcFlfhR6rc5';

--- a/lit-payments/src/auto_topup/reconciler_tests.rs
+++ b/lit-payments/src/auto_topup/reconciler_tests.rs
@@ -54,6 +54,8 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_accounts_contract_address: alloy_primitives::Address::ZERO,
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 60,
+        enterprise_billing_interval_secs: 3600,
+        stripe_dashboard_base: "https://dashboard.stripe.com".to_string(),
         cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }

--- a/lit-payments/src/auto_topup/webhook/handler_tests.rs
+++ b/lit-payments/src/auto_topup/webhook/handler_tests.rs
@@ -82,6 +82,8 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_accounts_contract_address: alloy_primitives::Address::ZERO,
         stripe_webhook_secret: WEBHOOK_SECRET.into(),
         reconciler_interval_secs: 900,
+        enterprise_billing_interval_secs: 3600,
+        stripe_dashboard_base: "https://dashboard.stripe.com".to_string(),
         cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }

--- a/lit-payments/src/billing/auto_topup_config_tests.rs
+++ b/lit-payments/src/billing/auto_topup_config_tests.rs
@@ -74,6 +74,8 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_accounts_contract_address: alloy_primitives::Address::ZERO,
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        enterprise_billing_interval_secs: 3600,
+        stripe_dashboard_base: "https://dashboard.stripe.com".to_string(),
         cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }

--- a/lit-payments/src/billing/sca_resume_tests.rs
+++ b/lit-payments/src/billing/sca_resume_tests.rs
@@ -52,6 +52,8 @@ fn test_config(stripe_secret_key: String, db_url: String) -> Config {
         lit_accounts_contract_address: alloy_primitives::Address::ZERO,
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        enterprise_billing_interval_secs: 3600,
+        stripe_dashboard_base: "https://dashboard.stripe.com".to_string(),
         cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }

--- a/lit-payments/src/billing/setup_intent_tests.rs
+++ b/lit-payments/src/billing/setup_intent_tests.rs
@@ -60,6 +60,8 @@ fn test_config(stripe_secret_key: String) -> Config {
         lit_accounts_contract_address: alloy_primitives::Address::ZERO,
         stripe_webhook_secret: "unused".into(),
         reconciler_interval_secs: 900,
+        enterprise_billing_interval_secs: 3600,
+        stripe_dashboard_base: "https://dashboard.stripe.com".to_string(),
         cors_allowed_origins: vec!["http://localhost".to_string()],
     }
 }

--- a/lit-payments/src/config.rs
+++ b/lit-payments/src/config.rs
@@ -87,6 +87,15 @@ pub struct Config {
     /// `balance_transactions` write). Default 900 (15 minutes); set lower
     /// (e.g. 60) for local testing.
     pub reconciler_interval_secs: i64,
+    /// Interval (seconds) between enterprise committed-use billing sweeps. Each
+    /// sweep checks every active `enterprise_accounts` row and, when its anchor
+    /// day has arrived, drafts that cycle's invoice. Hourly is plenty (the work
+    /// is per-period idempotent); set lower for local testing. Default 3600.
+    pub enterprise_billing_interval_secs: i64,
+    /// Base URL for Stripe dashboard links in the enterprise review email.
+    /// Live: `https://dashboard.stripe.com`; test mode:
+    /// `https://dashboard.stripe.com/test`. Default is the live base.
+    pub stripe_dashboard_base: String,
     /// Exact-match CORS allowlist. Browser requests from any other origin
     /// will be rejected at the preflight gate. Default in production is
     /// the `PUBLIC_BASE_URL` (the dashboard is served from the same
@@ -128,6 +137,12 @@ impl Config {
             lit_accounts_contract_address: parse_accounts_contract_address()?,
             stripe_webhook_secret: required("STRIPE_WEBHOOK_SECRET")?,
             reconciler_interval_secs: optional_i64("RECONCILER_INTERVAL_SECS", 900)?,
+            enterprise_billing_interval_secs: optional_i64(
+                "ENTERPRISE_BILLING_INTERVAL_SECS",
+                3600,
+            )?,
+            stripe_dashboard_base: optional_trimmed("STRIPE_DASHBOARD_BASE")
+                .unwrap_or_else(|| "https://dashboard.stripe.com".to_string()),
             cors_allowed_origins,
         })
     }

--- a/lit-payments/src/enterprise/billing.rs
+++ b/lit-payments/src/enterprise/billing.rs
@@ -29,11 +29,14 @@ use crate::mail::Mailer;
 /// Net-30 payment terms.
 const DAYS_UNTIL_DUE: i64 = 30;
 
-/// Refuse to (re)issue the per-period regrant once the row is older than this:
-/// Stripe drops a given idempotency key after ~24h, so reusing
-/// `ent_regrant:{acct}:{period}` beyond that would post a NEW credit and double
-/// the buffer. Mirrors the auto-topup reconciler's 23h cap.
-const MAX_REGRANT_AGE_HOURS: i64 = 23;
+/// Refuse to (re)issue any money-moving Stripe call once its tracking row/attempt
+/// is older than this. Stripe drops a given idempotency key after ~24h, so reusing
+/// the same key beyond that posts a NEW side effect instead of deduping — a second
+/// draft invoice, a doubled buffer credit, a second baseline grant. Inside the
+/// window a retry is safe (Stripe dedupes); outside it we refuse and ask for human
+/// verification rather than risk double-moving money. Mirrors the auto-topup
+/// reconciler's 23h cap.
+const MAX_RETRY_AGE_HOURS: i64 = 23;
 
 /// Spawn the billing loop. Returns immediately.
 pub fn spawn(cfg: Config, stripe: StripeClient, pool: PgPool, mailer: Mailer) {
@@ -81,9 +84,27 @@ async fn run_account(
     account: &EnterpriseAccount,
     today: time::Date,
 ) -> Result<()> {
+    // 0. Eligibility window — checked BEFORE any money movement (baseline/regrant).
+    if let Some(term_start) = account.term_start
+        && today < term_start
+    {
+        return Ok(()); // term has not started yet
+    }
+    if let Some(term_end) = account.term_end
+        && today >= term_end
+    {
+        tracing::info!(
+            account_id = account.id,
+            "enterprise term ended; billing paused (renewal / final invoice are manual)"
+        );
+        return Ok(());
+    }
+
     // Hard invariant: any non-regrant credit on the payer account corrupts the
-    // consumed = target + balance identity. Auto-topup is the only automated
-    // credit source that could sneak in — refuse loudly if it's on.
+    // consumed = target + balance identity. Auto-topup is the only *automated*
+    // credit source we can cheaply detect — refuse loudly if it's on. Manual
+    // admin grants and LITKEY credits to the payer would also corrupt it; the
+    // balance-range anomaly check in step 4 is the backstop for those.
     if db::payer_auto_topup_enabled(pool, &account.payer_customer_id).await? {
         anyhow::bail!(
             "payer {} has auto-topup enabled; refusing to meter (would corrupt usage accounting)",
@@ -94,16 +115,36 @@ async fn run_account(
     // 1. Establish the buffer once (no-op after the first successful run).
     ensure_baseline(stripe, pool, account).await?;
 
-    // 2. Which anchor period are we ensuring an invoice for?
-    let anchor = period::current_anchor(today, account.billing_anchor_day as u8);
-    if let Some(term_start) = account.term_start
-        && anchor < term_start
-    {
-        return Ok(()); // before the term begins
-    }
+    // 2. Anchor period to ensure an invoice for.
+    let day = account.billing_anchor_day as u8;
+    let anchor = period::current_anchor(today, day);
     let period_key = period::period_key(anchor);
+    let prev_anchor = period::previous_anchor(anchor, day);
+    let next_anchor = period::next_anchor(anchor, day);
 
-    // 3. Already have a row for this period?
+    // 3. Missed-cycle guard. The immediately-preceding in-term anchor must
+    //    already have an invoice row; otherwise a prior cycle went unbilled and
+    //    folding its usage into this one (one allotment for multi-cycle usage,
+    //    one committed fee for several months) would mis-bill. Refuse and surface
+    //    rather than silently lump — a >1-cycle outage needs a human.
+    let prev_in_term = account.term_start.is_none_or(|ts| prev_anchor >= ts);
+    if prev_in_term {
+        let prev_key = period::period_key(prev_anchor);
+        if db::get_invoice(pool, account.id, &prev_key)
+            .await?
+            .is_none()
+        {
+            anyhow::bail!(
+                "enterprise billing gap for account {}: period {prev_key} has no invoice row, so \
+                 a prior cycle went unbilled. Refusing to bill {period_key} (would lump multiple \
+                 cycles into one allotment / skip a committed fee). Backfill the missing period(s) \
+                 manually, then this resumes automatically.",
+                account.id
+            );
+        }
+    }
+
+    // 4. Already have a row for this period?
     if let Some(existing) = db::get_invoice(pool, account.id, &period_key).await? {
         return match existing.status.as_str() {
             // Terminal / handled — nothing to do.
@@ -113,17 +154,34 @@ async fn run_account(
         };
     }
 
-    // 4. Fresh period: snapshot consumption from the live balance and freeze it.
+    // 5. Fresh period: snapshot consumption from the live balance and freeze it.
     let balance_cents = balance::fetch(stripe, &account.payer_customer_id)
         .await
         .context("fetch payer balance")?;
+    // Metering-invariant backstop: with one regrant per cycle the balance should
+    // sit between -target (full buffer) and 0. Outside that range something
+    // credited or over-drew the payer outside our flow and consumed is suspect.
+    if balance_cents > 0 {
+        tracing::error!(
+            account_id = account.id,
+            balance_cents,
+            "payer balance is positive (buffer exhausted); consumed reading is unreliable — \
+             verify before the invoice is sent"
+        );
+    } else if balance_cents < -account.target_credit_cents {
+        tracing::warn!(
+            account_id = account.id,
+            balance_cents,
+            target_credit_cents = account.target_credit_cents,
+            "payer credit exceeds target; an external credit likely hit the payer — overage may \
+             be understated"
+        );
+    }
     let consumed = calc::consumed_units(account.target_credit_cents, balance_cents);
     let overage_u = calc::overage_units(consumed, account.included_units);
     let overage_c = calc::overage_cents(overage_u, account.overage_rate_hundredths_cent_per_unit);
     let total = account.committed_fee_cents + overage_c;
 
-    let prev_anchor = period::previous_anchor(anchor, account.billing_anchor_day as u8);
-    let next_anchor = period::next_anchor(anchor, account.billing_anchor_day as u8);
     let committed_period = format!("{anchor} → {next_anchor}");
 
     db::insert_pending_invoice(
@@ -164,6 +222,24 @@ async fn resume_invoice(
     let invoice_id = match row.stripe_invoice_id.clone() {
         Some(id) => id,
         None => {
+            // Durability guard (mirror of the regrant guard): past the idempotency
+            // window with no recorded invoice id, a fresh create would duplicate
+            // the draft (and its line items). Refuse and surface.
+            let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
+            if age_hours >= MAX_RETRY_AGE_HOURS {
+                db::set_invoice_status(pool, row.id, "error").await?;
+                anyhow::bail!(
+                    "invoice {} has no recorded Stripe invoice id and is {}h old (past the {}h \
+                     idempotency window); retrying could create a DUPLICATE draft. Check Stripe \
+                     for an invoice with idempotency key ent_inv:{}:{} and record/clear it before \
+                     retrying.",
+                    row.id,
+                    age_hours,
+                    MAX_RETRY_AGE_HOURS,
+                    account.id,
+                    row.period_key
+                );
+            }
             let desc = format!(
                 "Lit Protocol — committed {} + overage {} → {}",
                 row.committed_period, row.period_start, row.period_end
@@ -221,14 +297,19 @@ async fn resume_invoice(
             row.regrant_balance_txn_id = Some("none".to_string());
         } else {
             let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
-            if age_hours >= MAX_REGRANT_AGE_HOURS {
+            if age_hours >= MAX_RETRY_AGE_HOURS {
                 db::set_invoice_status(pool, row.id, "error").await?;
                 anyhow::bail!(
-                    "invoice {} regrant past the {}h idempotency window ({}h old); \
-                     manual regrant required to avoid double-crediting the buffer",
+                    "invoice {} regrant is unconfirmed and {}h old (past the {}h idempotency \
+                     window). The credit MAY have already landed — do NOT blindly re-credit. \
+                     Check the payer's Stripe balance_transactions for idempotency key \
+                     ent_regrant:{}:{}: if it exists, record the txn id on this row; only credit \
+                     manually if it is truly absent.",
                     row.id,
-                    MAX_REGRANT_AGE_HOURS,
-                    age_hours
+                    age_hours,
+                    MAX_RETRY_AGE_HOURS,
+                    account.id,
+                    row.period_key
                 );
             }
             let regrant_key = format!("ent_regrant:{}:{}", account.id, row.period_key);
@@ -277,6 +358,30 @@ async fn ensure_baseline(
 ) -> Result<()> {
     if account.baseline_granted_at.is_some() {
         return Ok(());
+    }
+    // Retry-window guard (same class as the regrant/invoice guards). If a prior
+    // attempt may have credited the baseline but we never recorded success, the
+    // idempotency key (ent_baseline:{id}) only dedupes for ~24h. Past that we
+    // cannot safely re-credit a full $target buffer.
+    if let Some(attempted) = account.baseline_attempted_at {
+        let age_hours = (OffsetDateTime::now_utc() - attempted).whole_hours();
+        if age_hours >= MAX_RETRY_AGE_HOURS {
+            anyhow::bail!(
+                "baseline grant for account {} is unconfirmed and {}h since first attempt (past \
+                 the {}h idempotency window). The credit MAY have already landed — do NOT blindly \
+                 re-credit. Check the payer's Stripe balance_transactions for idempotency key \
+                 ent_baseline:{}: if it exists, set baseline_granted_at on the account; only \
+                 credit manually if it is truly absent.",
+                account.id,
+                age_hours,
+                MAX_RETRY_AGE_HOURS,
+                account.id
+            );
+        }
+    } else {
+        // Stamp the window-start BEFORE touching Stripe so a crash between the
+        // write and recording success is bounded by the guard above.
+        db::mark_baseline_attempted(pool, account.id).await?;
     }
     let balance_cents = balance::fetch(stripe, &account.payer_customer_id)
         .await

--- a/lit-payments/src/enterprise/billing.rs
+++ b/lit-payments/src/enterprise/billing.rs
@@ -1,0 +1,314 @@
+//! Enterprise committed-use billing job.
+//!
+//! One background task, spawned at startup. Each tick, for every active
+//! `enterprise_accounts` row:
+//!   1. Establish the credit buffer once (baseline grant to target).
+//!   2. Determine the current anchor period.
+//!   3. If no invoice exists for it yet, snapshot consumption from the payer's
+//!      live Stripe balance, create a DRAFT invoice on the invoice account,
+//!      regrant the payer buffer back to target, and email the breakdown for a
+//!      human to review + send.
+//!
+//! Idempotency: the `enterprise_invoices` row (UNIQUE per account+period) is the
+//! gate; each external side effect is guarded by a stored id so a crash mid-flow
+//! resumes rather than duplicates. Stripe idempotency keys back-stop the same.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use lit_billing_core::{StripeClient, balance, invoice};
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use tokio::time as tokio_time;
+
+use super::types::{EnterpriseAccount, EnterpriseInvoice};
+use super::{calc, db, email, period};
+use crate::config::Config;
+use crate::mail::Mailer;
+
+/// Net-30 payment terms.
+const DAYS_UNTIL_DUE: i64 = 30;
+
+/// Refuse to (re)issue the per-period regrant once the row is older than this:
+/// Stripe drops a given idempotency key after ~24h, so reusing
+/// `ent_regrant:{acct}:{period}` beyond that would post a NEW credit and double
+/// the buffer. Mirrors the auto-topup reconciler's 23h cap.
+const MAX_REGRANT_AGE_HOURS: i64 = 23;
+
+/// Spawn the billing loop. Returns immediately.
+pub fn spawn(cfg: Config, stripe: StripeClient, pool: PgPool, mailer: Mailer) {
+    let interval_secs = cfg.enterprise_billing_interval_secs.max(60) as u64;
+    tracing::info!("enterprise billing job: interval = {interval_secs}s");
+    tokio::spawn(async move {
+        let mut ticker = tokio_time::interval(Duration::from_secs(interval_secs));
+        loop {
+            ticker.tick().await;
+            if let Err(e) = run_once(&cfg, &stripe, &pool, &mailer).await {
+                tracing::warn!("enterprise billing tick failed: {e:?}");
+            }
+        }
+    });
+}
+
+/// One sweep over all active accounts. Public for tests.
+pub async fn run_once(
+    cfg: &Config,
+    stripe: &StripeClient,
+    pool: &PgPool,
+    mailer: &Mailer,
+) -> Result<()> {
+    let accounts = db::list_active_accounts(pool)
+        .await
+        .context("list active enterprise accounts")?;
+    let today = OffsetDateTime::now_utc().date();
+    for account in &accounts {
+        if let Err(e) = run_account(cfg, stripe, pool, mailer, account, today).await {
+            tracing::error!(
+                account_id = account.id,
+                name = %account.name,
+                "enterprise billing for account failed: {e:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn run_account(
+    cfg: &Config,
+    stripe: &StripeClient,
+    pool: &PgPool,
+    mailer: &Mailer,
+    account: &EnterpriseAccount,
+    today: time::Date,
+) -> Result<()> {
+    // Hard invariant: any non-regrant credit on the payer account corrupts the
+    // consumed = target + balance identity. Auto-topup is the only automated
+    // credit source that could sneak in — refuse loudly if it's on.
+    if db::payer_auto_topup_enabled(pool, &account.payer_customer_id).await? {
+        anyhow::bail!(
+            "payer {} has auto-topup enabled; refusing to meter (would corrupt usage accounting)",
+            account.payer_customer_id
+        );
+    }
+
+    // 1. Establish the buffer once (no-op after the first successful run).
+    ensure_baseline(stripe, pool, account).await?;
+
+    // 2. Which anchor period are we ensuring an invoice for?
+    let anchor = period::current_anchor(today, account.billing_anchor_day as u8);
+    if let Some(term_start) = account.term_start
+        && anchor < term_start
+    {
+        return Ok(()); // before the term begins
+    }
+    let period_key = period::period_key(anchor);
+
+    // 3. Already have a row for this period?
+    if let Some(existing) = db::get_invoice(pool, account.id, &period_key).await? {
+        return match existing.status.as_str() {
+            // Terminal / handled — nothing to do.
+            "draft" | "sent" | "paid" | "manual" => Ok(()),
+            // Interrupted mid-flow — resume.
+            _ => resume_invoice(cfg, stripe, pool, mailer, account, existing).await,
+        };
+    }
+
+    // 4. Fresh period: snapshot consumption from the live balance and freeze it.
+    let balance_cents = balance::fetch(stripe, &account.payer_customer_id)
+        .await
+        .context("fetch payer balance")?;
+    let consumed = calc::consumed_units(account.target_credit_cents, balance_cents);
+    let overage_u = calc::overage_units(consumed, account.included_units);
+    let overage_c = calc::overage_cents(overage_u, account.overage_rate_hundredths_cent_per_unit);
+    let total = account.committed_fee_cents + overage_c;
+
+    let prev_anchor = period::previous_anchor(anchor, account.billing_anchor_day as u8);
+    let next_anchor = period::next_anchor(anchor, account.billing_anchor_day as u8);
+    let committed_period = format!("{anchor} → {next_anchor}");
+
+    db::insert_pending_invoice(
+        pool,
+        account.id,
+        &period_key,
+        prev_anchor,
+        anchor,
+        &committed_period,
+        consumed,
+        account.included_units,
+        overage_u,
+        account.committed_fee_cents,
+        overage_c,
+        total,
+    )
+    .await
+    .context("insert pending invoice")?;
+
+    // Re-read (ON CONFLICT DO NOTHING means another run may already own it).
+    let row = db::get_invoice(pool, account.id, &period_key)
+        .await?
+        .context("pending invoice row missing after insert")?;
+    resume_invoice(cfg, stripe, pool, mailer, account, row).await
+}
+
+/// Drive a pending/interrupted invoice row to `draft` + review email. Each step
+/// is guarded so a resumed run never duplicates a Stripe side effect.
+async fn resume_invoice(
+    cfg: &Config,
+    stripe: &StripeClient,
+    pool: &PgPool,
+    mailer: &Mailer,
+    account: &EnterpriseAccount,
+    mut row: EnterpriseInvoice,
+) -> Result<()> {
+    // a. Draft invoice + line items on the INVOICE account.
+    let invoice_id = match row.stripe_invoice_id.clone() {
+        Some(id) => id,
+        None => {
+            let desc = format!(
+                "Lit Protocol — committed {} + overage {} → {}",
+                row.committed_period, row.period_start, row.period_end
+            );
+            let id = invoice::create_draft_invoice(
+                stripe,
+                &account.invoice_customer_id,
+                DAYS_UNTIL_DUE,
+                &desc,
+                &format!("ent_inv:{}:{}", account.id, row.period_key),
+            )
+            .await
+            .context("create draft invoice")?;
+
+            invoice::add_invoice_item(
+                stripe,
+                &account.invoice_customer_id,
+                &id,
+                row.committed_fee_cents,
+                &format!("Committed monthly fee ({})", row.committed_period),
+                &format!("ent_ii_committed:{}:{}", account.id, row.period_key),
+            )
+            .await
+            .context("add committed fee line item")?;
+
+            if row.overage_cents > 0 {
+                let d = format!(
+                    "Compute overage — {} units over {} included @ $0.0025/unit ({} → {})",
+                    row.overage_units, row.included_units, row.period_start, row.period_end
+                );
+                invoice::add_invoice_item(
+                    stripe,
+                    &account.invoice_customer_id,
+                    &id,
+                    row.overage_cents,
+                    &d,
+                    &format!("ent_ii_overage:{}:{}", account.id, row.period_key),
+                )
+                .await
+                .context("add overage line item")?;
+            }
+
+            db::set_invoice_stripe_id(pool, row.id, &id).await?;
+            row.stripe_invoice_id = Some(id.clone());
+            id
+        }
+    };
+
+    // b. Regrant the payer buffer back to target (the metering closure).
+    if row.regrant_balance_txn_id.is_none() {
+        if row.consumed_units <= 0 {
+            // Nothing consumed this cycle (e.g. the first period right after the
+            // baseline grant). Record a sentinel so we don't retry forever.
+            db::set_invoice_regrant_txn(pool, row.id, "none").await?;
+            row.regrant_balance_txn_id = Some("none".to_string());
+        } else {
+            let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
+            if age_hours >= MAX_REGRANT_AGE_HOURS {
+                db::set_invoice_status(pool, row.id, "error").await?;
+                anyhow::bail!(
+                    "invoice {} regrant past the {}h idempotency window ({}h old); \
+                     manual regrant required to avoid double-crediting the buffer",
+                    row.id,
+                    MAX_REGRANT_AGE_HOURS,
+                    age_hours
+                );
+            }
+            let regrant_key = format!("ent_regrant:{}:{}", account.id, row.period_key);
+            let txn = balance::write_transaction(
+                stripe,
+                &account.payer_customer_id,
+                -row.consumed_units, // negative = credit; restores buffer to target
+                &format!("Enterprise buffer regrant — {}", row.period_key),
+                Some(&regrant_key),
+            )
+            .await
+            .context("regrant payer buffer")?;
+            db::set_invoice_regrant_txn(pool, row.id, &txn).await?;
+            row.regrant_balance_txn_id = Some(txn);
+        }
+    }
+
+    // c. Email the breakdown + draft link, then mark drafted.
+    let invoice_url = format!(
+        "{}/invoices/{}",
+        cfg.stripe_dashboard_base.trim_end_matches('/'),
+        invoice_id
+    );
+    email::send_review_email(mailer, account, &row, &invoice_url)
+        .await
+        .context("send review email")?;
+    db::set_invoice_drafted(pool, row.id, OffsetDateTime::now_utc()).await?;
+
+    tracing::info!(
+        account_id = account.id,
+        period = %row.period_key,
+        invoice = %invoice_id,
+        total_cents = row.total_cents,
+        overage_units = row.overage_units,
+        "enterprise invoice drafted; review email sent"
+    );
+    Ok(())
+}
+
+/// One-time: bring the payer's credit up to `target_credit_cents`. Idempotent —
+/// gated on `baseline_granted_at`; never claws credit back if already funded.
+async fn ensure_baseline(
+    stripe: &StripeClient,
+    pool: &PgPool,
+    account: &EnterpriseAccount,
+) -> Result<()> {
+    if account.baseline_granted_at.is_some() {
+        return Ok(());
+    }
+    let balance_cents = balance::fetch(stripe, &account.payer_customer_id)
+        .await
+        .context("fetch payer balance for baseline")?;
+    let amount = calc::regrant_amount_cents(account.target_credit_cents, balance_cents);
+    if amount >= 0 {
+        // Already at/above target — record baseline without crediting.
+        db::mark_baseline(pool, account.id, "none").await?;
+        tracing::info!(
+            account_id = account.id,
+            "enterprise baseline: payer already funded ≥ target; no credit written"
+        );
+        return Ok(());
+    }
+    let baseline_key = format!("ent_baseline:{}", account.id);
+    let txn = balance::write_transaction(
+        stripe,
+        &account.payer_customer_id,
+        amount,
+        &format!(
+            "Enterprise credit buffer (baseline → ${})",
+            account.target_credit_cents / 100
+        ),
+        Some(&baseline_key),
+    )
+    .await
+    .context("write baseline buffer credit")?;
+    db::mark_baseline(pool, account.id, &txn).await?;
+    tracing::info!(
+        account_id = account.id,
+        amount_cents = amount,
+        "enterprise baseline buffer established"
+    );
+    Ok(())
+}

--- a/lit-payments/src/enterprise/calc.rs
+++ b/lit-payments/src/enterprise/calc.rs
@@ -90,6 +90,9 @@ mod tests {
     fn regrant_magnitude_equals_consumed() {
         let target = 50_000_000;
         let balance = -47_000_000;
-        assert_eq!(-regrant_amount_cents(target, balance), consumed_units(target, balance));
+        assert_eq!(
+            -regrant_amount_cents(target, balance),
+            consumed_units(target, balance)
+        );
     }
 }

--- a/lit-payments/src/enterprise/calc.rs
+++ b/lit-payments/src/enterprise/calc.rs
@@ -1,0 +1,95 @@
+//! Enterprise billing arithmetic (pure, integer-exact).
+//!
+//! The payer Stripe customer is debited at the standard $0.01/unit rate (1 cent
+//! == 1 unit). Because the billing job keeps the payer's credit topped to
+//! `target_credit_cents` with exactly ONE regrant per cycle, the amount consumed
+//! during the cycle is recoverable from the current balance alone.
+//!
+//! Stripe balances are signed: negative == credit available, positive == owed.
+
+/// Units consumed since the buffer was last restored to target.
+///
+/// `consumed = target + balance` (balance is negative while credit remains, so
+/// this subtracts the remaining credit from the target). Clamped at 0: if the
+/// account somehow holds *more* than target credit, consumption reads as 0
+/// rather than negative.
+pub fn consumed_units(target_credit_cents: i64, balance_cents: i64) -> i64 {
+    target_credit_cents.saturating_add(balance_cents).max(0)
+}
+
+/// Units beyond the included allotment.
+pub fn overage_units(consumed: i64, included: i64) -> i64 {
+    consumed.saturating_sub(included).max(0)
+}
+
+/// Overage charge in cents, rounded to the nearest cent. The rate is expressed
+/// in hundredths-of-a-cent per unit ($0.0025 == 25) to keep this exact.
+pub fn overage_cents(overage_units: i64, rate_hundredths_cent_per_unit: i64) -> i64 {
+    (overage_units.saturating_mul(rate_hundredths_cent_per_unit) + 50) / 100
+}
+
+/// Signed balance-transaction amount that restores the buffer to target.
+/// Negative == credit. Returns 0 when the account already holds ≥ target credit
+/// (we never claw credit back).
+pub fn regrant_amount_cents(target_credit_cents: i64, balance_cents: i64) -> i64 {
+    let amount = -(target_credit_cents.saturating_add(balance_cents));
+    amount.min(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // $500k target, ~$470k credit remaining → consumed exactly the 3M allotment.
+    #[test]
+    fn consumed_at_allotment() {
+        assert_eq!(consumed_units(50_000_000, -47_000_000), 3_000_000);
+    }
+
+    #[test]
+    fn consumed_clamps_when_over_credited() {
+        // More credit than target → 0, never negative.
+        assert_eq!(consumed_units(50_000_000, -60_000_000), 0);
+    }
+
+    #[test]
+    fn no_overage_at_or_below_allotment() {
+        assert_eq!(overage_units(3_000_000, 3_000_000), 0);
+        assert_eq!(overage_units(2_500_000, 3_000_000), 0);
+    }
+
+    // 1,000,000 units over @ $0.0025 = $2,500 = 250,000 cents.
+    #[test]
+    fn overage_million_units() {
+        let over = overage_units(4_000_000, 3_000_000);
+        assert_eq!(over, 1_000_000);
+        assert_eq!(overage_cents(over, 25), 250_000);
+    }
+
+    // Rounding: 3 units @ 25 hundredths-cent = 75 hundredths-cent = 0.75¢ → 1¢.
+    #[test]
+    fn overage_rounds_to_nearest_cent() {
+        assert_eq!(overage_cents(3, 25), 1);
+        assert_eq!(overage_cents(1, 25), 0); // 0.25¢ → 0¢
+        assert_eq!(overage_cents(2, 25), 1); // 0.50¢ → 1¢ (round half up)
+    }
+
+    // Regrant restores -$470k credit back to -$500k by crediting $30k.
+    #[test]
+    fn regrant_restores_to_target() {
+        assert_eq!(regrant_amount_cents(50_000_000, -47_000_000), -3_000_000);
+    }
+
+    #[test]
+    fn regrant_noop_when_above_target() {
+        assert_eq!(regrant_amount_cents(50_000_000, -60_000_000), 0);
+    }
+
+    // Consumed and the (negated) regrant magnitude agree.
+    #[test]
+    fn regrant_magnitude_equals_consumed() {
+        let target = 50_000_000;
+        let balance = -47_000_000;
+        assert_eq!(-regrant_amount_cents(target, balance), consumed_units(target, balance));
+    }
+}

--- a/lit-payments/src/enterprise/db.rs
+++ b/lit-payments/src/enterprise/db.rs
@@ -10,7 +10,7 @@ use super::types::{EnterpriseAccount, EnterpriseInvoice};
 const ACCOUNT_COLS: &str = "id, name, payer_customer_id, invoice_customer_id, \
     committed_fee_cents, included_units, overage_rate_hundredths_cent_per_unit, \
     target_credit_cents, billing_anchor_day, notify_email, auto_send, \
-    term_start, term_end, baseline_granted_at";
+    term_start, term_end, baseline_granted_at, baseline_attempted_at";
 
 const INVOICE_COLS: &str = "id, enterprise_account_id, period_key, period_start, period_end, \
     committed_period, consumed_units, included_units, overage_units, \
@@ -25,6 +25,21 @@ pub async fn list_active_accounts(pool: &PgPool) -> Result<Vec<EnterpriseAccount
     .fetch_all(pool)
     .await?;
     Ok(rows)
+}
+
+/// Stamp the baseline attempt window-start (idempotent: only when unset). Called
+/// before the baseline Stripe write so a lost success-record is recoverable
+/// within the idempotency window and refused past it.
+pub async fn mark_baseline_attempted(pool: &PgPool, account_id: i64) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_accounts \
+         SET baseline_attempted_at = now(), updated_at = now() \
+         WHERE id = $1 AND baseline_attempted_at IS NULL",
+    )
+    .bind(account_id)
+    .execute(pool)
+    .await?;
+    Ok(())
 }
 
 /// Record the one-time baseline buffer grant (or `"none"` when already funded).

--- a/lit-payments/src/enterprise/db.rs
+++ b/lit-payments/src/enterprise/db.rs
@@ -1,0 +1,155 @@
+//! Postgres access for enterprise billing. Runtime `sqlx::query*` (no
+//! compile-time macros), matching the rest of this crate.
+
+use anyhow::Result;
+use sqlx::PgPool;
+use time::{Date, OffsetDateTime};
+
+use super::types::{EnterpriseAccount, EnterpriseInvoice};
+
+const ACCOUNT_COLS: &str = "id, name, payer_customer_id, invoice_customer_id, \
+    committed_fee_cents, included_units, overage_rate_hundredths_cent_per_unit, \
+    target_credit_cents, billing_anchor_day, notify_email, auto_send, \
+    term_start, term_end, baseline_granted_at";
+
+const INVOICE_COLS: &str = "id, enterprise_account_id, period_key, period_start, period_end, \
+    committed_period, consumed_units, included_units, overage_units, \
+    committed_fee_cents, overage_cents, total_cents, stripe_invoice_id, \
+    regrant_balance_txn_id, status, created_at";
+
+/// All active committed-use accounts.
+pub async fn list_active_accounts(pool: &PgPool) -> Result<Vec<EnterpriseAccount>> {
+    let rows = sqlx::query_as::<_, EnterpriseAccount>(&format!(
+        "SELECT {ACCOUNT_COLS} FROM enterprise_accounts WHERE active = true ORDER BY id"
+    ))
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Record the one-time baseline buffer grant (or `"none"` when already funded).
+pub async fn mark_baseline(pool: &PgPool, account_id: i64, balance_txn_id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_accounts \
+         SET baseline_balance_txn_id = $2, baseline_granted_at = now(), updated_at = now() \
+         WHERE id = $1 AND baseline_granted_at IS NULL",
+    )
+    .bind(account_id)
+    .bind(balance_txn_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch the invoice row for a period, if any.
+pub async fn get_invoice(
+    pool: &PgPool,
+    account_id: i64,
+    period_key: &str,
+) -> Result<Option<EnterpriseInvoice>> {
+    let row = sqlx::query_as::<_, EnterpriseInvoice>(&format!(
+        "SELECT {INVOICE_COLS} FROM enterprise_invoices \
+         WHERE enterprise_account_id = $1 AND period_key = $2"
+    ))
+    .bind(account_id)
+    .bind(period_key)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Insert the frozen amount snapshot for a fresh period. `ON CONFLICT DO
+/// NOTHING` makes this safe across restarts / a second worker.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_pending_invoice(
+    pool: &PgPool,
+    account_id: i64,
+    period_key: &str,
+    period_start: Date,
+    period_end: Date,
+    committed_period: &str,
+    consumed_units: i64,
+    included_units: i64,
+    overage_units: i64,
+    committed_fee_cents: i64,
+    overage_cents: i64,
+    total_cents: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO enterprise_invoices ( \
+             enterprise_account_id, period_key, period_start, period_end, committed_period, \
+             consumed_units, included_units, overage_units, \
+             committed_fee_cents, overage_cents, total_cents, status \
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'pending') \
+         ON CONFLICT (enterprise_account_id, period_key) DO NOTHING",
+    )
+    .bind(account_id)
+    .bind(period_key)
+    .bind(period_start)
+    .bind(period_end)
+    .bind(committed_period)
+    .bind(consumed_units)
+    .bind(included_units)
+    .bind(overage_units)
+    .bind(committed_fee_cents)
+    .bind(overage_cents)
+    .bind(total_cents)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn set_invoice_stripe_id(pool: &PgPool, id: i64, stripe_invoice_id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_invoices SET stripe_invoice_id = $2, updated_at = now() WHERE id = $1",
+    )
+    .bind(id)
+    .bind(stripe_invoice_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn set_invoice_regrant_txn(pool: &PgPool, id: i64, txn_id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_invoices SET regrant_balance_txn_id = $2, updated_at = now() WHERE id = $1",
+    )
+    .bind(id)
+    .bind(txn_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn set_invoice_status(pool: &PgPool, id: i64, status: &str) -> Result<()> {
+    sqlx::query("UPDATE enterprise_invoices SET status = $2, updated_at = now() WHERE id = $1")
+        .bind(id)
+        .bind(status)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark the invoice drafted and the review email sent.
+pub async fn set_invoice_drafted(pool: &PgPool, id: i64, now: OffsetDateTime) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_invoices SET status = 'draft', notified_at = $2, updated_at = now() \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(now)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Whether the payer account has auto-topup enabled — a hard stop, since any
+/// non-regrant credit corrupts the `consumed = target + balance` identity.
+pub async fn payer_auto_topup_enabled(pool: &PgPool, payer_customer_id: &str) -> Result<bool> {
+    let row: Option<(bool,)> =
+        sqlx::query_as("SELECT enabled FROM auto_topup_config WHERE customer_id = $1")
+            .bind(payer_customer_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(enabled,)| enabled).unwrap_or(false))
+}

--- a/lit-payments/src/enterprise/email.rs
+++ b/lit-payments/src/enterprise/email.rs
@@ -26,8 +26,30 @@ pub async fn send_review_email(
     let overage = cents_to_display(inv.overage_cents);
     let total = cents_to_display(inv.total_cents);
 
+    // Metering sanity flag surfaced to the reviewer. 0 units for an active
+    // enterprise account is unusual and usually means an external credit hit the
+    // payer (which understates overage) or usage genuinely stopped — either way,
+    // worth a look before sending.
+    let caution = (inv.consumed_units == 0).then_some(
+        "0 units recorded this cycle — unusual for an active account. Verify the payer's Stripe \
+         balance and that no external credit (admin grant / LITKEY top-up) hit the payer account, \
+         which would understate overage.",
+    );
+    let text_caution = caution
+        .map(|c| format!("\n⚠ HEADS UP: {c}\n"))
+        .unwrap_or_default();
+    let html_caution = caution
+        .map(|c| {
+            format!(
+                "<p style=\"background:#fff3cd;border:1px solid #ffe69c;padding:8px;\">\
+                 ⚠ <b>Heads up:</b> {c}</p>"
+            )
+        })
+        .unwrap_or_default();
+
     let text = format!(
         "Draft invoice for {name} is ready for review.\n\
+         {text_caution}\
          \n\
          Period (issued): {period}\n\
          Committed cycle (advance): {committed_period}\n\
@@ -63,10 +85,12 @@ pub async fn send_review_email(
         invoice_cust = account.invoice_customer_id,
         payer_cust = account.payer_customer_id,
         target = account.target_credit_cents / 100,
+        text_caution = text_caution,
     );
 
     let html = format!(
         "<h2>Draft invoice for {name} is ready for review</h2>\
+         {html_caution}\
          <table cellpadding=\"4\">\
            <tr><td><b>Period (issued)</b></td><td>{period}</td></tr>\
            <tr><td><b>Committed cycle (advance)</b></td><td>{committed_period}</td></tr>\
@@ -103,6 +127,7 @@ pub async fn send_review_email(
         invoice_cust = account.invoice_customer_id,
         payer_cust = account.payer_customer_id,
         target = account.target_credit_cents / 100,
+        html_caution = html_caution,
     );
 
     mailer

--- a/lit-payments/src/enterprise/email.rs
+++ b/lit-payments/src/enterprise/email.rs
@@ -1,0 +1,111 @@
+//! Review email for the monthly enterprise invoice. Sent to the account's
+//! `notify_email` so a human can sanity-check the numbers and click Send on the
+//! draft invoice in Stripe (v1, before we drop the human-in-the-loop step).
+
+use anyhow::Result;
+use lit_billing_core::format::cents_to_display;
+
+use super::types::{EnterpriseAccount, EnterpriseInvoice};
+use crate::mail::Mailer;
+
+/// Send the breakdown email with a link to the draft invoice.
+pub async fn send_review_email(
+    mailer: &Mailer,
+    account: &EnterpriseAccount,
+    inv: &EnterpriseInvoice,
+    invoice_url: &str,
+) -> Result<()> {
+    let subject = format!(
+        "[Lit] {} — draft invoice {} ready ({})",
+        account.name,
+        inv.period_key,
+        cents_to_display(inv.total_cents),
+    );
+
+    let committed = cents_to_display(inv.committed_fee_cents);
+    let overage = cents_to_display(inv.overage_cents);
+    let total = cents_to_display(inv.total_cents);
+
+    let text = format!(
+        "Draft invoice for {name} is ready for review.\n\
+         \n\
+         Period (issued): {period}\n\
+         Committed cycle (advance): {committed_period}\n\
+         Overage window (arrears): {p_start} -> {p_end}\n\
+         \n\
+         Usage this cycle:\n\
+         - Consumed:  {consumed} units\n\
+         - Included:  {included} units\n\
+         - Overage:   {over} units\n\
+         \n\
+         Charges:\n\
+         - Committed monthly fee: {committed}\n\
+         - Overage @ $0.0025/unit: {overage}\n\
+         - TOTAL: {total}\n\
+         \n\
+         Review and send the draft invoice here:\n\
+         {url}\n\
+         \n\
+         (Invoice goes to {invoice_cust}; credits/usage are on payer {payer_cust}.)\n\
+         The payer's credit buffer has been topped back up to ${target}.\n",
+        name = account.name,
+        period = inv.period_key,
+        committed_period = inv.committed_period,
+        p_start = inv.period_start,
+        p_end = inv.period_end,
+        consumed = inv.consumed_units,
+        included = inv.included_units,
+        over = inv.overage_units,
+        committed = committed,
+        overage = overage,
+        total = total,
+        url = invoice_url,
+        invoice_cust = account.invoice_customer_id,
+        payer_cust = account.payer_customer_id,
+        target = account.target_credit_cents / 100,
+    );
+
+    let html = format!(
+        "<h2>Draft invoice for {name} is ready for review</h2>\
+         <table cellpadding=\"4\">\
+           <tr><td><b>Period (issued)</b></td><td>{period}</td></tr>\
+           <tr><td><b>Committed cycle (advance)</b></td><td>{committed_period}</td></tr>\
+           <tr><td><b>Overage window (arrears)</b></td><td>{p_start} → {p_end}</td></tr>\
+         </table>\
+         <h3>Usage this cycle</h3>\
+         <table cellpadding=\"4\">\
+           <tr><td>Consumed</td><td align=\"right\">{consumed} units</td></tr>\
+           <tr><td>Included</td><td align=\"right\">{included} units</td></tr>\
+           <tr><td>Overage</td><td align=\"right\">{over} units</td></tr>\
+         </table>\
+         <h3>Charges</h3>\
+         <table cellpadding=\"4\">\
+           <tr><td>Committed monthly fee</td><td align=\"right\">{committed}</td></tr>\
+           <tr><td>Overage @ $0.0025/unit</td><td align=\"right\">{overage}</td></tr>\
+           <tr><td><b>Total</b></td><td align=\"right\"><b>{total}</b></td></tr>\
+         </table>\
+         <p><a href=\"{url}\">Review &amp; send the draft invoice in Stripe →</a></p>\
+         <p style=\"color:#666;font-size:12px\">Invoice goes to {invoice_cust}; credits/usage \
+         are on payer {payer_cust}. The payer's credit buffer has been topped back up to \
+         ${target}.</p>",
+        name = account.name,
+        period = inv.period_key,
+        committed_period = inv.committed_period,
+        p_start = inv.period_start,
+        p_end = inv.period_end,
+        consumed = inv.consumed_units,
+        included = inv.included_units,
+        over = inv.overage_units,
+        committed = committed,
+        overage = overage,
+        total = total,
+        url = invoice_url,
+        invoice_cust = account.invoice_customer_id,
+        payer_cust = account.payer_customer_id,
+        target = account.target_credit_cents / 100,
+    );
+
+    mailer
+        .send(&account.notify_email, &subject, &html, &text)
+        .await
+}

--- a/lit-payments/src/enterprise/mod.rs
+++ b/lit-payments/src/enterprise/mod.rs
@@ -1,0 +1,14 @@
+//! Enterprise committed-use billing: prepaid allotment + arrears overage,
+//! across a split payer/invoice Stripe-customer pair.
+//!
+//! See `plans/enterprise-committed-billing.md` for the full design. Entry point
+//! is [`billing::spawn`], wired in `main.rs`.
+
+pub mod billing;
+pub mod calc;
+pub mod db;
+pub mod email;
+pub mod period;
+pub mod types;
+
+pub use billing::spawn;

--- a/lit-payments/src/enterprise/period.rs
+++ b/lit-payments/src/enterprise/period.rs
@@ -66,19 +66,34 @@ mod tests {
 
     #[test]
     fn current_anchor_on_or_after_anchor_is_this_month() {
-        assert_eq!(current_anchor(date!(2026 - 07 - 17), 17), date!(2026 - 07 - 17));
-        assert_eq!(current_anchor(date!(2026 - 07 - 30), 17), date!(2026 - 07 - 17));
+        assert_eq!(
+            current_anchor(date!(2026 - 07 - 17), 17),
+            date!(2026 - 07 - 17)
+        );
+        assert_eq!(
+            current_anchor(date!(2026 - 07 - 30), 17),
+            date!(2026 - 07 - 17)
+        );
     }
 
     #[test]
     fn current_anchor_before_anchor_is_prev_month() {
-        assert_eq!(current_anchor(date!(2026 - 07 - 16), 17), date!(2026 - 06 - 17));
-        assert_eq!(current_anchor(date!(2026 - 07 - 01), 17), date!(2026 - 06 - 17));
+        assert_eq!(
+            current_anchor(date!(2026 - 07 - 16), 17),
+            date!(2026 - 06 - 17)
+        );
+        assert_eq!(
+            current_anchor(date!(2026 - 07 - 01), 17),
+            date!(2026 - 06 - 17)
+        );
     }
 
     #[test]
     fn current_anchor_crosses_year_boundary() {
-        assert_eq!(current_anchor(date!(2026 - 01 - 05), 17), date!(2025 - 12 - 17));
+        assert_eq!(
+            current_anchor(date!(2026 - 01 - 05), 17),
+            date!(2025 - 12 - 17)
+        );
     }
 
     #[test]
@@ -87,15 +102,24 @@ mod tests {
         assert_eq!(previous_anchor(a, 17), date!(2026 - 06 - 17));
         assert_eq!(next_anchor(a, 17), date!(2026 - 08 - 17));
         // January wraps to previous December.
-        assert_eq!(previous_anchor(date!(2026 - 01 - 17), 17), date!(2025 - 12 - 17));
+        assert_eq!(
+            previous_anchor(date!(2026 - 01 - 17), 17),
+            date!(2025 - 12 - 17)
+        );
         // December wraps to next January.
-        assert_eq!(next_anchor(date!(2026 - 12 - 17), 17), date!(2027 - 01 - 17));
+        assert_eq!(
+            next_anchor(date!(2026 - 12 - 17), 17),
+            date!(2027 - 01 - 17)
+        );
     }
 
     #[test]
     fn anchor_day_clamps_to_short_month() {
         // Anchor 31 in February clamps to the 28th (2026 is not a leap year).
-        assert_eq!(current_anchor(date!(2026 - 02 - 28), 31), date!(2026 - 02 - 28));
+        assert_eq!(
+            current_anchor(date!(2026 - 02 - 28), 31),
+            date!(2026 - 02 - 28)
+        );
     }
 
     #[test]

--- a/lit-payments/src/enterprise/period.rs
+++ b/lit-payments/src/enterprise/period.rs
@@ -1,0 +1,106 @@
+//! Anchor-to-anchor billing period math (pure).
+//!
+//! Each enterprise cycle runs anchor→anchor (e.g. the 17th → the 16th). The
+//! invoice issued on a given anchor covers the committed fee for the *upcoming*
+//! cycle (advance) and the overage for the *just-closed* cycle (arrears). All
+//! functions are pure and unit-tested.
+
+use time::{Date, Month};
+
+/// The most recent anchor date on or before `today`. `anchor_day` is clamped to
+/// the month length (the DB constrains it to 1..=28, so clamping is belt-and-
+/// suspenders).
+pub fn current_anchor(today: Date, anchor_day: u8) -> Date {
+    let this = anchor_in(today.year(), today.month(), anchor_day);
+    if today >= this {
+        this
+    } else {
+        let (y, m) = prev_month(today.year(), today.month());
+        anchor_in(y, m, anchor_day)
+    }
+}
+
+/// The anchor one cycle before `anchor` (start of the arrears window).
+pub fn previous_anchor(anchor: Date, anchor_day: u8) -> Date {
+    let (y, m) = prev_month(anchor.year(), anchor.month());
+    anchor_in(y, m, anchor_day)
+}
+
+/// The anchor one cycle after `anchor` (end of the advance window).
+pub fn next_anchor(anchor: Date, anchor_day: u8) -> Date {
+    let (y, m) = next_month(anchor.year(), anchor.month());
+    anchor_in(y, m, anchor_day)
+}
+
+/// `'YYYY-MM'` for the anchor's month — the per-period idempotency key.
+pub fn period_key(anchor: Date) -> String {
+    format!("{:04}-{:02}", anchor.year(), u8::from(anchor.month()))
+}
+
+fn anchor_in(year: i32, month: Month, anchor_day: u8) -> Date {
+    let dim = month.length(year);
+    let day = anchor_day.clamp(1, dim);
+    Date::from_calendar_date(year, month, day).expect("clamped anchor day is always valid")
+}
+
+fn prev_month(year: i32, month: Month) -> (i32, Month) {
+    if month == Month::January {
+        (year - 1, Month::December)
+    } else {
+        (year, month.previous())
+    }
+}
+
+fn next_month(year: i32, month: Month) -> (i32, Month) {
+    if month == Month::December {
+        (year + 1, Month::January)
+    } else {
+        (year, month.next())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::date;
+
+    #[test]
+    fn current_anchor_on_or_after_anchor_is_this_month() {
+        assert_eq!(current_anchor(date!(2026 - 07 - 17), 17), date!(2026 - 07 - 17));
+        assert_eq!(current_anchor(date!(2026 - 07 - 30), 17), date!(2026 - 07 - 17));
+    }
+
+    #[test]
+    fn current_anchor_before_anchor_is_prev_month() {
+        assert_eq!(current_anchor(date!(2026 - 07 - 16), 17), date!(2026 - 06 - 17));
+        assert_eq!(current_anchor(date!(2026 - 07 - 01), 17), date!(2026 - 06 - 17));
+    }
+
+    #[test]
+    fn current_anchor_crosses_year_boundary() {
+        assert_eq!(current_anchor(date!(2026 - 01 - 05), 17), date!(2025 - 12 - 17));
+    }
+
+    #[test]
+    fn prev_and_next_anchor() {
+        let a = date!(2026 - 07 - 17);
+        assert_eq!(previous_anchor(a, 17), date!(2026 - 06 - 17));
+        assert_eq!(next_anchor(a, 17), date!(2026 - 08 - 17));
+        // January wraps to previous December.
+        assert_eq!(previous_anchor(date!(2026 - 01 - 17), 17), date!(2025 - 12 - 17));
+        // December wraps to next January.
+        assert_eq!(next_anchor(date!(2026 - 12 - 17), 17), date!(2027 - 01 - 17));
+    }
+
+    #[test]
+    fn anchor_day_clamps_to_short_month() {
+        // Anchor 31 in February clamps to the 28th (2026 is not a leap year).
+        assert_eq!(current_anchor(date!(2026 - 02 - 28), 31), date!(2026 - 02 - 28));
+    }
+
+    #[test]
+    fn period_key_format() {
+        assert_eq!(period_key(date!(2026 - 07 - 17)), "2026-07");
+        assert_eq!(period_key(date!(2026 - 12 - 17)), "2026-12");
+    }
+}

--- a/lit-payments/src/enterprise/types.rs
+++ b/lit-payments/src/enterprise/types.rs
@@ -1,0 +1,48 @@
+//! Row types for the enterprise billing tables.
+
+use time::{Date, OffsetDateTime};
+
+/// One committed-use customer (`enterprise_accounts`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EnterpriseAccount {
+    pub id: i64,
+    pub name: String,
+    /// Stripe customer that consumes service and holds the credit buffer.
+    pub payer_customer_id: String,
+    /// Stripe customer that receives the invoice (a different customer).
+    pub invoice_customer_id: String,
+    pub committed_fee_cents: i64,
+    pub included_units: i64,
+    pub overage_rate_hundredths_cent_per_unit: i64,
+    pub target_credit_cents: i64,
+    pub billing_anchor_day: i32,
+    pub notify_email: String,
+    /// v1 = false: draft + email for manual send.
+    pub auto_send: bool,
+    pub term_start: Option<Date>,
+    pub term_end: Option<Date>,
+    /// Set once the one-time buffer-establishment credit has been written.
+    pub baseline_granted_at: Option<OffsetDateTime>,
+}
+
+/// One generated (or manually recorded) invoice (`enterprise_invoices`). Also
+/// the per-period idempotency gate for the billing job.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EnterpriseInvoice {
+    pub id: i64,
+    pub enterprise_account_id: i64,
+    pub period_key: String,
+    pub period_start: Date,
+    pub period_end: Date,
+    pub committed_period: String,
+    pub consumed_units: i64,
+    pub included_units: i64,
+    pub overage_units: i64,
+    pub committed_fee_cents: i64,
+    pub overage_cents: i64,
+    pub total_cents: i64,
+    pub stripe_invoice_id: Option<String>,
+    pub regrant_balance_txn_id: Option<String>,
+    pub status: String,
+    pub created_at: OffsetDateTime,
+}

--- a/lit-payments/src/enterprise/types.rs
+++ b/lit-payments/src/enterprise/types.rs
@@ -23,6 +23,9 @@ pub struct EnterpriseAccount {
     pub term_end: Option<Date>,
     /// Set once the one-time buffer-establishment credit has been written.
     pub baseline_granted_at: Option<OffsetDateTime>,
+    /// Stamped before the baseline Stripe write; bounds the retry window so a
+    /// lost success-record can't double-credit past Stripe's idempotency TTL.
+    pub baseline_attempted_at: Option<OffsetDateTime>,
 }
 
 /// One generated (or manually recorded) invoice (`enterprise_invoices`). Also

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -9,6 +9,7 @@ pub mod billing;
 pub mod chain;
 pub mod config;
 pub mod db;
+pub mod enterprise;
 pub mod internal;
 pub mod mail;
 pub mod portal;

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -49,12 +49,7 @@ async fn rocket() -> _ {
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
     // Enterprise committed-use billing: monthly draft invoice + buffer regrant.
     // See plans/enterprise-committed-billing.md.
-    lit_payments::enterprise::spawn(
-        cfg.clone(),
-        stripe.clone(),
-        pool.clone(),
-        mailer.clone(),
-    );
+    lit_payments::enterprise::spawn(cfg.clone(), stripe.clone(), pool.clone(), mailer.clone());
     // Keep the lit-api-server API payer pool topped up (no-op unless
     // GAS_FUNDER_PRIVATE_KEY is configured). Runs out of the TEE hot path.
     lit_payments::gas_funder::spawn(cfg.clone(), pool.clone(), mailer.clone());

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -47,6 +47,14 @@ async fn rocket() -> _ {
     rate::spawn_rate_poller(pool.clone());
     let per_customer_mutex = PerCustomerMutex::new();
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
+    // Enterprise committed-use billing: monthly draft invoice + buffer regrant.
+    // See plans/enterprise-committed-billing.md.
+    lit_payments::enterprise::spawn(
+        cfg.clone(),
+        stripe.clone(),
+        pool.clone(),
+        mailer.clone(),
+    );
 
     // Codex P1 (Phase 8): exact-match CORS allowlist driven by
     // `cors_allowed_origins`. The prior config used

--- a/plans/enterprise-committed-billing.md
+++ b/plans/enterprise-committed-billing.md
@@ -1,0 +1,182 @@
+# Enterprise committed-use billing (prepaid allotment + arrears overage)
+
+Status: implemented (branch glitch003/enterprise-net30-billing) — pending review + deploy
+Owner: chris
+First customer: Uneven Labs, Inc. (contract signed 2026-06-17, `.context/attachments/RGXuyR/`)
+
+## Goal
+
+Automate the monthly enterprise billing flow we currently do by hand:
+
+- Customer prepays a **committed monthly fee** for an **included allotment**, and pays
+  **overage in arrears** at a discounted rate.
+- The Stripe customer that **receives the invoice** ("invoice account") is **not** the
+  Stripe customer that **consumes service on Chipotle** ("payer account").
+- The payer account must **never run out of credits** — they settle by invoice (net 30).
+
+### Uneven Labs terms (signed contract §8)
+
+| Term | Value |
+|------|-------|
+| Committed fee | **$9,000 / month**, billed **monthly in advance** |
+| Included allotment | **3,000,000 compute seconds / calendar month**, no rollover |
+| Overage rate | **$0.0025 / compute second**, billed **in arrears** |
+| Standard internal rate | **$0.01 per unit** (`COST_LIT_ACTION_PER_SECOND_CENTS = 1`) |
+| Payment terms | Net 30 |
+| ACV | $108,000 (ex-overage, ex-tax) |
+| Term | 12 months from 2026-06-17 |
+
+> June 2026 was invoiced manually. Automation begins from the **next** cycle so we don't
+> double-bill the committed fee — see "First-cycle handling."
+
+---
+
+## Chosen approach (per chris)
+
+1. **No changes to `lit-api-server`.** The hot charge path is untouched.
+2. **Don't track real compute usage.** They're buying generic "Chipotle credits." We meter
+   purely on **dollars charged in Stripe at the standard $0.01 rate** and convert to their
+   contract rate. A management call ($0.01/request) and a compute-second ($0.01/sec) both
+   count as one unit — accepted and intended.
+3. **No polling job.** Grant a buffer that dwarfs monthly burn ($500k), and regrant it once a
+   month at billing time. They realistically can't burn $500k in a month, so they never run
+   out mid-cycle; if usage ever climbed, we just raise the buffer.
+
+### The metering trick
+
+Internal rate is **exactly 1 cent per unit**, so *dollars charged = unit count*:
+
+- 3,000,000 included compute-seconds ≡ **3,000,000 units** ≡ **$30,000** of internal charges.
+- They pay the flat **$9,000** for that allotment; each unit beyond 3,000,000 is overage at $0.0025.
+
+With a single monthly regrant up to a fixed **target** (e.g. $500k), usage is a **one-line
+balance read** — no Stripe transaction listing (there are hundreds of thousands/month):
+
+```
+consumed_units = target_credit_cents - credit_remaining_now   // credit_remaining = -balance
+```
+
+Then we regrant `consumed_units` cents back to restore the buffer to `target`, and bill on it.
+
+### Overage math (integer cents)
+
+```
+included_units = 3_000_000                          // = $30,000 of charges
+overage_units  = max(0, consumed_units - included_units)
+overage_cents  = round(overage_units * 25 / 100)    // $0.0025 = 25 hundredths-of-a-cent/unit
+total_cents    = 900_000 + overage_cents             // $9,000 committed + overage
+```
+
+---
+
+## The one job: monthly billing + regrant
+
+A single task in `lit-payments`, following the existing reconciler pattern
+(`auto_topup/reconciler.rs`, spawned in `main.rs`). Runs daily; acts only when today reaches
+an account's `billing_anchor_day` and no `enterprise_invoices` row exists for the period
+(idempotency guard). Per active `enterprise_accounts` row:
+
+1. Read the payer account's Stripe balance → `credit_remaining_now`.
+2. `consumed_units = target_credit_cents - credit_remaining_now`.
+3. Compute `overage_cents` and `total_cents` per the formula above.
+4. On the **invoice account**, create Stripe **invoice items**:
+   - committed fee `$9,000` (advance, next month)
+   - overage `$X` (arrears, month just closed) — only if > 0
+5. Create the invoice (`collection_method = send_invoice`, `days_until_due = 30`). For v1
+   leave it **draft + notify a human**; flip to auto-finalize+send after a couple clean cycles.
+6. **Regrant** `consumed_units` cents (negative balance transaction) to restore the payer
+   buffer back to `target`; log it.
+7. Persist the `enterprise_invoices` row (amounts, `stripe_invoice_id`, status).
+
+### Invariant this depends on
+The monthly regrant must be the **only** thing that credits the payer account between billing
+runs, or `consumed = target − remaining` is wrong. On the payer account we therefore:
+- **Disable auto-topup** (no `auto_topup_config` row / `enabled=false`).
+- **Never issue manual portal grants** to it.
+- Record the **initial onboarding grant** ($500k baseline) so we know the starting target.
+
+Since the buffer ($500k) is ~12× expected monthly burn (~$30–40k), one regrant per month is
+plenty and there's no mid-month run-out risk.
+
+---
+
+## Data model (new, in `lit-payments`)
+
+`enterprise_accounts` — one row per committed-use customer:
+
+| column | notes |
+|--------|-------|
+| `id` | uuid pk |
+| `name` | "Uneven Labs, Inc." |
+| `payer_stripe_customer_id` | consumes on Chipotle; receives regrants |
+| `invoice_stripe_customer_id` | the **different** customer that receives invoices |
+| `committed_fee_cents` | 900000 |
+| `included_units` | 3000000 |
+| `overage_rate_hundredths_cent_per_unit` | 25 (i.e. $0.0025; integer math) |
+| `target_credit_cents` | 50000000 ($500k buffer) |
+| `billing_anchor_day` | e.g. 17 |
+| `active` / `term_start` / `term_end` | lifecycle |
+
+`enterprise_invoices` — idempotency + audit (also records the regrant):
+
+| column | notes |
+|--------|-------|
+| `enterprise_account_id` | fk |
+| `period_start` / `period_end` | calendar month metered (arrears) |
+| `committed_period` | the advance month the $9k covers |
+| `consumed_units` / `included_units` / `overage_units` | snapshot |
+| `committed_fee_cents` / `overage_cents` / `total_cents` | snapshot |
+| `stripe_invoice_id` | set once created |
+| `regrant_balance_txn_id` | the Stripe credit that restored the buffer |
+| `status` | `draft` / `sent` / `paid` / `error` |
+| `idempotency_key` | `entinv:{account}:{period}` — one invoice + one regrant per period |
+
+> The onboarding $500k baseline grant can be recorded as a simple seeded row / migration note;
+> it isn't tied to an invoice.
+
+---
+
+## Stripe surface to add (none exists today)
+
+In `lit-billing-core` (mirroring `balance::write_transaction`'s idempotency style):
+`POST /v1/invoiceitems`, `POST /v1/invoices`, `POST /v1/invoices/{id}/finalize`,
+`POST /v1/invoices/{id}/send`. Credits reuse the existing `balance::write_transaction`.
+
+---
+
+## Phasing
+
+1. **Schema + onboarding.** `enterprise_accounts`, `enterprise_invoices` migrations. Seed
+   Uneven Labs row; disable auto-topup on the payer account; write the initial $500k baseline
+   grant.
+2. **Stripe invoice primitives** in `lit-billing-core`.
+3. **Monthly billing + regrant job** (draft + notify). Seed June as `sent` (manual) so the
+   first generated invoice is July's $9k advance + June's overage arrears.
+4. **Operate one cycle as draft-review**, reconcile the amounts, then flip to auto-send.
+
+## First-cycle handling
+June 2026 committed fee was invoiced manually. Mark June `sent` (manual) in
+`enterprise_invoices` and treat the onboarding grant as the starting target, so the job's
+first invoice = July $9k advance + June overage arrears — no double committed fee.
+
+## Honest caveats (accepted)
+- Management calls count toward the allotment as units, so a management-heavy month bills
+  slightly differently than a strict compute-second reading — accepted; they're buying credits.
+- `consumed = target − remaining` is only correct if nothing else credits the payer account
+  between regrants (hence the invariant above).
+
+## Decisions (locked 2026-06-23)
+1. **Stripe customers** — payer (gets grants): `cus_UXvHcFlfhR6rc5` (engineering@unevenlabs.com);
+   invoice (gets invoices): `cus_UiVuFoABiqcMs5` (accounting@unevenlabs.com).
+2. **Billing anchor day = 17** (contract Effective Date = date of last signature, 2026-06-17,
+   per §1). Period = **anchor-to-anchor** (17th→16th); the contract's "calendar month" wording
+   can't coexist with a 17th anchor, so each anchor-to-anchor cycle *is* "the month" for the
+   $9k, the 3M allotment, and overage. No rollover. The manual-review email is the safety net
+   if this interpretation ever needs adjusting.
+3. **Buffer target = $500k.** Single regrant per cycle (no polling); $500k ≫ monthly burn so
+   no mid-cycle run-out.
+4. **Human-in-the-loop send (v1):** the job creates a **draft** invoice and **emails
+   chris@litprotocol.com** the full breakdown (consumed units, included, overage units, overage
+   $, committed $, total) plus a link to the draft. Chris sanity-checks and clicks **Send** in
+   Stripe. Once proven over a few cycles, flip a flag to auto-finalize+send and drop the draft
+   stage.

--- a/plans/enterprise-committed-billing.md
+++ b/plans/enterprise-committed-billing.md
@@ -159,6 +159,24 @@ June 2026 committed fee was invoiced manually. Mark June `sent` (manual) in
 `enterprise_invoices` and treat the onboarding grant as the starting target, so the job's
 first invoice = July $9k advance + June overage arrears — no double committed fee.
 
+## Post-review hardening (codex adversarial pass)
+- Term window (`term_start`/`term_end`) is checked **before** any money movement, so
+  no baseline buffer is granted before a contract starts, and billing + regrants stop
+  at `term_end` (renewal and any final invoice are manual).
+- Baseline grant now has the same retry-window guard as the regrant: `baseline_attempted_at`
+  is stamped before the Stripe write, and past the 23h idempotency window an unconfirmed
+  baseline refuses to re-credit and asks for human verification (no double $500k).
+- Invoice creation has the same 23h durability guard (no duplicate draft past the window).
+- Missed-cycle guard: if the immediately-preceding in-term anchor has no invoice row, the
+  job **refuses** to bill the current period (which would lump multi-cycle usage into one
+  allotment / skip a committed fee) and surfaces it for manual backfill.
+- Balance-range anomaly check logs when the payer balance is positive (buffer exhausted) or
+  below `-target` (external credit suspected); the review email flags a 0-unit cycle.
+- "Manual regrant required" messages now say to **verify whether the credit already landed**
+  (check the idempotency key) before any manual credit.
+- Migration constraints: status enum, non-negative amount columns, `payer <> invoice`
+  customer, `term_start <= term_end`.
+
 ## Honest caveats (accepted)
 - Management calls count toward the allotment as units, so a management-heavy month bills
   slightly differently than a strict compute-second reading — accepted; they're buying credits.


### PR DESCRIPTION
Automates the monthly enterprise committed-use billing flow (first customer: Uneven Labs, contract signed 2026-06-17): a customer prepays a flat committed fee for an included unit allotment and pays overage in arrears, where the Stripe customer that receives the invoice differs from the one consuming service. With no `lit-api-server` changes, the job meters off the payer's standard $0.01/unit Stripe debits — keeping its credit topped to a fixed target with one regrant per cycle so `consumed = target + balance` (a single balance read, no transaction listing) — then drafts an invoice (committed fee + overage) on the invoice account, regrants the payer buffer, and emails a breakdown for manual review/send (an `auto_send` flag will later drop the human step). Adds `enterprise_accounts`/`enterprise_invoices` migrations (seeded for the first customer with June recorded as manually invoiced), `lit-billing-core` invoice primitives, and the idempotent/resumable `lit-payments/src/enterprise/` module + background job wired into `main.rs`, plus config for the sweep interval and Stripe dashboard base URL. Design doc in `plans/enterprise-committed-billing.md`; unit tests cover the period and overage/regrant math, and `cargo build`/`clippy` are clean. Note: on first boot the job auto-grants the one-time $500k baseline credit to the payer Stripe customer, so verify the seeded customer IDs before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)