### PR TITLE
build(payments): bust stale COPY layer so the build embeds committed migrations

### DIFF
--- a/lit-payments/Dockerfile
+++ b/lit-payments/Dockerfile
@@ -16,19 +16,18 @@ RUN apt-get update \
 
 WORKDIR /build
 
+# Cache-bust BEFORE the COPY so the build re-reads the committed source (incl. the
+# migrations/ dir). A bust placed after the COPY only re-runs the compile against
+# whatever the cached COPY layer brought in — which let a stale draft migration
+# persist in the embedded `sqlx::migrate!` set. Bump on any migrations/ change.
+ARG MIGRATIONS_REV=20260629000001-r3
+RUN echo "source rev: ${MIGRATIONS_REV}"
+
 # Copy the crates this service depends on.
 COPY lit-billing-core ./lit-billing-core
 COPY lit-payments    ./lit-payments
 
 WORKDIR /build/lit-payments
-# Cache-bust the compile. `sqlx::migrate!` embeds migration SQL + checksums into
-# the binary at COMPILE time and cargo does NOT recompile the crate when only a
-# file under migrations/ changes — so a warm build cache can ship a binary with
-# STALE embedded migrations (boot panic: "previously applied but has been
-# modified"). Bumping this token forces a clean compile so the embedded
-# migrations always match the migrations/ dir. BUMP ON EVERY migrations/ CHANGE.
-ARG MIGRATIONS_REV=20260629000001-r2
-RUN echo "migrations rev: ${MIGRATIONS_REV}"
 RUN cargo build --release --bin lit-payments
 
 # ── Runtime stage ──────────────────────────────────────────────────────────


### PR DESCRIPTION
**Why production won't boot.** `db::run_migrations` uses `sqlx::migrate!("./migrations")`, embedding migration SQL + checksums at compile time. Railway's build cache is serving a **stale `COPY lit-payments` layer** that pulls an old, uncommitted-draft `migrations/` dir into the build, so the binary embeds a phantom `20260623000001` (checksum `297d4775…`, which matches no committed version) and panics `previously applied but has been modified` on every deploy.

The earlier cache-bust (#544) sat *after* the COPY, so it only re-ran the compile against the already-stale copied files. This moves a `MIGRATIONS_REV` cache-bust **before** the COPY, invalidating the COPY layer (and everything downstream) so the build re-reads the committed source. Result: the binary embeds the real committed migrations (`20260623000001` original + `20260629000001` hardening), which match the production DB → it boots, applies the hardening migration, and runs the billing job.

No code/migration/schema change — Dockerfile only. Bump `MIGRATIONS_REV` on any future `migrations/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)