### PR TITLE
ci(payments): guard duplicate migration versions + revert cache-bust cruft

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,6 +15,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Reject two migration files that share a version prefix. sqlx keys migrations
+  # by the leading numeric token, so a collision crash-loops the service at boot
+  # ("previously applied but has been modified"). Cheap repo-wide guard.
+  migration-versions:
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: migration-versions
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reset workspace to HEAD
+        run: git checkout HEAD -- .
+      - name: Check for duplicate migration versions
+        run: ./scripts/check-migration-versions.sh
+
   check:
     if: >
       github.event_name == 'push' ||

--- a/lit-payments/Dockerfile
+++ b/lit-payments/Dockerfile
@@ -16,13 +16,6 @@ RUN apt-get update \
 
 WORKDIR /build
 
-# Cache-bust BEFORE the COPY so the build re-reads the committed source (incl. the
-# migrations/ dir). A bust placed after the COPY only re-runs the compile against
-# whatever the cached COPY layer brought in — which let a stale draft migration
-# persist in the embedded `sqlx::migrate!` set. Bump on any migrations/ change.
-ARG MIGRATIONS_REV=20260629000001-r3
-RUN echo "source rev: ${MIGRATIONS_REV}"
-
 # Copy the crates this service depends on.
 COPY lit-billing-core ./lit-billing-core
 COPY lit-payments    ./lit-payments
@@ -38,13 +31,6 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
-# Cache-bust before copying migrations into the runtime image. The app now loads
-# migrations from this directory at RUNTIME (see db::run_migrations), so these
-# files — not anything embedded in the binary — are the source of truth. Keep
-# this bust in lockstep with the builder one above. Bump on any migrations/ change.
-ARG MIGRATIONS_REV=20260629000001-r3
-RUN echo "runtime migrations rev: ${MIGRATIONS_REV}"
 
 COPY --from=builder /build/lit-payments/target/release/lit-payments /app/lit-payments
 COPY lit-payments/static     ./static

--- a/lit-payments/src/db.rs
+++ b/lit-payments/src/db.rs
@@ -1,9 +1,7 @@
 //! Postgres connection pool + migration helper.
 
 use anyhow::{Context, Result};
-use sqlx::migrate::Migrator;
 use sqlx::postgres::{PgPool, PgPoolOptions};
-use std::path::Path;
 use std::time::Duration;
 
 pub async fn connect(database_url: &str) -> Result<PgPool> {
@@ -16,35 +14,11 @@ pub async fn connect(database_url: &str) -> Result<PgPool> {
     Ok(pool)
 }
 
-/// Run all pending migrations, loaded from the `./migrations` directory at
-/// RUNTIME.
-///
-/// We deliberately do NOT use `sqlx::migrate!("./migrations")`. That macro
-/// embeds the migration SQL (and its checksums) into the binary at COMPILE
-/// time, and cargo does not reliably recompile this crate when only a file
-/// under `migrations/` changes (proc-macros can't emit `rerun-if-changed` for
-/// their inputs). The result: an incremental build can ship a binary whose
-/// embedded migrations are STALE relative to the source files, which then
-/// panics at boot with "migration … was previously applied but has been
-/// modified" even though the committed files and the database agree.
-///
-/// Loading at runtime via [`Migrator::new`] reads the actual deployed
-/// `./migrations` directory (the Docker image copies it to `/app/migrations`,
-/// and the working directory is `/app`), so the migration set always matches
-/// what's on disk — no stale-embed failure mode. We log each loaded migration's
-/// version + checksum first so any future mismatch is diagnosable from the logs
-/// instead of guessing.
+/// Run all pending migrations from `migrations/`.
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
-    let migrator = Migrator::new(Path::new("./migrations"))
+    sqlx::migrate!("./migrations")
+        .run(pool)
         .await
-        .context("loading migrations from ./migrations")?;
-    for m in migrator.iter() {
-        tracing::info!(
-            version = m.version,
-            checksum = %hex::encode(m.checksum.as_ref()),
-            "migration loaded"
-        );
-    }
-    migrator.run(pool).await.context("running migrations")?;
+        .context("running migrations")?;
     Ok(())
 }

--- a/scripts/check-migration-versions.sh
+++ b/scripts/check-migration-versions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fail if two migration files in the same migrations/ directory share a version
+# prefix (the leading numeric token before the first underscore).
+#
+# sqlx derives a migration's version from that prefix, so two files with the
+# same prefix collide: the _sqlx_migrations row for that version can only match
+# one checksum, and the other trips "migration <v> was previously applied but
+# has been modified" on every boot. This happened in production when
+# 20260623000001_gas_funder.sql and 20260623000001_enterprise_billing.sql were
+# merged independently. This check makes that a CI failure instead.
+set -euo pipefail
+
+status=0
+
+# Every sqlx migrations dir in the repo (excluding build/vendor output).
+while IFS= read -r dir; do
+  # Collect duplicate version prefixes among *.sql files in this dir.
+  dupes=$(
+    find "$dir" -maxdepth 1 -name '*.sql' -exec basename {} \; \
+      | sed -E 's/^([0-9]+)_.*/\1/' \
+      | sort \
+      | uniq -d
+  )
+  if [ -n "$dupes" ]; then
+    status=1
+    while IFS= read -r v; do
+      echo "ERROR: duplicate migration version '$v' in $dir:"
+      find "$dir" -maxdepth 1 -name "${v}_*.sql" -exec echo "    {}" \;
+    done <<< "$dupes"
+  fi
+done < <(find . -type d -name migrations -not -path '*/node_modules/*' -not -path '*/target/*' | sort)
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: no duplicate migration versions"
+fi
+exit "$status"


### PR DESCRIPTION
**Guard:** adds a Rust CI job (`migration-versions`) and `scripts/check-migration-versions.sh` that fails when two files in a `migrations/` dir share a version prefix. sqlx derives the migration version from that prefix, so a collision crash-loops the service at boot with "previously applied but has been modified" — exactly the `20260623000001_gas_funder.sql` vs `20260623000001_enterprise_billing.sql` clash that took down the lit-payments deploy. Now it fails at PR time. (Tested: passes clean, exits 1 with a clear message on a planted collision.)

**Cleanup:** reverts the debugging cruft I added while (wrongly) chasing this as a build-cache problem:
- Dockerfile: remove the `MIGRATIONS_REV` cache-bust ARGs (builder + runtime stages).
- `db.rs`: restore the standard `sqlx::migrate!("./migrations")` (the runtime-loader + checksum logging was a detour; with unique migration versions the embed works cleanly).

No migration/schema change. The real fix (renaming the enterprise migration to `20260623000002`) already shipped in #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)