### PR TITLE
fix(ci): normalize prettier formatting in k6 openapi drift checks

### DIFF
--- a/.github/workflows/k6-client-check.yml
+++ b/.github/workflows/k6-client-check.yml
@@ -53,14 +53,21 @@ jobs:
 
       - name: Compare with committed litApiServer.ts
         run: |
-          if ! diff -q "${{ runner.temp }}/k6-generated/litApiServer.ts" ./k6/litApiServer.ts; then
+          # openapi-to-k6 does not pin its internal prettier, so union-type
+          # formatting (e.g. `A | B` vs leading-pipe multiline) drifts between
+          # tool installs even at the same tool version. Normalize both sides
+          # through a pinned prettier before diffing so only real spec changes
+          # fail this check.
+          cp ./k6/litApiServer.ts "${{ runner.temp }}/k6-committed.ts"
+          npx --yes prettier@3.9.5 --write "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts"
+          if ! diff -q "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts"; then
             echo "::error::k6/litApiServer.ts is out of date. Run 'npx @grafana/openapi-to-k6' to regenerate it from the current OpenAPI spec."
             echo ""
             echo "To fix, run from the repo root:"
             echo "  cd lit-api-server && cargo run --bin openapi_spec > spec.json"
             echo "  npx @grafana/openapi-to-k6 spec.json ./k6"
             echo ""
-            diff "${{ runner.temp }}/k6-generated/litApiServer.ts" ./k6/litApiServer.ts || true
+            diff "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts" || true
             exit 1
           fi
           echo "k6/litApiServer.ts is up to date with sources"

--- a/.github/workflows/openapi-spec-check.yml
+++ b/.github/workflows/openapi-spec-check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Generate litApiServer from deployed OpenAPI spec
         run: |
           npm install -g @grafana/openapi-to-k6
-          openapi-to-k6 --verbose "${{ inputs.api_root_url }}/openapi.json" ./k6-generated
+          openapi-to-k6 --verbose "${{ inputs.api_root_url }}/openapi.json" "${{ runner.temp }}/k6-generated"
 
       - name: Compare with committed litApiServer.ts
         run: |
@@ -55,11 +55,11 @@ jobs:
           # tool installs even at the same tool version. Normalize both sides
           # through a pinned prettier before diffing so only real spec changes
           # fail this check.
-          cp ./k6/litApiServer.ts ./k6-committed.ts
-          npx --yes prettier@3.9.5 --write ./k6-generated/litApiServer.ts ./k6-committed.ts
-          if ! diff -q ./k6-generated/litApiServer.ts ./k6-committed.ts; then
+          cp ./k6/litApiServer.ts "${{ runner.temp }}/k6-committed.ts"
+          npx --yes prettier@3.9.5 --write "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts"
+          if ! diff -q "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts"; then
             echo "::error::Deployed OpenAPI spec differs from committed k6/litApiServer.ts. Regenerate with: openapi-to-k6 <BASE_URL>/openapi.json ./k6"
-            diff ./k6-generated/litApiServer.ts ./k6-committed.ts || true
+            diff "${{ runner.temp }}/k6-generated/litApiServer.ts" "${{ runner.temp }}/k6-committed.ts" || true
             exit 1
           fi
           echo "litApiServer.ts matches deployed OpenAPI spec"

--- a/.github/workflows/openapi-spec-check.yml
+++ b/.github/workflows/openapi-spec-check.yml
@@ -50,9 +50,16 @@ jobs:
 
       - name: Compare with committed litApiServer.ts
         run: |
-          if ! diff -q ./k6-generated/litApiServer.ts ./k6/litApiServer.ts; then
+          # openapi-to-k6 does not pin its internal prettier, so union-type
+          # formatting (e.g. `A | B` vs leading-pipe multiline) drifts between
+          # tool installs even at the same tool version. Normalize both sides
+          # through a pinned prettier before diffing so only real spec changes
+          # fail this check.
+          cp ./k6/litApiServer.ts ./k6-committed.ts
+          npx --yes prettier@3.9.5 --write ./k6-generated/litApiServer.ts ./k6-committed.ts
+          if ! diff -q ./k6-generated/litApiServer.ts ./k6-committed.ts; then
             echo "::error::Deployed OpenAPI spec differs from committed k6/litApiServer.ts. Regenerate with: openapi-to-k6 <BASE_URL>/openapi.json ./k6"
-            diff ./k6-generated/litApiServer.ts ./k6/litApiServer.ts || true
+            diff ./k6-generated/litApiServer.ts ./k6-committed.ts || true
             exit 1
           fi
           echo "litApiServer.ts matches deployed OpenAPI spec"


### PR DESCRIPTION
The `openapi-spec-check` job flagged drift in `k6/litApiServer.ts`, but the diff was purely prettier formatting of union types (`A | B` vs leading-pipe multiline) — `@grafana/openapi-to-k6` does not pin its internal prettier, so output drifts between tool installs even at the same tool version. This PR makes both k6 drift checks (`openapi-spec-check.yml` and `k6-client-check.yml`) normalize the generated and committed files through a pinned `prettier@3.9.5` before diffing, so only genuine spec changes fail. The committed `k6/litApiServer.ts` is intentionally left untouched to avoid ping-ponging the currently-green `k6-client-check` gate.