### PR TITLE
fix(payments): repair enterprise billing migration checksum mismatch

### DIFF
--- a/lit-payments/migrations/20260623000001_enterprise_billing.sql
+++ b/lit-payments/migrations/20260623000001_enterprise_billing.sql
@@ -49,17 +49,8 @@ CREATE TABLE enterprise_accounts (
     -- has been written; gates the onboarding step so it never double-grants.
     baseline_balance_txn_id               TEXT,
     baseline_granted_at                   TIMESTAMPTZ,
-    -- Window-start for the baseline credit, stamped BEFORE the Stripe write so a
-    -- crash between the write and recording success is recoverable within
-    -- Stripe's idempotency window — and refused (not double-credited) past it.
-    baseline_attempted_at                 TIMESTAMPTZ,
     created_at                            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at                            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    -- Payer and invoice customers are deliberately DIFFERENT Stripe customers.
-    CONSTRAINT enterprise_accounts_distinct_customers
-        CHECK (payer_customer_id <> invoice_customer_id),
-    CONSTRAINT enterprise_accounts_term_order
-        CHECK (term_start IS NULL OR term_end IS NULL OR term_start <= term_end)
+    updated_at                            TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE enterprise_invoices (
@@ -75,16 +66,16 @@ CREATE TABLE enterprise_invoices (
     committed_period         TEXT        NOT NULL,
     -- Snapshot, frozen at first attempt so resume/retry never recomputes from a
     -- balance that the regrant has since changed.
-    consumed_units           BIGINT      NOT NULL CHECK (consumed_units >= 0),
-    included_units           BIGINT      NOT NULL CHECK (included_units >= 0),
-    overage_units            BIGINT      NOT NULL CHECK (overage_units >= 0),
-    committed_fee_cents      BIGINT      NOT NULL CHECK (committed_fee_cents >= 0),
-    overage_cents            BIGINT      NOT NULL CHECK (overage_cents >= 0),
-    total_cents              BIGINT      NOT NULL CHECK (total_cents >= 0),
+    consumed_units           BIGINT      NOT NULL,
+    included_units           BIGINT      NOT NULL,
+    overage_units            BIGINT      NOT NULL,
+    committed_fee_cents      BIGINT      NOT NULL,
+    overage_cents            BIGINT      NOT NULL,
+    total_cents              BIGINT      NOT NULL,
     stripe_invoice_id        TEXT,
     regrant_balance_txn_id   TEXT,
-    status                   TEXT        NOT NULL DEFAULT 'pending'
-        CHECK (status IN ('pending', 'draft', 'sent', 'paid', 'error', 'manual')),
+    -- pending | draft | sent | paid | error | manual
+    status                   TEXT        NOT NULL DEFAULT 'pending',
     notified_at              TIMESTAMPTZ,
     created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -120,13 +111,6 @@ INSERT INTO enterprise_accounts (
 -- June 2026 committed fee was invoiced MANUALLY. Record it so the billing job's
 -- first generated invoice is the July anchor (July advance + June arrears
 -- overage) rather than re-billing June's committed fee.
---
--- NOTE on the window columns: this is the FIRST invoice, which is committed-fee
--- in advance only (there is no prior cycle to meter), so period_start/period_end
--- here are the committed cycle it paid for (2026-06-17 → 2026-07-17). Generated
--- rows differ by design: their period_start/period_end is the ARREARS window
--- (previous_anchor → anchor) that the overage line covers. consumed/overage are
--- 0 because nothing was metered for this seed.
 INSERT INTO enterprise_invoices (
     enterprise_account_id, period_key, period_start, period_end, committed_period,
     consumed_units, included_units, overage_units,

--- a/lit-payments/migrations/20260629000001_enterprise_billing_hardening.sql
+++ b/lit-payments/migrations/20260629000001_enterprise_billing_hardening.sql
@@ -1,0 +1,61 @@
+-- Hardening for enterprise billing (codex adversarial review follow-up).
+--
+-- Additive ALTERs ONLY. The original 20260623000001 migration is already applied
+-- in deployed environments; sqlx checksums each migration file and refuses to
+-- boot if an applied one changes, so the hardening that was briefly (and wrongly)
+-- folded into 20260623000001 lives here instead. See PR history for #541.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, and each ADD CONSTRAINT is wrapped to
+-- swallow duplicate_object, so this applies cleanly whether a given environment
+-- previously applied the original 20260623000001 (no constraints) or the briefly
+-- modified one (constraints already present).
+--
+-- See plans/enterprise-committed-billing.md ("Post-review hardening").
+
+-- enterprise_accounts -------------------------------------------------------
+
+-- Baseline retry-window guard: stamped before the baseline Stripe write so a lost
+-- success-record can't double-credit the buffer past Stripe's idempotency TTL.
+ALTER TABLE enterprise_accounts
+    ADD COLUMN IF NOT EXISTS baseline_attempted_at TIMESTAMPTZ;
+
+-- Payer and invoice customers are deliberately DIFFERENT Stripe customers.
+DO $$ BEGIN
+    ALTER TABLE enterprise_accounts
+        ADD CONSTRAINT enterprise_accounts_distinct_customers
+            CHECK (payer_customer_id <> invoice_customer_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- A term cannot end before it starts.
+DO $$ BEGIN
+    ALTER TABLE enterprise_accounts
+        ADD CONSTRAINT enterprise_accounts_term_order
+            CHECK (term_start IS NULL OR term_end IS NULL OR term_start <= term_end);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- enterprise_invoices -------------------------------------------------------
+
+-- Frozen amount/usage snapshots are never negative.
+DO $$ BEGIN
+    ALTER TABLE enterprise_invoices
+        ADD CONSTRAINT enterprise_invoices_nonneg
+            CHECK (
+                consumed_units      >= 0 AND
+                included_units      >= 0 AND
+                overage_units       >= 0 AND
+                committed_fee_cents >= 0 AND
+                overage_cents       >= 0 AND
+                total_cents         >= 0
+            );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Status is a fixed lifecycle set.
+DO $$ BEGIN
+    ALTER TABLE enterprise_invoices
+        ADD CONSTRAINT enterprise_invoices_status_valid
+            CHECK (status IN ('pending', 'draft', 'sent', 'paid', 'error', 'manual'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
PR #541 (squash-merged) shipped a hardening change that edited the already-applied `20260623000001_enterprise_billing.sql` migration in place, so any environment that had previously applied the **original** version now panics on boot: `migration 20260623000001 was previously applied but has been modified` (sqlx checksums each migration file). This PR restores `20260623000001` to its exact original applied bytes so the checksum matches again, and moves the additive hardening (the `baseline_attempted_at` column and the CHECK constraints) into a new forward migration `20260629000001_enterprise_billing_hardening.sql`. The new migration is idempotent (`ADD COLUMN IF NOT EXISTS` + `duplicate_object`-guarded constraint adds), so it applies cleanly whether an environment had the original or the briefly-modified `20260623000001`, and the end-state schema is identical to what #541 intended. No code changes — the hardening code from #541 already references the new column, which this migration provides at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)