### PR TITLE
fix(payments): force fresh migration compile + clear anyhow advisory (RUSTSEC-2026-0190)

### DIFF
--- a/lit-actions/Cargo.lock
+++ b/lit-actions/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/lit-api-server/Cargo.lock
+++ b/lit-api-server/Cargo.lock
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apalis"

--- a/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"

--- a/lit-billing-core/Cargo.lock
+++ b/lit-billing-core/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"

--- a/lit-core/Cargo.lock
+++ b/lit-core/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/lit-payments/Cargo.lock
+++ b/lit-payments/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"

--- a/lit-payments/Dockerfile
+++ b/lit-payments/Dockerfile
@@ -21,6 +21,14 @@ COPY lit-billing-core ./lit-billing-core
 COPY lit-payments    ./lit-payments
 
 WORKDIR /build/lit-payments
+# Cache-bust the compile. `sqlx::migrate!` embeds migration SQL + checksums into
+# the binary at COMPILE time and cargo does NOT recompile the crate when only a
+# file under migrations/ changes — so a warm build cache can ship a binary with
+# STALE embedded migrations (boot panic: "previously applied but has been
+# modified"). Bumping this token forces a clean compile so the embedded
+# migrations always match the migrations/ dir. BUMP ON EVERY migrations/ CHANGE.
+ARG MIGRATIONS_REV=20260629000001-r2
+RUN echo "migrations rev: ${MIGRATIONS_REV}"
 RUN cargo build --release --bin lit-payments
 
 # ── Runtime stage ──────────────────────────────────────────────────────────

--- a/lit-payments/src/db.rs
+++ b/lit-payments/src/db.rs
@@ -15,6 +15,17 @@ pub async fn connect(database_url: &str) -> Result<PgPool> {
 }
 
 /// Run all pending migrations from `migrations/`.
+///
+/// GOTCHA: `sqlx::migrate!` embeds the migration SQL (and its checksums) into
+/// the binary at COMPILE time, and does NOT cause cargo to recompile this crate
+/// when only a file under `migrations/` changes. With a warm build cache (e.g.
+/// Railway's), adding or editing a migration can ship a STALE binary that still
+/// embeds the old SQL — which then panics at boot with "migration … was
+/// previously applied but has been modified". When you touch `migrations/`, also
+/// bump the marker below so this source file changes and the crate is forced to
+/// recompile (re-embedding the current migrations).
+///
+/// migrations-embedded-through: 20260629000001
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     sqlx::migrate!("./migrations")
         .run(pool)

--- a/lit-triggers/Cargo.lock
+++ b/lit-triggers/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"


### PR DESCRIPTION
Two fixes; the second unblocks CI repo-wide.

**1. Stale embedded migrations (the production boot panic).** `db::run_migrations` uses `sqlx::migrate!("./migrations")`, which embeds migration SQL + checksums into the binary at compile time. cargo does NOT recompile the crate when only a file under `migrations/` changes, so Railway's warm build cache shipped a binary embedding #541's old migration → panic `migration 20260623000001 was previously applied but has been modified` on every redeploy. This changes `db.rs` (a `migrations-embedded-through` marker) and adds a `MIGRATIONS_REV` cache-bust `ARG` in the Dockerfile before `cargo build`, forcing a clean recompile so the embedded migrations always match the files. Bump both whenever `migrations/` changes. No migration/schema change.

**2. RUSTSEC-2026-0190 (anyhow unsoundness).** cargo-deny started failing the advisory check across crates pinning `anyhow <1.0.103`. Lockfile-only bump to `1.0.103` (semver-compatible patch) in every affected workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)