### PR TITLE
feat(gvisor): per-deploy env default + on-chain contract gate (CPL-361)

### DIFF
--- a/.github/workflows/deploy-prod-1-propose.yml
+++ b/.github/workflows/deploy-prod-1-propose.yml
@@ -258,6 +258,7 @@ jobs:
             -e "s|\${GCP_PROJECT_ID}|chipotle-prod|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
+            -e "s|\${LIT_GVISOR_ENABLED}|false|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -392,6 +392,7 @@ jobs:
             -e "s|\${GCP_PROJECT_ID}|${{ needs.determine-target.outputs.gcp_project_id }}|g" \
             -e "s|\${CERTBOT_DOMAIN}|${DOMAIN}|g" \
             -e "s|\${CERTBOT_AWS_REGION}|${{ vars.CERTBOT_AWS_REGION }}|g" \
+            -e "s|\${LIT_GVISOR_ENABLED}|true|g" \
             docker-compose.phala.yml > docker-compose.deploy.yml
 
       - name: Setup Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ doesn't describe endpoints the released server lacks.
   enabled (the gVisor runner image build opts in), and `POST /lit_binary_action`
   stays mounted but returns `503` ("feature disabled") unless the api-server is
   started with `LIT_GVISOR_ENABLED=true`.
+- The gVisor runner's run-time gate now has **three axes**, all fail-closed
+  (CPL-361). `LIT_GVISOR_ENABLED` is rendered per-deploy — testing/manual/staging
+  deploys default it **on**, the production deploy defaults it **off** — and a
+  new on-chain `GVISOR_RUNNER_ENABLED` node-configuration value in the
+  AccountConfig contract must *also* be truthy before `POST /lit_binary_action`
+  runs, giving operators a network-wide runner kill-switch that needs no redeploy.
 - `max_get_keys_count` is now enforced in the key handlers; oversized
   `get_keys` requests are rejected.
 

--- a/architectureDocs/gvisor-server.md
+++ b/architectureDocs/gvisor-server.md
@@ -421,9 +421,11 @@ Deploy caveats: the pipeline must build + substitute
 
 ---
 
-## Feature flag — off by default (CPL-359)
+## Feature flag — off by default (CPL-359, CPL-361)
 
-gVisor is opt-in on both axes:
+gVisor is opt-in on **three independent axes**. A `/lit_binary_action` call
+succeeds past the gate only when all three opt in; any one off degrades cleanly
+to `503` rather than hanging on an absent socket.
 
 - **Build.** The `lit_actions_gvisor` supervisor and the guest `lit` CLI are
   gated behind the `gvisor` cargo feature on `lit-actions-gvisor-server`
@@ -432,18 +434,30 @@ gVisor is opt-in on both axes:
   in. `Dockerfile.lit-actions-gvisor` passes `--features gvisor` (the image
   build is the opt-in), and CI's `--all-features` keeps the binaries linted and
   tested.
-- **Run.** lit-api-server always mounts `/lit_binary_action` (its OpenAPI
-  surface is stable), but the `GvisorEnabled` request guard (`actions::gvisor`,
-  driven by the `LIT_GVISOR_ENABLED` env var) runs *before* the CPU and billing
-  guards. Unless the var is truthy (`1`/`true`/`yes`/`on`) the guard
-  short-circuits with `503` — *"The gVisor any-language runner is disabled on
-  this node."* — so a disabled node sheds the call without a Stripe credit check
-  or dialing the runner socket. `docker-compose.phala.yml` sets
-  `LIT_GVISOR_ENABLED=true` on the api-server because that stack ships the
-  runner container.
+- **Run (process / env).** lit-api-server always mounts `/lit_binary_action`
+  (its OpenAPI surface is stable), but the `GvisorEnabled` request guard
+  (`actions::gvisor`, driven by the `LIT_GVISOR_ENABLED` env var) runs *before*
+  the CPU and billing guards. Unless the var is truthy (`1`/`true`/`yes`/`on`)
+  the guard short-circuits with `503` — *"The gVisor any-language runner is
+  disabled on this node."* — so a disabled node sheds the call without a Stripe
+  credit check or dialing the runner socket. Since **CPL-361** the value is
+  rendered per-deploy from `docker-compose.phala.yml`'s `${LIT_GVISOR_ENABLED}`
+  placeholder: testing/manual/staging deploys substitute `true`
+  (`deploy-staging.yml`, `justfile.deploy`), the production workflow substitutes
+  `false` (`deploy-prod-1-propose.yml`). An unsubstituted/empty value fails
+  closed.
+- **Run (on-chain / contract).** Even a built, env-enabled node stays gated
+  until the `GVISOR_RUNNER_ENABLED` key in the AccountConfig contract's
+  `nodeConfigurationValues` map is truthy (**CPL-361**). The guard reads it via
+  the cached `ChainConfig` snapshot (`accounts::chain_config`, 30 s refresh,
+  no per-request I/O); absent/non-truthy fails closed with a distinct `503` —
+  *"…disabled network-wide by contract configuration."*. This is the runtime
+  kill-switch that flips the runner off/on **network-wide without redeploying**
+  the binary. Set it with `WritesFacet.setNodeConfiguration("GVISOR_RUNNER_ENABLED", "true")`.
 
-The two halves are independent: an api-server image built without a runner
-alongside it degrades cleanly to 503 rather than hanging on an absent socket.
+The axes are independent and all fail closed: an api-server image built without
+a runner alongside it, a prod deploy that never set the env, or a contract that
+never opted in each degrade to 503 rather than hanging on an absent socket.
 
 ---
 

--- a/docker-compose.phala.yml
+++ b/docker-compose.phala.yml
@@ -109,11 +109,14 @@ services:
       # internal cache-invalidation endpoint (/internal/invalidate_balance_cache).
       # Must match the value set on lit-payments (Railway env var of the same name).
       LIT_INTERNAL_SHARED_SECRET: ${LIT_INTERNAL_SHARED_SECRET}
-      # gVisor any-language runner is off by default (CPL-359); this stack ships
-      # the lit-actions-gvisor service above, so opt in here to route
-      # /lit_binary_action to it. Drop this to disable the runner without
-      # removing the service (the endpoint then answers 503 "feature disabled").
-      LIT_GVISOR_ENABLED: "true"
+      # gVisor any-language runner gate (CPL-359, CPL-361). Rendered per-deploy:
+      # testing/manual deploys substitute "true"; the production workflow
+      # substitutes "false" (see deploy-staging.yml / deploy-prod-1-propose.yml /
+      # justfile.deploy). Even when "true", /lit_binary_action stays gated until
+      # the on-chain GVISOR_RUNNER_ENABLED node-config value is also truthy — so
+      # this is the process-level half of the run-time gate, the contract the
+      # other. An unsubstituted/empty value fails closed (503 "feature disabled").
+      LIT_GVISOR_ENABLED: "${LIT_GVISOR_ENABLED}"
     volumes:
       - lit-socket:/tmp
       - /var/run/dstack.sock:/var/run/dstack.sock

--- a/justfile.deploy
+++ b/justfile.deploy
@@ -74,6 +74,7 @@ deploy name=(app_name): docker-push _check_phala
         -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${CERTBOT_AWS_SECRET_ACCESS_KEY}|g" \
         -e "s|\${CERTBOT_AWS_ROLE_ARN}|${CERTBOT_AWS_ROLE_ARN}|g" \
         -e "s|\${CERTBOT_AWS_REGION}|${CERTBOT_AWS_REGION}|g" \
+        -e "s|\${LIT_GVISOR_ENABLED}|true|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
     cat docker-compose.deploy.yml
     [ -n "${PHALA_PRIVATE_KEY}" ] || { echo "error: PHALA_PRIVATE_KEY not set. Copy .env.example to .env and set your DstackApp key."; exit 1; }
@@ -110,6 +111,7 @@ deploy-new name=(app_name): docker-push _check_phala
         -e "s|\${CERTBOT_AWS_SECRET_ACCESS_KEY}|${CERTBOT_AWS_SECRET_ACCESS_KEY}|g" \
         -e "s|\${CERTBOT_AWS_ROLE_ARN}|${CERTBOT_AWS_ROLE_ARN}|g" \
         -e "s|\${CERTBOT_AWS_REGION}|${CERTBOT_AWS_REGION}|g" \
+        -e "s|\${LIT_GVISOR_ENABLED}|true|g" \
         docker-compose.phala.yml > docker-compose.deploy.yml
     cat docker-compose.deploy.yml
     [ -n "${PHALA_PRIVATE_KEY}" ] || { echo "error: PHALA_PRIVATE_KEY not set. Copy .env.example to .env and set your DstackApp key."; exit 1; }
@@ -125,6 +127,7 @@ docker-run-local: docker-build
     DOCKER_IMAGE_LIT_API_SERVER={{image_lit_api_server}} \
     DOCKER_IMAGE_OTEL_COLLECTOR={{image_otel_collector}} \
     GCP_PROJECT_ID={{gcp_project_id}} \
+    LIT_GVISOR_ENABLED=true \
     docker compose -f docker-compose.phala.yml up -d
 
 [private]

--- a/lit-api-server/src/accounts/chain_config.rs
+++ b/lit-api-server/src/accounts/chain_config.rs
@@ -31,6 +31,13 @@ pub enum ConfigKeys {
     LIT_ACTION_DEFAULT_MAX_RESPONSE_LENGTH,
     LIT_ACTION_DEFAULT_MAX_GET_KEYS_COUNT,
     LIT_ACTION_DEFAULT_MAX_RETRIES,
+    /// Contract-side gate for the gVisor any-language runner (CPL-361). This is
+    /// the third, independent axis of the gVisor gate: even on a node that
+    /// compiled the runner (`gvisor` cargo feature) and enabled it at run time
+    /// (`LIT_GVISOR_ENABLED`), `/lit_binary_action` stays disabled unless this
+    /// on-chain key is truthy. Absent/non-truthy => disabled (fail closed).
+    /// See `actions::gvisor`.
+    GVISOR_RUNNER_ENABLED,
 }
 
 /// Returns the display name of every `ConfigKeys` variant in declaration order.
@@ -162,18 +169,27 @@ pub async fn run_config_refresh_loop(snapshot: Arc<ArcSwap<ConfigValues>>, state
     }
 }
 
+/// Test-only constructor: build a [`ChainConfig`] from literal key/value pairs,
+/// bypassing the chain fetch. Crate-visible so other modules' tests (e.g. the
+/// gVisor guard in `actions::gvisor`) can wire a `ChainConfig` into a Rocket
+/// instance without touching the network.
+#[cfg(test)]
+pub(crate) fn from_pairs_for_test(pairs: &[(&str, &str)]) -> ChainConfig {
+    let map: ConfigValues = pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    ChainConfig {
+        snapshot: Arc::new(ArcSwap::from_pointee(map)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn config_from(pairs: &[(&str, &str)]) -> ChainConfig {
-        let map: ConfigValues = pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-        ChainConfig {
-            snapshot: Arc::new(ArcSwap::from_pointee(map)),
-        }
+        from_pairs_for_test(pairs)
     }
 
     #[tokio::test]

--- a/lit-api-server/src/actions/gvisor.rs
+++ b/lit-api-server/src/actions/gvisor.rs
@@ -275,4 +275,52 @@ mod tests {
             Status::ServiceUnavailable
         );
     }
+
+    /// The env-disabled and contract-disabled 503s must render *distinct*
+    /// bodies so operators can tell a node-level opt-out from a network-wide
+    /// contract flip. Registers the real 503 catcher and asserts on the JSON
+    /// body, so the operator-facing distinction can't regress to identical
+    /// messages while the status stays 503.
+    #[tokio::test]
+    async fn env_and_contract_disabled_return_distinct_bodies() {
+        use crate::accounts::chain_config::from_pairs_for_test;
+        use std::sync::Arc;
+
+        async fn body_for(feature: GvisorFeature, chain_value: &str) -> String {
+            let rocket = rocket::build()
+                .mount("/", routes![gated_route])
+                .register("/", crate::core::v1::catchers::catchers())
+                .manage(feature)
+                .manage(Arc::new(from_pairs_for_test(&[(
+                    "GVISOR_RUNNER_ENABLED",
+                    chain_value,
+                )])));
+            let client = Client::tracked(rocket).await.expect("valid rocket");
+            client
+                .get("/gated")
+                .dispatch()
+                .await
+                .into_string()
+                .await
+                .expect("503 body")
+        }
+
+        // Env off short-circuits with the node-level message; env on + contract
+        // off falls through to the contract message.
+        let env_off = body_for(GvisorFeature::new(false), "true").await;
+        let contract_off = body_for(GvisorFeature::new(true), "false").await;
+
+        assert!(
+            env_off.contains(DISABLED_MESSAGE),
+            "env-off body should carry the node-level message: {env_off}"
+        );
+        assert!(
+            contract_off.contains(CONTRACT_DISABLED_MESSAGE),
+            "contract-off body should carry the contract message: {contract_off}"
+        );
+        assert_ne!(
+            env_off, contract_off,
+            "the two 503 bodies must be distinguishable"
+        );
+    }
 }

--- a/lit-api-server/src/actions/gvisor.rs
+++ b/lit-api-server/src/actions/gvisor.rs
@@ -1,17 +1,27 @@
-//! Runtime gate for the gVisor any-language runner (CPL-359).
+//! Gate for the gVisor any-language runner (CPL-359, CPL-361).
 //!
-//! gVisor is **off by default**. The two halves of the gate are independent:
+//! gVisor is **off by default** and enabled only when **all three** independent
+//! axes opt in — a call to `/lit_binary_action` succeeds past this gate iff:
 //!
-//!   * Build time — the runner binaries live behind the `gvisor` cargo feature
-//!     on `lit-actions-gvisor-server`, so a default build never compiles them.
-//!   * Run time — this flag. When gVisor is disabled the `/lit_binary_action`
-//!     endpoint stays mounted (its OpenAPI surface is unchanged) but the
-//!     [`GvisorEnabled`] request guard rejects every call with a "feature
-//!     disabled" 503 *before* the CPU and billing guards run — so a disabled
-//!     node sheds the call without a Stripe credit check or any other work,
-//!     rather than dialing a socket that will never answer.
+//!   1. Build time — the runner binaries live behind the `gvisor` cargo feature
+//!      on `lit-actions-gvisor-server`, so a default build never compiles them.
+//!   2. Run time (process) — the [`LIT_GVISOR_ENABLED_ENV`] env var. Defaulted
+//!      **on** for testing/manual deploys and **off** for production by the
+//!      deploy config (`docker-compose.phala.yml` + the deploy workflows).
+//!   3. Run time (on-chain) — the [`GVISOR_RUNNER_ENABLED`](ConfigKeys::GVISOR_RUNNER_ENABLED)
+//!      key in the contract's `nodeConfigurationValues` map (CPL-361). This lets
+//!      an operator flip the runner off/on network-wide **without redeploying**
+//!      the binary: even a built, env-enabled node stays gated until the
+//!      contract opts in. Read through the cached [`ChainConfig`] snapshot.
 //!
-//! A deploy that ships the gVisor runner opts in with `LIT_GVISOR_ENABLED`.
+//! When any axis is off the endpoint stays mounted (its OpenAPI surface is
+//! unchanged) but the [`GvisorEnabled`] request guard rejects every call with a
+//! "feature disabled" 503 *before* the CPU and billing guards run — so a
+//! disabled node sheds the call without a Stripe credit check or any other work,
+//! rather than dialing a socket that will never answer. All axes **fail closed**:
+//! absent state or a non-truthy value leaves the runner disabled.
+
+use std::sync::Arc;
 
 use rocket::http::Status;
 use rocket::request::{FromRequest, Outcome, Request};
@@ -19,6 +29,7 @@ use rocket_okapi::Result as RocketOkapiResult;
 use rocket_okapi::r#gen::OpenApiGenerator;
 use rocket_okapi::request::{OpenApiFromRequest, RequestHeaderInput};
 
+use crate::accounts::chain_config::{ChainConfig, ConfigKeys};
 use crate::core::v1::catchers::set_error_detail;
 
 /// Env var enabling the gVisor runner. Unset — or any value other than a
@@ -27,11 +38,20 @@ use crate::core::v1::catchers::set_error_detail;
 pub const LIT_GVISOR_ENABLED_ENV: &str = "LIT_GVISOR_ENABLED";
 
 /// Message returned when a gVisor-backed endpoint is called on a node that has
-/// the runner disabled.
+/// the runner disabled at the process level (env off / not built).
 const DISABLED_MESSAGE: &str = "The gVisor any-language runner is disabled on this node.";
 const DISABLED_FIX: &str = "This node runs JavaScript actions only (POST /lit_action). Send \
      binary/any-language actions to a node that advertises gVisor languages via \
      GET /get_supported_languages.";
+
+/// Message returned when the node has the runner built + env-enabled but the
+/// on-chain contract gate ([`GVISOR_RUNNER_ENABLED`](ConfigKeys::GVISOR_RUNNER_ENABLED))
+/// is off. Distinct from [`DISABLED_MESSAGE`] so operators can tell a
+/// node-level opt-out apart from a network-wide contract flip (CPL-361).
+const CONTRACT_DISABLED_MESSAGE: &str =
+    "The gVisor any-language runner is disabled network-wide by contract configuration.";
+const CONTRACT_DISABLED_FIX: &str = "This is a transient, network-wide setting toggled on-chain \
+     via the GVISOR_RUNNER_ENABLED node configuration value; retry later or contact an operator.";
 
 /// Whether the gVisor any-language runner is enabled on this node. Rocket
 /// managed state, built once at startup from [`LIT_GVISOR_ENABLED_ENV`].
@@ -57,9 +77,10 @@ impl GvisorFeature {
     }
 }
 
-/// Request guard for gVisor-backed endpoints. Reads [`GvisorFeature`] from
-/// managed state and rejects with `503` + a "feature disabled" detail when the
-/// runner is off. Absent state fails closed (disabled).
+/// Request guard for gVisor-backed endpoints. Both run-time axes must opt in:
+/// the process-level [`GvisorFeature`] (env) **and** the on-chain contract gate
+/// read from [`ChainConfig`]. Either off => `503` + a "feature disabled" detail.
+/// Absent state fails closed (disabled) on both axes.
 ///
 /// Place it as the **first** handler parameter so the gate is evaluated before
 /// the CPU-overload and billing guards — a disabled node then never reaches the
@@ -71,18 +92,44 @@ impl<'r> FromRequest<'r> for GvisorEnabled {
     type Error = ();
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let enabled = req
+        // Process-level (env) gate first — cheap and the most common opt-out.
+        let env_enabled = req
             .rocket()
             .state::<GvisorFeature>()
             .is_some_and(|f| f.enabled());
-        if enabled {
-            Outcome::Success(GvisorEnabled)
-        } else {
+        if !env_enabled {
             // Populate the request-local detail the 503 catcher renders as JSON.
             set_error_detail(req, DISABLED_MESSAGE, DISABLED_FIX);
-            Outcome::Error((Status::ServiceUnavailable, ()))
+            return Outcome::Error((Status::ServiceUnavailable, ()));
         }
+
+        // On-chain contract gate (CPL-361). Reads the cached ChainConfig
+        // snapshot; absent state or a non-truthy value fails closed.
+        let contract_enabled = match req.rocket().state::<Arc<ChainConfig>>() {
+            Some(cfg) => contract_gate_enabled(cfg).await,
+            None => false,
+        };
+        if !contract_enabled {
+            set_error_detail(req, CONTRACT_DISABLED_MESSAGE, CONTRACT_DISABLED_FIX);
+            return Outcome::Error((Status::ServiceUnavailable, ()));
+        }
+
+        Outcome::Success(GvisorEnabled)
     }
+}
+
+/// Reads the on-chain [`GVISOR_RUNNER_ENABLED`](ConfigKeys::GVISOR_RUNNER_ENABLED)
+/// value from the cached config snapshot and maps it through [`parse_enabled`].
+/// Absent key or non-truthy value => `false` (fail closed).
+///
+/// `ChainConfig::get` is `async` for source compatibility but reads a lock-free
+/// `ArcSwap` snapshot with no I/O, so this adds nothing to the request latency.
+async fn contract_gate_enabled(cfg: &ChainConfig) -> bool {
+    cfg.get(ConfigKeys::GVISOR_RUNNER_ENABLED)
+        .await
+        .ok()
+        .flatten()
+        .is_some_and(|v| parse_enabled(Some(&v)))
 }
 
 impl<'r> OpenApiFromRequest<'r> for GvisorEnabled {
@@ -138,31 +185,94 @@ mod tests {
         "ok"
     }
 
-    async fn status_for(feature: Option<GvisorFeature>) -> Status {
+    /// Builds a Rocket with the given env feature and optional on-chain
+    /// contract value for `GVISOR_RUNNER_ENABLED`, then dispatches the gated
+    /// route and returns the resulting status. `chain_value: None` => no
+    /// `ChainConfig` managed at all (state-absent case); `Some(v)` => a
+    /// `ChainConfig` carrying that raw value under the gate key.
+    async fn status_for(feature: Option<GvisorFeature>, chain_value: Option<&str>) -> Status {
+        use crate::accounts::chain_config::from_pairs_for_test;
+        use std::sync::Arc;
+
         let mut rocket = rocket::build().mount("/", routes![gated_route]);
         if let Some(feature) = feature {
             rocket = rocket.manage(feature);
+        }
+        if let Some(value) = chain_value {
+            let cfg = from_pairs_for_test(&[("GVISOR_RUNNER_ENABLED", value)]);
+            rocket = rocket.manage(Arc::new(cfg));
         }
         let client = Client::tracked(rocket).await.expect("valid rocket");
         client.get("/gated").dispatch().await.status()
     }
 
     #[tokio::test]
-    async fn guard_passes_when_enabled() {
-        assert_eq!(status_for(Some(GvisorFeature::new(true))).await, Status::Ok);
+    async fn guard_passes_when_env_and_contract_enabled() {
+        assert_eq!(
+            status_for(Some(GvisorFeature::new(true)), Some("true")).await,
+            Status::Ok
+        );
     }
 
     #[tokio::test]
-    async fn guard_rejects_when_disabled() {
+    async fn guard_rejects_when_env_disabled() {
+        // Env off short-circuits before the contract gate, even if contract is on.
         assert_eq!(
-            status_for(Some(GvisorFeature::new(false))).await,
+            status_for(Some(GvisorFeature::new(false)), Some("true")).await,
             Status::ServiceUnavailable
         );
     }
 
     #[tokio::test]
-    async fn guard_fails_closed_when_state_absent() {
+    async fn guard_rejects_when_contract_disabled() {
+        // Env on, but the on-chain gate is off => disabled (CPL-361).
+        assert_eq!(
+            status_for(Some(GvisorFeature::new(true)), Some("false")).await,
+            Status::ServiceUnavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_rejects_when_contract_value_non_truthy() {
+        // Env on, gate key present but empty (a non-truthy value) => disabled.
+        assert_eq!(
+            status_for(Some(GvisorFeature::new(true)), Some("")).await,
+            Status::ServiceUnavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_fails_closed_when_contract_key_absent() {
+        // Env on, ChainConfig present but the gate key is not among its values.
+        use crate::accounts::chain_config::from_pairs_for_test;
+        use std::sync::Arc;
+
+        let rocket = rocket::build()
+            .mount("/", routes![gated_route])
+            .manage(GvisorFeature::new(true))
+            .manage(Arc::new(from_pairs_for_test(&[("SOME_OTHER_KEY", "true")])));
+        let client = Client::tracked(rocket).await.expect("valid rocket");
+        assert_eq!(
+            client.get("/gated").dispatch().await.status(),
+            Status::ServiceUnavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_fails_closed_when_chain_config_absent() {
+        // Env on, but no ChainConfig managed at all => fail closed.
+        assert_eq!(
+            status_for(Some(GvisorFeature::new(true)), None).await,
+            Status::ServiceUnavailable
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_fails_closed_when_env_state_absent() {
         // No GvisorFeature managed => treat as disabled, never as enabled.
-        assert_eq!(status_for(None).await, Status::ServiceUnavailable);
+        assert_eq!(
+            status_for(None, Some("true")).await,
+            Status::ServiceUnavailable
+        );
     }
 }


### PR DESCRIPTION
Adds two more fail-closed axes to the gVisor any-language runner gate (on top of the CPL-359 build feature), so `/lit_binary_action` runs only when build + env + contract all opt in. The `LIT_GVISOR_ENABLED` env is now rendered per-deploy from a `${LIT_GVISOR_ENABLED}` placeholder in `docker-compose.phala.yml` — testing/manual/staging deploys substitute `true` (`deploy-staging.yml`, `justfile.deploy`) and the production workflow substitutes `false` (`deploy-prod-1-propose.yml`). A new on-chain `GVISOR_RUNNER_ENABLED` value in the AccountConfig contract's `nodeConfigurationValues` map is read through the cached `ChainConfig` snapshot (no per-request I/O) and must also be truthy, giving operators a network-wide runner kill-switch that needs no redeploy (toggled via the existing `WritesFacet.setNodeConfiguration`). The `GvisorEnabled` guard checks env then contract and returns a distinct 503 when the contract gate is off, so a node-level opt-out is distinguishable from a network-wide flip. No contract or Rocket route changes; guard/config unit tests, clippy, and rustfmt all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)