### PR TITLE
test(gvisor): Python hello-world deploy smoke via /lit_binary_action (CPL-362)

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -69,7 +69,7 @@ jobs:
       # guaranteed on in the test/next staging environment, so gate the
       # gVisor smoke to non-prod deploys until it ships to prod.
       - name: gvisor-smoke.spec.ts
-        if: ${{ inputs.env != 'prod' }}
+        if: ${{ inputs.env && inputs.env != 'prod' }}
         env:
           BASE_URL: ${{ inputs.api_root_url }}
           K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-gvisor-smoke

--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -65,6 +65,18 @@ jobs:
           K6_ENV: ${{ inputs.env }}
         run: k6 run k6/smoke.spec.ts
 
+      # gVisor (any-language runner) is off by default (CPL-359) and only
+      # guaranteed on in the test/next staging environment, so gate the
+      # gVisor smoke to non-prod deploys until it ships to prod.
+      - name: gvisor-smoke.spec.ts
+        if: ${{ inputs.env != 'prod' }}
+        env:
+          BASE_URL: ${{ inputs.api_root_url }}
+          K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-gvisor-smoke
+          K6_ACCOUNTS_FILE: ${{ steps.accounts-file.outputs.path || env.K6_ACCOUNTS_FILE }}
+          K6_ENV: ${{ inputs.env }}
+        run: k6 run k6/gvisor-smoke.spec.ts
+
       - name: Clean up accounts file
         if: ${{ always() && steps.accounts-file.outputs.path }}
         run: rm -f "${{ steps.accounts-file.outputs.path }}"

--- a/k6/LitActionCode/gvisor/main.py
+++ b/k6/LitActionCode/gvisor/main.py
@@ -1,0 +1,41 @@
+"""gVisor deployment smoke test action.
+
+Proves that a recent Python and a `pip install` both work inside the
+any-language sandbox. Talks to the host via the preinstalled `lit` CLI - the
+same op-loop path `/lit_binary_action` drives in production.
+"""
+
+import json
+import subprocess
+import sys
+
+import cowsay  # installed by startup.sh; importing it proves the pip install worked
+
+
+def lit(*args, stdin=None):
+    """Call the guest `lit` CLI, returning stdout without the trailing newline."""
+    out = subprocess.run(
+        ["lit", *args], input=stdin, capture_output=True, text=True, check=True
+    )
+    return out.stdout.rstrip("\n")
+
+
+params = json.loads(lit("params") or "null") or {}
+name = params.get("name", "world")
+python_version = "{}.{}.{}".format(*sys.version_info[:3])
+greeting = f"hello {name} from python {python_version}"
+
+# cowsay's art lands in the action logs (the sandbox forwards stdout as logs).
+lit("print", cowsay.get_output_string("cow", greeting))
+
+lit(
+    "set-response",
+    stdin=json.dumps(
+        {
+            "ok": True,
+            "greeting": greeting,
+            "python": python_version,
+            "cowsay": cowsay.__version__,
+        }
+    ),
+)

--- a/k6/LitActionCode/gvisor/startup.sh
+++ b/k6/LitActionCode/gvisor/startup.sh
@@ -1,0 +1,14 @@
+# gVisor deployment smoke test: prove a recent Python plus a `pip install`
+# both work inside the any-language sandbox. The sandbox only ever runs
+# `bash startup.sh` (CPL-355); launching the interpreter is this script's job.
+# Top-level js-params are already in the environment.
+set -eu
+
+python3 --version
+
+# Debian's system Python is externally-managed (PEP 668). This is a throwaway,
+# per-execution sandbox, so install straight into it rather than a venv. Pin
+# the version so the gate stays deterministic across deploys.
+python3 -m pip install --quiet --break-system-packages --root-user-action=ignore cowsay==6.1
+
+python3 main.py

--- a/k6/README.md
+++ b/k6/README.md
@@ -83,4 +83,10 @@ ACCOUNTS_FILE=./data/my-accounts.json k6 run k6/loadtest/soak.spec.ts
 - `litApiServer.ts` – Generated TypeScript client (do not edit manually)
 - `k6-script.sample.ts` – Sample script exercising all endpoints
 - `smoke.spec.ts` – Minimal smoke test for `get_node_chain_config`
-- `LitActionCode/` – Shared Lit Action code (Hello World, Encrypt, Decrypt) for tests
+- `gvisor-smoke.spec.ts` – gVisor deploy smoke test: runs a Python hello-world
+  bundle (with a `pip install`) through `POST /lit_binary_action`. Staging/next
+  only (gVisor is off by default; see CPL-359)
+- `gvisorBundle.ts` – Minimal tar builder that packs a gVisor action bundle for
+  `gvisor-smoke.spec.ts`
+- `LitActionCode/` – Shared Lit Action code (Hello World, Encrypt, Decrypt) for
+  tests; `LitActionCode/gvisor/` holds the Python bundle source

--- a/k6/gvisor-smoke.spec.ts
+++ b/k6/gvisor-smoke.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * gVisor smoke test - runs a "hello world" any-language (Python) action through
+ * the gVisor runner via POST /lit_binary_action.
+ *
+ * The bundle installs a pinned pip package and runs a recent Python that greets
+ * and reports its version, proving the any-language sandbox is live in the
+ * target environment. gVisor is off by default (CPL-359) and only guaranteed on
+ * in the Phala test/next staging environment, so the deploy pipeline runs this
+ * against staging only — not prod.
+ *
+ * Use: k6 run gvisor-smoke.spec.ts
+ */
+import { checkAndLog, warnOnHttpFailures, assertOk } from "./helpers.ts";
+import { LitApiServerClient } from "./litApiServer.ts";
+import { PRECREATED_ACCOUNTS } from "./setup.ts";
+import { BASE_URL, COMMON_PARAMS } from "./defaults.ts";
+import { ensureAccountCredits } from "./stripe.ts";
+import { buildBundleBase64 } from "./gvisorBundle.ts";
+
+// Bundle source lives as real files (linted, reviewable) and is packed into the
+// tar at init time. `startup.sh` is the sandbox entrypoint; `main.py` is the action.
+const STARTUP_SCRIPT = open(
+  import.meta.resolve("./LitActionCode/gvisor/startup.sh"),
+) as unknown as string;
+const MAIN_PY = open(
+  import.meta.resolve("./LitActionCode/gvisor/main.py"),
+) as unknown as string;
+
+const BUNDLE_BASE64 = buildBundleBase64([
+  { name: "startup.sh", content: STARTUP_SCRIPT, mode: 0o755 },
+  { name: "main.py", content: MAIN_PY },
+]);
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    http_reqs: ["count>=1"],
+    checks: ["rate==1"],
+  },
+};
+
+export interface GvisorSmokeSetupData {
+  usageApiKey: string;
+}
+
+export function setup(): GvisorSmokeSetupData {
+  if (PRECREATED_ACCOUNTS.length === 0) {
+    throw new Error(
+      "No pre-created accounts found. Run accounts.seed.spec.ts first to generate k6/data/accounts.json",
+    );
+  }
+  const account =
+    PRECREATED_ACCOUNTS[Math.floor(Math.random() * PRECREATED_ACCOUNTS.length)];
+
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  ensureAccountCredits(client, { "X-Api-Key": account.apiKey });
+
+  return { usageApiKey: account.usageApiKey };
+}
+
+export default function (data: GvisorSmokeSetupData) {
+  const client = new LitApiServerClient({ baseUrl: BASE_URL, commonRequestParameters: COMMON_PARAMS });
+  const usageKeyHeaders = { "X-Api-Key": data.usageApiKey };
+
+  const res = client.litBinaryAction(
+    { bundle: BUNDLE_BASE64, js_params: { name: "chipotle" } },
+    usageKeyHeaders,
+  );
+  if (!assertOk("litBinaryAction", "POST /lit_binary_action", res)) return;
+
+  checkAndLog(res.response, {
+    "binary action has no error": (r) => {
+      try {
+        return JSON.parse(r.body as string).has_error === false;
+      } catch {
+        return false;
+      }
+    },
+    "python hello-world ran and pip install worked": (r) => {
+      try {
+        // The action set-response with a JSON string; the API returns it in
+        // `response` (as a string, or already parsed — accept both).
+        const body = JSON.parse(r.body as string);
+        const payload =
+          typeof body.response === "string"
+            ? JSON.parse(body.response)
+            : body.response;
+        return (
+          payload.ok === true &&
+          typeof payload.python === "string" &&
+          payload.python.startsWith("3.") &&
+          payload.greeting === `hello chipotle from python ${payload.python}`
+        );
+      } catch {
+        return false;
+      }
+    },
+  }, "litBinaryAction");
+}
+
+export const handleSummary = warnOnHttpFailures;

--- a/k6/gvisorBundle.ts
+++ b/k6/gvisorBundle.ts
@@ -45,6 +45,16 @@ function writeOctal(
 }
 
 function header(file: BundleFile, size: number): Uint8Array {
+  if (file.name.length > 100) {
+    throw new Error(`gvisorBundle: filename too long for ustar header (${file.name.length} > 100): ${file.name}`);
+  }
+  for (let i = 0; i < file.name.length; i++) {
+    const c = file.name.charCodeAt(i);
+    if (c === 0 || c > 0x7f) {
+      throw new Error(`gvisorBundle: filename must be ASCII without NUL bytes: ${file.name}`);
+    }
+  }
+
   const h = new Uint8Array(BLOCK);
   writeAscii(h, 0, file.name); // name[100]
   writeOctal(h, 100, 8, file.mode ?? 0o644); // mode[8]

--- a/k6/gvisorBundle.ts
+++ b/k6/gvisorBundle.ts
@@ -38,9 +38,11 @@ function writeOctal(
   value: number,
 ): void {
   const digits = len - 1;
-  let s = value.toString(8);
-  while (s.length < digits) s = "0" + s;
-  writeAscii(buf, offset, s);
+  const s = value.toString(8);
+  if (s.length > digits) {
+    throw new Error(`gvisorBundle: value ${value} does not fit in ${digits}-digit octal field`);
+  }
+  writeAscii(buf, offset, s.padStart(digits, "0"));
   buf[offset + digits] = 0;
 }
 

--- a/k6/gvisorBundle.ts
+++ b/k6/gvisorBundle.ts
@@ -1,0 +1,111 @@
+/**
+ * Minimal ustar tar builder for k6.
+ *
+ * The `/lit_binary_action` endpoint takes a base64-encoded tar(.gz) bundle
+ * (see litApiServer.ts). k6's JS runtime (goja) has no tar/gzip library, so
+ * this packs a handful of small ASCII text files into a plain (uncompressed)
+ * ustar archive by hand — enough to ship a gVisor action bundle. The server
+ * derives the content id from the decoded bytes, so no checksum is sent.
+ *
+ * Kept intentionally small: regular files only, ASCII content only (one byte
+ * per character), deterministic (zeroed mtime/uid/gid) so identical inputs
+ * hash to the same CID the runner caches under.
+ */
+import encoding from "k6/encoding";
+
+export interface BundleFile {
+  /** Path within the bundle root, e.g. "startup.sh". */
+  name: string;
+  /** File contents. ASCII only — one byte per character. */
+  content: string;
+  /** Octal file mode. Defaults to 0o644 (0o755 for e.g. an entrypoint). */
+  mode?: number;
+}
+
+const BLOCK = 512;
+
+function writeAscii(buf: Uint8Array, offset: number, str: string): void {
+  for (let i = 0; i < str.length; i++) {
+    buf[offset + i] = str.charCodeAt(i) & 0xff;
+  }
+}
+
+/** Zero-padded octal of `len - 1` digits followed by a NUL, into `len` bytes. */
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  len: number,
+  value: number,
+): void {
+  const digits = len - 1;
+  let s = value.toString(8);
+  while (s.length < digits) s = "0" + s;
+  writeAscii(buf, offset, s);
+  buf[offset + digits] = 0;
+}
+
+function header(file: BundleFile, size: number): Uint8Array {
+  const h = new Uint8Array(BLOCK);
+  writeAscii(h, 0, file.name); // name[100]
+  writeOctal(h, 100, 8, file.mode ?? 0o644); // mode[8]
+  writeOctal(h, 108, 8, 0); // uid[8]
+  writeOctal(h, 116, 8, 0); // gid[8]
+  writeOctal(h, 124, 12, size); // size[12]
+  writeOctal(h, 136, 12, 0); // mtime[12] — zeroed for determinism
+  writeAscii(h, 148, "        "); // chksum[8] — spaces while summing
+  h[156] = "0".charCodeAt(0); // typeflag '0' = regular file
+  writeAscii(h, 257, "ustar"); // magic[6] = "ustar\0"
+  h[262] = 0;
+  writeAscii(h, 263, "00"); // version[2]
+
+  // Header checksum: sum of every header byte (chksum field counted as
+  // spaces), stored as 6 octal digits + NUL + space (the traditional format
+  // the Rust `tar` crate and every extractor accept).
+  let sum = 0;
+  for (let i = 0; i < BLOCK; i++) sum += h[i];
+  let cs = sum.toString(8);
+  while (cs.length < 6) cs = "0" + cs;
+  writeAscii(h, 148, cs);
+  h[154] = 0;
+  h[155] = 0x20;
+  return h;
+}
+
+/** Build a plain (uncompressed) ustar archive of `files`. */
+export function buildTar(files: BundleFile[]): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  for (const f of files) {
+    // ASCII only: content.length is used as the tar byte size, and the CID the
+    // server derives depends on exact bytes. A non-ASCII char would make length
+    // (chars) disagree with the UTF-8 byte count and corrupt the archive.
+    for (let i = 0; i < f.content.length; i++) {
+      if (f.content.charCodeAt(i) > 0x7f) {
+        throw new Error(
+          `gvisorBundle: ${f.name} has a non-ASCII byte at index ${i}; bundle files must be ASCII-only`,
+        );
+      }
+    }
+    const size = f.content.length; // ASCII → byte length
+    blocks.push(header(f, size));
+    const padded = Math.ceil(size / BLOCK) * BLOCK;
+    const data = new Uint8Array(padded);
+    writeAscii(data, 0, f.content);
+    blocks.push(data);
+  }
+  // Two zero blocks mark end-of-archive.
+  blocks.push(new Uint8Array(BLOCK * 2));
+
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const b of blocks) {
+    out.set(b, offset);
+    offset += b.length;
+  }
+  return out;
+}
+
+/** Build the archive of `files` and base64-encode it for the request body. */
+export function buildBundleBase64(files: BundleFile[]): string {
+  return encoding.b64encode(buildTar(files).buffer);
+}

--- a/k6/justfile
+++ b/k6/justfile
@@ -37,6 +37,11 @@ smoke:
 smoke-local:
     K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} K6_ACCOUNTS_FILE={{ACCOUNTS_FILE}} K6_ENV={{_env}} k6 run smoke.spec.ts
 
+# gVisor deploy smoke: Python hello-world bundle via /lit_binary_action.
+# Needs gVisor enabled on the target (staging/next); prod has it off by default.
+gvisor-smoke-local:
+    K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} K6_ACCOUNTS_FILE={{ACCOUNTS_FILE}} K6_ENV={{_env}} k6 run gvisor-smoke.spec.ts
+
 soak:
     # K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} k6 cloud run --local-execution loadtest/soak.spec.ts
     K6_CORRELATION_ID={{_corr_id}} BASE_URL={{BASE_URL}} K6_ACCOUNTS_FILE={{ACCOUNTS_FILE}} K6_ENV={{_env}} k6 run --out cloud loadtest/soak.spec.ts


### PR DESCRIPTION
Adds a gVisor "hello world" smoke test (CPL-362) that runs a recent Python plus a `pip install cowsay==6.1` through the any-language sandbox via `POST /lit_binary_action`, wired into the deploy pipeline (`k6-smoke.yml`) to run on the non-prod test/next environment where gVisor is enabled (gated `if: inputs.env != 'prod'`). The test (`k6/gvisor-smoke.spec.ts`) reuses the existing smoke-test accounts, packs a Python bundle with a hand-rolled minimal ustar tar builder (`k6/gvisorBundle.ts`, since k6's goja runtime has no tar lib), and asserts the action ran without error and returned the expected Python payload. Bundle source lives as real ASCII files under `k6/LitActionCode/gvisor/`. Verified locally end-to-end: the tar extracts cleanly (system `tar` + Python `tarfile`) and `main.py` produces a response matching the spec's assertions. Docs and a `gvisor-smoke-local` justfile recipe are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)