### PR TITLE
docs(actions): plan for any-language Lit Action runner via gVisor-in-TEE

### DIFF
--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -1,0 +1,202 @@
+# Any-Language Lit Action Runner — Plan
+
+**Status:** Draft / spike phase
+**Owner:** Chris
+**Created:** 2026-07-01
+**Updated:** 2026-07-01
+
+## Goal
+
+Let users write Lit Actions in **any programming language**, not just JavaScript. A user
+gets an isolated sandbox with a full filesystem and runtime, imports whatever libraries they
+want (e.g. a Solana signing lib), and the sandbox talks to `lit-api-server` over the **same
+gRPC op-loop** the current JS runner uses, via a **CLI/SDK preinstalled in the sandbox image**.
+
+Original idea: [bhatti](https://github.com/sahil-shubham/bhatti) (Go orchestrator around
+Firecracker + jailer) microVMs, ideally inside a Phala TEE. **That specific combo is not
+viable** — see below — but the goal stands, and there's a clean path to it.
+
+---
+
+## Two hard constraints that determine the whole design
+
+### Constraint 1 — the runner must hold raw derived key material (preserve the paradigm)
+
+The entire value of Lit Actions is **bring-your-own-crypto**: the user imports any signing
+library and signs whatever they want (Solana, Cosmos, some chain we've never heard of) without
+us implementing it server-side. We refuse to get stuck maintaining per-user signing algorithms.
+
+Consequence: we **cannot** use a "scoped op" model (where the runner asks the api-server to
+`sign(hash)` and never sees the key). The user's own imported code does the signing, so the
+runner **must receive the raw derived private key**.
+
+Confirmed against the proto (`lit-actions/grpc/schema/lit_actions.proto`): the ops that cross
+into the runner today already return raw material —
+`GetPrivateKeyResponse.secret` (raw per-PKP key), `GetLitActionPrivateKeyResponse.secret`,
+`AesDecryptResponse.plaintext`. There is **no `sign` op**; the runner calls `getPrivateKey` and
+signs itself. This is why `lit-actions` lives in the TEE today.
+
+### Constraint 2 — if the runner holds raw keys, it must be inside the TEE
+
+If the runner holds a raw derived key, then anyone who can read runner memory can exfiltrate a
+**persistent** user key (sign as that user until rotation). To stop the operator/host from doing
+that, the runner must run **inside the TDX CVM**.
+
+**Therefore: Firecracker-outside-the-TEE is dead for the general case** (it would expose derived
+keys to the operator). And Firecracker-*inside*-the-TEE is impossible because **Intel TDX guests
+have no nested `/dev/kvm`** (traditional nested virt is forbidden by TDX design; TDX 1.5 "TD
+Partitioning" is not stock KVM-in-guest and Phala doesn't expose it). So **Firecracker is out
+either way.**
+
+---
+
+## Reframing: inside the TEE, the problem gets easier
+
+Once the runner is inside the TDX CVM, the threat model shrinks to a well-trodden one:
+
+- The **host/operator is already excluded by the hardware** — they can't see into the CVM.
+- The **guest kernel is attested** and part of the measured image — trusted.
+- The **only** remaining threat is **tenant A escaping its sandbox to read tenant B's derived
+  key** from another execution's memory.
+
+So we are *not* defending against a malicious host (the TEE did that). We need a strong
+**tenant-from-tenant** boundary, with **no `/dev/kvm`**, that can **run any binary**. Narrow,
+solved problem.
+
+---
+
+## Option space: no-KVM, any-language isolation inside a TEE
+
+| Option | Tenant isolation | Any binary? | No KVM? | Notes |
+|---|---|---|---|---|
+| **gVisor (`runsc`)** | strong (2nd userspace kernel) | **yes** | **yes** (ptrace/systrap) | Purpose-built for untrusted multi-tenant code; what GKE Sandbox / Cloud Run use. **Primary choice.** |
+| Hardened container (runc + seccomp/Landlock/userns) | weak-ish | yes | yes | One shared kernel; a kernel LPE = cross-tenant key read. gVisor exists to fix exactly this. |
+| QEMU / Cloud-Hypervisor **TCG** (software emulation) | VM-grade | yes | yes | A real VM with no KVM — but pure emulation is ~10–50× slower CPU. Too slow for sign-heavy actions. |
+| WASM (wasmtime) | strong | **no** | yes | Fails "import the Solana lib and sign." Out. |
+| **Fresh TDX CVM per execution** | total (separate VM) | yes | n/a | Isolation = the TEE boundary itself, no sandbox needed. But per-exec CVM boot is seconds + Phala provisioning cost. The **max-isolation alternative**. |
+
+Two real survivors: **gVisor** (fast, shared-CVM, sandbox boundary) and **per-execution CVM**
+(slow, total isolation). gVisor is the pragmatic winner; per-exec-CVM is the extreme fallback.
+
+Firecracker is demoted: only viable *outside* the TEE, which breaks key custody (Constraint 2).
+
+---
+
+## Primary architecture: gVisor sandboxes inside the Phala TDX CVM
+
+```
+lit-api-server (TDX, holds root/signer keys)
+        │  gRPC op-loop (unchanged: getPrivateKey, aesDecrypt, setResponse, print, fetch-count …)
+        ▼
+gVisor sandbox supervisor (new, inside same CVM)  ── mirrors worker_pool.rs pre-warm pattern
+        │  each execution:
+        ▼
+runsc sandbox = Sentry (userspace kernel) + gofer (FS proxy)
+   • own overlay rootfs: read-only base image  +  per-exec writable tmpfs
+   • own PID / mount / network namespaces
+   • op-loop socket mounted in  → raw derived key flows in, user's imported lib signs, dies with tmpfs
+   • preinstalled `lit` CLI/SDK exposes the ops to user code in any language
+```
+
+### How the per-execution filesystem works
+1. **Base image** (the "sandbox image" analog): read-only rootfs with language runtimes + the
+   preinstalled `lit` CLI/SDK + optional cached libs. Built once, measured as part of the TEE image.
+2. **Per execution:** a new `runsc` sandbox with an **overlay rootfs** — read-only base as the
+   lower layer + a **writable `tmpfs` upper layer** unique to this run. Clean, private, ephemeral
+   FS; all writes vanish when the sandbox dies. (This is the "each execution gets its own virtual
+   filesystem" property.)
+3. Own PID/mount/network namespaces — user code sees a whole isolated Linux box.
+4. Syscalls are intercepted by the **Sentry** in userspace; user code never touches the real CVM
+   kernel directly. To escape: need a Sentry bug **and then** a CVM-kernel bug (two layers).
+5. The **op-loop channel** to `lit-api-server` is handed in as a mounted socket. Raw keys flow in,
+   are used, and never leave the TEE.
+
+### Performance note (favorable)
+Signing is CPU-bound, and gVisor runs CPU **natively** — only *syscalls* are intercepted. So
+`secp256k1`/`ed25519` math is full speed; overhead lands only on I/O syscalls and `fetch`. Good
+fit for sign-oriented actions.
+
+### Pre-warming
+Maps onto the existing `worker_pool.rs` pattern: keep N warm `runsc` sandboxes, or use gVisor
+checkpoint/restore for fast resume (same warm/cold idea bhatti uses, minus the hypervisor).
+
+---
+
+## What we keep vs. what's new
+
+**Keep unchanged:**
+- The gRPC op-loop + proto contract (`lit-actions/grpc/schema/lit_actions.proto`). The ops
+  (`getPrivateKey`, `aesDecrypt`, `setResponse`, `print`, fetch-count/billing) are the
+  language-agnostic ABI. No scoped-op redesign — raw material still crosses the boundary.
+- All api-server op handlers: `lit-api-server/src/actions/client/handle_ops.rs`,
+  `op_code_helpers/{private_keys,encryption}.rs`.
+- Auth + key derivation server-side; runner still only ever gets a **derived per-PKP key**, never
+  a root — same as today.
+- Wall-second billing + fetch counting (enforced api-server-side, carry over).
+
+**New:**
+- A **gVisor sandbox supervisor** replacing the V8/Deno worker (`lit-actions/server/worker_pool.rs`
+  is the pattern to mirror; timeout/memory enforced at supervisor level, not V8 heap callbacks).
+- A **base sandbox image** with language runtimes + preinstalled `lit` CLI/SDK.
+- A **guest `lit` CLI/SDK** that receives the job (code + `js_params` + `auth_context` + headers)
+  and exposes the ops to user code over the op-loop socket.
+- Transport inside the CVM stays a Unix/vsock socket (same as `/tmp/lit_actions.sock` today).
+
+### Key existing files
+- Proto / contract: `lit-actions/grpc/schema/lit_actions.proto`
+- Runner gRPC server / Unix listener: `lit-actions/server/server.rs:183`, `lit-actions/grpc/unix.rs`
+- Pre-warm pool pattern to mirror: `lit-actions/server/worker_pool.rs`
+- api-server op dispatch + impls: `lit-api-server/src/actions/client/handle_ops.rs`,
+  `.../op_code_helpers/{private_keys,encryption}.rs`
+- api-server gRPC client / socket: `lit-api-server/src/actions/client/execution.rs:162`
+- HTTP entry: `lit-api-server/src/core/v1/endpoints/actions.rs:24`
+- Phala deploy: `docker-compose.phala.yml`, `.github/workflows/deploy-staging.yml`
+- Attestation: `lit-api-server/src/dstack/v1/dstack.rs`, `endpoints.rs`
+
+---
+
+## Spikes (priority order)
+
+| # | Spike | Answers | Cost |
+|---|-------|---------|------|
+| **1** | **Boot a `runsc` hello-world inside a dev Phala CVM.** gVisor's ptrace/systrap platform needs `PTRACE`/`seccomp` and possibly specific caps a locked-down guest might restrict. Confirm `runsc` runs at all. | Is the primary architecture viable inside TDX? Replaces the old "/dev/kvm?" spike. | small |
+| **2** | **Per-exec overlay rootfs + op-loop socket:** run a non-JS guest (Go/Python) in `runsc` that does one `getPrivateKey` + local sign + `setResponse` round-trip against a local api-server, over a mounted socket, with a per-exec tmpfs overlay. | Proves the language-agnostic ABI end-to-end + the FS isolation model. | medium |
+| **3** | **Sandbox escape / isolation review of gVisor inside TDX.** Threat-model tenant-A→tenant-B key theft; confirm the two-layer (Sentry + CVM kernel) argument holds for our config; check known `runsc` CVEs vs our kernel. | Is "tenant isolation inside the TEE" actually sufficient for raw-key custody? | medium |
+| **4** | **Pre-warm + perf:** warm-pool of `runsc` sandboxes (mirror `worker_pool.rs`); measure cold/warm start + a representative sign workload vs the current Deno path. | Latency/throughput acceptable? Checkpoint/restore needed? | medium |
+| **5** | **(Alt path) Per-execution TDX CVM:** measure Phala CVM provisioning/boot latency + cost for the max-isolation model. | Is per-exec-CVM ever worth it (high-value/long-running actions)? | small (external) |
+
+**Spikes 1 and 2 gate everything.** Spike 1 says whether `runsc` runs in the CVM at all; spike 2
+proves the any-language op-loop + per-exec FS. Image build, supervisor, guest SDKs, and examples
+all wait on those.
+
+---
+
+## Recommendation
+
+Build **gVisor sandboxes inside the Phala TDX CVM**, one per execution, each with an overlay
+rootfs (read-only base + per-exec tmpfs), all speaking the existing op-loop. It preserves the
+bring-your-own-crypto paradigm (raw key in, user's own lib signs), keeps keys in the TEE, needs
+no `/dev/kvm`, and runs any language.
+
+- **Firecracker was never the point** — *VM-grade tenant isolation without a hypervisor* was, and
+  gVisor is the right tool inside a TEE.
+- **Per-execution TDX CVM** is the max-isolation alternative if gVisor's boundary proves
+  insufficient (spike 3) or for special high-value workloads — at the cost of seconds-scale boot.
+
+Do **spike 1 today**: it's the one thing that can kill the primary architecture, and it's a
+`runsc` hello-world in a dev CVM.
+
+---
+
+## Constraint note
+
+Per standing guidance: all Phala/TEE experimentation stays on the **dev environment /
+dev.litprotocol.com** only. Do not touch staging/prod CVMs for spikes.
+
+## Sources
+- Intel TDX — Linux Kernel docs (nested virt / TD Partitioning): https://docs.kernel.org/virt/kvm/x86/intel-tdx.html
+- gVisor architecture / platforms (ptrace, systrap, KVM): https://gvisor.dev/docs/architecture_guide/platforms/
+- Firecracker issue #1721 (KVM inside guest): https://github.com/firecracker-microvm/firecracker/issues/1721
+- Firecracker without KVM (why it can't, gVisor as the answer): https://blog.alexellis.io/how-to-run-firecracker-without-kvm-on-regular-cloud-vms/
+- Intel TDX for KVM mainlined in Linux 6.16 (Phoronix): https://www.phoronix.com/news/Intel-TDX-For-KVM-Linux-6.16
+- bhatti: https://github.com/sahil-shubham/bhatti

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -1,8 +1,8 @@
 # Any-Language Lit Action Runner — Build Plan
 
-**Status:** Feasibility validated; ready to build
+**Status:** Feasibility validated; implementation spec complete — ready to build
 **Owner:** Chris
-**Updated:** 2026-07-01
+**Updated:** 2026-07-03
 
 ## Goal
 
@@ -50,7 +50,7 @@ gVisor sandbox supervisor (new; mirrors worker_pool.rs pre-warm pattern)
 runsc sandbox = Sentry (userspace kernel) + gofer (FS proxy)
    • overlay rootfs: read-only base image  +  per-exec writable tmpfs
    • own PID / mount / network namespaces
-   • host-UDS op-loop socket mounted in → raw derived key flows in, user's lib signs, dies with tmpfs
+   • per-exec host-UDS op socket mounted in → raw derived key flows in, user's lib signs, dies with tmpfs
    • preinstalled `lit` CLI/SDK exposes the ops to user code in any language
 ```
 
@@ -82,6 +82,67 @@ runsc sandbox = Sentry (userspace kernel) + gofer (FS proxy)
 - api-server gRPC client / socket: `lit-api-server/src/actions/client/execution.rs:162`
 - HTTP entry: `lit-api-server/src/core/v1/endpoints/actions.rs:24`
 - Phala deploy: `docker-compose.phala.yml`, `.github/workflows/deploy-staging.yml`
+
+## Proto & routing spec
+
+**Today:** one service, `Action.ExecuteJs(stream ExecuteJsRequest) returns (stream ExecuteJsResponse)`
+(`lit_actions.proto:5-6`). `ExecutionRequest` carries `code: string`, `js_params`, `auth_context`,
+`timeout`, `memory_limit`, `http_headers`, `ipfs_id` (proto:25-33). The op union is: `set_response`,
+`print`, `increment_fetch_count`, `update_resource_usage`, `aes_encrypt`, `aes_decrypt`,
+`get_private_key`, `get_lit_action_{private_key,public_key,wallet_address}`, `report_error`
+(proto:10-23). **lit-actions is the gRPC server; lit-api-server is the client**, connecting over the
+hardcoded socket `/tmp/lit_actions.sock` (`execution.rs:190`).
+
+**Changes:**
+- Extend `ExecutionRequest` with `oneof source { string code; bytes bundle; }` (a bare CID in
+  `ipfs_id` referencing a cached bundle also works, as today for JS). Entrypoint + runtime come from
+  the bundle's manifest, not the proto.
+- **Routing:** api-server picks the runner socket by source shape — JS `code`/`ipfs_id` → existing
+  `/tmp/lit_actions.sock`; `bundle` → the sandbox runner's socket (new, e.g.
+  `/tmp/lit_actions_vm.sock`, same `lit-socket` volume). Make the socket path per-runner config
+  instead of the current hardcode. The JS runner is untouched; the new runner implements the same
+  `Action` service, so `execution.rs` client code and all op handlers are reused verbatim.
+- **HTTP entry:** extend `LitActionRequest` (`models/request.rs:169-177`) with `bundle`
+  (base64, mutually exclusive with `code`/`ipfs_id`). Existing size limits already fit bundles:
+  `max_code_length` 16 MB default / 160 MB cap (`client/mod.rs:24,38`).
+- **v1 guest op surface:** same op set minus `increment_fetch_count` (replaced by the egress model
+  below); `update_resource_usage` is emitted by the supervisor, never the guest (see billing note).
+
+## Bundle format & manifest
+
+- **Format:** gzipped tarball. Manifest `lit.json` at the root:
+  `{ "runtime": "bin" | "python3.12" | "node22", "entrypoint": "./main.py", "env": {...} }`.
+  The `bin` runtime = user ships a static binary — every compiled language works day one with zero
+  runtime support from us.
+- **CID:** same `IpfsHasher` CIDv0 (sha2-256 multihash) over the exact bundle bytes as JS uses
+  today (`runtime.rs:288-291`, `core_features.rs:135-138`) — so `keccak256(cid)` permissions
+  (`parse_with_hash.rs:74-106`) and action-key derivation (`dstack/v1/mod.rs:14-20`) reuse verbatim.
+- **Extraction safety:** unpack as an unprivileged uid into a per-CID read-only dir; reject absolute
+  paths, `..` traversal, symlinks/hardlinks escaping the root, device/FIFO entries; cap unpacked
+  size (hard cap ~512 MB) and file count. Bundles are self-contained — **deps are vendored in the
+  bundle; no network installs at runtime** (predictable cold start, artifact = what runs).
+- **Cache:** per-CID unpacked layer + LRU eviction — the disk analog of `ActionCodeCache`
+  (100 MB / 30-min TTL today, `runtime.rs:62-63`); ours can be bigger (~5 GB disk LRU).
+
+## Op-loop scoping & job delivery
+
+Today there is **no execution ID in the proto** — the per-execution bidirectional stream *is* the
+auth boundary, and api-server authorizes every op against per-execution client state (api key +
+ipfs_id + wallet-permission cache, `handle_ops.rs:72-127`). Preserve exactly that:
+
+- The **supervisor** terminates each `ExecuteJs` stream, generates an `execution_id` (never trust
+  guest-supplied IDs), spawns the sandbox, and creates a **per-execution guest socket**
+  (`/run/lit/exec-<id>/ops.sock`, bind-mounted in — this is what `--host-uds` permits). It bridges
+  guest CLI calls 1:1 onto **that execution's stream only**. A sandbox can only reach its own
+  socket → cross-execution op forgery is structurally impossible, and the api-server trust model is
+  unchanged.
+- **Job delivery into the sandbox:** bundle unpacked read-only at `/action`; writable tmpfs workdir;
+  params and auth_context as files (`/lit/params.json`, `/lit/auth_context.json`); env
+  `LIT_OPS_SOCKET=/lit/ops.sock`. The guest `lit` CLI/SDK reads these — and the local-dev mock CLI
+  honors the same contract.
+- **stdout/stderr** are captured by the supervisor and forwarded via the `Print` op path, keeping
+  the existing 100 KB console cap (`client/mod.rs:25`). `lit set-response` forwards `SetResponse`;
+  the existing 1 MB response cap applies (`client/mod.rs:27`).
 
 ## Deployment topology on Phala
 
@@ -139,9 +200,12 @@ Grounded in how JS actions work today (file:line refs for the builder).
 
 1. **Charging — same as JS.** Flat **$0.01/wall-clock-second** (`stripe.rs:33,774`), min 1s, via
    the `UpdateResourceUsage` op flushed every 5s (`handle_ops.rs:9,155-199`, `execution.rs:215`).
-   The guest/supervisor emits the same usage ticks — no new billing code. **Do not bill cold boot:**
-   start the clock at *user-code start* (cold path is ~150–500 ms; hidden by the warm pool, and not
-   billed regardless).
+   Two mechanism notes: (a) **the supervisor emits the ticks, never the guest** — a malicious guest
+   could simply not tick (today the trusted runner samples every 500 ms, `runtime.rs`); (b) billing
+   elapsed is computed **api-server-side** from `execution_start`, which is set *before* boot
+   (`execution.rs:215`, `handle_ops.rs:161-167`) — so **"don't bill cold boot" needs a small
+   api-server change**: start the clock at the first usage tick (or an explicit started marker)
+   for sandbox executions. Cold path is ~150–500 ms, hidden by the warm pool.
 2. **Action identity — content hash, preserving the code-string path.** Permissions key on the
    code's IPFS CID: `keccak256(ipfs_id)` (`parse_with_hash.rs:74-106`) →
    `canUseWalletInAction(apiKeyHash, cidHash, wallet)` (`accounts/mod.rs:695-727`), and the action's
@@ -153,10 +217,17 @@ Grounded in how JS actions work today (file:line refs for the builder).
    OCI images deferred.
 3. **Egress — bandwidth cap, no fetch-count quota.** The `DEFAULT_MAX_FETCH_COUNT = 50` quota
    guarded the old MPC/many-node network against fan-out DDoS; on one TEE box that risk is gone.
-   Route egress through a **single proxied path** (keeps the venue-proxy feature + logging) and apply
-   a **bandwidth/rate limit** instead of a call count — since users pay per second, bandwidth × time
-   bounds abuse without an arbitrary cap. (User code holds the key and can exfiltrate via network —
-   identical to today's JS model; the author already holds the permission.)
+   Route egress through a **single proxied path** and apply a **bandwidth/rate limit** instead of a
+   call count — since users pay per second, bandwidth × time bounds abuse without an arbitrary cap.
+   **Mechanism** (note: today's JS fetch is *not* an op-loop op — it's local reqwest in lit-actions,
+   `op_lit_proxied_fetch` in `ext/bindings.rs:429`, 10 MB/30 s per request, venue-proxy chaining):
+   the sandbox gets gVisor netstack with **no default route**; the only egress is an HTTP(S) CONNECT
+   proxy the supervisor runs, exposed inside the sandbox with standard `HTTP_PROXY`/`HTTPS_PROXY`
+   env set. CONNECT preserves end-to-end TLS; the proxy is the choke point for byte counting,
+   throughput caps, logging, and venue-proxy chaining parity. Websockets work over CONNECT; raw
+   non-HTTP TCP is unsupported in v1 (document it). Libraries that ignore proxy env have no route —
+   **fail closed**. (User code holds the key and can exfiltrate via network — identical to today's
+   JS model; the author already holds the permission.)
 4. **Determinism — N/A.** Single TEE, no MPC/multi-node result comparison, so user code need not be
    deterministic.
 5. **Job/response contract + termination.** Params in via the `lit` SDK/CLI; response out via a
@@ -164,6 +235,38 @@ Grounded in how JS actions work today (file:line refs for the builder).
    `lit print`/stdout. **Termination = the entrypoint process exits** (serverless/CLI semantics) —
    `set-response` only *records* the value; on exit we return the last-recorded response and tear
    down the sandbox. Timeout/OOM are hard caps. No response set ⇒ empty response.
+
+## Supervisor lifecycle & failure handling
+
+- **Concurrency:** cap concurrent sandboxes (start at the JS pool's default of 10,
+  `LIT_ACTIONS_POOL_SIZE`, `server.rs:32-33`) with a small bounded queue; overflow → error on the
+  stream → HTTP 429 with retry-after. Mirror the worker-pool breaker (5 consecutive spawn failures
+  → open 60 s, `worker_pool.rs:44,50`).
+- **Exit mapping** — users must be able to tell these apart in the error response:
+  exit 0 → last recorded `set-response` (or empty); nonzero exit → error with exit code + stderr
+  tail; cgroup OOM kill (`memory.events` `oom_kill`) → "memory limit exceeded"; deadline → SIGKILL
+  the `runsc` process → "timed out".
+- **One sandbox per execution, never reused** — same rationale as the JS pool ("cheap to start,
+  expensive to scrub", `worker_pool.rs:5-8`).
+- **Crash reconciliation:** on supervisor startup, `runsc delete -f` every label-matched leftover
+  sandbox and remove orphaned leaf cgroups, exec dirs, and per-exec sockets; per-execution teardown
+  runs in a drop-guard so a panicking handler still cleans up.
+
+## Base sandbox image
+
+- **v1 runtimes:** `bin` (static binaries — Go/Rust/Zig/C covered for free), `python3.12`,
+  `node22`. Add more by demand; exact versions pinned in the manifest enum.
+- The image is built in CI and **pinned by digest in the compose file**, so it's part of the
+  attested `compose_hash` identity — no runtime pulls.
+- The `lit` CLI is a small static binary on `PATH`; language SDKs (pip/npm packages) either shell
+  out to it or speak gRPC-over-UDS directly. Keep the image lean — user deps live in the bundle.
+
+## Observability
+
+- Per-execution structured log line (execution_id, CID, api-key hash, duration, `memory.peak`,
+  egress bytes, exit class) → existing `otel-collector` container.
+- Metrics: warm-pool depth, spawn latency p50/p99, active sandboxes, queue depth, OOM/timeout/error
+  counts, egress bytes. `runsc` debug logs off by default; per-exec flag on dev.
 
 ## Local development & docs (build alongside, or fast-follow on adoption)
 
@@ -191,6 +294,31 @@ first-class deliverable**, not an afterthought:
   `--host-uds` to a per-sandbox socket, not a shared one.
 - **Perf / pre-warm** — warm-pool sizing, cold/warm start, a representative sign workload vs the
   current Deno path; evaluate checkpoint/restore.
+
+## Testing & CI
+
+gVisor's systrap/ptrace platforms run on stock Linux GitHub runners (no KVM needed), so real-runsc
+integration tests run in CI, not just on dev CVMs:
+
+- **E2E per language:** each shipped example (Go/`bin`, Python, Node) executes under real `runsc`
+  against a mock op-server implementing the `Action` service; assert response, logs, key ops.
+- **Malicious-bundle suite:** tar traversal / symlink escape, fork bomb (→ pids cap), memory hog
+  (→ OOM exit class), egress-bypass attempts (direct dial with no proxy → fails closed), probing
+  for other executions' sockets, oversized response/logs.
+- **Perf:** wire a sandbox sign workload into the existing k6 perf gate on deploy-staging.
+
+## Milestones
+
+1. **Walking skeleton (dev-only flag):** proto `oneof source` + api-server routing + minimal
+   supervisor (no pool, `bin` runtime only, `--ignore-cgroups` OK) → e2e Solana sign with a static
+   Go binary on a dev CVM.
+2. **Contract complete:** bundle/manifest + CID/permissions parity, Python + Node runtimes, guest
+   `lit` CLI/SDK, per-exec sockets, egress proxy, exit mapping.
+3. **Production shape:** delegated leaf cgroups + both limit layers, supervisor-emitted billing
+   ticks + cold-boot clock change, crash reconciliation, warm pool, observability;
+   malicious-bundle suite green in CI.
+4. **Gate & ship (dev):** isolation review + perf gate (above), compose change on dev, docs +
+   authoring skill, ≥2 non-JS examples published.
 
 ## Constraint note
 

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -255,6 +255,71 @@ no remaining "is it possible" unknowns. **Next is implementation**: deploy the r
 
 ---
 
+## Deployment topology on Phala
+
+### How Phala/dstack works
+A dstack **"app" = one CVM = one TDX VM** running **one `docker-compose`**. The compose file's
+`compose_hash` is what gets measured and attested — it *is* the app's identity. Multiple
+*containers* run inside that single VM; services are **never** split across VMs within an app.
+An app *can* be replicated to **N identical VMs** behind Phala's gateway for horizontal scale, but
+each VM runs the *whole* compose — so it's "1 app → N identical full-stack VMs," never "services
+sharded across VMs." To give a component its own VM/resources, it must be its **own app**.
+
+### Today
+One app, one VM (replicable), 4 containers in `docker-compose.phala.yml`:
+`lit-api-server` (Rocket :8000, holds keys, mounts `/var/run/dstack.sock`), `lit-actions`
+(JS runner, gRPC over the shared `lit-socket` volume), `otel-collector`, `dstack-ingress`
+(RA-TLS :443 → api-server). Note `lit-actions` and `lit-api-server` are already separate
+images/containers sharing the `lit-socket` unix-socket volume — that's the seam the new runner
+slots into.
+
+### Decision: Option A — new container in the existing compose (same VM)
+Start the gVisor runner as **another service in `docker-compose.phala.yml`**, in the same CVM:
+
+- New service (e.g. `lit-runner-gvisor`) mounts the same `lit-socket` volume → talks to
+  `lit-api-server` over the **identical op-loop path** the JS runner uses. Roughly "add a service
+  block."
+- `runsc` runs *inside* that container (nesting: CVM → container → gVisor sandbox). The container
+  needs the privileges exercised in the spikes (`privileged` / `SYS_ADMIN`-ish + the `--host-uds`
+  path); production should scope these down to the minimum that lets `runsc` create sandboxes.
+- **Shares the VM's attestation boundary and key-custody context** — raw keys stay inside the same
+  attested VM, so there is **zero new cross-VM trust plumbing**. Simplest and safest.
+
+**Graduate to Option B (its own dstack app / own VM) later** only when the runner needs dedicated
+resources, independent scaling/upgrade cadence, or a distinct trust profile. Cost of graduating: a
+secured CVM↔CVM channel (RA-TLS/mTLS between two attested apps) for the op-loop, plus its own
+attestation whitelisting. Raw-key custody still requires it to be a TEE, so a separate CVM is fine
+trust-wise — the cross-app channel is the new thing to secure.
+
+### Two operational flags
+1. **`compose_hash` changes are governed in production.** Adding the service changes the hash; in
+   prod the new hash + image must be whitelisted on the `DstackApp` contract on Base (governed
+   change, not a plain redeploy). On dev it's just a redeploy.
+2. **Resource contention** — see below.
+
+### Resource limits for the new container
+Today the compose sets **no** per-service `cpus`/`mem_limit`, so a heavy action could starve
+`lit-api-server` (noisy neighbor) since they share one VM. dstack runs plain `docker compose`
+(not swarm), so use the **non-swarm** compose keys (the `deploy.resources` block is ignored
+outside swarm). Apply **two layers**:
+
+- **Container-level cap (compose)** — bounds the runner's *total* footprint so `lit-api-server`
+  always has headroom. On the `lit-runner-gvisor` service set:
+  - `cpus:` — e.g. leave ≥1 vCPU reserved for api-server + ingress + otel; cap the runner at the
+    remainder.
+  - `mem_limit:` + `mem_reservation:` — hard ceiling + soft floor.
+  - `pids_limit:` — cap total processes (defense against fork bombs across sandboxes).
+- **Per-execution cap (supervisor)** — the runner supervisor gives *each* `runsc` sandbox its own
+  **delegated leaf cgroup** (the spike-1 fix) with per-execution CPU/memory/pids limits + timeout,
+  mirroring today's per-action 64 MB / 15-min budget. gVisor enforces the sandbox side; the leaf
+  cgroup enforces the host side.
+
+Net: compose limits keep the *runner as a whole* from starving its VM-mates; the supervisor's
+per-sandbox cgroups keep one tenant's action from starving another. Revisit the compose split (→
+Option B) once perf data shows the shared VM is the bottleneck.
+
+---
+
 ## Constraint note
 
 Per standing guidance: all Phala/TEE experimentation stays on the **dev environment /

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -1,459 +1,201 @@
-# Any-Language Lit Action Runner — Plan
+# Any-Language Lit Action Runner — Build Plan
 
-**Status:** Draft / spike phase
+**Status:** Feasibility validated; ready to build
 **Owner:** Chris
-**Created:** 2026-07-01
 **Updated:** 2026-07-01
 
 ## Goal
 
-Let users write Lit Actions in **any programming language**, not just JavaScript. A user
-gets an isolated sandbox with a full filesystem and runtime, imports whatever libraries they
-want (e.g. a Solana signing lib), and the sandbox talks to `lit-api-server` over the **same
-gRPC op-loop** the current JS runner uses, via a **CLI/SDK preinstalled in the sandbox image**.
+Let users write Lit Actions in **any programming language**, not just JavaScript. A user gets an
+isolated sandbox with a full filesystem and runtime, imports whatever libraries they want (e.g. a
+Solana signing lib), and the sandbox talks to `lit-api-server` over the **same gRPC op-loop** the
+current JS runner uses, via a **`lit` CLI/SDK preinstalled in the sandbox image**.
 
-Original idea: [bhatti](https://github.com/sahil-shubham/bhatti) (Go orchestrator around
-Firecracker + jailer) microVMs, ideally inside a Phala TEE. **That specific combo is not
-viable** — see below — but the goal stands, and there's a clean path to it.
+## Isolation tech: gVisor (`runsc`)
 
----
+We use **gVisor** to sandbox each execution. Rationale, in one breath: the user's own imported
+code must do the signing, so the sandbox holds a **raw derived key** and must run **inside the TDX
+CVM** (the TEE excludes the host/operator); inside the TEE, TDX gives us **no `/dev/kvm`**, so a
+hypervisor (Firecracker/microVM) is off the table, and we only need **tenant-from-tenant**
+isolation for arbitrary binaries — which is exactly what gVisor's userspace kernel provides with no
+KVM. (For very-high-value/isolated workloads, a **fresh TDX CVM per execution** is a future
+max-isolation alternative; not v1.)
 
-## Two hard constraints that determine the whole design
+**Signing is CPU-bound and gVisor runs CPU natively** (only syscalls are intercepted), so
+`secp256k1`/`ed25519` math is full speed — a good fit.
 
-### Constraint 1 — the runner must hold raw derived key material (preserve the paradigm)
+## Feasibility — validated (2026-07-01)
 
-The entire value of Lit Actions is **bring-your-own-crypto**: the user imports any signing
-library and signs whatever they want (Solana, Cosmos, some chain we've never heard of) without
-us implementing it server-side. We refuse to get stuck maintaining per-user signing algorithms.
+Confirmed on real dev CVMs (scratch composes in `.context/spikes/`):
+- **gVisor runs inside a Phala TDX CVM** on the **systrap** (default) and **ptrace** platforms —
+  real sandboxing confirmed (guest reports `4.19.0-gvisor`, host `6.9.0-dstack`). Same on the
+  **production** OS image (`dstack-0.5.9`), not just dev.
+- **Two implementation facts fell out of the spikes:**
+  - Launch `runsc` with **`--host-uds=all`** or the sandbox can't reach the host op-loop socket
+    (default is refused). Verified both ways.
+  - Give each sandbox a **delegated leaf cgroup**; otherwise `runsc` hits cgroup-v2
+    `subtree_control: EBUSY` (container-in-container). `--ignore-cgroups` sidesteps it for tests.
 
-Consequence: we **cannot** use a "scoped op" model (where the runner asks the api-server to
-`sign(hash)` and never sees the key). The user's own imported code does the signing, so the
-runner **must receive the raw derived private key**.
+There are no remaining "is it possible" unknowns.
 
-Confirmed against the proto (`lit-actions/grpc/schema/lit_actions.proto`): the ops that cross
-into the runner today already return raw material —
-`GetPrivateKeyResponse.secret` (raw per-PKP key), `GetLitActionPrivateKeyResponse.secret`,
-`AesDecryptResponse.plaintext`. There is **no `sign` op**; the runner calls `getPrivateKey` and
-signs itself. This is why `lit-actions` lives in the TEE today.
-
-### Constraint 2 — if the runner holds raw keys, it must be inside the TEE
-
-If the runner holds a raw derived key, then anyone who can read runner memory can exfiltrate a
-**persistent** user key (sign as that user until rotation). To stop the operator/host from doing
-that, the runner must run **inside the TDX CVM**.
-
-**Therefore: Firecracker-outside-the-TEE is dead for the general case** (it would expose derived
-keys to the operator). And Firecracker-*inside*-the-TEE is impossible because **Intel TDX guests
-have no nested `/dev/kvm`** (traditional nested virt is forbidden by TDX design; TDX 1.5 "TD
-Partitioning" is not stock KVM-in-guest and Phala doesn't expose it). So **Firecracker is out
-either way.**
-
----
-
-## Reframing: inside the TEE, the problem gets easier
-
-Once the runner is inside the TDX CVM, the threat model shrinks to a well-trodden one:
-
-- The **host/operator is already excluded by the hardware** — they can't see into the CVM.
-- The **guest kernel is attested** and part of the measured image — trusted.
-- The **only** remaining threat is **tenant A escaping its sandbox to read tenant B's derived
-  key** from another execution's memory.
-
-So we are *not* defending against a malicious host (the TEE did that). We need a strong
-**tenant-from-tenant** boundary, with **no `/dev/kvm`**, that can **run any binary**. Narrow,
-solved problem.
-
----
-
-## Option space: no-KVM, any-language isolation inside a TEE
-
-| Option | Tenant isolation | Any binary? | No KVM? | Notes |
-|---|---|---|---|---|
-| **gVisor (`runsc`)** | strong (2nd userspace kernel) | **yes** | **yes** (ptrace/systrap) | Purpose-built for untrusted multi-tenant code; what GKE Sandbox / Cloud Run use. **Primary choice.** |
-| Hardened container (runc + seccomp/Landlock/userns) | weak-ish | yes | yes | One shared kernel; a kernel LPE = cross-tenant key read. gVisor exists to fix exactly this. |
-| QEMU / Cloud-Hypervisor **TCG** (software emulation) | VM-grade | yes | yes | A real VM with no KVM — but pure emulation is ~10–50× slower CPU. Too slow for sign-heavy actions. |
-| WASM (wasmtime) | strong | **no** | yes | Fails "import the Solana lib and sign." Out. |
-| **Fresh TDX CVM per execution** | total (separate VM) | yes | n/a | Isolation = the TEE boundary itself, no sandbox needed. But per-exec CVM boot is seconds + Phala provisioning cost. The **max-isolation alternative**. |
-
-Two real survivors: **gVisor** (fast, shared-CVM, sandbox boundary) and **per-execution CVM**
-(slow, total isolation). gVisor is the pragmatic winner; per-exec-CVM is the extreme fallback.
-
-Firecracker is demoted: only viable *outside* the TEE, which breaks key custody (Constraint 2).
-
----
-
-## Primary architecture: gVisor sandboxes inside the Phala TDX CVM
+## Architecture
 
 ```
 lit-api-server (TDX, holds root/signer keys)
-        │  gRPC op-loop (unchanged: getPrivateKey, aesDecrypt, setResponse, print, fetch-count …)
+        │  gRPC op-loop (unchanged: getPrivateKey, aesDecrypt, setResponse, print, usage …)
         ▼
-gVisor sandbox supervisor (new, inside same CVM)  ── mirrors worker_pool.rs pre-warm pattern
-        │  each execution:
+gVisor sandbox supervisor (new; mirrors worker_pool.rs pre-warm pattern)
+        │  one runsc sandbox per execution:
         ▼
 runsc sandbox = Sentry (userspace kernel) + gofer (FS proxy)
-   • own overlay rootfs: read-only base image  +  per-exec writable tmpfs
+   • overlay rootfs: read-only base image  +  per-exec writable tmpfs
    • own PID / mount / network namespaces
-   • op-loop socket mounted in  → raw derived key flows in, user's imported lib signs, dies with tmpfs
+   • host-UDS op-loop socket mounted in → raw derived key flows in, user's lib signs, dies with tmpfs
    • preinstalled `lit` CLI/SDK exposes the ops to user code in any language
 ```
 
-### How the per-execution filesystem works
-1. **Base image** (the "sandbox image" analog): read-only rootfs with language runtimes + the
-   preinstalled `lit` CLI/SDK + optional cached libs. Built once, measured as part of the TEE image.
-2. **Per execution:** a new `runsc` sandbox with an **overlay rootfs** — read-only base as the
-   lower layer + a **writable `tmpfs` upper layer** unique to this run. Clean, private, ephemeral
-   FS; all writes vanish when the sandbox dies. (This is the "each execution gets its own virtual
-   filesystem" property.)
-3. Own PID/mount/network namespaces — user code sees a whole isolated Linux box.
-4. Syscalls are intercepted by the **Sentry** in userspace; user code never touches the real CVM
-   kernel directly. To escape: need a Sentry bug **and then** a CVM-kernel bug (two layers).
-5. The **op-loop channel** to `lit-api-server` is handed in as a mounted socket. Raw keys flow in,
-   are used, and never leave the TEE.
-
-### Performance note (favorable)
-Signing is CPU-bound, and gVisor runs CPU **natively** — only *syscalls* are intercepted. So
-`secp256k1`/`ed25519` math is full speed; overhead lands only on I/O syscalls and `fetch`. Good
-fit for sign-oriented actions.
-
-### Pre-warming
-Maps onto the existing `worker_pool.rs` pattern: keep N warm `runsc` sandboxes, or use gVisor
-checkpoint/restore for fast resume (same warm/cold idea bhatti uses, minus the hypervisor).
-
----
-
-## What we keep vs. what's new
-
-**Keep unchanged:**
-- The gRPC op-loop + proto contract (`lit-actions/grpc/schema/lit_actions.proto`). The ops
-  (`getPrivateKey`, `aesDecrypt`, `setResponse`, `print`, fetch-count/billing) are the
-  language-agnostic ABI. No scoped-op redesign — raw material still crosses the boundary.
+### Keep unchanged
+- The gRPC op-loop + proto (`lit-actions/grpc/schema/lit_actions.proto`) — the language-agnostic ABI.
 - All api-server op handlers: `lit-api-server/src/actions/client/handle_ops.rs`,
   `op_code_helpers/{private_keys,encryption}.rs`.
-- Auth + key derivation server-side; runner still only ever gets a **derived per-PKP key**, never
-  a root — same as today.
-- Wall-second billing + fetch counting (enforced api-server-side, carry over).
+- Auth + key derivation server-side; the runner only ever gets a **derived per-PKP key**, never a root.
+- Per-second billing (enforced api-server-side).
 
-**New:**
-- A **gVisor sandbox supervisor** replacing the V8/Deno worker (`lit-actions/server/worker_pool.rs`
-  is the pattern to mirror; timeout/memory enforced at supervisor level, not V8 heap callbacks).
-- A **base sandbox image** with language runtimes + preinstalled `lit` CLI/SDK.
-- A **guest `lit` CLI/SDK** that receives the job (code + `js_params` + `auth_context` + headers)
-  and exposes the ops to user code over the op-loop socket.
-- Transport inside the CVM stays a Unix/vsock socket (same as `/tmp/lit_actions.sock` today).
+### New components to build
+1. **Generalize the proto** so the op-loop is language-neutral (`ExecuteRequest` etc.); keep op
+   semantics identical so the api-server op-handlers are reused verbatim.
+2. **Sandbox supervisor** (replaces the Deno worker; mirror `lit-actions/server/worker_pool.rs`):
+   launches `runsc` per execution with `--host-uds`, a **delegated leaf cgroup**, a per-exec
+   **overlay rootfs** (read-only base + tmpfs upper), and supervisor-level timeout/memory/pids limits.
+3. **Base sandbox image** with language runtimes + the preinstalled `lit` CLI/SDK.
+4. **Guest `lit` CLI/SDK**: receives the job (code + params + auth_context + headers) and exposes
+   the ops to user code over the host-UDS op-loop socket.
+5. **Wire into `lit-api-server`** as a new runner target alongside the JS runner; ship examples in
+   ≥2 non-JS languages (e.g. a Solana sign in Go + Python).
 
 ### Key existing files
-- Proto / contract: `lit-actions/grpc/schema/lit_actions.proto`
+- Proto: `lit-actions/grpc/schema/lit_actions.proto`
 - Runner gRPC server / Unix listener: `lit-actions/server/server.rs:183`, `lit-actions/grpc/unix.rs`
-- Pre-warm pool pattern to mirror: `lit-actions/server/worker_pool.rs`
+- Pre-warm pool to mirror: `lit-actions/server/worker_pool.rs`
 - api-server op dispatch + impls: `lit-api-server/src/actions/client/handle_ops.rs`,
-  `.../op_code_helpers/{private_keys,encryption}.rs`
+  `op_code_helpers/{private_keys,encryption}.rs`
 - api-server gRPC client / socket: `lit-api-server/src/actions/client/execution.rs:162`
 - HTTP entry: `lit-api-server/src/core/v1/endpoints/actions.rs:24`
 - Phala deploy: `docker-compose.phala.yml`, `.github/workflows/deploy-staging.yml`
-- Attestation: `lit-api-server/src/dstack/v1/dstack.rs`, `endpoints.rs`
-
----
-
-## Spike 1 result — ✅ DONE (2026-07-01): gVisor runs inside a Phala TDX CVM
-
-Deployed a throwaway `gvisor-spike` CVM (tdx.small, image `dstack-dev-0.5.9`, kernel
-`6.9.0-dstack`), downloaded `runsc release-20260622.0`, and booted sandboxes. **Result:**
-
-- **systrap platform (modern default): WORKS.** **ptrace platform: WORKS.** Confirmed real
-  sandboxing, not passthrough — inside the sandbox `uname` reports `4.19.0-gvisor` (vs host
-  `6.9.0-dstack`) and dmesg shows gVisor's `Starting gVisor... / Synthesizing system calls...`
-  banner.
-- **kvm platform: N/A** — `/dev/kvm` absent (confirms TDX has no nested KVM, as predicted).
-- Kernel prerequisites all present: `tdx_guest` cpuinfo flag (real TDX), **user namespaces
-  enabled** (`user.max_user_namespaces = 7360`), **no yama `ptrace_scope`** restriction, no
-  seccomp on the host process.
-- **One real gotcha, now understood:** the first attempt failed for *all* platforms at the same
-  pre-platform step — `cgroup.subtree_control: device or resource busy`. This is the classic
-  cgroup-v2 "no internal processes" container-in-container issue (runsc tried to enable
-  controllers on a cgroup that already held PID 1), **not** a gVisor/kernel blocker. Fixed
-  instantly with `runsc --ignore-cgroups`. **Production implication:** the sandbox supervisor
-  must give each `runsc` sandbox a properly *delegated* leaf cgroup (or run with cgroup handling
-  disabled and enforce limits ourselves) — a solved problem, but a design item for the supervisor.
-- **Access pattern learned:** `phala deploy` auto-attaches `~/.ssh/id_*.pub` and picks a dev OS
-  image, so `phala ssh --cvm-id … -- 'docker exec <container> …'` gives a fast interactive loop —
-  no redeploy needed to iterate inside a running CVM.
-
-**Scratch compose:** `.context/spikes/docker-compose.gvisor-spike.yml`.
-
----
-
-## Spike 2 result — ✅ DONE (2026-07-01): prod-image parity + host-UDS socket reachability
-
-Original "spike 2" was going to build a dummy op-loop server and prove a non-JS gRPC round-trip.
-**Dropped as redundant** — gRPC over a unix socket is the production path today, `lit-api-server`
-*is* the op-loop server, and protobuf has codegen for every language. The round-trip isn't in
-doubt. What *was* genuinely unverified were two cheap things, now both closed on a `gvisor-uds`
-CVM deployed on the **production** OS image (`dstack-0.5.9`, non-dev):
-
-- **Production-image parity: ✅.** gVisor boots identically on the prod image — sandbox reports
-  `4.19.0-gvisor`, host `6.9.0-dstack`, `tdx_guest` present. No dev-vs-prod kernel difference that
-  matters for us.
-- **Host-UDS gate (the one gVisor-specific wrinkle): ✅ understood.** By default a gVisor sandbox
-  **cannot** connect to a host unix domain socket — proven: without the flag, `socat` in the
-  sandbox got `connect(/tmp/op.sock): Connection refused`. Launch `runsc` with **`--host-uds=all`**
-  and it works — full round trip returned `PONG_FROM_HOST`. So the guest reaches the
-  `lit-api-server` socket iff the supervisor launches `runsc --host-uds=…` (or we expose the op-loop
-  over vsock/TCP instead). Known flag, not a research question.
-
-Scratch compose: `.context/spikes/docker-compose.gvisor-uds.yml`.
-
-**Both feasibility gates are now green.** No remaining "is it possible" unknowns — the rest is
-implementation. Remaining *research* items (isolation review, perf) are quality gates, not
-blockers, and move below.
-
----
-
-## Feasibility: settled. What's left is implementation + quality gates.
-
-### Implementation phases (this is the actual work — not spikes)
-Deploy the **real `lit-api-server`** to a dev Phala box and build the runner against it:
-
-1. **Generalize the runner protocol.** Fork/rename the proto so the op-loop is language-neutral
-   (`ExecuteRequest` etc.); keep op semantics identical so api-server op-handlers are reused verbatim.
-2. **Sandbox supervisor** (replaces the Deno worker; mirror `worker_pool.rs`): launches `runsc`
-   per execution with `--host-uds`, a **delegated leaf cgroup** per sandbox (spike-1 fix), a
-   per-exec **overlay rootfs** (read-only base + tmpfs upper), and supervisor-level timeout/memory
-   enforcement.
-3. **Base sandbox image** with language runtimes + the preinstalled `lit` CLI/SDK.
-4. **Guest `lit` CLI/SDK**: receives the job (code + params + auth_context + headers), exposes the
-   ops to user code over the host-UDS op-loop socket.
-5. **Wire into `lit-api-server`** as a new runner target alongside the JS runner; examples in ≥2
-   non-JS languages (e.g. a Solana sign in Rust/Go/Python).
-
-### Quality gates (before shipping — not feasibility blockers)
-| Gate | Question |
-|---|---|
-| **Isolation review** | Threat-model tenant-A→tenant-B key theft; validate the two-layer (Sentry + CVM kernel) argument for our config; review known `runsc` CVEs vs kernel `6.9.0-dstack`; decide `--host-uds` scope (per-sandbox socket, not shared). |
-| **Perf / pre-warm** | Warm-pool of `runsc` sandboxes (mirror `worker_pool.rs`); measure cold/warm start + a representative sign workload vs the current Deno path; evaluate gVisor checkpoint/restore. |
-| **Alt path (optional)** | Per-execution TDX CVM for max-isolation/high-value workloads — measure Phala provisioning/boot latency + cost. |
-
----
-
-## Recommendation
-
-Build **gVisor sandboxes inside the Phala TDX CVM**, one per execution, each with an overlay
-rootfs (read-only base + per-exec tmpfs), all speaking the existing op-loop. It preserves the
-bring-your-own-crypto paradigm (raw key in, user's own lib signs), keeps keys in the TEE, needs
-no `/dev/kvm`, and runs any language.
-
-- **Firecracker was never the point** — *VM-grade tenant isolation without a hypervisor* was, and
-  gVisor is the right tool inside a TEE.
-- **Per-execution TDX CVM** is the max-isolation alternative if gVisor's boundary proves
-  insufficient (isolation review) or for special high-value workloads — at the cost of
-  seconds-scale boot.
-
-**Feasibility is settled and green** — gVisor runs on systrap + ptrace inside a real TDX CVM
-(prod image), and a sandboxed process reaches the host op-loop socket via `--host-uds`. There are
-no remaining "is it possible" unknowns. **Next is implementation**: deploy the real
-`lit-api-server` to a dev Phala box and build the runner against it (phases above).
-
----
 
 ## Deployment topology on Phala
 
-### How Phala/dstack works
-A dstack **"app" = one CVM = one TDX VM** running **one `docker-compose`**. The compose file's
-`compose_hash` is what gets measured and attested — it *is* the app's identity. Multiple
-*containers* run inside that single VM; services are **never** split across VMs within an app.
-An app *can* be replicated to **N identical VMs** behind Phala's gateway for horizontal scale, but
-each VM runs the *whole* compose — so it's "1 app → N identical full-stack VMs," never "services
-sharded across VMs." To give a component its own VM/resources, it must be its **own app**.
+A dstack **"app" = one CVM = one TDX VM** running **one `docker-compose`** (the `compose_hash` is
+the attested identity). Containers never split across VMs within an app; horizontal scale = N
+identical full-stack VMs behind the gateway. Today it's one app / one VM with 4 containers
+(`lit-api-server`, `lit-actions`, `otel-collector`, `dstack-ingress`), where `lit-actions` and
+`lit-api-server` already share the `lit-socket` unix-socket volume.
 
-### Today
-One app, one VM (replicable), 4 containers in `docker-compose.phala.yml`:
-`lit-api-server` (Rocket :8000, holds keys, mounts `/var/run/dstack.sock`), `lit-actions`
-(JS runner, gRPC over the shared `lit-socket` volume), `otel-collector`, `dstack-ingress`
-(RA-TLS :443 → api-server). Note `lit-actions` and `lit-api-server` are already separate
-images/containers sharing the `lit-socket` unix-socket volume — that's the seam the new runner
-slots into.
+**Decision — ship the runner as a new container in the existing `docker-compose.phala.yml`**
+(same VM). It mounts the same `lit-socket` volume → uses the identical op-loop path; `runsc` runs
+nested inside that container (which needs enough privilege to create sandboxes — the spikes used
+`privileged` + `--host-uds`; scope down in production). Raw keys stay in the same attested VM, so
+there's zero new cross-VM trust plumbing.
 
-### Decision: Option A — new container in the existing compose (same VM)
-Start the gVisor runner as **another service in `docker-compose.phala.yml`**, in the same CVM:
+Graduate to its **own dstack app** (own VM) only when the runner needs dedicated resources or
+independent scaling — the cost is a secured RA-TLS CVM↔CVM channel for the op-loop plus its own
+attestation whitelisting.
 
-- New service (e.g. `lit-runner-gvisor`) mounts the same `lit-socket` volume → talks to
-  `lit-api-server` over the **identical op-loop path** the JS runner uses. Roughly "add a service
-  block."
-- `runsc` runs *inside* that container (nesting: CVM → container → gVisor sandbox). The container
-  needs the privileges exercised in the spikes (`privileged` / `SYS_ADMIN`-ish + the `--host-uds`
-  path); production should scope these down to the minimum that lets `runsc` create sandboxes.
-- **Shares the VM's attestation boundary and key-custody context** — raw keys stay inside the same
-  attested VM, so there is **zero new cross-VM trust plumbing**. Simplest and safest.
+**Operational note:** adding the service changes `compose_hash` → in production that's a governed
+change on the `DstackApp` contract on Base (plain redeploy on dev).
 
-**Graduate to Option B (its own dstack app / own VM) later** only when the runner needs dedicated
-resources, independent scaling/upgrade cadence, or a distinct trust profile. Cost of graduating: a
-secured CVM↔CVM channel (RA-TLS/mTLS between two attested apps) for the op-loop, plus its own
-attestation whitelisting. Raw-key custody still requires it to be a TEE, so a separate CVM is fine
-trust-wise — the cross-app channel is the new thing to secure.
+## Resource model, limits, and caching
 
-### Two operational flags
-1. **`compose_hash` changes are governed in production.** Adding the service changes the hash; in
-   prod the new hash + image must be whitelisted on the `DstackApp` contract on Base (governed
-   change, not a plain redeploy). On dev it's just a redeploy.
-2. **Resource contention** — see below.
+**gVisor is not a fixed-size VM** — the Sentry is a host process bounded by the cgroup the
+supervisor assigns:
+- **CPU** via `cpu.max` (fractional/burstable; `cpuset` to pin).
+- **RAM grows on demand up to a `memory.max` ceiling** — not pre-allocated like a microVM. So we're
+  **not** locked to a launch-time RAM size, and per-execution usage is meterable (`memory.peak`),
+  leaving the door open to usage-based pricing later. **v1 stays flat per-second.**
 
-### Resource limits for the new container
-Today the compose sets **no** per-service `cpus`/`mem_limit`, so a heavy action could starve
-`lit-api-server` (noisy neighbor) since they share one VM. dstack runs plain `docker compose`
-(not swarm), so use the **non-swarm** compose keys (the `deploy.resources` block is ignored
-outside swarm). Apply **two layers**:
+**Two layers of limits:**
+- **Container-level (compose):** `cpus` / `mem_limit` / `mem_reservation` / `pids_limit` on the
+  runner service, so it can't starve `lit-api-server` (use non-swarm compose keys; `deploy.resources`
+  is ignored outside swarm).
+- **Per-execution (supervisor):** each sandbox's delegated leaf cgroup + gVisor enforce
+  CPU/memory/pids/timeout, so one tenant can't starve another.
 
-- **Container-level cap (compose)** — bounds the runner's *total* footprint so `lit-api-server`
-  always has headroom. On the `lit-runner-gvisor` service set:
-  - `cpus:` — e.g. leave ≥1 vCPU reserved for api-server + ingress + otel; cap the runner at the
-    remainder.
-  - `mem_limit:` + `mem_reservation:` — hard ceiling + soft floor.
-  - `pids_limit:` — cap total processes (defense against fork bombs across sandboxes).
-- **Per-execution cap (supervisor)** — the runner supervisor gives *each* `runsc` sandbox its own
-  **delegated leaf cgroup** (the spike-1 fix) with per-execution CPU/memory/pids limits + timeout,
-  mirroring today's per-action 64 MB / 15-min budget. gVisor enforces the sandbox side; the leaf
-  cgroup enforces the host side.
+**Starting defaults** (current JS is 64 MB / 15-min; a whole runtime needs more): **1 vCPU
+(burstable), memory default ~256–512 MB / max ~2 GB, tmpfs ~512 MB–1 GB, timeout 15 min default /
+150 min max, plus a pids cap.** First-draft — confirm in the perf gate.
 
-Net: compose limits keep the *runner as a whole* from starving its VM-mates; the supervisor's
-per-sandbox cgroups keep one tenant's action from starving another. Revisit the compose split (→
-Option B) once perf data shows the shared VM is the bottleneck.
+**Caching** — cache the read-only pieces, fresh writable layer per run:
+- **Base image rootfs** — read-only, shared by all executions, baked into the CVM image.
+- **Artifact by content hash (CID)** — unpack a bundle once into a read-only layer keyed by CID;
+  same CID next call = cache hit (the any-language analog of the existing `ActionCodeCache`).
+- **Optional warm pool / checkpoint-restore** for near-instant clean starts (mirror `worker_pool.rs`).
+- **Clean state:** each execution gets a **fresh tmpfs upper layer + fresh namespaces** — nothing
+  persists between runs though the read-only layers are cached. **Never reuse a dirty sandbox across
+  tenants**; run each execution in its own fresh Sentry (or restore from a clean snapshot).
 
----
+## Resolved design decisions
 
-## Resolved design decisions (handoff)
+Grounded in how JS actions work today (file:line refs for the builder).
 
-All decided with the team (2026-07-01). Grounded in how JS actions work today (file:line refs).
+1. **Charging — same as JS.** Flat **$0.01/wall-clock-second** (`stripe.rs:33,774`), min 1s, via
+   the `UpdateResourceUsage` op flushed every 5s (`handle_ops.rs:9,155-199`, `execution.rs:215`).
+   The guest/supervisor emits the same usage ticks — no new billing code. **Do not bill cold boot:**
+   start the clock at *user-code start* (cold path is ~150–500 ms; hidden by the warm pool, and not
+   billed regardless).
+2. **Action identity — content hash, preserving the code-string path.** Permissions key on the
+   code's IPFS CID: `keccak256(ipfs_id)` (`parse_with_hash.rs:74-106`) →
+   `canUseWalletInAction(apiKeyHash, cidHash, wallet)` (`accounts/mod.rs:695-727`), and the action's
+   own key derives from the CID (`dstack/v1/mod.rs:14-20`). Most users don't pin to IPFS — they send
+   bytes and the server derives the CID. **The artifact is a content-addressed bundle** (tarball:
+   entrypoint + manifest declaring a supported base runtime); **the user sends bundle bytes inline,
+   the server hashes them to the CID** (no IPFS round-trip) for permissions + key derivation — same
+   security model as JS, fast dev iteration. A CID reference to a cached bundle is also allowed.
+   OCI images deferred.
+3. **Egress — bandwidth cap, no fetch-count quota.** The `DEFAULT_MAX_FETCH_COUNT = 50` quota
+   guarded the old MPC/many-node network against fan-out DDoS; on one TEE box that risk is gone.
+   Route egress through a **single proxied path** (keeps the venue-proxy feature + logging) and apply
+   a **bandwidth/rate limit** instead of a call count — since users pay per second, bandwidth × time
+   bounds abuse without an arbitrary cap. (User code holds the key and can exfiltrate via network —
+   identical to today's JS model; the author already holds the permission.)
+4. **Determinism — N/A.** Single TEE, no MPC/multi-node result comparison, so user code need not be
+   deterministic.
+5. **Job/response contract + termination.** Params in via the `lit` SDK/CLI; response out via a
+   preinstalled CLI, e.g. `lit set-response '<json>'` (forwards over the `SetResponse` op); logs via
+   `lit print`/stdout. **Termination = the entrypoint process exits** (serverless/CLI semantics) —
+   `set-response` only *records* the value; on exit we return the last-recorded response and tear
+   down the sandbox. Timeout/OOM are hard caps. No response set ⇒ empty response.
 
-### 1. Charging / payment — reuse JS pricing; no cold-start charge
-JS actions bill **flat $0.01 per wall-clock second** (`COST_LIT_ACTION_PER_SECOND_CENTS = 1`,
-`stripe.rs:33`; charge `stripe.rs:774`), **min 1s**, accumulated via `UpdateResourceUsage` and
-flushed every 5s (`handle_ops.rs:9,155-199`, `execution.rs:25-49,215`).
-- **✅ Reuse the exact same pricing + metering primitive.** Guest SDK / supervisor emits
-  `UpdateResourceUsage` ticks over the op-loop; the per-second Stripe path is unchanged. No new
-  billing code.
-- **✅ Do not charge for cold boot.** Start the billing clock at *user-code start*, not sandbox
-  provisioning. `execution_start` is set api-server-side before the stream (`execution.rs:215`) —
-  the runner must signal "user code started" so the clock reflects user time, not our cold start.
-- **Cold-boot estimate:** plain `runsc` sandbox start is ~**100–300 ms** (Sentry + gofer), plus the
-  in-sandbox runtime init (static Go/Rust binary ~single-digit ms; Python ~30–100 ms; Node
-  ~100 ms). So realistic cold path ~**150–500 ms**. **Mitigated to ~ms via a warm pool** (pre-booted
-  sandboxes, one-execution-each, mirroring `worker_pool.rs`) and/or gVisor checkpoint/restore
-  (tens of ms). Net: users shouldn't perceive cold start once pre-warming exists, and either way
-  they aren't billed for it.
-- Resource-tier pricing stays a **future hook**, not v1 (see resource model below).
+## Local development & docs (build alongside, or fast-follow on adoption)
 
-### 2 + 3. Action identity, artifact format, and the "code string" fast path — combined decision
-Authorization is keyed on the **content hash (IPFS CID) of the action code**: `ipfs_cid_to_u256 =
-keccak256(ipfs_id)` (`parse_with_hash.rs:74-106`) → on-chain `canUseWalletInAction(apiKeyHash,
-cidHash, walletAddress)` (`accounts/mod.rs:695-727`, cached `op_code_helpers/mod.rs:34-50`), and the
-action's own key derives from the CID (`get_lit_action_key("lit_action_{ipfs_id}")`,
-`dstack/v1/mod.rs:14-20`). **Key insight from the team:** most users don't actually pin to IPFS —
-they send a **code string**, and `lit-api-server` **derives the CID from the bytes server-side**.
-IPFS pinning is slow and painful during dev iteration, so we preserve the "send bytes, we hash"
-model.
-- **✅ Artifact = a content-addressed bundle** loaded into the preinstalled base image. The bundle
-  (tarball: entrypoint + a manifest declaring the base runtime from a supported set + any files) is
-  the "code".
-- **✅ Preserve the code-string fast path.** The user **sends the bundle bytes inline**; the server
-  **derives the CID by hashing the bytes** (no IPFS round-trip, no pinning) and uses that CID for
-  permissions + key derivation — identical security model to JS today. Optionally a user *may* pass
-  a CID reference to a previously-cached/pinned bundle (production reuse), mirroring today's "inline
-  code OR `ipfs_id`" choice. Dev iteration stays fast; identity stays a content hash.
-- **Defer OCI images** to a later phase (pull latency, registry trust, larger measured surface).
+The point of "any language" is broad adoption, so **the developer/agent experience is a
+first-class deliverable**, not an afterthought:
 
-### 4. Network egress — drop the fetch *count* quota; use a bandwidth cap instead
-The fetch-count quota (`DEFAULT_MAX_FETCH_COUNT = 50`, `handle_ops.rs:57-70`) exists for a threat
-that **no longer applies**: it guarded the old **MPC / many-node** network against a single action
-fanning out a DDoS across all nodes. Everything now runs on **one TEE box**, so that risk is gone.
-- **✅ Replace the per-call count quota with a bandwidth/rate limit.** Since users already pay
-  **per second of execution**, a bandwidth ceiling (bytes/sec) naturally bounds abuse: limited
-  bandwidth × billed seconds ≈ the same protection, without an arbitrary "50 fetches" cap that
-  confuses users. Implement as an egress rate limit on the sandbox's network path (tc/netem on the
-  proxied path, or gVisor netstack throttling). Keep the existing 10 MiB per-response cap
-  (`PROXIED_FETCH_MAX_BYTES`) if useful; drop the count.
-- **Egress path:** keep a **single proxied egress path** (for the venue-proxy feature + egress
-  logging + where the bandwidth cap is applied) rather than raw sandbox networking. No hard domain
-  allowlist (parity with today).
-- **Note (not a new risk):** user code holds the derived key and can make network calls, so it can
-  exfiltrate the key — **identical to today's JS model**; the action author already holds the
-  permission.
+- **Skillfile + docs so an agent can build these actions.** Ship a skill (and matching docs) that
+  teaches an AI agent to scaffold, write, and test a gVisor action end-to-end: the bundle/manifest
+  format, the `lit` CLI surface (`set-response`, `print`, `get-private-key`, `fetch`, …), the
+  params/auth_context contract, and a working example per supported language. Treat this as part of
+  "done," since most authors (human or agent) will start from it.
+- **Local dev via a mock `lit` CLI (future — build out as adoption grows).** Ship a local-mode `lit`
+  CLI/SDK with the **same interface** as the in-sandbox gRPC CLI, but which **derives all keys
+  locally from a locally-generated private key** instead of calling `lit-api-server` in a TEE. A
+  developer runs their action on their laptop (in a local `runsc`/container or even bare), gets
+  deterministic local keys/signatures, and iterates without deploying to Phala or spending real
+  balance. When they deploy, the identical CLI surface is backed by the real op-loop. This is the
+  single biggest DX unlock; we don't have to build it day one, but the interface should be designed
+  so the real CLI and the mock CLI are drop-in interchangeable from the start.
 
-### 5. Resource limits & timeouts — starting defaults (from current JS limits)
-Current JS limits (chain-config-driven via `ConfigKeys::LIT_ACTION_DEFAULT_*`, with `MAX_MAX_*`
-ceilings): **memory default 64 MB**; **timeout default 15 min, max 150 min** (`MAX_TIMEOUT_MS =
-DEFAULT_TIMEOUT_MS * 10`, `client/mod.rs:19-34`); **fetch count default 50** (being replaced, see
-#4); per-fetch 10 MiB / 30 s caps; **pool size 10**.
-- **✅ Pick starting numbers now, tune later.** Proposed runner v1 defaults (a whole OS/runtime
-  needs more than a 64 MB JS heap): **1 vCPU** (burstable), **memory default ~256–512 MB / max
-  ~2 GB**, **tmpfs disk ~512 MB–1 GB**, **timeout: reuse 15 min default / 150 min max**, plus a
-  **pids limit** (fork-bomb guard). Enforced by the supervisor's per-sandbox delegated cgroup.
-  Treat these as first-draft; confirm against real workloads in the perf gate.
+## Quality gates (before shipping)
 
-### 6. Determinism / multi-node consensus — ✅ N/A
-Confirmed with the team: everything runs in a **single TEE**, no MPC / multiple nodes / result
-comparison. **User code need not be deterministic.** No consensus constraint on the runtime.
-
-### 7. Guest job/response contract + termination — ✅ decided
-- **Params in:** the job (`js_params` + `auth_context` + `http_headers` + the bundle) is delivered
-  to the guest; the `lit` SDK/CLI (preinstalled in the base image) exposes them to user code.
-- **Response out:** the user calls a **preinstalled CLI**, e.g. `lit set-response '<json>'`, which
-  forwards the value over the op-loop `SetResponse` op. Logs via `lit print` / stdout.
-- **✅ Termination = the user's entrypoint process exits** (natural serverless/CLI semantics). No
-  explicit "I'm done" call: `set-response` just *records* the value; when the entrypoint (sandbox
-  PID 1) exits, gVisor tears down the whole sandbox (children included) and we return the
-  last-recorded response. Timeout and OOM are hard caps that also terminate. If they never call
-  `set-response`, the response is empty/null.
-
----
-
-## Resource allocation model (gVisor specifics)
-
-A gVisor sandbox is **not a fixed-size VM** — the Sentry is a host process constrained by the
-**cgroup** the supervisor assigns it. This is an advantage over a microVM for our billing:
-
-- **CPU:** set via the sandbox's cgroup (`cpu.max` quota — e.g. ~1 core, fractional or burstable;
-  `cpuset` to pin). Meterable as CPU-seconds if we ever want it.
-- **RAM grows on demand up to a ceiling.** gVisor allocates guest memory lazily as the workload
-  uses it — it is **not pre-allocated** the way Firecracker fixes RAM at boot. The supervisor sets a
-  cgroup **`memory.max` ceiling** (the tier max) for safety; actual usage floats up to it. So the
-  answer to "are we stuck with the RAM level at launch?" is **no** — usage is dynamic within the
-  ceiling.
-- **Charging for growth is therefore possible** (a gVisor-specific win): `memory.peak` / cgroup
-  accounting gives us per-execution memory usage, so a future tier/usage-based price can bill on
-  observed memory-seconds. **v1 stays flat per-second** (decision #1); we just make sure the
-  accounting is available so we're not blocked from usage pricing later.
-
-## Caching model
-
-Cache the expensive read-only pieces; give every execution a clean, ephemeral writable layer.
-
-- **Layer 1 — base image rootfs:** read-only lower layer with runtimes + `lit` CLI, shared by
-  **all** executions, always warm (baked into the CVM image).
-- **Layer 2 — artifact cache by content hash (CID):** unpack a bundle once into a read-only layer
-  keyed by its CID; a second call with the same CID is a cache hit — no re-upload/re-unpack. This is
-  the any-language analog of the existing `ActionCodeCache` / `ipfs_id` code cache.
-- **Layer 3 — warm sandbox pool** (optional): pre-booted `runsc` sandboxes ready to accept work
-  (mirror `worker_pool.rs`), and/or **checkpoint/restore** from a clean "runtime-loaded, pre-entry"
-  snapshot for near-instant clean starts.
-- **Clean state between runs (the key requirement):** each execution gets a **fresh `tmpfs` upper
-  layer** in the overlay + fresh PID/mount/net namespaces, so **nothing persists between runs** even
-  though Layers 1–2 are cached. Exactly the "cache the image, clean tmpfs each run" model.
-- **Security rule:** never reuse a *dirty* sandbox across executions/tenants — reuse the cached
-  read-only layers, but run each execution in its **own fresh sandbox instance** (fresh Sentry) or a
-  **restore-from-clean-snapshot**, so there is no memory or filesystem residue between tenants. (The
-  current JS pool already follows this: one execution per worker, then dropped.)
-
----
+- **Isolation review** — tenant-A→tenant-B key-theft threat model; validate the two-layer (Sentry +
+  CVM kernel) boundary for our config; review known `runsc` CVEs vs kernel `6.9.0-dstack`; scope
+  `--host-uds` to a per-sandbox socket, not a shared one.
+- **Perf / pre-warm** — warm-pool sizing, cold/warm start, a representative sign workload vs the
+  current Deno path; evaluate checkpoint/restore.
 
 ## Constraint note
 
-Per standing guidance: all Phala/TEE experimentation stays on the **dev environment /
-dev.litprotocol.com** only. Do not touch staging/prod CVMs for spikes.
+All Phala/TEE experimentation stays on the **dev environment / dev.litprotocol.com** only. Do not
+touch staging/prod CVMs.
 
-## Sources
-- Intel TDX — Linux Kernel docs (nested virt / TD Partitioning): https://docs.kernel.org/virt/kvm/x86/intel-tdx.html
-- gVisor architecture / platforms (ptrace, systrap, KVM): https://gvisor.dev/docs/architecture_guide/platforms/
-- Firecracker issue #1721 (KVM inside guest): https://github.com/firecracker-microvm/firecracker/issues/1721
-- Firecracker without KVM (why it can't, gVisor as the answer): https://blog.alexellis.io/how-to-run-firecracker-without-kvm-on-regular-cloud-vms/
-- Intel TDX for KVM mainlined in Linux 6.16 (Phoronix): https://www.phoronix.com/news/Intel-TDX-For-KVM-Linux-6.16
-- bhatti: https://github.com/sahil-shubham/bhatti
+## Reference
+- gVisor platforms (systrap/ptrace/kvm): https://gvisor.dev/docs/architecture_guide/platforms/

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -155,19 +155,83 @@ checkpoint/restore for fast resume (same warm/cold idea bhatti uses, minus the h
 
 ---
 
-## Spikes (priority order)
+## Spike 1 result — ✅ DONE (2026-07-01): gVisor runs inside a Phala TDX CVM
 
-| # | Spike | Answers | Cost |
-|---|-------|---------|------|
-| **1** | **Boot a `runsc` hello-world inside a dev Phala CVM.** gVisor's ptrace/systrap platform needs `PTRACE`/`seccomp` and possibly specific caps a locked-down guest might restrict. Confirm `runsc` runs at all. | Is the primary architecture viable inside TDX? Replaces the old "/dev/kvm?" spike. | small |
-| **2** | **Per-exec overlay rootfs + op-loop socket:** run a non-JS guest (Go/Python) in `runsc` that does one `getPrivateKey` + local sign + `setResponse` round-trip against a local api-server, over a mounted socket, with a per-exec tmpfs overlay. | Proves the language-agnostic ABI end-to-end + the FS isolation model. | medium |
-| **3** | **Sandbox escape / isolation review of gVisor inside TDX.** Threat-model tenant-A→tenant-B key theft; confirm the two-layer (Sentry + CVM kernel) argument holds for our config; check known `runsc` CVEs vs our kernel. | Is "tenant isolation inside the TEE" actually sufficient for raw-key custody? | medium |
-| **4** | **Pre-warm + perf:** warm-pool of `runsc` sandboxes (mirror `worker_pool.rs`); measure cold/warm start + a representative sign workload vs the current Deno path. | Latency/throughput acceptable? Checkpoint/restore needed? | medium |
-| **5** | **(Alt path) Per-execution TDX CVM:** measure Phala CVM provisioning/boot latency + cost for the max-isolation model. | Is per-exec-CVM ever worth it (high-value/long-running actions)? | small (external) |
+Deployed a throwaway `gvisor-spike` CVM (tdx.small, image `dstack-dev-0.5.9`, kernel
+`6.9.0-dstack`), downloaded `runsc release-20260622.0`, and booted sandboxes. **Result:**
 
-**Spikes 1 and 2 gate everything.** Spike 1 says whether `runsc` runs in the CVM at all; spike 2
-proves the any-language op-loop + per-exec FS. Image build, supervisor, guest SDKs, and examples
-all wait on those.
+- **systrap platform (modern default): WORKS.** **ptrace platform: WORKS.** Confirmed real
+  sandboxing, not passthrough — inside the sandbox `uname` reports `4.19.0-gvisor` (vs host
+  `6.9.0-dstack`) and dmesg shows gVisor's `Starting gVisor... / Synthesizing system calls...`
+  banner.
+- **kvm platform: N/A** — `/dev/kvm` absent (confirms TDX has no nested KVM, as predicted).
+- Kernel prerequisites all present: `tdx_guest` cpuinfo flag (real TDX), **user namespaces
+  enabled** (`user.max_user_namespaces = 7360`), **no yama `ptrace_scope`** restriction, no
+  seccomp on the host process.
+- **One real gotcha, now understood:** the first attempt failed for *all* platforms at the same
+  pre-platform step — `cgroup.subtree_control: device or resource busy`. This is the classic
+  cgroup-v2 "no internal processes" container-in-container issue (runsc tried to enable
+  controllers on a cgroup that already held PID 1), **not** a gVisor/kernel blocker. Fixed
+  instantly with `runsc --ignore-cgroups`. **Production implication:** the sandbox supervisor
+  must give each `runsc` sandbox a properly *delegated* leaf cgroup (or run with cgroup handling
+  disabled and enforce limits ourselves) — a solved problem, but a design item for the supervisor.
+- **Access pattern learned:** `phala deploy` auto-attaches `~/.ssh/id_*.pub` and picks a dev OS
+  image, so `phala ssh --cvm-id … -- 'docker exec <container> …'` gives a fast interactive loop —
+  no redeploy needed to iterate inside a running CVM.
+
+**Scratch compose:** `.context/spikes/docker-compose.gvisor-spike.yml`.
+
+---
+
+## Spike 2 result — ✅ DONE (2026-07-01): prod-image parity + host-UDS socket reachability
+
+Original "spike 2" was going to build a dummy op-loop server and prove a non-JS gRPC round-trip.
+**Dropped as redundant** — gRPC over a unix socket is the production path today, `lit-api-server`
+*is* the op-loop server, and protobuf has codegen for every language. The round-trip isn't in
+doubt. What *was* genuinely unverified were two cheap things, now both closed on a `gvisor-uds`
+CVM deployed on the **production** OS image (`dstack-0.5.9`, non-dev):
+
+- **Production-image parity: ✅.** gVisor boots identically on the prod image — sandbox reports
+  `4.19.0-gvisor`, host `6.9.0-dstack`, `tdx_guest` present. No dev-vs-prod kernel difference that
+  matters for us.
+- **Host-UDS gate (the one gVisor-specific wrinkle): ✅ understood.** By default a gVisor sandbox
+  **cannot** connect to a host unix domain socket — proven: without the flag, `socat` in the
+  sandbox got `connect(/tmp/op.sock): Connection refused`. Launch `runsc` with **`--host-uds=all`**
+  and it works — full round trip returned `PONG_FROM_HOST`. So the guest reaches the
+  `lit-api-server` socket iff the supervisor launches `runsc --host-uds=…` (or we expose the op-loop
+  over vsock/TCP instead). Known flag, not a research question.
+
+Scratch compose: `.context/spikes/docker-compose.gvisor-uds.yml`.
+
+**Both feasibility gates are now green.** No remaining "is it possible" unknowns — the rest is
+implementation. Remaining *research* items (isolation review, perf) are quality gates, not
+blockers, and move below.
+
+---
+
+## Feasibility: settled. What's left is implementation + quality gates.
+
+### Implementation phases (this is the actual work — not spikes)
+Deploy the **real `lit-api-server`** to a dev Phala box and build the runner against it:
+
+1. **Generalize the runner protocol.** Fork/rename the proto so the op-loop is language-neutral
+   (`ExecuteRequest` etc.); keep op semantics identical so api-server op-handlers are reused verbatim.
+2. **Sandbox supervisor** (replaces the Deno worker; mirror `worker_pool.rs`): launches `runsc`
+   per execution with `--host-uds`, a **delegated leaf cgroup** per sandbox (spike-1 fix), a
+   per-exec **overlay rootfs** (read-only base + tmpfs upper), and supervisor-level timeout/memory
+   enforcement.
+3. **Base sandbox image** with language runtimes + the preinstalled `lit` CLI/SDK.
+4. **Guest `lit` CLI/SDK**: receives the job (code + params + auth_context + headers), exposes the
+   ops to user code over the host-UDS op-loop socket.
+5. **Wire into `lit-api-server`** as a new runner target alongside the JS runner; examples in ≥2
+   non-JS languages (e.g. a Solana sign in Rust/Go/Python).
+
+### Quality gates (before shipping — not feasibility blockers)
+| Gate | Question |
+|---|---|
+| **Isolation review** | Threat-model tenant-A→tenant-B key theft; validate the two-layer (Sentry + CVM kernel) argument for our config; review known `runsc` CVEs vs kernel `6.9.0-dstack`; decide `--host-uds` scope (per-sandbox socket, not shared). |
+| **Perf / pre-warm** | Warm-pool of `runsc` sandboxes (mirror `worker_pool.rs`); measure cold/warm start + a representative sign workload vs the current Deno path; evaluate gVisor checkpoint/restore. |
+| **Alt path (optional)** | Per-execution TDX CVM for max-isolation/high-value workloads — measure Phala provisioning/boot latency + cost. |
 
 ---
 
@@ -181,10 +245,13 @@ no `/dev/kvm`, and runs any language.
 - **Firecracker was never the point** — *VM-grade tenant isolation without a hypervisor* was, and
   gVisor is the right tool inside a TEE.
 - **Per-execution TDX CVM** is the max-isolation alternative if gVisor's boundary proves
-  insufficient (spike 3) or for special high-value workloads — at the cost of seconds-scale boot.
+  insufficient (isolation review) or for special high-value workloads — at the cost of
+  seconds-scale boot.
 
-Do **spike 1 today**: it's the one thing that can kill the primary architecture, and it's a
-`runsc` hello-world in a dev CVM.
+**Feasibility is settled and green** — gVisor runs on systrap + ptrace inside a real TDX CVM
+(prod image), and a sandboxed process reaches the host op-loop socket via `--host-uds`. There are
+no remaining "is it possible" unknowns. **Next is implementation**: deploy the real
+`lit-api-server` to a dev Phala box and build the runner against it (phases above).
 
 ---
 

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -320,6 +320,87 @@ Option B) once perf data shows the shared VM is the bottleneck.
 
 ---
 
+## Open questions to resolve before/early in the build (with recommended defaults)
+
+Each has a recommended v1 answer so the builder gets decisions, not just questions. Grounded in
+how JS actions work today (file:line refs included).
+
+### 1. Charging / payment — mostly "same as JS", two real decisions
+Today JS actions bill **flat $0.01 per wall-clock second** (`COST_LIT_ACTION_PER_SECOND_CENTS = 1`,
+`stripe.rs:33`; charge in `stripe.rs:774`), **min 1s**, accumulated via the `UpdateResourceUsage`
+op and flushed to Stripe every 5s (`handle_ops.rs:9,155-199`, `execution.rs:25-49,215`). Fetch
+count is a **quota only, not billed** (`handle_ops.rs:57-70`; per-fetch charging is commented out
+at `stripe.rs:59`).
+- **Reuse the exact metering primitive.** The guest SDK / supervisor emits `UpdateResourceUsage`
+  ticks over the op-loop just like the JS runtime; the per-second Stripe path is unchanged. No new
+  billing code.
+- **Decision — don't bill cold start.** Start the billing clock at *user-code start*, not sandbox
+  boot. JS runs from a warm pool; a gVisor sandbox has real cold-start. `execution_start` is set
+  api-server-side before the stream (`execution.rs:215`) — ensure the clock reflects user code, or
+  users pay for our provisioning.
+- **Decision — resource tiers (defer, but design the hook now).** JS is flat-rate regardless of
+  its 64 MB cap. A sandbox may request far more memory/vCPU, which costs us more. **v1:** keep flat
+  per-second at a single default tier. **Leave room** for a tier multiplier (memory/vCPU) on the
+  per-second rate later — don't hard-code "flat forever".
+
+### 2. Action identity & PKP permissioning — MUST be preserved (highest-risk item)
+Authorization is keyed on the **IPFS CID of the action code**: `ipfs_cid_to_u256 =
+keccak256(ipfs_id)` (`parse_with_hash.rs:74-106`) → on-chain `canUseWalletInAction(apiKeyHash,
+cidHash, walletAddress)` (`accounts/mod.rs:695-727`, cached `op_code_helpers/mod.rs:34-50`). The
+action's *own* derived key also comes from the CID (`get_lit_action_key("lit_action_{ipfs_id}")`,
+`dstack/v1/mod.rs:14-20`) — same CID ⇒ same key, deterministically.
+- **Decision — content-address the any-language artifact and reuse this model unchanged.** The
+  runner artifact (bundle/image/binary — see #3) gets a content hash used as `ipfs_id`. Then
+  permissions *and* action-key derivation work with **zero changes**, and PKP permissions bind to
+  exact code exactly as today. If the builder skips this and uses a mutable identity, the whole
+  permission + key-derivation model breaks. This is the one thing not to improvise.
+
+### 3. Code/artifact delivery & format — the biggest genuinely-open design axis
+JS actions arrive as inline code or an IPFS CID. "Any language" needs a defined artifact format.
+Options: (a) **source bundle + manifest** declaring entrypoint + a supported base runtime we
+preinstall; (b) **static binary / tarball**; (c) **full OCI image** (most flexible, but pull time
++ supply-chain/attestation surface).
+- **v1 recommendation:** a **content-addressed bundle** (tarball) with a small manifest
+  (entrypoint + declared base runtime from a supported set), hashed → IPFS CID (feeds #2). Runs on
+  the preinstalled base image. **Defer OCI images** to a later phase (image pull latency, registry
+  trust, larger measured surface). Document this as a decision so the builder doesn't default to
+  "bring any container" and inherit the hard problems first.
+
+### 4. Network egress & fetch quota — needs an enforcement model
+JS `fetch()` is an **in-process `reqwest` call** inside the runner, and quota is enforced only
+because the JS wrapper *cooperatively* calls `op_increment_fetch_count` before each fetch
+(`bindings.rs:95-102,407-459`; quota check `handle_ops.rs:57-70`). There is **no hard egress
+allowlist** — the proxy is optional/per-request. A sandbox running arbitrary code **won't
+cooperate**: it can open raw sockets and bypass the counter entirely.
+- **Decision — proxy-only egress.** Give the sandbox **no direct network**; route all HTTP through
+  a **lit proxy exposed over the op-loop** (the guest `lit` SDK provides `fetch`). Then the fetch
+  counter/quota is enforced by construction (there's no other path out), we keep the existing
+  venue-proxy feature, and we get egress logging. gVisor's netstack makes "no direct egress, one
+  proxied path" straightforward.
+- **Note (not a new risk):** user code holds the derived key *and* can fetch, so it can exfiltrate
+  the key — but that's **identical to today's JS model** (a JS action with `getPrivateKey` + fetch
+  can already do this), and the action is authored by the party who already holds the permission.
+  Proxy-only egress at least gives us logging/rate-limiting we don't fully have today.
+
+### 5. Resource limits & timeouts — define defaults + maxes
+JS defaults: **64 MB heap, 15-min timeout**. Sandboxes will be larger. Define the runner's
+**default and max** memory / vCPU / disk / timeout / pids, enforced by the supervisor's per-sandbox
+delegated cgroup (see "Resource limits" above). Tie the chosen tier to #1's pricing hook.
+
+### 6. Determinism / multi-node consensus — confirm N/A
+The classic Lit network runs actions on many nodes and compares results for signing consensus.
+This TEE single-server model (`lit-api-server` in one attested CVM) does **not** appear to do
+multi-node result comparison — so user code need **not** be deterministic. **Confirm** with the
+team before building; if wrong, it constrains the whole runtime.
+
+### 7. Guest job/response contract — mirror `main(params)` → `setResponse`
+Define how the job reaches the guest (code + `js_params` + `auth_context` + `http_headers`) and how
+the result returns (the `SetResponse` op). Keep semantics identical to JS: params in, one response
+out, `print` for logs. For arbitrary languages the `lit` SDK exposes this (e.g. read params from a
+known path/env; `lit set-response …`).
+
+---
+
 ## Constraint note
 
 Per standing guidance: all Phala/TEE experimentation stays on the **dev environment /

--- a/plans/microvm-action-runner.md
+++ b/plans/microvm-action-runner.md
@@ -320,84 +320,128 @@ Option B) once perf data shows the shared VM is the bottleneck.
 
 ---
 
-## Open questions to resolve before/early in the build (with recommended defaults)
+## Resolved design decisions (handoff)
 
-Each has a recommended v1 answer so the builder gets decisions, not just questions. Grounded in
-how JS actions work today (file:line refs included).
+All decided with the team (2026-07-01). Grounded in how JS actions work today (file:line refs).
 
-### 1. Charging / payment — mostly "same as JS", two real decisions
-Today JS actions bill **flat $0.01 per wall-clock second** (`COST_LIT_ACTION_PER_SECOND_CENTS = 1`,
-`stripe.rs:33`; charge in `stripe.rs:774`), **min 1s**, accumulated via the `UpdateResourceUsage`
-op and flushed to Stripe every 5s (`handle_ops.rs:9,155-199`, `execution.rs:25-49,215`). Fetch
-count is a **quota only, not billed** (`handle_ops.rs:57-70`; per-fetch charging is commented out
-at `stripe.rs:59`).
-- **Reuse the exact metering primitive.** The guest SDK / supervisor emits `UpdateResourceUsage`
-  ticks over the op-loop just like the JS runtime; the per-second Stripe path is unchanged. No new
+### 1. Charging / payment — reuse JS pricing; no cold-start charge
+JS actions bill **flat $0.01 per wall-clock second** (`COST_LIT_ACTION_PER_SECOND_CENTS = 1`,
+`stripe.rs:33`; charge `stripe.rs:774`), **min 1s**, accumulated via `UpdateResourceUsage` and
+flushed every 5s (`handle_ops.rs:9,155-199`, `execution.rs:25-49,215`).
+- **✅ Reuse the exact same pricing + metering primitive.** Guest SDK / supervisor emits
+  `UpdateResourceUsage` ticks over the op-loop; the per-second Stripe path is unchanged. No new
   billing code.
-- **Decision — don't bill cold start.** Start the billing clock at *user-code start*, not sandbox
-  boot. JS runs from a warm pool; a gVisor sandbox has real cold-start. `execution_start` is set
-  api-server-side before the stream (`execution.rs:215`) — ensure the clock reflects user code, or
-  users pay for our provisioning.
-- **Decision — resource tiers (defer, but design the hook now).** JS is flat-rate regardless of
-  its 64 MB cap. A sandbox may request far more memory/vCPU, which costs us more. **v1:** keep flat
-  per-second at a single default tier. **Leave room** for a tier multiplier (memory/vCPU) on the
-  per-second rate later — don't hard-code "flat forever".
+- **✅ Do not charge for cold boot.** Start the billing clock at *user-code start*, not sandbox
+  provisioning. `execution_start` is set api-server-side before the stream (`execution.rs:215`) —
+  the runner must signal "user code started" so the clock reflects user time, not our cold start.
+- **Cold-boot estimate:** plain `runsc` sandbox start is ~**100–300 ms** (Sentry + gofer), plus the
+  in-sandbox runtime init (static Go/Rust binary ~single-digit ms; Python ~30–100 ms; Node
+  ~100 ms). So realistic cold path ~**150–500 ms**. **Mitigated to ~ms via a warm pool** (pre-booted
+  sandboxes, one-execution-each, mirroring `worker_pool.rs`) and/or gVisor checkpoint/restore
+  (tens of ms). Net: users shouldn't perceive cold start once pre-warming exists, and either way
+  they aren't billed for it.
+- Resource-tier pricing stays a **future hook**, not v1 (see resource model below).
 
-### 2. Action identity & PKP permissioning — MUST be preserved (highest-risk item)
-Authorization is keyed on the **IPFS CID of the action code**: `ipfs_cid_to_u256 =
+### 2 + 3. Action identity, artifact format, and the "code string" fast path — combined decision
+Authorization is keyed on the **content hash (IPFS CID) of the action code**: `ipfs_cid_to_u256 =
 keccak256(ipfs_id)` (`parse_with_hash.rs:74-106`) → on-chain `canUseWalletInAction(apiKeyHash,
-cidHash, walletAddress)` (`accounts/mod.rs:695-727`, cached `op_code_helpers/mod.rs:34-50`). The
-action's *own* derived key also comes from the CID (`get_lit_action_key("lit_action_{ipfs_id}")`,
-`dstack/v1/mod.rs:14-20`) — same CID ⇒ same key, deterministically.
-- **Decision — content-address the any-language artifact and reuse this model unchanged.** The
-  runner artifact (bundle/image/binary — see #3) gets a content hash used as `ipfs_id`. Then
-  permissions *and* action-key derivation work with **zero changes**, and PKP permissions bind to
-  exact code exactly as today. If the builder skips this and uses a mutable identity, the whole
-  permission + key-derivation model breaks. This is the one thing not to improvise.
+cidHash, walletAddress)` (`accounts/mod.rs:695-727`, cached `op_code_helpers/mod.rs:34-50`), and the
+action's own key derives from the CID (`get_lit_action_key("lit_action_{ipfs_id}")`,
+`dstack/v1/mod.rs:14-20`). **Key insight from the team:** most users don't actually pin to IPFS —
+they send a **code string**, and `lit-api-server` **derives the CID from the bytes server-side**.
+IPFS pinning is slow and painful during dev iteration, so we preserve the "send bytes, we hash"
+model.
+- **✅ Artifact = a content-addressed bundle** loaded into the preinstalled base image. The bundle
+  (tarball: entrypoint + a manifest declaring the base runtime from a supported set + any files) is
+  the "code".
+- **✅ Preserve the code-string fast path.** The user **sends the bundle bytes inline**; the server
+  **derives the CID by hashing the bytes** (no IPFS round-trip, no pinning) and uses that CID for
+  permissions + key derivation — identical security model to JS today. Optionally a user *may* pass
+  a CID reference to a previously-cached/pinned bundle (production reuse), mirroring today's "inline
+  code OR `ipfs_id`" choice. Dev iteration stays fast; identity stays a content hash.
+- **Defer OCI images** to a later phase (pull latency, registry trust, larger measured surface).
 
-### 3. Code/artifact delivery & format — the biggest genuinely-open design axis
-JS actions arrive as inline code or an IPFS CID. "Any language" needs a defined artifact format.
-Options: (a) **source bundle + manifest** declaring entrypoint + a supported base runtime we
-preinstall; (b) **static binary / tarball**; (c) **full OCI image** (most flexible, but pull time
-+ supply-chain/attestation surface).
-- **v1 recommendation:** a **content-addressed bundle** (tarball) with a small manifest
-  (entrypoint + declared base runtime from a supported set), hashed → IPFS CID (feeds #2). Runs on
-  the preinstalled base image. **Defer OCI images** to a later phase (image pull latency, registry
-  trust, larger measured surface). Document this as a decision so the builder doesn't default to
-  "bring any container" and inherit the hard problems first.
+### 4. Network egress — drop the fetch *count* quota; use a bandwidth cap instead
+The fetch-count quota (`DEFAULT_MAX_FETCH_COUNT = 50`, `handle_ops.rs:57-70`) exists for a threat
+that **no longer applies**: it guarded the old **MPC / many-node** network against a single action
+fanning out a DDoS across all nodes. Everything now runs on **one TEE box**, so that risk is gone.
+- **✅ Replace the per-call count quota with a bandwidth/rate limit.** Since users already pay
+  **per second of execution**, a bandwidth ceiling (bytes/sec) naturally bounds abuse: limited
+  bandwidth × billed seconds ≈ the same protection, without an arbitrary "50 fetches" cap that
+  confuses users. Implement as an egress rate limit on the sandbox's network path (tc/netem on the
+  proxied path, or gVisor netstack throttling). Keep the existing 10 MiB per-response cap
+  (`PROXIED_FETCH_MAX_BYTES`) if useful; drop the count.
+- **Egress path:** keep a **single proxied egress path** (for the venue-proxy feature + egress
+  logging + where the bandwidth cap is applied) rather than raw sandbox networking. No hard domain
+  allowlist (parity with today).
+- **Note (not a new risk):** user code holds the derived key and can make network calls, so it can
+  exfiltrate the key — **identical to today's JS model**; the action author already holds the
+  permission.
 
-### 4. Network egress & fetch quota — needs an enforcement model
-JS `fetch()` is an **in-process `reqwest` call** inside the runner, and quota is enforced only
-because the JS wrapper *cooperatively* calls `op_increment_fetch_count` before each fetch
-(`bindings.rs:95-102,407-459`; quota check `handle_ops.rs:57-70`). There is **no hard egress
-allowlist** — the proxy is optional/per-request. A sandbox running arbitrary code **won't
-cooperate**: it can open raw sockets and bypass the counter entirely.
-- **Decision — proxy-only egress.** Give the sandbox **no direct network**; route all HTTP through
-  a **lit proxy exposed over the op-loop** (the guest `lit` SDK provides `fetch`). Then the fetch
-  counter/quota is enforced by construction (there's no other path out), we keep the existing
-  venue-proxy feature, and we get egress logging. gVisor's netstack makes "no direct egress, one
-  proxied path" straightforward.
-- **Note (not a new risk):** user code holds the derived key *and* can fetch, so it can exfiltrate
-  the key — but that's **identical to today's JS model** (a JS action with `getPrivateKey` + fetch
-  can already do this), and the action is authored by the party who already holds the permission.
-  Proxy-only egress at least gives us logging/rate-limiting we don't fully have today.
+### 5. Resource limits & timeouts — starting defaults (from current JS limits)
+Current JS limits (chain-config-driven via `ConfigKeys::LIT_ACTION_DEFAULT_*`, with `MAX_MAX_*`
+ceilings): **memory default 64 MB**; **timeout default 15 min, max 150 min** (`MAX_TIMEOUT_MS =
+DEFAULT_TIMEOUT_MS * 10`, `client/mod.rs:19-34`); **fetch count default 50** (being replaced, see
+#4); per-fetch 10 MiB / 30 s caps; **pool size 10**.
+- **✅ Pick starting numbers now, tune later.** Proposed runner v1 defaults (a whole OS/runtime
+  needs more than a 64 MB JS heap): **1 vCPU** (burstable), **memory default ~256–512 MB / max
+  ~2 GB**, **tmpfs disk ~512 MB–1 GB**, **timeout: reuse 15 min default / 150 min max**, plus a
+  **pids limit** (fork-bomb guard). Enforced by the supervisor's per-sandbox delegated cgroup.
+  Treat these as first-draft; confirm against real workloads in the perf gate.
 
-### 5. Resource limits & timeouts — define defaults + maxes
-JS defaults: **64 MB heap, 15-min timeout**. Sandboxes will be larger. Define the runner's
-**default and max** memory / vCPU / disk / timeout / pids, enforced by the supervisor's per-sandbox
-delegated cgroup (see "Resource limits" above). Tie the chosen tier to #1's pricing hook.
+### 6. Determinism / multi-node consensus — ✅ N/A
+Confirmed with the team: everything runs in a **single TEE**, no MPC / multiple nodes / result
+comparison. **User code need not be deterministic.** No consensus constraint on the runtime.
 
-### 6. Determinism / multi-node consensus — confirm N/A
-The classic Lit network runs actions on many nodes and compares results for signing consensus.
-This TEE single-server model (`lit-api-server` in one attested CVM) does **not** appear to do
-multi-node result comparison — so user code need **not** be deterministic. **Confirm** with the
-team before building; if wrong, it constrains the whole runtime.
+### 7. Guest job/response contract + termination — ✅ decided
+- **Params in:** the job (`js_params` + `auth_context` + `http_headers` + the bundle) is delivered
+  to the guest; the `lit` SDK/CLI (preinstalled in the base image) exposes them to user code.
+- **Response out:** the user calls a **preinstalled CLI**, e.g. `lit set-response '<json>'`, which
+  forwards the value over the op-loop `SetResponse` op. Logs via `lit print` / stdout.
+- **✅ Termination = the user's entrypoint process exits** (natural serverless/CLI semantics). No
+  explicit "I'm done" call: `set-response` just *records* the value; when the entrypoint (sandbox
+  PID 1) exits, gVisor tears down the whole sandbox (children included) and we return the
+  last-recorded response. Timeout and OOM are hard caps that also terminate. If they never call
+  `set-response`, the response is empty/null.
 
-### 7. Guest job/response contract — mirror `main(params)` → `setResponse`
-Define how the job reaches the guest (code + `js_params` + `auth_context` + `http_headers`) and how
-the result returns (the `SetResponse` op). Keep semantics identical to JS: params in, one response
-out, `print` for logs. For arbitrary languages the `lit` SDK exposes this (e.g. read params from a
-known path/env; `lit set-response …`).
+---
+
+## Resource allocation model (gVisor specifics)
+
+A gVisor sandbox is **not a fixed-size VM** — the Sentry is a host process constrained by the
+**cgroup** the supervisor assigns it. This is an advantage over a microVM for our billing:
+
+- **CPU:** set via the sandbox's cgroup (`cpu.max` quota — e.g. ~1 core, fractional or burstable;
+  `cpuset` to pin). Meterable as CPU-seconds if we ever want it.
+- **RAM grows on demand up to a ceiling.** gVisor allocates guest memory lazily as the workload
+  uses it — it is **not pre-allocated** the way Firecracker fixes RAM at boot. The supervisor sets a
+  cgroup **`memory.max` ceiling** (the tier max) for safety; actual usage floats up to it. So the
+  answer to "are we stuck with the RAM level at launch?" is **no** — usage is dynamic within the
+  ceiling.
+- **Charging for growth is therefore possible** (a gVisor-specific win): `memory.peak` / cgroup
+  accounting gives us per-execution memory usage, so a future tier/usage-based price can bill on
+  observed memory-seconds. **v1 stays flat per-second** (decision #1); we just make sure the
+  accounting is available so we're not blocked from usage pricing later.
+
+## Caching model
+
+Cache the expensive read-only pieces; give every execution a clean, ephemeral writable layer.
+
+- **Layer 1 — base image rootfs:** read-only lower layer with runtimes + `lit` CLI, shared by
+  **all** executions, always warm (baked into the CVM image).
+- **Layer 2 — artifact cache by content hash (CID):** unpack a bundle once into a read-only layer
+  keyed by its CID; a second call with the same CID is a cache hit — no re-upload/re-unpack. This is
+  the any-language analog of the existing `ActionCodeCache` / `ipfs_id` code cache.
+- **Layer 3 — warm sandbox pool** (optional): pre-booted `runsc` sandboxes ready to accept work
+  (mirror `worker_pool.rs`), and/or **checkpoint/restore** from a clean "runtime-loaded, pre-entry"
+  snapshot for near-instant clean starts.
+- **Clean state between runs (the key requirement):** each execution gets a **fresh `tmpfs` upper
+  layer** in the overlay + fresh PID/mount/net namespaces, so **nothing persists between runs** even
+  though Layers 1–2 are cached. Exactly the "cache the image, clean tmpfs each run" model.
+- **Security rule:** never reuse a *dirty* sandbox across executions/tenants — reuse the cached
+  read-only layers, but run each execution in its **own fresh sandbox instance** (fresh Sentry) or a
+  **restore-from-clean-snapshot**, so there is no memory or filesystem residue between tenants. (The
+  current JS pool already follows this: one execution per worker, then dropped.)
 
 ---
 


### PR DESCRIPTION
Adds a design plan (`plans/microvm-action-runner.md`) for running Lit Actions in any programming language, not just JS. It rules out Firecracker/bhatti microVMs — TDX guests have no nested `/dev/kvm`, and since the bring-your-own-crypto paradigm requires the runner to hold raw derived keys, the runner can't live outside the TEE either. It lands on gVisor (`runsc`) sandboxes running inside the Phala TDX CVM, one per execution with its own overlay rootfs, all speaking the existing gRPC op-loop via a preinstalled `lit` CLI/SDK. The plan also captures per-execution TDX CVMs as a max-isolation alternative and a prioritized spike list starting with booting `runsc` inside a dev CVM. Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)