### PR TITLE
feat(lit-actions): Claude-in-startup-script example on the base rootfs (CPL-356)

### DIFF
--- a/lit-actions/gvisor-server/README.md
+++ b/lit-actions/gvisor-server/README.md
@@ -188,8 +188,9 @@ cargo test -p lit-actions-gvisor-server
 ```
 
 `image/` has the base-image Dockerfile; `examples/` has bundle examples —
-`shell`/`python` are minimal, and `claude` installs Claude Code from its
-`startup.sh` onto the base rootfs (debian:bookworm-slim) and runs a headless
+`shell`/`python` are minimal, and `claude` executes the official Claude
+Code installer script (`https://claude.ai/install.sh`) from its `startup.sh`
+onto the base rootfs (debian:bookworm-slim) and runs a headless
 prompt, demonstrating a startup script that provisions its own toolchain
 (needs sandbox network egress + an `ANTHROPIC_API_KEY` js-param).
 

--- a/lit-actions/gvisor-server/README.md
+++ b/lit-actions/gvisor-server/README.md
@@ -187,7 +187,11 @@ anywhere (macOS included):
 cargo test -p lit-actions-gvisor-server
 ```
 
-`image/` has the base-image Dockerfile; `examples/` has bundle examples.
+`image/` has the base-image Dockerfile; `examples/` has bundle examples —
+`shell`/`python` are minimal, and `claude` installs Claude Code from its
+`startup.sh` onto the base rootfs (debian:bookworm-slim) and runs a headless
+prompt, demonstrating a startup script that provisions its own toolchain
+(needs sandbox network egress + an `ANTHROPIC_API_KEY` js-param).
 
 ## v1 non-goals / follow-ups
 

--- a/lit-actions/gvisor-server/examples/claude/startup.sh
+++ b/lit-actions/gvisor-server/examples/claude/startup.sh
@@ -15,7 +15,10 @@
 set -euo pipefail
 
 lit print "installing Claude Code on $(. /etc/os-release && echo "$PRETTY_NAME")"
-curl -fsSL https://claude.ai/install.sh | bash
+INSTALLER="$(mktemp)"
+curl -fsSL https://claude.ai/install.sh -o "$INSTALLER"
+bash "$INSTALLER"
+rm -f "$INSTALLER"
 export PATH="$HOME/.local/bin:$PATH"
 
 VERSION="$(claude --version)"

--- a/lit-actions/gvisor-server/examples/claude/startup.sh
+++ b/lit-actions/gvisor-server/examples/claude/startup.sh
@@ -1,0 +1,37 @@
+# Install and run Claude Code inside a Lit binary action.
+#
+# The sandbox base rootfs ("Slimworm" = debian:bookworm-slim, see
+# ../../image/Dockerfile.rootfs) ships curl + ca-certificates but no Node, so
+# we use Claude Code's native installer — it drops a standalone binary under
+# ~/.local/bin. The sandbox only ever runs `bash startup.sh`; installing and
+# launching Claude is this script's job.
+#
+# Top-level js-params arrive as environment variables (CPL-355):
+#   ANTHROPIC_API_KEY  — Claude API key (optional; install-only run without it)
+#   PROMPT             — the prompt to run headlessly (optional)
+#
+# Requires sandbox network egress to claude.ai (install) and, when a key is
+# supplied, api.anthropic.com (the prompt).
+set -euo pipefail
+
+lit print "installing Claude Code on $(. /etc/os-release && echo "$PRETTY_NAME")"
+curl -fsSL https://claude.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+
+VERSION="$(claude --version)"
+lit print "installed Claude Code: $VERSION"
+
+# No key ⇒ prove the install worked and stop (exit 0 returns success).
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  lit print "no ANTHROPIC_API_KEY param — install-only run"
+  lit set-response "$(jq -n --arg v "$VERSION" '{installed: true, version: $v}')"
+  exit 0
+fi
+
+# Headless run: `-p` prints the reply and exits. Meter the outbound call the
+# same way any action fetch is metered.
+lit increment-fetch-count >/dev/null
+REPLY="$(claude -p "${PROMPT:-Say hello from a Lit binary action in one sentence.}")"
+
+lit print "claude replied: $REPLY"
+lit set-response "$(jq -n --arg v "$VERSION" --arg r "$REPLY" '{ok: true, version: $v, reply: $r}')"

--- a/lit-actions/local-cli/README.md
+++ b/lit-actions/local-cli/README.md
@@ -85,10 +85,12 @@ other.sh` — the local analog of the `startup_script` field on
 Serverless semantics: the run ends when the startup script exits; a non-zero
 exit is propagated as this process's exit code.
 
-See `examples/shell` and `examples/python` — bundles adapted from the
-gvisor-server examples (they exercise a few more ops for demonstration). The
-bundle layout and `lit` calls are identical, so the same bundle shape runs
-in both places.
+See `examples/shell`, `examples/python`, and `examples/claude` — bundles
+adapted from the gvisor-server examples (they exercise a few more ops for
+demonstration). The bundle layout and `lit` calls are identical, so the same
+bundle shape runs in both places. `examples/claude` installs Claude Code from
+its startup script and runs a headless prompt (needs `curl`/`jq`, network, and
+an `ANTHROPIC_API_KEY` js-param); run locally it installs onto your machine.
 
 ## Command surface
 

--- a/lit-actions/local-cli/README.md
+++ b/lit-actions/local-cli/README.md
@@ -88,9 +88,9 @@ exit is propagated as this process's exit code.
 See `examples/shell`, `examples/python`, and `examples/claude` — bundles
 adapted from the gvisor-server examples (they exercise a few more ops for
 demonstration). The bundle layout and `lit` calls are identical, so the same
-bundle shape runs in both places. `examples/claude` installs Claude Code from
-its startup script and runs a headless prompt (needs `curl`/`jq`, network, and
-an `ANTHROPIC_API_KEY` js-param); run locally it installs onto your machine.
+bundle shape runs in both places. `examples/claude` executes the official
+Claude Code installer script (`https://claude.ai/install.sh`) before running
+a headless prompt (needs `curl`/`jq`, network, and an `ANTHROPIC_API_KEY` js-param); run locally it installs onto your machine.
 
 ## Command surface
 

--- a/lit-actions/local-cli/examples/claude/startup.sh
+++ b/lit-actions/local-cli/examples/claude/startup.sh
@@ -1,0 +1,36 @@
+# Install and run Claude Code inside a Lit binary action.
+#
+# `lit run` executes exactly what the sandbox executes — `bash startup.sh` —
+# so this is the same bundle you'd ship to the TEE. In the sandbox the base
+# rootfs is "Slimworm" (debian:bookworm-slim) with curl but no Node; the
+# native installer drops a standalone binary under ~/.local/bin either way.
+#
+# NOTE: run locally, this really installs Claude Code onto *your* machine
+# (~/.local/bin) and, with a key set, calls api.anthropic.com.
+#
+# Top-level js-params arrive as environment variables (CPL-355):
+#   ANTHROPIC_API_KEY  — Claude API key (optional; install-only run without it)
+#   PROMPT             — the prompt to run headlessly (optional)
+set -euo pipefail
+
+lit print "installing Claude Code on $(uname -sm)"
+curl -fsSL https://claude.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+
+VERSION="$(claude --version)"
+lit print "installed Claude Code: $VERSION"
+
+# No key ⇒ prove the install worked and stop (exit 0 returns success).
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  lit print "no ANTHROPIC_API_KEY param — install-only run"
+  lit set-response "$(jq -n --arg v "$VERSION" '{installed: true, version: $v}')"
+  exit 0
+fi
+
+# Headless run: `-p` prints the reply and exits. Meter the outbound call the
+# same way any action fetch is metered.
+lit increment-fetch-count >/dev/null
+REPLY="$(claude -p "${PROMPT:-Say hello from a Lit binary action in one sentence.}")"
+
+lit print "claude replied: $REPLY"
+lit set-response "$(jq -n --arg v "$VERSION" --arg r "$REPLY" '{ok: true, version: $v, reply: $r}')"

--- a/lit-actions/local-cli/examples/claude/startup.sh
+++ b/lit-actions/local-cli/examples/claude/startup.sh
@@ -14,7 +14,10 @@
 set -euo pipefail
 
 lit print "installing Claude Code on $(uname -sm)"
-curl -fsSL https://claude.ai/install.sh | bash
+INSTALLER="$(mktemp)"
+curl -fsSL https://claude.ai/install.sh -o "$INSTALLER"
+bash "$INSTALLER"
+rm -f "$INSTALLER"
 export PATH="$HOME/.local/bin:$PATH"
 
 VERSION="$(claude --version)"


### PR DESCRIPTION
Adds a `claude` example bundle to both the gVisor runner and the local CLI, demonstrating PR #571's startup-script contract (the sandbox only runs `bash startup.sh`, so the script provisions its own toolchain). The `startup.sh` installs Claude Code onto the "Slimworm" base rootfs (debian:bookworm-slim, which has `curl` but no Node) via the native installer, then — when an `ANTHROPIC_API_KEY` top-level js-param is present — runs a headless `claude -p` prompt and records the reply with `lit set-response` (metering the call via `lit increment-fetch-count`); with no key it does an install-only run returning the version. The two `startup.sh` copies are near-identical (the local one warns it installs onto your machine and uses `uname -sm`), and both crate READMEs now list the example plus its network + API-key requirements. No test harness enumerates `examples/`, so this is never auto-executed in CI (it hits the network + installer).

**Base branch note:** this is stacked on the CPL-355 startup-script contract, so it targets `feature/cpl-355-startup-script-for-gvisor` (PR #571) rather than `main` — retarget to `main` once #571 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)