### PR TITLE
fix(ci): Contract Upgrade checks out main, not the retired next branch

### DIFF
--- a/.github/workflows/manual_contract-upgrade.yml
+++ b/.github/workflows/manual_contract-upgrade.yml
@@ -1,7 +1,9 @@
 # Upgrade existing Diamond contract facets.
 #
-# Network and contract address are always read from the NodeConfig file
-# for the selected branch:
+# Network and contract address are read from the NodeConfig file for the
+# selected deploy target. All NodeConfig.*.toml files live on main (the
+# `next` branch was retired in CPL-272), so we always check out main and the
+# `target` input only selects which config to read:
 #   main → lit-api-server/NodeConfig.main.toml
 #   next → lit-api-server/NodeConfig.next.toml
 #
@@ -17,8 +19,8 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: "Branch whose NodeConfig to use"
+      target:
+        description: "Deploy target whose NodeConfig to use"
         required: true
         type: choice
         options:
@@ -27,7 +29,7 @@ on:
         default: next
 
 concurrency:
-  group: contract-upgrade-${{ inputs.branch }}
+  group: contract-upgrade-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
@@ -36,12 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: main
 
       - name: Read config from NodeConfig
         id: config
         run: |
-          CONFIG="lit-api-server/NodeConfig.${{ inputs.branch }}.toml"
+          CONFIG="lit-api-server/NodeConfig.${{ inputs.target }}.toml"
 
           if [ ! -f "$CONFIG" ]; then
             echo "::error::$CONFIG not found."


### PR DESCRIPTION
## Problem

The **Contract Upgrade** workflow failed with `lit-api-server/NodeConfig.next.toml not found` ([run 29962175213](https://github.com/LIT-Protocol/chipotle/actions/runs/29962175213/job/89065494888)), even though that file exists on `main`.

Root cause: the workflow coupled two things that shouldn't be coupled:
- `actions/checkout` used `ref: ${{ inputs.branch }}` (default `next`), and
- it then read `NodeConfig.<branch>.toml` from that checkout.

Dispatching with the default `next` checked out the **`next` branch** — which was **retired in CPL-272** (`3b0a7a2e`, "main now drives staging deploys") and had its `NodeConfig.next.toml` deleted. `origin/next` is now 481 commits behind `main`.

## Fix

All `NodeConfig.*.toml` files now live on `main` (`NodeConfig.main.toml` and `NodeConfig.next.toml` both present). So:
- Always check out `main`.
- The dispatch input now only selects which config to read; renamed `branch` → `target` to reflect it picks a deploy target, not a git ref.

Both `next` and `main` targets now resolve their config correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)