### PR TITLE
fix(api,k6): ride out chain read-after-write races that flake the staging deploy gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,10 @@ doesn't describe endpoints the released server lacks.
 - `CONTRIBUTING.md`, expanded `.env.example`, and per-component READMEs.
 
 ### Fixed
-- `POST /new_account` no longer intermittently returns a 500
-  (`NoAccountAccess`) when the RPC provider serves the follow-up wallet
+- `POST /new_account` now retries (with backoff) the intermittent 500
+  (`NoAccountAccess`) seen when the RPC provider serves the follow-up wallet
   registration's dry-run from a node that hasn't executed the just-mined
-  `newAccount` block; the propagation window is now retried with backoff.
+  `newAccount` block, riding out the typical propagation window.
 - Release builds no longer report a spurious `-modified` version suffix
   (`.dockerignore` excluded a tracked file, dirtying `git describe` inside the
   image build).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ doesn't describe endpoints the released server lacks.
 - `CONTRIBUTING.md`, expanded `.env.example`, and per-component READMEs.
 
 ### Fixed
+- `POST /new_account` no longer intermittently returns a 500
+  (`NoAccountAccess`) when the RPC provider serves the follow-up wallet
+  registration's dry-run from a node that hasn't executed the just-mined
+  `newAccount` block; the propagation window is now retried with backoff.
 - Release builds no longer report a spurious `-modified` version suffix
   (`.dockerignore` excluded a tracked file, dirtying `git describe` inside the
   image build).

--- a/k6/correctness/integration.spec.ts
+++ b/k6/correctness/integration.spec.ts
@@ -6,6 +6,7 @@
  *   k6 run k6/integration.spec.ts
  *   BASE_URL=https://your-instance.phala.network/core/v1 k6 run k6/integration.spec.ts
  */
+import { sleep } from "k6";
 import { checkAndLog, warnOnHttpFailures } from "../helpers.ts";
 import { LitApiServerClient } from "../litApiServer.ts";
 import { PRECREATED_ACCOUNTS } from "../setup.ts";
@@ -206,10 +207,41 @@ export default function (data: IntegrationSetupData) {
   }, "addActionToGroup");
 
   // ── 10a. listActions (account-level, no group_id) ────────────────────────
-  const listActionsAccountRes = client.listActions(
+  // The action metadata + group membership were written on-chain moments ago;
+  // list reads can briefly lag the write (the RPC can serve the read from a
+  // node that hasn't executed those blocks yet). Poll until the action is
+  // visible with a real id so propagation lag doesn't fail the deploy gate —
+  // a genuinely missing action still fails the checks after the retries, and
+  // a stale group listing would otherwise send hash 0x0 to
+  // update_action_metadata below.
+  const LIST_ACTIONS_ATTEMPTS = 5;
+  const findHelloWorld = (body: unknown): { id: string; name: string } | undefined => {
+    try {
+      const items = JSON.parse(body as string) as { id: string; name: string }[];
+      const item = Array.isArray(items) ? items.find((a) => a.name === "hello-world") : undefined;
+      // An all-zero id means the membership row landed but the metadata read
+      // is still stale — treat as not-yet-visible and keep polling.
+      return item && item.id && !/^(0x)?0*$/.test(item.id) ? item : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  let listActionsAccountRes = client.listActions(
     { page_number: 0, page_size: 10 },
     authHeaders,
   );
+  for (
+    let i = 1;
+    i < LIST_ACTIONS_ATTEMPTS && !findHelloWorld(listActionsAccountRes.response.body);
+    i++
+  ) {
+    sleep(2);
+    listActionsAccountRes = client.listActions(
+      { page_number: 0, page_size: 10 },
+      authHeaders,
+    );
+  }
   if (!assertOk("listActionsAccount", "GET /list_actions (account)", listActionsAccountRes)) return;
   checkAndLog(listActionsAccountRes.response, {
     "listActionsAccount returns array": (r) => {
@@ -229,11 +261,22 @@ export default function (data: IntegrationSetupData) {
     },
   }, "listActionsAccount");
 
-  // ── 10b. listActions (in group) ─────────────────────────────────────────
-  const listActionsRes = client.listActions(
+  // ── 10b. listActions (in group) — same propagation-lag polling as 10a ────
+  let listActionsRes = client.listActions(
     { group_id: parseInt(groupId), page_number: 0, page_size: 10 },
     authHeaders,
   );
+  for (
+    let i = 1;
+    i < LIST_ACTIONS_ATTEMPTS && !findHelloWorld(listActionsRes.response.body);
+    i++
+  ) {
+    sleep(2);
+    listActionsRes = client.listActions(
+      { group_id: parseInt(groupId), page_number: 0, page_size: 10 },
+      authHeaders,
+    );
+  }
   if (!assertOk("listActions", "GET /list_actions", listActionsRes)) return;
   checkAndLog(listActionsRes.response, {
     "listActions returns array": (r) => {
@@ -244,8 +287,14 @@ export default function (data: IntegrationSetupData) {
       }
     },
   }, "listActions");
-  const listActionsBody = JSON.parse(listActionsRes.response.body as string) as { id: string; name: string }[];
-  const actionItem = listActionsBody.find((a) => a.name === "hello-world");
+  const actionItem = findHelloWorld(listActionsRes.response.body);
+  if (
+    !checkAndLog(listActionsRes.response, {
+      "listActions group contains added action with non-zero id": () => actionItem !== undefined,
+    }, "listActions")
+  ) {
+    return;
+  }
   const hashedCid = actionItem?.id ?? "";
   // ── 10. addPkpToGroup ─────────────────────────────────────────────────────
   const addPkpRes = client.addPkpToGroup(

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -42,6 +42,11 @@ use rocket::serde::json::Json;
 /// to include the NotAllowedTo* error types. Track as follow-up.
 const PERMISSION_ERROR_PATTERNS: &[&str] = &["NotAllowedTo", "NotMasterAccount", "NoAccountAccess"];
 
+/// Attempts for the registerWalletDerivation follow-up write inside `new_account`
+/// (1 initial + 3 retries, exponential backoff from 250ms). Only the stale-read
+/// NoAccountAccess revert is retried — see the comment at the call site.
+const REGISTER_WALLET_DERIVATION_ATTEMPTS: u32 = 4;
+
 fn map_contract_error(e: anyhow::Error, context: &str) -> ApiStatus {
     let msg = format!("{}", e);
     if PERMISSION_ERROR_PATTERNS
@@ -125,15 +130,42 @@ pub async fn new_account(
     }
 
     // technically this is NOT a derivaton path at all, but it's a stand-in for now
-    accounts::register_wallet_derivation(
-        signer_pool,
-        &api_key,
-        wallet_address,
-        derivation_path,
-        "AMW",
-        "Account Master Wallet",
-    )
-    .await?;
+    //
+    // The newAccount receipt above proves the account exists on-chain, but
+    // send_transaction dry-runs this follow-up write via eth_call, and the RPC
+    // provider can serve that call from a node that hasn't executed the
+    // newAccount block yet — reverting NoAccountAccess for an account that was
+    // just mined. That stale-read window is the only way NoAccountAccess can
+    // occur here, so retry it briefly; any other error fails immediately.
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        match accounts::register_wallet_derivation(
+            signer_pool.clone(),
+            &api_key,
+            wallet_address,
+            derivation_path,
+            "AMW",
+            "Account Master Wallet",
+        )
+        .await
+        {
+            Ok(_) => break,
+            Err(e)
+                if attempt < REGISTER_WALLET_DERIVATION_ATTEMPTS
+                    && e.to_string().contains("NoAccountAccess") =>
+            {
+                let backoff_ms = 250u64 << (attempt - 1);
+                tracing::warn!(
+                    "new_account: registerWalletDerivation simulation hit stale-read \
+                     NoAccountAccess (attempt {attempt}/{REGISTER_WALLET_DERIVATION_ATTEMPTS}); \
+                     retrying in {backoff_ms}ms"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
 
     // Best-effort: eagerly create the Stripe customer (with $0 balance), set the email
     // if provided, and grant starter credits when STARTER_CREDITS_CENTS is configured.

--- a/lit-api-server/src/core/account_management.rs
+++ b/lit-api-server/src/core/account_management.rs
@@ -47,6 +47,23 @@ const PERMISSION_ERROR_PATTERNS: &[&str] = &["NotAllowedTo", "NotMasterAccount",
 /// NoAccountAccess revert is retried — see the comment at the call site.
 const REGISTER_WALLET_DERIVATION_ATTEMPTS: u32 = 4;
 
+/// Retry policy for the registerWalletDerivation follow-up inside `new_account`:
+/// returns the backoff before the next attempt, or `None` to stop retrying.
+/// `attempt` is 1-based (the attempt that just failed). Only the stale-read
+/// NoAccountAccess revert is retryable — the newAccount receipt proves the
+/// account exists, so that revert can only mean the dry-run's eth_call hit an
+/// RPC node that hasn't executed the newAccount block yet.
+fn register_wallet_derivation_retry_backoff(
+    attempt: u32,
+    error_msg: &str,
+) -> Option<std::time::Duration> {
+    if attempt < REGISTER_WALLET_DERIVATION_ATTEMPTS && error_msg.contains("NoAccountAccess") {
+        Some(std::time::Duration::from_millis(250u64 << (attempt - 1)))
+    } else {
+        None
+    }
+}
+
 fn map_contract_error(e: anyhow::Error, context: &str) -> ApiStatus {
     let msg = format!("{}", e);
     if PERMISSION_ERROR_PATTERNS
@@ -151,19 +168,19 @@ pub async fn new_account(
         .await
         {
             Ok(_) => break,
-            Err(e)
-                if attempt < REGISTER_WALLET_DERIVATION_ATTEMPTS
-                    && e.to_string().contains("NoAccountAccess") =>
-            {
-                let backoff_ms = 250u64 << (attempt - 1);
-                tracing::warn!(
-                    "new_account: registerWalletDerivation simulation hit stale-read \
-                     NoAccountAccess (attempt {attempt}/{REGISTER_WALLET_DERIVATION_ATTEMPTS}); \
-                     retrying in {backoff_ms}ms"
-                );
-                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
-            }
-            Err(e) => return Err(e.into()),
+            Err(e) => match register_wallet_derivation_retry_backoff(attempt, &e.to_string()) {
+                Some(backoff) => {
+                    tracing::warn!(
+                        "new_account: registerWalletDerivation simulation hit stale-read \
+                             NoAccountAccess (attempt \
+                             {attempt}/{REGISTER_WALLET_DERIVATION_ATTEMPTS}); retrying in \
+                             {}ms",
+                        backoff.as_millis()
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+                None => return Err(e.into()),
+            },
         }
     }
 
@@ -983,6 +1000,53 @@ mod tests {
             assert!(
                 !crate::utils::parse_with_hash::is_precomputed_hash_shape(&encoded),
                 "encoded API key {encoded:?} unexpectedly matched precomputed-hash shape",
+            );
+        }
+    }
+
+    const STALE_READ_MSG: &str = "Simulation failed: Contract error: NoAccountAccess (0x7b0f9c07…)";
+
+    /// The stale-read NoAccountAccess revert retries with doubling backoff until
+    /// the attempt budget is spent; the final attempt's failure is not retried.
+    #[test]
+    fn register_wallet_derivation_retries_stale_read_with_doubling_backoff() {
+        assert_eq!(
+            register_wallet_derivation_retry_backoff(1, STALE_READ_MSG),
+            Some(std::time::Duration::from_millis(250))
+        );
+        assert_eq!(
+            register_wallet_derivation_retry_backoff(2, STALE_READ_MSG),
+            Some(std::time::Duration::from_millis(500))
+        );
+        assert_eq!(
+            register_wallet_derivation_retry_backoff(3, STALE_READ_MSG),
+            Some(std::time::Duration::from_millis(1000))
+        );
+        // Attempt budget spent (4 = REGISTER_WALLET_DERIVATION_ATTEMPTS): stop.
+        assert_eq!(
+            register_wallet_derivation_retry_backoff(
+                REGISTER_WALLET_DERIVATION_ATTEMPTS,
+                STALE_READ_MSG
+            ),
+            None
+        );
+    }
+
+    /// Any error other than the stale-read NoAccountAccess revert fails
+    /// immediately — retrying e.g. a nonce failure or a genuine permission
+    /// error would only add latency to a request that cannot succeed.
+    #[test]
+    fn register_wallet_derivation_does_not_retry_other_errors() {
+        for msg in [
+            "Simulation failed: Contract error: InvalidRequest (PKP already registered)",
+            "Failed to send transaction: nonce too low",
+            "transaction reverted on-chain (tx hash: 0xabc, block: Some(1))",
+            "",
+        ] {
+            assert_eq!(
+                register_wallet_derivation_retry_backoff(1, msg),
+                None,
+                "must not retry: {msg:?}"
             );
         }
     }


### PR DESCRIPTION
### HOLD

I think I may have merged a second branch into `main` before the first one completed - this also matches the results of the investigation... and by Occum's Razor ...

## Why

Three consecutive `Deploy Staging` runs on main were rolled back by k6-correctness failures, leaving staging stuck on `2c972ff3` (v1.1.10-58):

| Run | Commit | Failure |
|---|---|---|
| [29880089230](https://github.com/LIT-Protocol/chipotle/actions/runs/29880089230) | 6e98d2b1 | `POST /new_account` → 500 `Simulation failed: NoAccountAccess` (1 of 4 iterations) |
| [29880104213](https://github.com/LIT-Protocol/chipotle/actions/runs/29880104213) | d40b01d4 | `POST /update_action_metadata` → 400 `Cannot update action with hash 0x0` |
| [29882923105](https://github.com/LIT-Protocol/chipotle/actions/runs/29882923105) | e79f93af | every request EOF — cold box unreachable ~6 min after boot |

The [Jul 20 run](https://github.com/LIT-Protocol/chipotle/actions/runs/29768860524) (pre-dating all three commits) failed with the **identical** `NoAccountAccess` error, so failures 1–2 are chronic flakes, not regressions from those commits. Both reduce to the same root cause: **reads racing just-mined writes on the load-balanced RPC.**

## What

**`new_account` 500 (real user-facing bug, not just a gate flake):** the `newAccount` receipt proves the account exists, but `send_transaction` dry-runs the follow-up `registerWalletDerivation` via `eth_call`, which the provider can serve from a node that hasn't executed that block yet — reverting `NoAccountAccess` for an account that was just mined. `newAccount` itself never reverts `NoAccountAccess` (checked WritesFacet.sol), so at this call site the revert can only be the stale-read window. Retry it (4 attempts, 250 ms exponential backoff); any other error still fails immediately.

**`hash 0x0` 400:** `integration.spec.ts` took `hashed_cid` from a `list_actions` read issued immediately after `add_action`/`add_action_to_group`; a stale read returned the action without a usable id and the spec forwarded `0x0`. Both list reads now poll until the action is visible with a non-zero id (up to 5 attempts, 2 s apart — worst case ~8 s per list, paid only while the read is actually stale; the fast path costs nothing), and the spec fails explicitly if it never appears.

## Not addressed: the EOF in run 29882923105

The cold box (`chipotle-next-rep-sa6xj`, prod2) passed wait-for-api/attestation/openapi/smoke at minute ~2 after boot and was fully unreachable by minute ~7. Runs 1–2 stopped their cold box before minute 5, so they can't rule a dies-after-boot defect in or out. The ping-pong rollback worked as designed (domain restored to `...-rep-w4hdl`, bad box stopped). The next deploy is the second data point — if it EOFs again ~6 min after boot, the new build has a genuine post-boot crash and the box's phala logs need a look before it's stopped.

## Testing

- `cargo +1.91 check` / `cargo +1.91 test --lib account_management` / `cargo +1.91 fmt` on lit-api-server
- `k6 inspect k6/correctness/integration.spec.ts` parses clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
