### PR TITLE
fix(payments): load migrations at runtime to end the stale-embed boot panic

### DIFF
--- a/lit-payments/Dockerfile
+++ b/lit-payments/Dockerfile
@@ -39,6 +39,13 @@ RUN apt-get update \
 
 WORKDIR /app
 
+# Cache-bust before copying migrations into the runtime image. The app now loads
+# migrations from this directory at RUNTIME (see db::run_migrations), so these
+# files — not anything embedded in the binary — are the source of truth. Keep
+# this bust in lockstep with the builder one above. Bump on any migrations/ change.
+ARG MIGRATIONS_REV=20260629000001-r3
+RUN echo "runtime migrations rev: ${MIGRATIONS_REV}"
+
 COPY --from=builder /build/lit-payments/target/release/lit-payments /app/lit-payments
 COPY lit-payments/static     ./static
 COPY lit-payments/migrations ./migrations

--- a/lit-payments/src/db.rs
+++ b/lit-payments/src/db.rs
@@ -1,7 +1,9 @@
 //! Postgres connection pool + migration helper.
 
 use anyhow::{Context, Result};
+use sqlx::migrate::Migrator;
 use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::path::Path;
 use std::time::Duration;
 
 pub async fn connect(database_url: &str) -> Result<PgPool> {
@@ -14,22 +16,35 @@ pub async fn connect(database_url: &str) -> Result<PgPool> {
     Ok(pool)
 }
 
-/// Run all pending migrations from `migrations/`.
+/// Run all pending migrations, loaded from the `./migrations` directory at
+/// RUNTIME.
 ///
-/// GOTCHA: `sqlx::migrate!` embeds the migration SQL (and its checksums) into
-/// the binary at COMPILE time, and does NOT cause cargo to recompile this crate
-/// when only a file under `migrations/` changes. With a warm build cache (e.g.
-/// Railway's), adding or editing a migration can ship a STALE binary that still
-/// embeds the old SQL — which then panics at boot with "migration … was
-/// previously applied but has been modified". When you touch `migrations/`, also
-/// bump the marker below so this source file changes and the crate is forced to
-/// recompile (re-embedding the current migrations).
+/// We deliberately do NOT use `sqlx::migrate!("./migrations")`. That macro
+/// embeds the migration SQL (and its checksums) into the binary at COMPILE
+/// time, and cargo does not reliably recompile this crate when only a file
+/// under `migrations/` changes (proc-macros can't emit `rerun-if-changed` for
+/// their inputs). The result: an incremental build can ship a binary whose
+/// embedded migrations are STALE relative to the source files, which then
+/// panics at boot with "migration … was previously applied but has been
+/// modified" even though the committed files and the database agree.
 ///
-/// migrations-embedded-through: 20260629000001
+/// Loading at runtime via [`Migrator::new`] reads the actual deployed
+/// `./migrations` directory (the Docker image copies it to `/app/migrations`,
+/// and the working directory is `/app`), so the migration set always matches
+/// what's on disk — no stale-embed failure mode. We log each loaded migration's
+/// version + checksum first so any future mismatch is diagnosable from the logs
+/// instead of guessing.
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
-    sqlx::migrate!("./migrations")
-        .run(pool)
+    let migrator = Migrator::new(Path::new("./migrations"))
         .await
-        .context("running migrations")?;
+        .context("loading migrations from ./migrations")?;
+    for m in migrator.iter() {
+        tracing::info!(
+            version = m.version,
+            checksum = %hex::encode(m.checksum.as_ref()),
+            "migration loaded"
+        );
+    }
+    migrator.run(pool).await.context("running migrations")?;
     Ok(())
 }


### PR DESCRIPTION
**Real root cause.** The deployed commit's `20260623000001` and the production DB are *both* `4715c149` — they match — yet the binary panics `previously applied but has been modified`. That means the binary embeds a checksum that disagrees with its own source file. `sqlx::migrate!("./migrations")` embeds migrations at **compile time**, and cargo doesn't reliably recompile the crate when only files under `migrations/` change (proc-macros can't emit `rerun-if-changed`). So an incremental build ships a **stale embedded migration set** even though the committed files and DB agree — and no DB-side reconciliation can fix a binary that disagrees with its own source. (This is why it never bit us before: it only triggers when a `migrations/` dir changes after being applied.)

**Fix.** `run_migrations` now uses `Migrator::new(Path::new("./migrations"))` to load migrations from the filesystem **at runtime** (the image copies `migrations/` to `/app/migrations`, workdir is `/app`), so the set always matches the deployed files — the stale-embed failure mode is gone. It logs each migration's version+checksum at boot for diagnosability, and the runtime `COPY migrations` layer is cache-busted to match.

No migration/schema change. Switching `db.rs` is a real source change, so cargo recompiles and the runtime-loading binary actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)