### PR TITLE
docs(agents): add per-folder AGENTS.md context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@ This is a Web3/crypto monorepo. It features a Rust backend, Solidity smart contr
 and a JavaScript/TypeScript frontend / monorepo tooling layer.
 
 ## Monorepo Architecture
-- Tooling: Rust crates built per-crate with Cargo (no repo-root workspace); the `e2e`
-  suite uses pnpm.
+- Tooling: there is no repo-root Cargo workspace — build each Rust crate from its own
+  `Cargo.toml`. Some crates are themselves multi-crate workspaces (e.g. `lit-actions`,
+  `lit-core`), so run `cargo` from that crate's directory. The `e2e` suite uses pnpm.
 - Language Boundaries:
   - `lit-actions`, `lit-api-server`, `lit-billing-core`, `lit-payments`,
     `lit-triggers`, `lit-core`: Rust (services & indexers)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,30 @@
-# Agent instructions
+# Repository Agent Context (Root)
 
-## Running E2E tests (`e2e/`)
+## Purpose
+Monorepo root for Chipotle — the Lit Protocol management API and its surrounding
+services. This file holds repo-wide conventions; each subfolder has its own
+`AGENTS.md` describing what lives there. Start here, then read the folder-level file
+before modifying code.
 
-When you (an AI agent) run the Playwright E2E suite, you must produce and inspect
-screenshots of what actually happened on screen — for passing tests too, not just
-failures. A green exit code is not sufficient evidence that the UI did what the
-test claims.
+## Project Overview
+This is a Web3/crypto monorepo. It features a Rust backend, Solidity smart contracts,
+and a JavaScript/TypeScript frontend / monorepo tooling layer.
 
-1. **Run with `AGENT_SCREENSHOTS=1`** (the stack must already be up — `make -C e2e up`):
+## Monorepo Architecture
+- Tooling: Rust crates built per-crate with Cargo (no repo-root workspace); the `e2e`
+  suite uses pnpm.
+- Language Boundaries:
+  - `lit-actions`, `lit-api-server`, `lit-billing-core`, `lit-payments`,
+    `lit-triggers`, `lit-core`: Rust (services & indexers)
+  - `lit-static`: JavaScript (static dapps, SDK bundles, contract ABIs)
+  - `e2e`: TypeScript / Playwright (end-to-end tests) — see `e2e/AGENTS.md`
+  - `otel-collector`: OpenTelemetry collector config
 
-   ```sh
-   cd e2e && AGENT_SCREENSHOTS=1 pnpm test        # or pnpm test:api / test:eoa / test:wc / test:flows
-   ```
-
-   This flips `playwright.config.ts` to `screenshot: 'on'`, so every test —
-   pass or fail — writes a PNG into `e2e/test-results/<test-name>/`.
-
-2. **After the run, open the screenshots with the Read tool** and describe what is
-   visible: dashboard state, wallet dialogs, error banners. Verify the screen
-   matches what the test asserts, and flag anything that looks wrong even if the
-   test passed.
-
-3. **For step-by-step evidence, add `--trace on`.** Example:
-
-   - `pnpm test -- --trace on` (or `pnpm test:api -- --trace on`, etc.)
-
-   The trace zip in `e2e/test-results/` contains a screenshot of every action; point the user at
-   `pnpm exec playwright show-trace <zip>` to replay it.
-
-4. **Include the screenshot file paths in your final report** so the user can open
-   them directly.
-
-Note: the `api-mode` project is HTTP-only, so its screenshots are blank pages —
-visual evidence matters for the `eoa`, `walletconnect`, and `flows-*` projects.
+## Global Constraints
+- CRITICAL: Never mix package commands. Use each language's own tool — `cargo`
+  (per-crate `--manifest-path`) for Rust, `pnpm` for the `e2e` suite. There is no
+  repo-root cargo workspace, so build each crate from its own `Cargo.toml`.
+- Always check for a folder-level `AGENTS.md` inside subdirectories before modifying
+  code there.
+- Language boundaries are strict. Do not introduce Rust dependencies into JS tools, or
+  vice versa, without human approval.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,43 @@
+# Agent Context: End-to-End Tests (Playwright / TypeScript)
+
+## Purpose
+UI-level Playwright coverage for the Chipotle dashboard (`lit-static/dapps/dashboard`).
+Exercises the same functional surface as the k6 suite (chain config, account creation,
+usage API keys, Lit Action execution, encrypt/decrypt) through the dashboard UI, plus
+ChainSecured (wallet) flows. Projects: `api-mode`, `eoa`, `walletconnect`, `flows-*`.
+Fixtures live in `fixtures/`, wallet cache setup in `wallet-setup/`, and the `Makefile`
+wraps `../local_test.sh` to boot the stack.
+
+## Running E2E tests
+
+When you (an AI agent) run the Playwright E2E suite, you must produce and inspect
+screenshots of what actually happened on screen — for passing tests too, not just
+failures. A green exit code is not sufficient evidence that the UI did what the
+test claims.
+
+1. **Run with `AGENT_SCREENSHOTS=1`** (the stack must already be up — `make -C e2e up`):
+
+   ```sh
+   cd e2e && AGENT_SCREENSHOTS=1 pnpm test        # or pnpm test:api / test:eoa / test:wc / test:flows
+   ```
+
+   This flips `playwright.config.ts` to `screenshot: 'on'`, so every test —
+   pass or fail — writes a PNG into `e2e/test-results/<test-name>/`.
+
+2. **After the run, open the screenshots with the Read tool** and describe what is
+   visible: dashboard state, wallet dialogs, error banners. Verify the screen
+   matches what the test asserts, and flag anything that looks wrong even if the
+   test passed.
+
+3. **For step-by-step evidence, add `--trace on`.** Example:
+
+   - `pnpm test -- --trace on` (or `pnpm test:api -- --trace on`, etc.)
+
+   The trace zip in `e2e/test-results/` contains a screenshot of every action; point the user at
+   `pnpm exec playwright show-trace <zip>` to replay it.
+
+4. **Include the screenshot file paths in your final report** so the user can open
+   them directly.
+
+Note: the `api-mode` project is HTTP-only, so its screenshots are blank pages —
+visual evidence matters for the `eoa`, `walletconnect`, and `flows-*` projects.

--- a/k6/AGENTS.md
+++ b/k6/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Context: Load & Correctness Tests (k6 / TypeScript)
+
+## Purpose
+k6 performance and correctness tests for `lit-api-server`. The HTTP client
+(`litApiServer.ts`) is **auto-generated** from the OpenAPI spec via
+`@grafana/openapi-to-k6` — do not hand-edit it. Layout: `correctness/` (functional
+specs — integration, api-key-security, billing, Lit Action signing), `loadtest/`
+(soak, spike, breakpoint), `LitActionCode/` (JS payloads executed under test),
+`data/` (pre-seeded account pools), `baselines/` (soak baselines). Shared helpers in
+`helpers.ts`, `setup.ts`, `defaults.ts`, `stripe.ts`.
+
+## Stack & Tooling
+- Runner: [k6](https://grafana.com/docs/k6/) (Grafana). Tests are TypeScript, run with `k6 run <spec>`.
+- Client generation: `@grafana/openapi-to-k6` (Node.js) regenerates `litApiServer.ts` from the OpenAPI spec.
+- Task runner: `just -f k6/justfile <recipe>` (smoke/soak/spike/breakpoint, `-local` variants, account seeding).
+
+## Coding Rules
+- Never hand-edit `litApiServer.ts` — it is generated. Regenerate it whenever a Rocket route / the OpenAPI spec changes (this is enforced by the `k6-client-check` CI gate).
+- The OpenAPI spec paths omit the `/core/v1` prefix; set `BASE_URL` with `/core/v1` when targeting the Phala deployment.
+- Reuse the pre-seeded account pool (`data/accounts.json`, seeded via `just -f k6/justfile seed-accounts`) instead of creating accounts in `setup()` where possible, to reduce system noise.
+- Keep secrets out of committed specs and `data/` fixtures; pass them via environment variables (`BASE_URL`, `ACCOUNTS_FILE`, etc.).
+
+## Definition of Done
+1. After any change to a Rocket route or the OpenAPI surface, regenerate `litApiServer.ts` and commit it (keeps `k6-client-check` green).
+2. Smoke test passes: `just -f k6/justfile smoke-local` (or `k6 run k6/smoke.spec.ts`).
+3. Relevant correctness specs pass against a running stack.
+4. For load specs, compare results against the checked-in `baselines/` and update them deliberately (`update-soak-baseline.sh`) when a shift is intended.

--- a/lit-actions/AGENTS.md
+++ b/lit-actions/AGENTS.md
@@ -7,13 +7,14 @@ client. Deno "ops" are proxied back to the client mid-execution. JS extension fi
 live in `ext/js/`.
 
 ## Stack & Tooling
-- Toolchain: Stable Rust (latest)
-- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Toolchain: Rust 1.91 (pinned via `rust-toolchain.toml`)
+- Architecture: multi-crate Cargo workspace (`[workspace]` in `lit-actions/Cargo.toml`)
+- Key Libraries: Tokio (async), Tonic (gRPC server over a Unix socket), Deno core (sandboxed JS execution)
 - Linting: `cargo clippy`
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
 
 ## Definition of Done

--- a/lit-actions/AGENTS.md
+++ b/lit-actions/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Context: Backend Services (Rust)
+
+## Purpose
+Runs user JavaScript (Lit Actions) inside a sandboxed Deno environment. Exposes a
+bidirectional gRPC API over a Unix socket (the server side); `lit_node` is the
+client. Deno "ops" are proxied back to the client mid-execution. JS extension files
+live in `ext/js/`.
+
+## Stack & Tooling
+- Toolchain: Stable Rust (latest)
+- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Linting: `cargo clippy`
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.

--- a/lit-api-server/AGENTS.md
+++ b/lit-api-server/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Context: Backend Services (Rust)
+
+## Purpose
+The Chipotle REST API — a Rust/Rocket server exposing account, key, group, and Lit
+Action execution endpoints under `/core/v1/` (plus `/attestation`, `/health`,
+`/dstack/v1/`). Runs inside a TEE (Phala dstack) in production; against the dstack
+simulator locally. Source is organized by domain: `accounts/`, `actions/`, `core/`,
+`dstack/`, `internal/`, `observability/`.
+
+## Stack & Tooling
+- Toolchain: Stable Rust (latest)
+- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Linting: `cargo clippy`
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.

--- a/lit-api-server/AGENTS.md
+++ b/lit-api-server/AGENTS.md
@@ -8,13 +8,13 @@ simulator locally. Source is organized by domain: `accounts/`, `actions/`, `core
 `dstack/`, `internal/`, `observability/`.
 
 ## Stack & Tooling
-- Toolchain: Stable Rust (latest)
-- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Toolchain: Rust 1.91 (pinned via `rust-toolchain.toml`)
+- Key Libraries: Tokio (async), Rocket 0.5 (web), Tonic (gRPC client to lit-actions), Alloy (Web3 interaction)
 - Linting: `cargo clippy`
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
 
 ## Definition of Done

--- a/lit-api-server/blockchain/AGENTS.md
+++ b/lit-api-server/blockchain/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Context: Blockchain
+
+## Purpose
+On-chain layer for the API server: the Solidity contracts plus the Rust tooling that
+compiles and deploys them. Two subfolders, each with its own `AGENTS.md` — read the
+folder-level file before modifying code there.
+
+## Subfolders
+- **`lit_node_express/`** — Solidity smart contracts (Diamond / EIP-2535 pattern):
+  `AccountConfig` and its facets, shared interfaces and libraries. Built and tested
+  with Foundry (`forge`) alongside Hardhat 3; `forge bind` produces the Rust bindings.
+  See `lit_node_express/AGENTS.md`.
+- **`rust_generator_and_deployer/`** — Rust CLI (`contract_deployer`) that deploys the
+  compiled contract artifacts to a chain (Anvil, Yellowstone, Base Sepolia, Base).
+  See `rust_generator_and_deployer/AGENTS.md`.
+
+## Language Boundary
+Solidity and Rust are kept separate. The contracts are the source of truth; the Rust
+side consumes their generated artifacts/bindings. Do not hand-edit generated bindings —
+regenerate them from the contracts.

--- a/lit-api-server/blockchain/lit_node_express/AGENTS.md
+++ b/lit-api-server/blockchain/lit_node_express/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Context: Smart Contracts (Solidity)
+
+## Purpose
+The on-chain contracts for Chipotle, built on the Diamond (EIP-2535) pattern.
+`AccountConfig.sol` is the diamond proxy; its facets live in `AccountConfigFacets/`,
+with shared `interfaces/` (IDiamond, IDiamondCut, IDiamondLoupe, IERC165/173) and
+`libraries/` (`LibDiamond.sol`, diamond helpers). Tests are in `test/`, Hardhat
+scripts/tasks in `tasks/`. `forge bind` generates the Rust bindings consumed by the
+deployer; `generate-diamond-abi.mjs` / `postprocess-forge-bindings.mjs` assemble the
+combined diamond ABI.
+
+## Stack & Tooling
+- Compiler: Solidity v0.8.28 (pinned in `foundry.toml`, `auto_detect_solc = false`),
+  `via_ir = true`, optimizer on (100 runs).
+- Framework: Foundry (`forge`) for build/test/bindings, alongside Hardhat 3 (`hardhat.config.ts`).
+- Linters: Solhint, Slither. Formatting via `forge fmt` (config in `foundry.toml` `[fmt]`).
+
+## Strict Coding Rules
+- Security First: Always protect against reentrancy. Use `ReentrancyGuard` or the Checks-Effects-Interactions pattern.
+- Diamond discipline: never collide storage slots across facets — use diamond storage (namespaced structs) and keep selectors unique across facets.
+- Gas Optimization: Prefer custom errors over `require` string messages. Use `uint256` unless tightly packing structs.
+- Code Style: Follow standard NatSpec formatting for all public/external functions.
+
+## Definition of Done
+1. Compile successfully with `forge build`.
+2. Write unit tests for all public state-changing functions.
+3. Ensure `forge test` passes with zero failures.
+4. Regenerate bindings (`forge bind` + the postprocess scripts) when the ABI changes, so the Rust deployer stays in sync.

--- a/lit-api-server/blockchain/rust_generator_and_deployer/AGENTS.md
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Context: Contract Deployer (Rust)
+
+## Purpose
+Rust CLI (`lit-contracts-minimal-generator`, binary `contract_deployer`) that deploys
+the compiled Lit blockchain contract artifacts to a chain — Anvil, Yellowstone, Base
+Sepolia, or Base. Reads Hardhat/Foundry-style artifact JSON (`abi` + `bytecode`) from
+the `lit_node_express` output and uses a built-in dev wallet (Anvil account #0) unless
+`--secret` is passed. Source: `bin/` (entrypoint), `deployer/` (deploy logic),
+`diamond/` (EIP-2535 cut/loupe helpers), `args.rs` (CLI args). Local/testnet use only.
+
+## Stack & Tooling
+- Toolchain: Rust `1.91` (pinned in `rust-toolchain.toml`), edition 2024.
+- Key Libraries: Tokio (async), Alloy 1.0 (`contract`, `dyn-abi`, `json-abi`, `network`, `providers`, `rpc-types`) for Web3 interaction.
+- Linting: `cargo clippy`.
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when encoding calldata / decoding events (e.g., `U256` mapping); these must track the `lit_node_express` contracts.
+- Never commit private keys; the dev wallet is for local/testnet only.
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.
+4. Build the release binary with `cargo build --release` (produces `target/release/contract_deployer`).

--- a/lit-api-server/blockchain/rust_generator_and_deployer/AGENTS.md
+++ b/lit-api-server/blockchain/rust_generator_and_deployer/AGENTS.md
@@ -15,7 +15,7 @@ the `lit_node_express` output and uses a built-in dev wallet (Anvil account #0) 
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when encoding calldata / decoding events (e.g., `U256` mapping); these must track the `lit_node_express` contracts.
 - Never commit private keys; the dev wallet is for local/testnet only.
 

--- a/lit-billing-core/AGENTS.md
+++ b/lit-billing-core/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Context: Backend Services (Rust)
+
+## Purpose
+Shared Stripe primitives — a library crate (no binary, no env vars) used by both
+`lit-api-server` (charges, balance checks) and `lit-payments` (credit grants) so the
+two services agree on the identity model. Core invariant: every Stripe customer is
+keyed by `metadata.wallet_address`; always look up via
+`customer::find_or_create_by_wallet`. Modules: `client`, `customer`, `balance`,
+`reporting`, `format`, plus `billing_auth/` and EIP-712 helpers.
+
+## Stack & Tooling
+- Toolchain: Stable Rust (latest)
+- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Linting: `cargo clippy`
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.

--- a/lit-billing-core/AGENTS.md
+++ b/lit-billing-core/AGENTS.md
@@ -9,13 +9,14 @@ keyed by `metadata.wallet_address`; always look up via
 `reporting`, `format`, plus `billing_auth/` and EIP-712 helpers.
 
 ## Stack & Tooling
-- Toolchain: Stable Rust (latest)
-- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Toolchain: Rust 1.91 (pinned via `rust-toolchain.toml`)
+- Crate type: shared library (no binary), consumed by lit-api-server and lit-payments
+- Key Libraries: Tokio (async), reqwest (Stripe HTTP client), Rocket 0.5 request guards (`FromRequest`), Alloy (Web3 / EIP-712)
 - Linting: `cargo clippy`
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
 
 ## Definition of Done

--- a/lit-payments/AGENTS.md
+++ b/lit-payments/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Context: Backend Services (Rust)
+
+## Purpose
+Ops-facing billing service, deployed outside the TEE (Railway). Provides magic-link
+auth, the admin credit portal, the LITKEY payment gateway, auto top-up (off-session
+card charges when a customer's balance drops below a threshold), enterprise billing,
+and a gas funder. Source is organized by domain: `auth/`, `auto_topup/`, `billing/`,
+`enterprise/`, `gas_funder/`, `internal/`, `portal/`. See `plans/lit-payments-app.md`
+and `plans/auto-top-up.md` for design.
+
+## Stack & Tooling
+- Toolchain: Stable Rust (latest)
+- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Linting: `cargo clippy`
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.

--- a/lit-payments/AGENTS.md
+++ b/lit-payments/AGENTS.md
@@ -9,13 +9,13 @@ and a gas funder. Source is organized by domain: `auth/`, `auto_topup/`, `billin
 and `plans/auto-top-up.md` for design.
 
 ## Stack & Tooling
-- Toolchain: Stable Rust (latest)
-- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Toolchain: Rust 1.91 (required by alloy)
+- Key Libraries: Tokio (async), Rocket 0.5 (web), Alloy (Web3 interaction)
 - Linting: `cargo clippy`
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
 
 ## Definition of Done

--- a/lit-static/AGENTS.md
+++ b/lit-static/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Context: Static Assets (JavaScript)
+
+This folder holds **browser-served static assets** — dapps, SDK bundles, and ABIs.
+It is NOT a Rust crate; the backend Rust rules do not apply here.
+
+## Purpose
+Browser-facing static assets served by `static-web-server` (locally on `:8080` via
+`local_test.sh`; behind the dashboard domain in production). Contains the JS Core SDK
+(`core_sdk.js` — the client for the `/core/v1/` API), the Chipotle dapps under
+`dapps/` (`dashboard/`, `monitor/`, `verify/`), AccountConfig contract ABIs
+(`*_abi.js`), and WalletConnect / tx-lifecycle helpers. No build step — files are
+served as-is.
+
+## Stack & Tooling
+- Plain JavaScript + HTML served as static files (no build step, no bundler).
+- Contents: `dapps/`, `core_sdk.js`, `wallet_connect.js`, `*_abi.js`, `tx_lifecycle.js`.
+
+## Coding Rules
+- Keep files framework-free and dependency-free unless a human approves otherwise — these ship as-is to the browser.
+- ABI files (`*_abi.js`) must match the deployed Solidity contracts exactly. Do not hand-edit ABIs; regenerate them from source.
+- Match Web3 types carefully (e.g., `BigInt`/`U256` boundaries) when talking to contracts.
+
+## Definition of Done
+1. Files load and run in the browser without console errors.
+2. ABIs match the on-chain contracts they target.
+3. No new external dependencies introduced without human approval.

--- a/lit-triggers/AGENTS.md
+++ b/lit-triggers/AGENTS.md
@@ -8,13 +8,13 @@ dispatcher. Backed by Postgres. Key modules: `auth/`, `chain_events.rs`,
 `dispatcher.rs`, `chipotle.rs`, `crypto.rs`, `mail.rs`.
 
 ## Stack & Tooling
-- Toolchain: Stable Rust (latest)
-- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Toolchain: Rust 1.91 (required by alloy)
+- Key Libraries: Tokio (async), Rocket 0.5 (web), alloy-primitives (Web3 types), Postgres
 - Linting: `cargo clippy`
 
 ## Coding Rules
 - Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
-- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Async: Keep blocking operations outside of the Tokio executor threads using `tokio::task::spawn_blocking`.
 - Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
 
 ## Definition of Done

--- a/lit-triggers/AGENTS.md
+++ b/lit-triggers/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Context: Backend Services (Rust)
+
+## Purpose
+Reactive Lit Action runner service. Users sign in with magic links, create trigger
+configs, and store scoped Chipotle usage API keys encrypted at rest. Supports
+webhook, scheduled, and EVM chain-event triggers that enqueue runs for a shared
+dispatcher. Backed by Postgres. Key modules: `auth/`, `chain_events.rs`,
+`dispatcher.rs`, `chipotle.rs`, `crypto.rs`, `mail.rs`.
+
+## Stack & Tooling
+- Toolchain: Stable Rust (latest)
+- Key Libraries: Tokio (async), Axum (web), Alloy/Ethers-rs (Web3 interaction)
+- Linting: `cargo clippy`
+
+## Coding Rules
+- Error Handling: Do not use `.unwrap()` or `.expect()` in production paths. Use `Result` and propagate errors with `?`.
+- Async: Keep blocking operations outside of the Tokio executive thread using `tokio::task::spawn_blocking`.
+- Types: Match Solidity types exactly when decoding events (e.g., `U256` mapping).
+
+## Definition of Done
+1. Run `cargo clippy --all-targets -- -D warnings` and fix all warnings.
+2. Run `cargo fmt --check`.
+3. All tests must pass via `cargo test`.

--- a/otel-collector/AGENTS.md
+++ b/otel-collector/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Context: OpenTelemetry Collector
+
+This folder configures the **OpenTelemetry Collector** that ships traces/metrics/logs
+for the stack. It is config + entrypoint only — not a Rust crate and not application code.
+
+## Purpose
+The OpenTelemetry Collector config for the Phala sidecar. Receives OTLP (gRPC) from
+`lit-api-server` and `lit-actions` on `0.0.0.0:4317`, scrapes CVM host metrics,
+enriches spans/metrics/logs with lit-protocol resource attributes, and exports them
+to GCP Cloud Monitoring / Trace / Logging via the `googlecloud` exporter. Auth comes
+from `GOOGLE_APPLICATION_CREDENTIALS`, which `entrypoint.sh` writes from the
+`GCP_SERVICE_ACCOUNT_JSON` Phala secret.
+
+## Stack & Tooling
+- `config.yaml`: collector pipeline (receivers, processors, exporters).
+- `entrypoint.sh`: container startup.
+
+## Coding Rules
+- Validate YAML before committing; a malformed config crashes the collector on boot.
+- Never hardcode secrets, tokens, or endpoints — reference environment variables.
+- Keep receiver/exporter changes in sync with what the services actually emit and where telemetry is shipped.
+
+## Definition of Done
+1. `config.yaml` is valid YAML and parses with the collector version in use.
+2. The collector starts cleanly via `entrypoint.sh` with no pipeline errors.
+3. No secrets committed; all sensitive values come from the environment.


### PR DESCRIPTION
Adds an `AGENTS.md` to each service folder (`lit-actions`, `lit-api-server`, `lit-billing-core`, `lit-payments`, `lit-static`, `lit-triggers`, `otel-collector`, `e2e`) and to the blockchain subtree (`lit_node_express` Solidity contracts and `rust_generator_and_deployer`), each documenting the folder's purpose, stack, coding rules, and definition of done. The Rust crates share a common backend template while the non-Rust folders (static JS, OTel config, Playwright e2e, Solidity) are tailored to their actual tooling. The E2E run instructions move out of the root `AGENTS.md` into `e2e/AGENTS.md`, and the root is repurposed as repo-wide agent context that points at the folder-level files. No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)