### PR TITLE
feat(monitor): CPL-363 layout overhaul for the monitor dApp

### DIFF
--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -31,6 +31,14 @@ const ACCOUNT_CONFIG_VIEW_ABI = [
     type: 'function',
   },
   {
+    // ERC-173 owner() — served by the diamond's OwnershipFacet.
+    inputs: [],
+    name: 'owner',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     inputs: [],
     name: 'adminApiPayerAccount',
     outputs: [{ internalType: 'address', name: '', type: 'address' }],
@@ -468,7 +476,7 @@ async function getNodeChainConfig(serverUrl) {
 
   if (errEl) errEl.style.display = 'none';
   if (resultsEl) resultsEl.style.display = 'block';
-  ['cc-chain-name','cc-chain-id','cc-is-evm','cc-testnet','cc-token','cc-contract-address']
+  ['cc-chain-name','cc-chain-id','cc-is-evm','cc-testnet','cc-token','cc-contract-address','ver-contract-address']
     .forEach(id => setValue(id, '…', false));
   const rpcUrlInput = el('cc-rpc-url');
   if (rpcUrlInput) rpcUrlInput.value = '';
@@ -492,12 +500,14 @@ async function getNodeChainConfig(serverUrl) {
     if (rpcInput) rpcInput.value = rpcUrl;
 
     setValue('cc-contract-address', cfg.contract_address ?? '—', !cfg.contract_address);
+    setValue('ver-contract-address', cfg.contract_address ?? '—', !cfg.contract_address);
 
     const contractInput = el('contract-address');
     if (contractInput && cfg.contract_address) contractInput.value = cfg.contract_address;
   } catch (e) {
     const rpcInput = el('cc-rpc-url');
     if (rpcInput) rpcInput.value = '';
+    setValue('ver-contract-address', '—', true);
     if (resultsEl) resultsEl.style.display = 'none';
     if (errEl) { errEl.textContent = e?.message || String(e); errEl.style.display = 'block'; }
   }
@@ -566,15 +576,16 @@ async function getApiPayers(serverUrl) {
   }
 }
 
+// Renders into the horizontal version bar just above the Pool Health bar.
 async function fetchVersion(serverUrl) {
-  const resultsEl = el('version-results');
   const errEl = el('version-error');
+  const submodulesEl = el('ver-submodules');
 
   if (errEl) errEl.style.display = 'none';
+  setValue('ver-name', '…', false);
   setValue('ver-version', '…', false);
-  const submodulesEl = el('ver-submodules');
+  setValue('ver-commit-version', '…', false);
   if (submodulesEl) submodulesEl.innerHTML = '';
-  if (resultsEl) resultsEl.style.display = 'block';
 
   try {
     const res = await fetch(`${serverUrl}/version`);
@@ -586,23 +597,15 @@ async function fetchVersion(serverUrl) {
     setValue('ver-commit-version', data.commit_version ?? '—', !data.commit_version);
 
     if (submodulesEl) {
-      const rows = (data.submodule_versions ?? []);
-      if (rows.length === 0) {
-        submodulesEl.innerHTML = '<span style="color:var(--muted);font-size:0.85rem">None</span>';
-      } else {
-        submodulesEl.innerHTML =
-          `<table>` +
-            `<thead><tr><th>Submodule</th><th>Version</th></tr></thead>` +
-            `<tbody>` +
-              rows.map(([name, ver]) =>
-                `<tr><td>${escapeHtml(name)}</td><td>${escapeHtml(ver)}</td></tr>`
-              ).join('') +
-            `</tbody>` +
-          `</table>`;
-      }
+      submodulesEl.innerHTML = (data.submodule_versions ?? []).map(([name, ver]) =>
+        `<div class="health-bar-item">` +
+          `<span class="health-bar-label">${escapeHtml(name)}</span>` +
+          `<span class="health-bar-value">${escapeHtml(ver)}</span>` +
+        `</div>`
+      ).join('');
     }
   } catch (e) {
-    if (resultsEl) resultsEl.style.display = 'none';
+    ['ver-name', 'ver-version', 'ver-commit-version'].forEach(id => setValue(id, '—', true));
     if (errEl) { errEl.textContent = e?.message || String(e); errEl.style.display = 'block'; }
   }
 }
@@ -630,6 +633,7 @@ async function fetchContractValues() {
   }
 
   hideError();
+  setValue('val-contract-owner', '…', false);
   setValue('val-pricing-operator', '…', false);
   setValue('val-pricing-operator-balance', '', false);
   setValue('val-admin-api-payer', '…', false);
@@ -655,6 +659,13 @@ async function fetchContractValues() {
 
     setValue('val-pricing-operator', pricingOperator ?? '—', !pricingOperator);
     setValue('val-admin-api-payer', adminApiPayer ?? '—', !adminApiPayer);
+
+    // owner() lives on the OwnershipFacet — fetch it separately so a diamond
+    // deployed without that facet doesn't blank the rest of the card.
+    contract.owner()
+      .then(owner => setValue('val-contract-owner', owner ?? '—', !owner))
+      .catch(() => setValue('val-contract-owner', '—', true));
+
     setValue('val-payer-count', String(apiPayerCount), false);
     setValue('val-requested-api-payer-count', String(requestedApiPayerCount), false);
     setValue('val-rebalance-amount', ethers.formatEther(rebalanceAmountWei) + ' ETH', false);
@@ -789,12 +800,17 @@ async function connectWallet() {
 
 // ── fetchChainConfigKeys ────────────────────────────────────────────────
 
+// Populates the Node Configuration key dropdown with the ConfigKeys variants
+// the node reads from chain (GET /get_chain_config_keys).
 async function fetchChainConfigKeys(serverUrl) {
-  const listEl = el('chain-config-keys-list');
-  const errEl = el('chain-config-keys-error');
+  const select = el('node-config-key');
+  const errEl = el('node-config-keys-error');
 
   if (errEl) errEl.style.display = 'none';
-  if (listEl) listEl.innerHTML = '<span style="color:var(--muted)">Loading…</span>';
+  if (!select) return;
+
+  const previous = select.value;
+  select.innerHTML = '<option value="" disabled selected>Loading keys…</option>';
 
   try {
     const res = await fetch(`${serverUrl}/get_chain_config_keys`);
@@ -802,13 +818,12 @@ async function fetchChainConfigKeys(serverUrl) {
     const data = await res.json();
     const keys = data.keys ?? [];
 
-    if (listEl) {
-      listEl.innerHTML = keys.length === 0
-        ? '<span style="color:var(--muted)">No keys returned.</span>'
-        : keys.map(k => `<div class="result-row"><span class="result-value">${escapeHtml(k)}</span></div>`).join('');
-    }
+    select.innerHTML =
+      '<option value="" disabled selected>Select a key…</option>' +
+      keys.map(k => `<option value="${escapeHtml(k)}">${escapeHtml(k)}</option>`).join('');
+    if (previous && keys.includes(previous)) select.value = previous;
   } catch (e) {
-    if (listEl) listEl.innerHTML = '';
+    select.innerHTML = '<option value="" disabled selected>Failed to load keys</option>';
     if (errEl) { errEl.textContent = e?.message || String(e); errEl.style.display = 'block'; }
   }
 }
@@ -1405,7 +1420,7 @@ el('btn-set-node-config')?.addEventListener('click', async () => {
     return;
   }
   if (!key) {
-    showStatus('node-config-status', 'Enter a configuration key.', true);
+    showStatus('node-config-status', 'Select a configuration key.', true);
     return;
   }
 
@@ -1505,6 +1520,12 @@ el('btn-set-payer-count')?.addEventListener('click', async () => {
 });
 
 /* ═══ Initialization ═════════════════════════════════════════════════════════ */
+
+el('ver-contract-address')?.addEventListener('click', () => {
+  const node = el('ver-contract-address');
+  const text = (node?.textContent || '').trim();
+  if (text && text !== '—' && text !== '…') copyText(text, node);
+});
 
 (function () {
   const select = el('network');

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -46,19 +46,44 @@
         margin-bottom: 1.5rem;
       }
 
-      /* ── Top bar: network selector + refresh ── */
-      .top-bar {
+      /* ── Header row: title + network selector & refresh (upper right) ── */
+      .header-row {
         display: flex;
-        align-items: flex-end;
-        gap: 1rem;
+        align-items: center;
+        gap: 1.25rem;
         margin-bottom: 1.5rem;
         flex-wrap: wrap;
+      }
+      .header-row h1 {
+        margin: 0 0 0.15rem;
+      }
+      .header-row .subtitle {
+        margin: 0;
+      }
+      select.network-select {
+        padding: 0.5rem 2rem 0.5rem 0.75rem;
+        font-family: 'Outfit', sans-serif;
+        font-size: 0.85rem;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--text);
+        cursor: pointer;
+        appearance: none;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2371717a' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: right 0.75rem center;
+        max-width: 260px;
+      }
+      select.network-select:focus {
+        outline: none;
+        border-color: var(--accent);
       }
       .refresh-controls {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        padding-bottom: 1px;
+        margin-left: auto;
       }
       .countdown {
         font-family: 'JetBrains Mono', monospace;
@@ -331,6 +356,11 @@
         margin-bottom: 1.5rem;
         align-items: start;
       }
+      .sys-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
       .sys-grid .card h2 {
         font-size: 1rem;
         font-weight: 600;
@@ -446,25 +476,45 @@
     </style>
   </head>
   <body>
-    <h1>Lit Node Monitor</h1>
-    <p class="subtitle">
-      Payer safety, runtime health, and CVM system monitoring for the Lit Node Express server.
-    </p>
-
-    <!-- ═══ Top bar: Network selector + refresh controls ═══ -->
-    <div class="top-bar">
-      <div class="form-group" style="flex: 1; max-width: 480px; margin-bottom: 0;">
-        <label for="network">Network</label>
-        <select id="network">
+    <!-- ═══ Header row: title + network selector & refresh (upper right) ═══ -->
+    <div class="header-row">
+      <div>
+        <h1>Lit Node Monitor</h1>
+        <p class="subtitle">
+          Payer safety, runtime health, and CVM system monitoring for the Lit Node Express server.
+        </p>
+      </div>
+      <div class="refresh-controls">
+        <select id="network" class="network-select" title="Network" aria-label="Network">
           <option value="http://localhost:8000/core/v1/">Local Development</option>
           <option value="https://test.chipotle.litprotocol.com/core/v1/">Next - Phala</option>
           <option value="https://api.chipotle.litprotocol.com/core/v1/">Prod - Phala</option>
         </select>
-      </div>
-      <div class="refresh-controls">
         <button type="button" id="btn-refresh-all" title="Refresh all data (R)" style="margin-top: 0; padding: 0.4rem 0.9rem; font-size: 0.85rem;">Refresh</button>
         <span id="refresh-countdown" class="countdown">30s</span>
       </div>
+    </div>
+
+    <!-- ═══ Server version bar (GET /version) ═══ -->
+    <div id="version-bar" class="health-bar">
+      <div class="health-bar-item">
+        <span class="health-bar-label">Server</span>
+        <span class="health-bar-value" id="ver-name">—</span>
+      </div>
+      <div class="health-bar-item">
+        <span class="health-bar-label">Version</span>
+        <span class="health-bar-value" id="ver-version">—</span>
+      </div>
+      <div class="health-bar-item">
+        <span class="health-bar-label">Commit</span>
+        <span class="health-bar-value" id="ver-commit-version">—</span>
+      </div>
+      <div class="health-bar-item">
+        <span class="health-bar-label">Contract</span>
+        <span class="health-bar-value copyable" id="ver-contract-address" title="Click to copy">—</span>
+      </div>
+      <div id="ver-submodules" style="display: contents"></div>
+      <span id="version-error" class="sys-error" style="display: none"></span>
     </div>
 
     <!-- ═══ Health summary bar ═══ -->
@@ -485,11 +535,20 @@
 
     <!-- ═══ CVM System dashboard ═══ -->
     <div class="sys-grid">
-      <div class="card">
-        <h2>Runtimes</h2>
-        <p class="endpoint-hint"><code>GET /health</code> &middot; <code>GET /get_system_stats</code> — Lit Action runners inside the CVM.</p>
-        <div id="runtimes-body"><span class="sys-empty">Loading&hellip;</span></div>
-        <div id="runtimes-error" class="sys-error" style="display: none"></div>
+      <div class="sys-stack">
+        <div class="card">
+          <h2>Runtimes</h2>
+          <p class="endpoint-hint"><code>GET /health</code> &middot; <code>GET /get_system_stats</code> — Lit Action runners inside the CVM.</p>
+          <div id="runtimes-body"><span class="sys-empty">Loading&hellip;</span></div>
+          <div id="runtimes-error" class="sys-error" style="display: none"></div>
+        </div>
+
+        <div class="card">
+          <h2>Supported Languages</h2>
+          <p class="endpoint-hint"><code>GET /get_supported_languages</code> — language capability surface of this node.</p>
+          <div id="languages-body"><span class="sys-empty">Loading&hellip;</span></div>
+          <div id="languages-error" class="sys-error" style="display: none"></div>
+        </div>
       </div>
 
       <div class="card">
@@ -504,13 +563,6 @@
         <p class="endpoint-hint"><code>GET /get_system_stats</code> — in-process cache population (action code, permissions, billing).</p>
         <div id="caches-body"><span class="sys-empty">Loading&hellip;</span></div>
         <div id="caches-error" class="sys-error" style="display: none"></div>
-      </div>
-
-      <div class="card">
-        <h2>Supported Languages</h2>
-        <p class="endpoint-hint"><code>GET /get_supported_languages</code> — language capability surface of this node.</p>
-        <div id="languages-body"><span class="sys-empty">Loading&hellip;</span></div>
-        <div id="languages-error" class="sys-error" style="display: none"></div>
       </div>
     </div>
 
@@ -558,36 +610,6 @@
         <div class="card" data-accordion>
           <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div>
-              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Server Version</h2>
-              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
-                <code>GET /version</code>
-              </p>
-            </div>
-            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
-          </div>
-          <div class="card-body">
-            <div id="version-results" style="display: none; margin-top: 1rem">
-              <div class="result-row">
-                <span class="result-label">name</span>
-                <span class="result-value" id="ver-name">—</span>
-              </div>
-              <div class="result-row">
-                <span class="result-label">version</span>
-                <span class="result-value" id="ver-version">—</span>
-              </div>
-              <div class="result-row">
-                <span class="result-label">commit</span>
-                <span class="result-value" id="ver-commit-version">—</span>
-              </div>
-              <div style="margin-top: 0.75rem" id="ver-submodules"></div>
-            </div>
-            <div id="version-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
-          </div>
-        </div>
-
-        <div class="card" data-accordion>
-          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
-            <div>
               <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Lit Node Express - Configuration</h2>
               <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
                 <code>GET /get_node_chain_config</code>
@@ -606,27 +628,6 @@
               <div class="result-row"><span class="result-label">contract_address</span><span class="result-value" id="cc-contract-address">—</span></div>
             </div>
             <div id="chain-config-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
-          </div>
-        </div>
-
-      </div>
-
-      <!-- ═══ RIGHT COLUMN — config & interactive ═══ -->
-      <div class="col">
-
-        <div class="card" data-accordion>
-          <div class="card-header" role="button" tabindex="0" aria-expanded="true">
-            <div>
-              <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 0.25rem">Supported Chain Config Keys</h2>
-              <p style="color: var(--muted); font-size: 0.85rem; margin: 0">
-                <code>GET /get_chain_config_keys</code> — all recognised <code>ConfigKeys</code> variants that the node reads from chain.
-              </p>
-            </div>
-            <svg class="chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M4.47 5.47a.75.75 0 011.06 0L8 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 010-1.06z"/></svg>
-          </div>
-          <div class="card-body">
-            <div id="chain-config-keys-list"></div>
-            <div id="chain-config-keys-error" style="display: none; color: #f87171; font-size: 0.85rem; margin-top: 0.75rem;"></div>
           </div>
         </div>
 
@@ -656,6 +657,11 @@
           </div>
         </div>
 
+      </div>
+
+      <!-- ═══ RIGHT COLUMN — config & interactive ═══ -->
+      <div class="col">
+
         <div class="card" data-accordion>
           <div class="card-header" role="button" tabindex="0" aria-expanded="true">
             <div style="display:flex;align-items:center;gap:0.75rem">
@@ -669,6 +675,10 @@
 
             <div class="results" id="results" style="display: none">
               <h2>Contract values</h2>
+              <div class="result-row">
+                <span class="result-label">owner</span
+                ><span class="result-value" id="val-contract-owner">—</span>
+              </div>
               <div class="result-row">
                 <span class="result-label">pricing</span
                 ><span class="result-value" id="val-pricing-operator">—</span
@@ -725,7 +735,10 @@
 
             <div class="form-group" style="margin-top:1.5rem">
               <label for="node-config-key">Key</label>
-              <input type="text" id="node-config-key" placeholder="e.g. LIT_ACTION_DEFAULT_TIMEOUT_MS" />
+              <select id="node-config-key" style="font-family:'JetBrains Mono',monospace">
+                <option value="" disabled selected>Loading keys…</option>
+              </select>
+              <div id="node-config-keys-error" style="display:none;color:#f87171;font-size:0.85rem;margin-top:0.35rem;"></div>
             </div>
             <div class="form-group">
               <label for="node-config-value">Value</label>

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -676,8 +676,8 @@
             <div class="results" id="results" style="display: none">
               <h2>Contract values</h2>
               <div class="result-row">
-                <span class="result-label">owner</span
-                ><span class="result-value" id="val-contract-owner">—</span>
+                <span class="result-label">owner</span>
+                <span class="result-value" id="val-contract-owner">—</span>
               </div>
               <div class="result-row">
                 <span class="result-label">pricing</span


### PR DESCRIPTION
Implements [CPL-363](https://linear.app/litprotocol/issue/CPL-363/updates-to-monitor-dapp-lit-static-project): the Supported Chain Config Keys card is removed and its keys now feed a dropdown for the Configuration Key in Node Configuration. The Account Configuration Contract card moves to the top of the right column and gains the contract owner, read via the diamond's ERC-173 `owner()` (OwnershipFacet). Server Version becomes a horizontal bar just above Pool Health and now includes the click-to-copy AccountConfig contract address. Per review feedback, the network selector moves into the header next to the Refresh button, Supported Languages stacks under Runtimes, and Lit Action Client Configuration moves to the left column to even out the column heights. UI-only changes to `lit-static/dapps/monitor/` — smoke-tested in headless Chrome (renders cleanly; fetch failures degrade to caught error states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)