### PR TITLE
fix(monitor): use optionalChains for WalletConnect Safe compatibility

### DIFF
--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -767,7 +767,19 @@ async function connectWallet() {
     try {
       _wcProvider = await EthereumProvider.init({
         projectId: WALLETCONNECT_PROJECT_ID,
-        chains: [chainId],
+        // CRITICAL: use `optionalChains`, NOT `chains`. @walletconnect/ethereum-provider
+        // turns `chains` into a *requiredNamespaces* entry. A Gnosis Safe (and any
+        // smart-contract wallet) only supports the single chain it was deployed to, and
+        // Reown's own guidance is explicit that required namespaces "cause issues" with
+        // such wallets: the session pairs successfully (the Safe app opens) but the
+        // eth_sendTransaction request never routes to the wallet, so the transaction to
+        // sign silently disappears. Declaring the chain as *optional* keeps EOA wallets
+        // (MetaMask, Rabby) working while letting the Safe negotiate its single chain.
+        // Methods intentionally left unset → they default to the full OPTIONAL_METHODS
+        // set (includes eth_sendTransaction), which the wallet echoes into the approved
+        // namespace so signing routes to the wallet rather than the read-only RPC.
+        // See https://docs.reown.com/advanced/providers/ethereum ("Smart Contract Wallets").
+        optionalChains: [chainId],
         rpcMap: rpcUrl ? { [chainId]: rpcUrl } : undefined,
         showQrModal: true,
       });


### PR DESCRIPTION
Signing with WalletConnect + a Gnosis Safe in the Monitor dApp broke: the Safe app opened but the transaction to sign never appeared. Root cause is that the Monitor's WalletConnect init passed `chains: [chainId]`, which `@walletconnect/ethereum-provider` compiles into a `requiredNamespaces` entry — and Reown documents required namespaces as incompatible with smart-contract wallets like Safe (which only support the single chain they were deployed to), so the session pairs but `eth_sendTransaction` never routes to the wallet. This switches to `optionalChains: [chainId]` so the Safe can negotiate its single chain while EOA wallets (MetaMask/Rabby) keep working; methods are left to default to the full OPTIONAL_METHODS set. No automated coverage exists for WalletConnect+Safe, so this needs a manual verification pass against a live Safe on Base before landing. Note: `lit-static/wallet_connect.js` (dashboard billing flow) has the same latent pattern but was left untouched to avoid regressing its typed-data namespace guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)