### PR TITLE
fix(k6): make integration test resolve action hash from account-level list

### DIFF
--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -358,10 +358,10 @@ export default function (data: IntegrationSetupData) {
   }, "listApiKeys");
 
   // ── 15. updateActionMetadata ──────────────────────────────────────────────
-  const hasActionHash = checkAndLog(hashedCid, {
-    "resolved action hash for updateActionMetadata": (h) =>
-      typeof h === "string" && h.length > 0 && h !== "0x0",
-  }, "updateActionMetadata");
+const hasActionHash = checkAndLog(hashedCid, {
+  "resolved action hash for updateActionMetadata": (h) =>
+    typeof h === "string" && /^0x(?!0{64}$)[0-9a-fA-F]{64}$/.test(h),
+}, "updateActionMetadata");
   if (!hasActionHash) return;
   const updateActionRes = client.updateActionMetadata(
     {

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -244,7 +244,10 @@ export default function (data: IntegrationSetupData) {
       }
     },
   }, "listActions");
-  const listActionsBody = JSON.parse(listActionsRes.response.body as string) as { id: string; name: string }[];
+  // Derive the action hash from the account-level list (verified above to contain
+  // the action). The in-group list depends on add_action_to_group membership
+  // propagation, which can lag the on-chain write and yield an empty hash → 0x0.
+  const listActionsBody = JSON.parse(listActionsAccountRes.response.body as string) as { id: string; name: string }[];
   const actionItem = listActionsBody.find((a) => a.name === "hello-world");
   const hashedCid = actionItem?.id ?? "";
   // ── 10. addPkpToGroup ─────────────────────────────────────────────────────
@@ -355,6 +358,11 @@ export default function (data: IntegrationSetupData) {
   }, "listApiKeys");
 
   // ── 15. updateActionMetadata ──────────────────────────────────────────────
+  const hasActionHash = checkAndLog(hashedCid, {
+    "resolved action hash for updateActionMetadata": (h) =>
+      typeof h === "string" && h.length > 0 && h !== "0x0",
+  }, "updateActionMetadata");
+  if (!hasActionHash) return;
   const updateActionRes = client.updateActionMetadata(
     {
       hashed_cid: hashedCid,


### PR DESCRIPTION
The `k6-correctness / correctness` integration test was failing in Deploy Staging with `updateActionMetadata | 400 | Cannot update action with hash 0x0`. The test derived the action hash from the **in-group** `list_actions` response, which depends on `add_action_to_group` membership being visible on-chain; when that read lagged the write, the action was absent and `hashedCid` resolved to `""`, which the server parses to `U256::ZERO` and rejects. This sources the hash from the account-level list instead (already verified to contain the action, and independent of group-membership propagation) and adds a guard that fails clearly on an empty/`0x0` hash. The two prior main failures were a separate transient `newAccount 500 NoAccountAccess` issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)