### PR TITLE
feat(billing): tag Stripe charges with BillingReason

### DIFF
--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -101,10 +101,23 @@ pub enum BillingReason {
 }
 
 impl BillingReason {
+    /// Machine-readable code. Used as the `reason` label on billing metrics, the
+    /// `billing_reason` field on per-payment events, and the `metadata[reason]`
+    /// key on the Stripe balance transaction (so Stripe-side reporting can slice
+    /// spend by charge type).
     pub fn as_str(self) -> &'static str {
         match self {
             BillingReason::Management => "management",
             BillingReason::LitAction => "lit_action",
+        }
+    }
+
+    /// Human-readable description sent as the Stripe balance transaction
+    /// `description`, so the charge type is legible in the Stripe dashboard.
+    pub fn description(self) -> &'static str {
+        match self {
+            BillingReason::Management => "Management API call",
+            BillingReason::LitAction => "Lit Action execution",
         }
     }
 }
@@ -900,7 +913,8 @@ async fn charge(
                     &[
                         ("amount", cost_str.as_str()),
                         ("currency", "usd"),
-                        ("description", "API call charge"),
+                        ("description", reason.description()),
+                        ("metadata[reason]", reason.as_str()),
                     ],
                     &idempotency_key,
                 )
@@ -1185,10 +1199,29 @@ mod tests {
 
     #[test]
     fn billing_reason_labels_are_stable() {
-        // These strings are emitted as metric labels (CPL-329); dashboards and
-        // alerts key off them, so the mapping must not drift.
+        // These strings are emitted as metric labels (CPL-329) and as the Stripe
+        // `metadata[reason]` code; dashboards, alerts, and Stripe-side reporting
+        // key off them, so the mapping must not drift.
         assert_eq!(BillingReason::Management.as_str(), "management");
         assert_eq!(BillingReason::LitAction.as_str(), "lit_action");
+    }
+
+    #[test]
+    fn billing_reason_descriptions_distinguish_charge_type() {
+        // Sent as the Stripe balance transaction `description`; must differ per
+        // reason so the charge type is legible in the Stripe dashboard.
+        assert_eq!(
+            BillingReason::Management.description(),
+            "Management API call"
+        );
+        assert_eq!(
+            BillingReason::LitAction.description(),
+            "Lit Action execution"
+        );
+        assert_ne!(
+            BillingReason::Management.description(),
+            BillingReason::LitAction.description()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Per-request charges previously landed in Stripe as an identical `customers/{id}/balance_transactions` POST with the hardcoded description `"API call charge"` — the same payload whether the charge was for a **management API call** or **Lit Action execution time**. The distinction existed *only* internally, as the `BillingReason` enum surfaced to metrics/logs (CPL-329), and was never encoded in anything sent to Stripe. As a result, Stripe-side reporting (dashboard filters, the Stripe API, exported data) could not tell the two charge types apart.

This PR maps `BillingReason` onto the Stripe balance transaction:

- **`metadata[reason]`** — the machine-readable code (`"management"` / `"lit_action"`), so Stripe reporting/API can slice spend by charge type. This is the same stable string already emitted as the `reason` metrics label, keeping the internal and Stripe-side taxonomies aligned.
- **`description`** — now reason-specific (`"Management API call"` / `"Lit Action execution"`) instead of the generic `"API call charge"`, so the charge type is legible directly in the Stripe dashboard.

## Changes

- `BillingReason::description()` — new method returning the human-readable Stripe description; `as_str()` gains a doc note that it is now also the `metadata[reason]` code.
- `charge()` background settlement task now sends `description = reason.description()` and `metadata[reason] = reason.as_str()`.
- Tests: extended `billing_reason_labels_are_stable` (metadata code stability) and added `billing_reason_descriptions_distinguish_charge_type`.

## Notes / follow-up

- Only the *machine-readable code* changes are load-bearing for reporting; the description change is cosmetic-but-useful.
- The in-repo `stripe_report` tool (`lit-billing-core/src/reporting.rs`) parses `description` but not `metadata`. Adding a per-reason breakdown column there is a natural follow-up, kept out of this PR to keep the diff focused.

## Testing

- `cargo +1.91 test -p lit-api-server --manifest-path lit-api-server/Cargo.toml stripe::` — 22 passed
- `cargo +1.91 fmt --check` — clean
- `cargo +1.91 build -p lit-api-server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)