### PR TITLE
fix(deploy): wire DOCKER_IMAGE_LIT_ACTIONS_GVISOR through the deploy path

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -101,8 +101,8 @@ jobs:
           # with deploy-staging.yml's DEPLOY_PATHS (minus the staging-only entries:
           # the workflow files and k6/, which don't affect prod image content).
           IMAGE_PATHS=(lit-actions/ lit-api-server/ lit-billing-core/ lit-core/ \
-            otel-collector/ Dockerfile.lit-actions Dockerfile.lit-api-server \
-            Dockerfile.otel-collector docker-compose.phala.yml)
+            otel-collector/ Dockerfile.lit-actions Dockerfile.lit-actions-gvisor \
+            Dockerfile.lit-api-server Dockerfile.otel-collector docker-compose.phala.yml)
 
           # 1. Most recent first-parent ancestor carrying a perf-gate/soak status.
           gated=""; state=""

--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -173,6 +173,8 @@ jobs:
         include:
           - service: lit-actions
             dockerfile: Dockerfile.lit-actions
+          - service: lit-actions-gvisor
+            dockerfile: Dockerfile.lit-actions-gvisor
           - service: lit-api-server
             dockerfile: Dockerfile.lit-api-server
           - service: otel-collector
@@ -244,11 +246,13 @@ jobs:
       - name: Prepare docker-compose for deployment (digest-pinned)
         run: |
           DIGEST_LIT_ACTIONS=$(cat digest-lit-actions.txt | tr -d '\n' | sed 's/}[}]*$//')
+          DIGEST_LIT_ACTIONS_GVISOR=$(cat digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_LIT_API_SERVER=$(cat digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_OTEL_COLLECTOR=$(cat digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
           DOMAIN="api.chipotle.litprotocol.com"
           sed \
             -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|${{ vars.DOCKER_IMAGE }}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+            -e "s|\${DOCKER_IMAGE_LIT_ACTIONS_GVISOR}|${{ vars.DOCKER_IMAGE }}-lit-actions-gvisor@${DIGEST_LIT_ACTIONS_GVISOR}|g" \
             -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|chipotle-prod|g" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -280,6 +280,7 @@ jobs:
             lit-core/
             otel-collector/
             Dockerfile.lit-actions
+            Dockerfile.lit-actions-gvisor
             Dockerfile.lit-api-server
             Dockerfile.otel-collector
             docker-compose.phala.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -311,6 +311,8 @@ jobs:
         include:
           - service: lit-actions
             dockerfile: Dockerfile.lit-actions
+          - service: lit-actions-gvisor
+            dockerfile: Dockerfile.lit-actions-gvisor
           - service: lit-api-server
             dockerfile: Dockerfile.lit-api-server
           - service: otel-collector
@@ -377,11 +379,13 @@ jobs:
       - name: Prepare docker-compose for deployment (digest-pinned)
         run: |
           DIGEST_LIT_ACTIONS=$(cat digest-lit-actions.txt | tr -d '\n' | sed 's/}[}]*$//')
+          DIGEST_LIT_ACTIONS_GVISOR=$(cat digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_LIT_API_SERVER=$(cat digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
           DIGEST_OTEL_COLLECTOR=$(cat digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
           DOMAIN="${{ needs.determine-target.outputs.domain }}"
           sed \
             -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|${{ vars.DOCKER_IMAGE }}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+            -e "s|\${DOCKER_IMAGE_LIT_ACTIONS_GVISOR}|${{ vars.DOCKER_IMAGE }}-lit-actions-gvisor@${DIGEST_LIT_ACTIONS_GVISOR}|g" \
             -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|${{ vars.DOCKER_IMAGE }}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
             -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|${{ vars.DOCKER_IMAGE }}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
             -e "s|\${GCP_PROJECT_ID}|${{ needs.determine-target.outputs.gcp_project_id }}|g" \

--- a/Dockerfile.lit-actions-gvisor
+++ b/Dockerfile.lit-actions-gvisor
@@ -1,0 +1,85 @@
+# Runner image for the any-language (gVisor) Lit Action runner.
+#
+# Bundles the three things the CVM needs to run untrusted, any-language
+# bundles in per-execution runsc sandboxes:
+#   1. the lit_actions_gvisor supervisor binary (serves the op-loop)
+#   2. runsc (gVisor), which the supervisor invokes to create sandboxes
+#      (--runsc-path defaults to `runsc` on PATH)
+#   3. the base sandbox rootfs exported to /var/lib/lit/sandbox-rootfs,
+#      shared read-only by every sandbox via --rootfs (mirrors
+#      lit-actions/gvisor-server/image/Dockerfile.rootfs)
+#
+# The runtime command is supplied by docker-compose.phala.yml; the CMD here is
+# only a sensible default for `docker run`.
+
+# ---- build the supervisor + guest `lit` CLI ------------------------------
+FROM rust:1.91-bookworm AS builder
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        clang \
+        libsqlite3-dev \
+        protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY lit-core ./lit-core/
+COPY lit-actions ./lit-actions/
+
+# Remove tests workspace member (excluded by .dockerignore; not needed for
+# release build) — same treatment as Dockerfile.lit-actions.
+RUN sed -i 's/, "tests"//; s/"tests", //' lit-actions/Cargo.toml
+
+# The guest `lit` CLI (baked into the rootfs) and the supervisor share this
+# crate so the guest wire contract and its server cannot drift apart.
+RUN cargo build --release --manifest-path lit-actions/Cargo.toml \
+        -p lit-actions-gvisor-server --bin lit_actions_gvisor --bin lit
+
+# ---- base sandbox rootfs (mirrors image/Dockerfile.rootfs) ---------------
+# Kept deliberately small: every runtime here is attack surface inside the
+# sandbox and bytes in the CVM image.
+FROM debian:bookworm-slim AS sandbox-rootfs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        python3 \
+        python3-pip \
+        curl \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/lit-actions/target/release/lit /usr/local/bin/lit
+# Guest-contract paths (see sandbox/mod.rs): the supervisor bind-mounts the
+# bundle at /action and the op socket dir at /run/lit.
+RUN mkdir -p /action /run/lit
+ENV LIT_OP_SOCK=/run/lit/ops.sock
+
+# ---- runtime -------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install runsc (gVisor). Pinned via ARG for reproducible, verifiable builds;
+# the download is integrity-checked against the release's own sha512 sums, and
+# the outer image digest (captured at deploy time) pins the exact bytes.
+# Bump GVISOR_RELEASE deliberately — it is validated inside the TDX CVM.
+ARG GVISOR_RELEASE=release/latest
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    url="https://storage.googleapis.com/gvisor/releases/${GVISOR_RELEASE}/${arch}"; \
+    curl -fsSL "${url}/runsc" -o /usr/local/bin/runsc; \
+    curl -fsSL "${url}/runsc.sha512" -o /tmp/runsc.sha512; \
+    (cd /usr/local/bin && sha512sum -c /tmp/runsc.sha512); \
+    chmod 0755 /usr/local/bin/runsc; \
+    rm -f /tmp/runsc.sha512; \
+    runsc --version
+
+COPY --from=builder /build/lit-actions/target/release/lit_actions_gvisor /usr/local/bin/
+
+# Export the base rootfs into the shared --rootfs path. COPY --from of a whole
+# stage filesystem is the multi-stage equivalent of `docker export`.
+COPY --from=sandbox-rootfs / /var/lib/lit/sandbox-rootfs/
+
+CMD ["lit_actions_gvisor", "--socket", "/tmp/lit_actions_gvisor.sock", "--rootfs", "/var/lib/lit/sandbox-rootfs"]

--- a/Dockerfile.lit-actions-gvisor
+++ b/Dockerfile.lit-actions-gvisor
@@ -61,10 +61,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install runsc (gVisor). Pinned via ARG for reproducible, verifiable builds;
-# the download is integrity-checked against the release's own sha512 sums, and
-# the outer image digest (captured at deploy time) pins the exact bytes.
-# Bump GVISOR_RELEASE deliberately — it is validated inside the TDX CVM.
+# Install runsc (gVisor). The default is the mutable `release/latest`; the
+# download is integrity-checked against that release's own sha512 sums, and the
+# outer image digest (captured at deploy time) still pins the exact bytes that
+# shipped. For byte-reproducible rebuilds, override GVISOR_RELEASE with a
+# specific tag (e.g. release/20250203.0) — pin a release validated inside the
+# TDX CVM before production.
 ARG GVISOR_RELEASE=release/latest
 RUN set -eux; \
     arch="$(uname -m)"; \

--- a/justfile
+++ b/justfile
@@ -5,9 +5,10 @@ image_base := env('DOCKER_IMAGE', 'litptcl/chipotle')
 # the @sha256: digest captured after push, never this tag. Override with
 # DOCKER_TAG to reuse a previously-pushed image (digest files must then exist).
 image_tag := env('DOCKER_TAG', `uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '\n'`)
-image_lit_actions     := image_base + '-lit-actions:'     + image_tag
-image_lit_api_server  := image_base + '-lit-api-server:'  + image_tag
-image_otel_collector  := image_base + '-otel-collector:'  + image_tag
+image_lit_actions        := image_base + '-lit-actions:'        + image_tag
+image_lit_actions_gvisor := image_base + '-lit-actions-gvisor:' + image_tag
+image_lit_api_server     := image_base + '-lit-api-server:'     + image_tag
+image_otel_collector     := image_base + '-otel-collector:'     + image_tag
 # main → chipotle-dev; any other branch → chipotle-next (override with PHALA_APP_NAME)
 app_name       := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo chipotle-dev || echo chipotle-next'`
 instance_type  := `git branch --show-current | xargs -I {} sh -c '[ "{}" = "main" ] && echo tdx.small || echo tdx.small'`

--- a/justfile.deploy
+++ b/justfile.deploy
@@ -1,5 +1,5 @@
 # Deploy group — included by root justfile. Uses: image_base, image_lit_actions,
-# image_lit_api_server, image_otel_collector, app_name,
+# image_lit_actions_gvisor, image_lit_api_server, image_otel_collector, app_name,
 # instance_type, gcp_project_id.
 
 # Install Phala CLI (optional; run before first deploy)
@@ -16,9 +16,10 @@ setup:
 docker-build: _check_docker
     #!/usr/bin/env sh
     set -eu
-    docker build --platform linux/amd64 -f Dockerfile.lit-actions     -t {{image_lit_actions}}     .
-    docker build --platform linux/amd64 -f Dockerfile.lit-api-server  -t {{image_lit_api_server}}  --build-arg NODE_CONFIG={{node_config}} .
-    docker build --platform linux/amd64 -f Dockerfile.otel-collector  -t {{image_otel_collector}}  .
+    docker build --platform linux/amd64 -f Dockerfile.lit-actions         -t {{image_lit_actions}}         .
+    docker build --platform linux/amd64 -f Dockerfile.lit-actions-gvisor  -t {{image_lit_actions_gvisor}}  .
+    docker build --platform linux/amd64 -f Dockerfile.lit-api-server      -t {{image_lit_api_server}}      --build-arg NODE_CONFIG={{node_config}} .
+    docker build --platform linux/amd64 -f Dockerfile.otel-collector      -t {{image_otel_collector}}      .
 
 # Push all images and capture each registry-assigned @sha256: digest.
 # Digests are written to .digest-{service}.txt and read by `deploy` (DR-1.1, DR-1.2).
@@ -31,12 +32,14 @@ docker-push: docker-build
     set -eu
     command -v jq >/dev/null 2>&1 || { echo "error: jq not found. Install from https://stedolan.github.io/jq/"; exit 1; }
     docker push {{image_lit_actions}}
+    docker push {{image_lit_actions_gvisor}}
     docker push {{image_lit_api_server}}
     docker push {{image_otel_collector}}
-    docker inspect {{image_lit_actions}}     | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-lit-actions.txt
-    docker inspect {{image_lit_api_server}}  | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-lit-api-server.txt
-    docker inspect {{image_otel_collector}}  | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-otel-collector.txt
-    for f in .digest-lit-actions.txt .digest-lit-api-server.txt .digest-otel-collector.txt; do
+    docker inspect {{image_lit_actions}}         | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-lit-actions.txt
+    docker inspect {{image_lit_actions_gvisor}}  | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-lit-actions-gvisor.txt
+    docker inspect {{image_lit_api_server}}      | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-lit-api-server.txt
+    docker inspect {{image_otel_collector}}      | jq -r '.[0].RepoDigests[0]' | sed 's/.*@//' > .digest-otel-collector.txt
+    for f in .digest-lit-actions.txt .digest-lit-actions-gvisor.txt .digest-lit-api-server.txt .digest-otel-collector.txt; do
         [ -s "$f" ] || { echo "error: digest capture failed for $f"; exit 1; }
         printf "captured %s: %s\n" "$f" "$(cat $f)"
     done
@@ -52,14 +55,17 @@ deploy name=(app_name): docker-push _check_phala
     #!/usr/bin/env sh
     set -eu
     DIGEST_LIT_ACTIONS=$(cat .digest-lit-actions.txt | tr -d '\n' | sed 's/}[}]*$//')
+    DIGEST_LIT_ACTIONS_GVISOR=$(cat .digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_LIT_API_SERVER=$(cat .digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_OTEL_COLLECTOR=$(cat .digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
-    [ -n "$DIGEST_LIT_ACTIONS" ]    || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_API_SERVER" ] || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_OTEL_COLLECTOR" ] || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
     if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+        -e "s|\${DOCKER_IMAGE_LIT_ACTIONS_GVISOR}|{{image_base}}-lit-actions-gvisor@${DIGEST_LIT_ACTIONS_GVISOR}|g" \
         -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
         -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|{{image_base}}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
         -e "s|\${GCP_PROJECT_ID}|{{gcp_project_id}}|g" \
@@ -85,14 +91,17 @@ deploy-new name=(app_name): docker-push _check_phala
     [ -n "$APP_NAME" ] || { echo "error: app name is empty"; exit 1; }
     echo "Deploying app: $APP_NAME"
     DIGEST_LIT_ACTIONS=$(cat .digest-lit-actions.txt | tr -d '\n' | sed 's/}[}]*$//')
+    DIGEST_LIT_ACTIONS_GVISOR=$(cat .digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_LIT_API_SERVER=$(cat .digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_OTEL_COLLECTOR=$(cat .digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
-    [ -n "$DIGEST_LIT_ACTIONS" ]    || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_API_SERVER" ] || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_OTEL_COLLECTOR" ] || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
     if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
+        -e "s|\${DOCKER_IMAGE_LIT_ACTIONS_GVISOR}|{{image_base}}-lit-actions-gvisor@${DIGEST_LIT_ACTIONS_GVISOR}|g" \
         -e "s|\${DOCKER_IMAGE_LIT_API_SERVER}|{{image_base}}-lit-api-server@${DIGEST_LIT_API_SERVER}|g" \
         -e "s|\${DOCKER_IMAGE_OTEL_COLLECTOR}|{{image_base}}-otel-collector@${DIGEST_OTEL_COLLECTOR}|g" \
         -e "s|\${GCP_PROJECT_ID}|{{gcp_project_id}}|g" \
@@ -112,6 +121,7 @@ deploy-new name=(app_name): docker-push _check_phala
 [group: 'deploy']
 docker-run-local: docker-build
     DOCKER_IMAGE_LIT_ACTIONS={{image_lit_actions}} \
+    DOCKER_IMAGE_LIT_ACTIONS_GVISOR={{image_lit_actions_gvisor}} \
     DOCKER_IMAGE_LIT_API_SERVER={{image_lit_api_server}} \
     DOCKER_IMAGE_OTEL_COLLECTOR={{image_otel_collector}} \
     GCP_PROJECT_ID={{gcp_project_id}} \

--- a/justfile.deploy
+++ b/justfile.deploy
@@ -58,10 +58,10 @@ deploy name=(app_name): docker-push _check_phala
     DIGEST_LIT_ACTIONS_GVISOR=$(cat .digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_LIT_API_SERVER=$(cat .digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_OTEL_COLLECTOR=$(cat .digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
-    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-push"; exit 1; }
     if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \
@@ -94,10 +94,10 @@ deploy-new name=(app_name): docker-push _check_phala
     DIGEST_LIT_ACTIONS_GVISOR=$(cat .digest-lit-actions-gvisor.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_LIT_API_SERVER=$(cat .digest-lit-api-server.txt | tr -d '\n' | sed 's/}[}]*$//')
     DIGEST_OTEL_COLLECTOR=$(cat .digest-otel-collector.txt | tr -d '\n' | sed 's/}[}]*$//')
-    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-build"; exit 1; }
-    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-build"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS" ]        || { echo "error: lit-actions digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_LIT_ACTIONS_GVISOR" ] || { echo "error: lit-actions-gvisor digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_LIT_API_SERVER" ]     || { echo "error: lit-api-server digest missing; run: just docker-push"; exit 1; }
+    [ -n "$DIGEST_OTEL_COLLECTOR" ]     || { echo "error: otel-collector digest missing; run: just docker-push"; exit 1; }
     if [ -f .env ]; then set -a && . ./.env && set +a; fi
     sed \
         -e "s|\${DOCKER_IMAGE_LIT_ACTIONS}|{{image_base}}-lit-actions@${DIGEST_LIT_ACTIONS}|g" \


### PR DESCRIPTION
The `lit-actions-gvisor` service in `docker-compose.phala.yml` referenced `${DOCKER_IMAGE_LIT_ACTIONS_GVISOR}`, but no deploy path built, pushed, or substituted it — the placeholder rendered literally, leaving the gVisor runner undeployable. This adds `Dockerfile.lit-actions-gvisor` (supervisor binary + `runsc` + an exported shared sandbox rootfs at `/var/lib/lit/sandbox-rootfs`) and the `image_lit_actions_gvisor` justfile var. It wires the gvisor image through build/push/digest-capture and the `sed` substitution in `justfile.deploy` (`deploy`, `deploy-new`, `docker-run-local`) and into the build matrix + substitution of both the staging and prod-propose workflows. Prod stage 2 is unchanged — it consumes stage 1's pre-rendered artifacts. Note: the compose_hash changes (a governed prod change, handled by the propose→Safe→execute flow), and the gVisor release is pinned via a build ARG defaulting to `latest` — pin a validated release before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)