### PR TITLE
feat(monitor): show configOperator address + authorize it in api-payer gates

### DIFF
--- a/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
+++ b/lit-api-server/blockchain/lit_node_express/contracts/AccountConfigFacets/SecurityLib.sol
@@ -133,7 +133,8 @@ library SecurityLib {
         if (
             !s.api_payers.contains(caller) &&
             caller != LibDiamond.contractOwner() &&
-            caller != s.adminApiPayerAccount
+            caller != s.adminApiPayerAccount &&
+            caller != s.configOperator
         ) {
             revert AppStorage.OnlyApiPayerOrOwner(caller);
         }
@@ -158,20 +159,22 @@ library SecurityLib {
         if (
             !s.api_payers.contains(caller) &&
             caller != LibDiamond.contractOwner() &&
-            caller != s.adminApiPayerAccount
+            caller != s.adminApiPayerAccount &&
+            caller != s.configOperator
         ) {
             revert AppStorage.OnlyApiPayerOrOwner(caller);
         }
     }
 
     /// @notice Non-reverting predicate: true if caller is an api payer, the
-    ///         diamond owner, or the admin api payer account.
+    ///         diamond owner, the admin api payer account, or the config operator.
     function isApiPayerOrOwner(address caller) internal view returns (bool) {
         AppStorage.AccountConfigStorage storage s = AppStorage.getStorage();
         return
             s.api_payers.contains(caller) ||
             caller == LibDiamond.contractOwner() ||
-            caller == s.adminApiPayerAccount;
+            caller == s.adminApiPayerAccount ||
+            caller == s.configOperator;
     }
 
     /// @notice Resolve any API key hash (master or usage) to the master account hash.

--- a/lit-static/dapps/monitor/app.js
+++ b/lit-static/dapps/monitor/app.js
@@ -31,6 +31,13 @@ const ACCOUNT_CONFIG_VIEW_ABI = [
     type: 'function',
   },
   {
+    inputs: [],
+    name: 'configOperator',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     // ERC-173 owner() — served by the diamond's OwnershipFacet.
     inputs: [],
     name: 'owner',
@@ -636,6 +643,8 @@ async function fetchContractValues() {
   setValue('val-contract-owner', '…', false);
   setValue('val-pricing-operator', '…', false);
   setValue('val-pricing-operator-balance', '', false);
+  setValue('val-config-operator', '…', false);
+  setValue('val-config-operator-balance', '', false);
   setValue('val-admin-api-payer', '…', false);
   setValue('val-admin-api-payer-balance', '', false);
   setValue('val-payer-count', '…', false);
@@ -659,6 +668,23 @@ async function fetchContractValues() {
 
     setValue('val-pricing-operator', pricingOperator ?? '—', !pricingOperator);
     setValue('val-admin-api-payer', adminApiPayer ?? '—', !adminApiPayer);
+
+    // configOperator() may be absent on older diamonds — fetch separately so a
+    // missing selector doesn't blank the rest of the card.
+    contract.configOperator()
+      .then(addr => {
+        setValue('val-config-operator', addr ?? '—', !addr);
+        if (addr && addr !== ethers.ZeroAddress) {
+          provider.getBalance(addr).then(wei => {
+            const node = el('val-config-operator-balance');
+            if (node) {
+              node.textContent = parseFloat(ethers.formatEther(wei)).toFixed(6) + ' ETH';
+              node.style.color = '';
+            }
+          }).catch(() => {});
+        }
+      })
+      .catch(() => setValue('val-config-operator', '—', true));
 
     // owner() lives on the OwnershipFacet — fetch it separately so a diamond
     // deployed without that facet doesn't blank the rest of the card.

--- a/lit-static/dapps/monitor/index.html
+++ b/lit-static/dapps/monitor/index.html
@@ -685,6 +685,11 @@
                 ><span class="result-value" id="val-pricing-operator-balance" style="color:var(--muted);margin-left:auto"></span>
               </div>
               <div class="result-row">
+                <span class="result-label">config operator</span
+                ><span class="result-value" id="val-config-operator">—</span
+                ><span class="result-value" id="val-config-operator-balance" style="color:var(--muted);margin-left:auto"></span>
+              </div>
+              <div class="result-row">
                 <span class="result-label">admin Payer</span
                 ><span class="result-value" id="val-admin-api-payer">—</span
                 ><span class="result-value" id="val-admin-api-payer-balance" style="color:var(--muted);margin-left:auto"></span>


### PR DESCRIPTION
Adds a **config operator** row (address + ETH balance) to the monitor dApp's Account Configuration Contract card, fetched via a new `configOperator()` view ABI entry; it's fetched separately with a fallback so older diamonds lacking the selector don't blank the card.

Also authorizes `s.configOperator` in `SecurityLib`'s `revertIfNotApiPayerOrOwner`, `checkIfApiPayerOrOwner`, and `isApiPayerOrOwner`, alongside the existing api payers, diamond owner, and admin api payer account (no existing members removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)