### PR TITLE
feat(lit-payments): auto-send the monthly enterprise invoice

### DIFF
--- a/lit-billing-core/src/invoice.rs
+++ b/lit-billing-core/src/invoice.rs
@@ -81,18 +81,28 @@ pub async fn add_invoice_item(
     Ok(id)
 }
 
-/// Finalize a draft invoice and send it to the customer (net-30). Used by the
+/// Finalize a draft invoice and email it to the customer (net-30). Used by the
 /// billing job for `auto_send` accounts; manual-send accounts finalize from the
-/// dashboard after review instead. Finalizing auto-sends because the invoice
-/// uses `collection_method = send_invoice`.
+/// dashboard after review instead.
+///
+/// The explicit `invoices/{id}/send` call is what guarantees the customer email:
+/// finalization alone only emails when the Stripe account's "email finalized
+/// invoices" dashboard setting happens to be on, which this code doesn't control.
+/// The two POSTs take separate idempotency keys so a retry that finds the
+/// invoice already finalized can still be deduped on the send step.
 pub async fn finalize_and_send(
     client: &StripeClient,
     invoice_id: &str,
-    idempotency_key: &str,
+    finalize_idempotency_key: &str,
+    send_idempotency_key: &str,
 ) -> Result<()> {
     let path = format!("invoices/{invoice_id}/finalize");
     client
-        .post_with_idempotency(&path, &[("auto_advance", "true")], idempotency_key)
+        .post_with_idempotency(&path, &[("auto_advance", "true")], finalize_idempotency_key)
+        .await?;
+    let path = format!("invoices/{invoice_id}/send");
+    client
+        .post_with_idempotency(&path, &[], send_idempotency_key)
         .await?;
     Ok(())
 }

--- a/lit-billing-core/src/invoice.rs
+++ b/lit-billing-core/src/invoice.rs
@@ -1,14 +1,15 @@
 //! Stripe invoicing primitives.
 //!
 //! Used by the enterprise committed-use billing job in `lit-payments`: create a
-//! *draft* invoice on the invoice customer, attach line items, and (later, when
-//! we drop the human-in-the-loop step) finalize + send it.
+//! *draft* invoice on the invoice customer, attach line items, and — for
+//! `auto_send` accounts — finalize + send it.
 //!
 //! Invoices are created with `collection_method = send_invoice` and
 //! `days_until_due = 30` (net-30), and `auto_advance = false` so they stay as a
-//! reviewable **draft** until explicitly finalized — either by a human in the
-//! Stripe dashboard (v1) or by [`finalize_and_send`] (future). All POSTs take an
-//! idempotency key so retries can't create duplicate invoices or line items.
+//! reviewable **draft** until explicitly finalized — by a human in the Stripe
+//! dashboard, or by [`finalize_and_send`] for `auto_send` accounts. All POSTs
+//! take an idempotency key so retries can't create duplicate invoices or line
+//! items.
 
 use anyhow::Result;
 
@@ -80,10 +81,10 @@ pub async fn add_invoice_item(
     Ok(id)
 }
 
-/// Finalize a draft invoice and send it to the customer (net-30). NOT used in
-/// v1 — invoices are sent manually from the dashboard after review — but kept
-/// here so the future "drop the human" switch is a one-line call. Finalizing
-/// auto-sends because the invoice uses `collection_method = send_invoice`.
+/// Finalize a draft invoice and send it to the customer (net-30). Used by the
+/// billing job for `auto_send` accounts; manual-send accounts finalize from the
+/// dashboard after review instead. Finalizing auto-sends because the invoice
+/// uses `collection_method = send_invoice`.
 pub async fn finalize_and_send(
     client: &StripeClient,
     invoice_id: &str,

--- a/lit-payments/migrations/20260724000001_uneven_labs_auto_send.sql
+++ b/lit-payments/migrations/20260724000001_uneven_labs_auto_send.sql
@@ -2,7 +2,8 @@
 -- monthly invoice itself instead of leaving a draft for manual review (the
 -- July 2026 cycle validated the draft flow end-to-end). notify_email gets an
 -- FYI breakdown instead of a review request. Anomalous cycles (0 consumed
--- units) are still held as drafts for human review.
+-- units, or a reading at/above the full buffer target) are still held as
+-- drafts for human review.
 UPDATE enterprise_accounts
 SET auto_send = true, updated_at = now()
 WHERE payer_customer_id = 'cus_UXvHcFlfhR6rc5';

--- a/lit-payments/migrations/20260724000001_uneven_labs_auto_send.sql
+++ b/lit-payments/migrations/20260724000001_uneven_labs_auto_send.sql
@@ -1,0 +1,8 @@
+-- Flip Uneven Labs to auto-send: the billing job now finalizes + sends the
+-- monthly invoice itself instead of leaving a draft for manual review (the
+-- July 2026 cycle validated the draft flow end-to-end). notify_email gets an
+-- FYI breakdown instead of a review request. Anomalous cycles (0 consumed
+-- units) are still held as drafts for human review.
+UPDATE enterprise_accounts
+SET auto_send = true, updated_at = now()
+WHERE payer_customer_id = 'cus_UXvHcFlfhR6rc5';

--- a/lit-payments/migrations/20260724000002_invoice_finalized_at.sql
+++ b/lit-payments/migrations/20260724000002_invoice_finalized_at.sql
@@ -1,0 +1,5 @@
+-- Durable marker for the auto-send finalize step. Set immediately after Stripe
+-- confirms finalize+send, BEFORE the FYI email and the status='sent' write, so
+-- a crash between them resumes at the email step instead of replaying the
+-- Stripe calls (whose idempotency keys expire after ~24h).
+ALTER TABLE enterprise_invoices ADD COLUMN finalized_at TIMESTAMPTZ;

--- a/lit-payments/src/enterprise/billing.rs
+++ b/lit-payments/src/enterprise/billing.rs
@@ -9,8 +9,8 @@
 //!      regrant the payer buffer back to target, and then either finalize +
 //!      send the invoice automatically (`auto_send` accounts, with an FYI email
 //!      to `notify_email`) or email the breakdown for a human to review + send.
-//!      Anomalous cycles (0 consumed units) are always held for review, even
-//!      with `auto_send` on.
+//!      Anomalous cycles (0 consumed units, or a reading at/above the full
+//!      buffer target) are always held for review, even with `auto_send` on.
 //!
 //! Idempotency: the `enterprise_invoices` row (UNIQUE per account+period) is the
 //! gate; each external side effect is guarded by a stored id so a crash mid-flow
@@ -126,24 +126,35 @@ async fn run_account(
     let next_anchor = period::next_anchor(anchor, day);
 
     // 3. Missed-cycle guard. The immediately-preceding in-term anchor must
-    //    already have an invoice row; otherwise a prior cycle went unbilled and
-    //    folding its usage into this one (one allotment for multi-cycle usage,
-    //    one committed fee for several months) would mis-bill. Refuse and surface
-    //    rather than silently lump — a >1-cycle outage needs a human.
+    //    already have a RESOLVED invoice row; otherwise a prior cycle went
+    //    unbilled (or died mid-flow) and folding its usage into this one (one
+    //    allotment for multi-cycle usage, one committed fee for several months)
+    //    would mis-bill. Refuse and surface rather than silently lump — a
+    //    >1-cycle outage needs a human. A mere row-exists check is not enough:
+    //    an `error`/`pending` row from last cycle means money state is
+    //    unresolved, and auto-billing the next cycle on top of it compounds it.
     let prev_in_term = account.term_start.is_none_or(|ts| prev_anchor >= ts);
     if prev_in_term {
         let prev_key = period::period_key(prev_anchor);
-        if db::get_invoice(pool, account.id, &prev_key)
-            .await?
-            .is_none()
-        {
-            anyhow::bail!(
+        match db::get_invoice(pool, account.id, &prev_key).await? {
+            None => anyhow::bail!(
                 "enterprise billing gap for account {}: period {prev_key} has no invoice row, so \
                  a prior cycle went unbilled. Refusing to bill {period_key} (would lump multiple \
                  cycles into one allotment / skip a committed fee). Backfill the missing period(s) \
                  manually, then this resumes automatically.",
                 account.id
-            );
+            ),
+            Some(prev) if !matches!(prev.status.as_str(), "draft" | "sent" | "paid" | "manual") => {
+                anyhow::bail!(
+                    "enterprise billing gap for account {}: period {prev_key} is stuck in status \
+                     '{}' — its money state is unresolved. Refusing to bill {period_key} until it \
+                     is resolved (draft/sent/paid/manual); fix the {prev_key} row, then this \
+                     resumes automatically.",
+                    account.id,
+                    prev.status
+                );
+            }
+            Some(_) => {}
         }
     }
 
@@ -331,41 +342,51 @@ async fn resume_invoice(
     }
 
     // c. Deliver. `auto_send` accounts get finalize + send with an FYI email;
-    //    otherwise the draft is left for a human to review + send. A 0-unit
-    //    cycle means the consumed reading is suspect (external credit hit the
-    //    payer, or usage genuinely stopped) — hold those for review even with
-    //    auto_send on, so a mis-metered invoice never goes out unseen.
+    //    otherwise the draft is left for a human to review + send. Cycles whose
+    //    consumed reading is untrustworthy (0 units, or at/above the full
+    //    buffer target — see `calc::hold_for_review`) are held for review even
+    //    with auto_send on, so a mis-metered invoice never goes out unseen.
     let invoice_url = format!(
         "{}/invoices/{}",
         cfg.stripe_dashboard_base.trim_end_matches('/'),
         invoice_id
     );
-    if account.auto_send && row.consumed_units > 0 {
-        // Durability guard (same class as the create/regrant guards). Past the
-        // idempotency window a finalize replay can't double-charge (Stripe
-        // rejects re-finalizing), but the customer MAY already have been
-        // emailed — hand off to a human instead of guessing.
-        let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
-        if age_hours >= MAX_RETRY_AGE_HOURS {
-            db::set_invoice_status(pool, row.id, "error").await?;
-            anyhow::bail!(
-                "invoice {} finalize+send is unconfirmed and {}h old (past the {}h idempotency \
-                 window). The invoice MAY already be finalized and emailed to the customer. \
-                 Check invoice {} in Stripe: if it is open/paid, mark this row 'sent'; if it is \
-                 still a draft, send it from the dashboard and mark this row 'manual'.",
-                row.id,
-                age_hours,
-                MAX_RETRY_AGE_HOURS,
-                invoice_id
-            );
+    if account.auto_send && !calc::hold_for_review(row.consumed_units, account.target_credit_cents)
+    {
+        if row.finalized_at.is_none() {
+            // Durability guard (same class as the create/regrant guards). Past
+            // the idempotency window a finalize replay can't double-charge
+            // (Stripe rejects re-finalizing), but the customer MAY already have
+            // been emailed — hand off to a human instead of guessing.
+            let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
+            if age_hours >= MAX_RETRY_AGE_HOURS {
+                db::set_invoice_status(pool, row.id, "error").await?;
+                anyhow::bail!(
+                    "invoice {} finalize+send is unconfirmed and {}h old (past the {}h \
+                     idempotency window). The invoice MAY already be finalized and emailed to \
+                     the customer. Check invoice {} in Stripe: if it is open/paid, set \
+                     finalized_at and mark this row 'sent'; if it is still a draft, send it from \
+                     the dashboard and mark this row 'manual'.",
+                    row.id,
+                    age_hours,
+                    MAX_RETRY_AGE_HOURS,
+                    invoice_id
+                );
+            }
+            invoice::finalize_and_send(
+                stripe,
+                &invoice_id,
+                &format!("ent_fin:{}:{}", account.id, row.period_key),
+                &format!("ent_send:{}:{}", account.id, row.period_key),
+            )
+            .await
+            .context("finalize and send invoice")?;
+            // Record BEFORE the FYI email: a crash from here on resumes at the
+            // email step and never re-touches Stripe for this invoice.
+            let now = OffsetDateTime::now_utc();
+            db::set_invoice_finalized(pool, row.id, now).await?;
+            row.finalized_at = Some(now);
         }
-        invoice::finalize_and_send(
-            stripe,
-            &invoice_id,
-            &format!("ent_send:{}:{}", account.id, row.period_key),
-        )
-        .await
-        .context("finalize and send invoice")?;
         email::send_sent_email(mailer, account, &row, &invoice_url)
             .await
             .context("send sent-notification email")?;

--- a/lit-payments/src/enterprise/billing.rs
+++ b/lit-payments/src/enterprise/billing.rs
@@ -6,8 +6,11 @@
 //!   2. Determine the current anchor period.
 //!   3. If no invoice exists for it yet, snapshot consumption from the payer's
 //!      live Stripe balance, create a DRAFT invoice on the invoice account,
-//!      regrant the payer buffer back to target, and email the breakdown for a
-//!      human to review + send.
+//!      regrant the payer buffer back to target, and then either finalize +
+//!      send the invoice automatically (`auto_send` accounts, with an FYI email
+//!      to `notify_email`) or email the breakdown for a human to review + send.
+//!      Anomalous cycles (0 consumed units) are always held for review, even
+//!      with `auto_send` on.
 //!
 //! Idempotency: the `enterprise_invoices` row (UNIQUE per account+period) is the
 //! gate; each external side effect is guarded by a stored id so a crash mid-flow
@@ -327,12 +330,58 @@ async fn resume_invoice(
         }
     }
 
-    // c. Email the breakdown + draft link, then mark drafted.
+    // c. Deliver. `auto_send` accounts get finalize + send with an FYI email;
+    //    otherwise the draft is left for a human to review + send. A 0-unit
+    //    cycle means the consumed reading is suspect (external credit hit the
+    //    payer, or usage genuinely stopped) — hold those for review even with
+    //    auto_send on, so a mis-metered invoice never goes out unseen.
     let invoice_url = format!(
         "{}/invoices/{}",
         cfg.stripe_dashboard_base.trim_end_matches('/'),
         invoice_id
     );
+    if account.auto_send && row.consumed_units > 0 {
+        // Durability guard (same class as the create/regrant guards). Past the
+        // idempotency window a finalize replay can't double-charge (Stripe
+        // rejects re-finalizing), but the customer MAY already have been
+        // emailed — hand off to a human instead of guessing.
+        let age_hours = (OffsetDateTime::now_utc() - row.created_at).whole_hours();
+        if age_hours >= MAX_RETRY_AGE_HOURS {
+            db::set_invoice_status(pool, row.id, "error").await?;
+            anyhow::bail!(
+                "invoice {} finalize+send is unconfirmed and {}h old (past the {}h idempotency \
+                 window). The invoice MAY already be finalized and emailed to the customer. \
+                 Check invoice {} in Stripe: if it is open/paid, mark this row 'sent'; if it is \
+                 still a draft, send it from the dashboard and mark this row 'manual'.",
+                row.id,
+                age_hours,
+                MAX_RETRY_AGE_HOURS,
+                invoice_id
+            );
+        }
+        invoice::finalize_and_send(
+            stripe,
+            &invoice_id,
+            &format!("ent_send:{}:{}", account.id, row.period_key),
+        )
+        .await
+        .context("finalize and send invoice")?;
+        email::send_sent_email(mailer, account, &row, &invoice_url)
+            .await
+            .context("send sent-notification email")?;
+        db::set_invoice_sent(pool, row.id, OffsetDateTime::now_utc()).await?;
+
+        tracing::info!(
+            account_id = account.id,
+            period = %row.period_key,
+            invoice = %invoice_id,
+            total_cents = row.total_cents,
+            overage_units = row.overage_units,
+            "enterprise invoice finalized and sent; notification email sent"
+        );
+        return Ok(());
+    }
+
     email::send_review_email(mailer, account, &row, &invoice_url)
         .await
         .context("send review email")?;

--- a/lit-payments/src/enterprise/calc.rs
+++ b/lit-payments/src/enterprise/calc.rs
@@ -28,6 +28,17 @@ pub fn overage_cents(overage_units: i64, rate_hundredths_cent_per_unit: i64) -> 
     (overage_units.saturating_mul(rate_hundredths_cent_per_unit) + 50) / 100
 }
 
+/// Whether an `auto_send` cycle must be held as a draft for human review
+/// because the consumed reading is untrustworthy:
+///   - 0 units: an external credit masked usage, or usage genuinely stopped.
+///   - at/above the full buffer target: since `consumed = target + balance`,
+///     a reading ≥ target means the payer's balance hit zero or positive during
+///     the cycle (buffer exhausted, or an external debit hit the payer) and the
+///     identity no longer measures this cycle's usage.
+pub fn hold_for_review(consumed_units: i64, target_credit_cents: i64) -> bool {
+    consumed_units <= 0 || consumed_units >= target_credit_cents
+}
+
 /// Signed balance-transaction amount that restores the buffer to target.
 /// Negative == credit. Returns 0 when the account already holds ≥ target credit
 /// (we never claw credit back).
@@ -83,6 +94,20 @@ mod tests {
     #[test]
     fn regrant_noop_when_above_target() {
         assert_eq!(regrant_amount_cents(50_000_000, -60_000_000), 0);
+    }
+
+    #[test]
+    fn hold_for_review_bounds() {
+        let target = 50_000_000;
+        // 0 units — external credit or usage stopped.
+        assert!(hold_for_review(0, target));
+        // Healthy readings in between are not held.
+        assert!(!hold_for_review(1, target));
+        assert!(!hold_for_review(3_000_000, target));
+        assert!(!hold_for_review(target - 1, target));
+        // At/above target — balance went zero/positive during the cycle.
+        assert!(hold_for_review(target, target));
+        assert!(hold_for_review(target + 940_000, target));
     }
 
     // Consumed and the (negated) regrant magnitude agree.

--- a/lit-payments/src/enterprise/db.rs
+++ b/lit-payments/src/enterprise/db.rs
@@ -158,6 +158,19 @@ pub async fn set_invoice_drafted(pool: &PgPool, id: i64, now: OffsetDateTime) ->
     Ok(())
 }
 
+/// Mark the invoice finalized + sent to the customer and the FYI email sent.
+pub async fn set_invoice_sent(pool: &PgPool, id: i64, now: OffsetDateTime) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_invoices SET status = 'sent', notified_at = $2, updated_at = now() \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(now)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Whether the payer account has auto-topup enabled — a hard stop, since any
 /// non-regrant credit corrupts the `consumed = target + balance` identity.
 pub async fn payer_auto_topup_enabled(pool: &PgPool, payer_customer_id: &str) -> Result<bool> {

--- a/lit-payments/src/enterprise/db.rs
+++ b/lit-payments/src/enterprise/db.rs
@@ -15,7 +15,7 @@ const ACCOUNT_COLS: &str = "id, name, payer_customer_id, invoice_customer_id, \
 const INVOICE_COLS: &str = "id, enterprise_account_id, period_key, period_start, period_end, \
     committed_period, consumed_units, included_units, overage_units, \
     committed_fee_cents, overage_cents, total_cents, stripe_invoice_id, \
-    regrant_balance_txn_id, status, created_at";
+    regrant_balance_txn_id, finalized_at, status, created_at";
 
 /// All active committed-use accounts.
 pub async fn list_active_accounts(pool: &PgPool) -> Result<Vec<EnterpriseAccount>> {
@@ -150,6 +150,19 @@ pub async fn set_invoice_drafted(pool: &PgPool, id: i64, now: OffsetDateTime) ->
     sqlx::query(
         "UPDATE enterprise_invoices SET status = 'draft', notified_at = $2, updated_at = now() \
          WHERE id = $1",
+    )
+    .bind(id)
+    .bind(now)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Record that Stripe confirmed finalize + send. Written BEFORE the FYI email
+/// so a crash between them resumes at the email, not the Stripe calls.
+pub async fn set_invoice_finalized(pool: &PgPool, id: i64, now: OffsetDateTime) -> Result<()> {
+    sqlx::query(
+        "UPDATE enterprise_invoices SET finalized_at = $2, updated_at = now() WHERE id = $1",
     )
     .bind(id)
     .bind(now)

--- a/lit-payments/src/enterprise/email.rs
+++ b/lit-payments/src/enterprise/email.rs
@@ -59,21 +59,36 @@ async fn send_invoice_email(
     let overage = cents_to_display(inv.overage_cents);
     let total = cents_to_display(inv.total_cents);
 
-    // Metering sanity flag surfaced to the reviewer. 0 units for an active
-    // enterprise account is unusual and usually means an external credit hit the
-    // payer (which understates overage) or usage genuinely stopped — either way,
-    // worth a look before sending. (0-unit cycles are always held as a draft,
-    // so this never appears on the sent variant.)
-    let caution = (inv.consumed_units == 0).then(|| {
-        let mut c = "0 units recorded this cycle — unusual for an active account. Verify the \
-                     payer's Stripe balance and that no external credit (admin grant / LITKEY \
-                     top-up) hit the payer account, which would understate overage."
-            .to_string();
-        if account.auto_send {
-            c.push_str(" Auto-send is enabled for this account but this cycle was HELD as a draft pending review.");
-        }
-        c
-    });
+    // Metering sanity flags surfaced to the reviewer, mirroring
+    // `calc::hold_for_review`. Anomalous cycles are always held as a draft, so
+    // neither flag ever appears on the sent variant.
+    let mut caution = if inv.consumed_units == 0 {
+        Some(
+            "0 units recorded this cycle — unusual for an active account. Verify the payer's \
+             Stripe balance and that no external credit (admin grant / LITKEY top-up) hit the \
+             payer account, which would understate overage."
+                .to_string(),
+        )
+    } else if inv.consumed_units >= account.target_credit_cents {
+        Some(format!(
+            "consumed reading ({} units) is at/above the full ${} buffer target — the payer's \
+             balance went to zero or positive during the cycle (buffer exhausted, or an external \
+             debit hit the payer), so the overage figure is unreliable. Verify the payer's Stripe \
+             balance history before sending.",
+            inv.consumed_units,
+            account.target_credit_cents / 100,
+        ))
+    } else {
+        None
+    };
+    if account.auto_send
+        && let Some(c) = caution.as_mut()
+    {
+        c.push_str(
+            " Auto-send is enabled for this account but this cycle was HELD as a draft pending \
+             review.",
+        );
+    }
     let text_caution = caution
         .as_ref()
         .map(|c| format!("\n⚠ HEADS UP: {c}\n"))

--- a/lit-payments/src/enterprise/email.rs
+++ b/lit-payments/src/enterprise/email.rs
@@ -1,6 +1,9 @@
-//! Review email for the monthly enterprise invoice. Sent to the account's
-//! `notify_email` so a human can sanity-check the numbers and click Send on the
-//! draft invoice in Stripe (v1, before we drop the human-in-the-loop step).
+//! Notification emails for the monthly enterprise invoice, sent to the
+//! account's `notify_email`.
+//!
+//! Two variants: a **review** email when the invoice is left as a draft (a
+//! human sanity-checks the numbers and clicks Send in Stripe), and a **sent**
+//! FYI when `auto_send` finalized + sent the invoice automatically.
 
 use anyhow::Result;
 use lit_billing_core::format::cents_to_display;
@@ -8,19 +11,49 @@ use lit_billing_core::format::cents_to_display;
 use super::types::{EnterpriseAccount, EnterpriseInvoice};
 use crate::mail::Mailer;
 
-/// Send the breakdown email with a link to the draft invoice.
+/// Send the review breakdown with a link to the draft invoice (manual-send
+/// accounts, and auto_send accounts whose cycle was held as anomalous).
 pub async fn send_review_email(
     mailer: &Mailer,
     account: &EnterpriseAccount,
     inv: &EnterpriseInvoice,
     invoice_url: &str,
 ) -> Result<()> {
-    let subject = format!(
-        "[Lit] {} — draft invoice {} ready ({})",
-        account.name,
-        inv.period_key,
-        cents_to_display(inv.total_cents),
-    );
+    send_invoice_email(mailer, account, inv, invoice_url, false).await
+}
+
+/// Send the FYI breakdown after `auto_send` finalized + sent the invoice.
+pub async fn send_sent_email(
+    mailer: &Mailer,
+    account: &EnterpriseAccount,
+    inv: &EnterpriseInvoice,
+    invoice_url: &str,
+) -> Result<()> {
+    send_invoice_email(mailer, account, inv, invoice_url, true).await
+}
+
+async fn send_invoice_email(
+    mailer: &Mailer,
+    account: &EnterpriseAccount,
+    inv: &EnterpriseInvoice,
+    invoice_url: &str,
+    sent: bool,
+) -> Result<()> {
+    let subject = if sent {
+        format!(
+            "[Lit] {} — invoice {} sent ({})",
+            account.name,
+            inv.period_key,
+            cents_to_display(inv.total_cents),
+        )
+    } else {
+        format!(
+            "[Lit] {} — draft invoice {} ready ({})",
+            account.name,
+            inv.period_key,
+            cents_to_display(inv.total_cents),
+        )
+    };
 
     let committed = cents_to_display(inv.committed_fee_cents);
     let overage = cents_to_display(inv.overage_cents);
@@ -29,16 +62,24 @@ pub async fn send_review_email(
     // Metering sanity flag surfaced to the reviewer. 0 units for an active
     // enterprise account is unusual and usually means an external credit hit the
     // payer (which understates overage) or usage genuinely stopped — either way,
-    // worth a look before sending.
-    let caution = (inv.consumed_units == 0).then_some(
-        "0 units recorded this cycle — unusual for an active account. Verify the payer's Stripe \
-         balance and that no external credit (admin grant / LITKEY top-up) hit the payer account, \
-         which would understate overage.",
-    );
+    // worth a look before sending. (0-unit cycles are always held as a draft,
+    // so this never appears on the sent variant.)
+    let caution = (inv.consumed_units == 0).then(|| {
+        let mut c = "0 units recorded this cycle — unusual for an active account. Verify the \
+                     payer's Stripe balance and that no external credit (admin grant / LITKEY \
+                     top-up) hit the payer account, which would understate overage."
+            .to_string();
+        if account.auto_send {
+            c.push_str(" Auto-send is enabled for this account but this cycle was HELD as a draft pending review.");
+        }
+        c
+    });
     let text_caution = caution
+        .as_ref()
         .map(|c| format!("\n⚠ HEADS UP: {c}\n"))
         .unwrap_or_default();
     let html_caution = caution
+        .as_ref()
         .map(|c| {
             format!(
                 "<p style=\"background:#fff3cd;border:1px solid #ffe69c;padding:8px;\">\
@@ -47,8 +88,23 @@ pub async fn send_review_email(
         })
         .unwrap_or_default();
 
+    let (text_lead, text_cta) = if sent {
+        (
+            format!(
+                "Invoice for {} has been finalized and sent to the customer (net-30)",
+                account.name
+            ),
+            "View the invoice here:",
+        )
+    } else {
+        (
+            format!("Draft invoice for {} is ready for review", account.name),
+            "Review and send the draft invoice here:",
+        )
+    };
+
     let text = format!(
-        "Draft invoice for {name} is ready for review.\n\
+        "{lead}.\n\
          {text_caution}\
          \n\
          Period (issued): {period}\n\
@@ -65,12 +121,12 @@ pub async fn send_review_email(
          - Overage @ $0.0025/unit: {overage}\n\
          - TOTAL: {total}\n\
          \n\
-         Review and send the draft invoice here:\n\
+         {cta}\n\
          {url}\n\
          \n\
          (Invoice goes to {invoice_cust}; credits/usage are on payer {payer_cust}.)\n\
          The payer's credit buffer has been topped back up to ${target}.\n",
-        name = account.name,
+        lead = text_lead,
         period = inv.period_key,
         committed_period = inv.committed_period,
         p_start = inv.period_start,
@@ -81,6 +137,7 @@ pub async fn send_review_email(
         committed = committed,
         overage = overage,
         total = total,
+        cta = text_cta,
         url = invoice_url,
         invoice_cust = account.invoice_customer_id,
         payer_cust = account.payer_customer_id,
@@ -88,8 +145,23 @@ pub async fn send_review_email(
         text_caution = text_caution,
     );
 
+    let (html_heading, html_cta) = if sent {
+        (
+            format!(
+                "Invoice for {} has been finalized and sent to the customer",
+                account.name
+            ),
+            "View the invoice in Stripe →",
+        )
+    } else {
+        (
+            format!("Draft invoice for {} is ready for review", account.name),
+            "Review &amp; send the draft invoice in Stripe →",
+        )
+    };
+
     let html = format!(
-        "<h2>Draft invoice for {name} is ready for review</h2>\
+        "<h2>{heading}</h2>\
          {html_caution}\
          <table cellpadding=\"4\">\
            <tr><td><b>Period (issued)</b></td><td>{period}</td></tr>\
@@ -108,11 +180,11 @@ pub async fn send_review_email(
            <tr><td>Overage @ $0.0025/unit</td><td align=\"right\">{overage}</td></tr>\
            <tr><td><b>Total</b></td><td align=\"right\"><b>{total}</b></td></tr>\
          </table>\
-         <p><a href=\"{url}\">Review &amp; send the draft invoice in Stripe →</a></p>\
+         <p><a href=\"{url}\">{cta}</a></p>\
          <p style=\"color:#666;font-size:12px\">Invoice goes to {invoice_cust}; credits/usage \
          are on payer {payer_cust}. The payer's credit buffer has been topped back up to \
          ${target}.</p>",
-        name = account.name,
+        heading = html_heading,
         period = inv.period_key,
         committed_period = inv.committed_period,
         p_start = inv.period_start,
@@ -123,6 +195,7 @@ pub async fn send_review_email(
         committed = committed,
         overage = overage,
         total = total,
+        cta = html_cta,
         url = invoice_url,
         invoice_cust = account.invoice_customer_id,
         payer_cust = account.payer_customer_id,

--- a/lit-payments/src/enterprise/types.rs
+++ b/lit-payments/src/enterprise/types.rs
@@ -18,7 +18,8 @@ pub struct EnterpriseAccount {
     pub billing_anchor_day: i32,
     pub notify_email: String,
     /// false: draft + review email for manual send. true: finalize + send
-    /// automatically (0-unit cycles are still held as drafts for review).
+    /// automatically (anomalous readings — see `calc::hold_for_review` — are
+    /// still held as drafts for review).
     pub auto_send: bool,
     pub term_start: Option<Date>,
     pub term_end: Option<Date>,
@@ -47,6 +48,9 @@ pub struct EnterpriseInvoice {
     pub total_cents: i64,
     pub stripe_invoice_id: Option<String>,
     pub regrant_balance_txn_id: Option<String>,
+    /// Set once Stripe has confirmed finalize + send (auto_send accounts only).
+    /// Written before the FYI email so a resume never replays the Stripe calls.
+    pub finalized_at: Option<OffsetDateTime>,
     pub status: String,
     pub created_at: OffsetDateTime,
 }

--- a/lit-payments/src/enterprise/types.rs
+++ b/lit-payments/src/enterprise/types.rs
@@ -17,7 +17,8 @@ pub struct EnterpriseAccount {
     pub target_credit_cents: i64,
     pub billing_anchor_day: i32,
     pub notify_email: String,
-    /// v1 = false: draft + email for manual send.
+    /// false: draft + review email for manual send. true: finalize + send
+    /// automatically (0-unit cycles are still held as drafts for review).
     pub auto_send: bool,
     pub term_start: Option<Date>,
     pub term_end: Option<Date>,


### PR DESCRIPTION
## Context

The July 2026 Uneven Labs invoice run surfaced a Stripe key permission gap (fixed out-of-band); once unblocked, the draft + review-email flow worked end-to-end. We're now comfortable dropping the human-in-the-loop send step, which the code was already built for: `enterprise_accounts.auto_send` existed (default false, "flip to true to finalize+send automatically (future)") and `finalize_and_send` was sitting unused in lit-billing-core.

## Changes

- **billing.rs**: after the draft-invoice and buffer-regrant steps, `auto_send` accounts get `finalize_and_send` (Stripe finalizes and emails the invoice to the customer, net-30) followed by an FYI email to `notify_email`, and the row is marked `sent`. Manual accounts keep the existing draft + review-email path.
  - The finalize call uses idempotency key `ent_send:{account}:{period}` and the same 23h retry-age guard as the create/regrant steps: past the window it refuses and surfaces for a human instead of guessing whether the customer was already emailed.
  - **Anomaly hold**: a 0-unit cycle (metering identity suspect — external credit or usage stopped) is always held as a draft for review, even with `auto_send` on. The review email says so explicitly.
- **email.rs**: the review email and new sent-FYI email share one breakdown body; only the subject, lead line, and CTA differ. Review copy is unchanged.
- **db.rs**: `set_invoice_sent` (status `sent` + `notified_at`); `sent` was already a valid status in the check constraint.
- **migration**: flips Uneven Labs to `auto_send = true`.
- Doc updates in lit-billing-core/invoice.rs and types.rs to stop calling this "future".

## Behavior notes

- Failure ordering is unchanged: any step failing leaves the row `pending` and the hourly tick resumes it, with each Stripe side effect deduped inside the idempotency window and refused past it.
- If the FYI email fails after finalize succeeds, the next tick replays finalize (deduped) and retries the email — worst case is a duplicate internal FYI, same as the existing draft-flow behavior.
- Rows already in `draft` (e.g. July 2026) stay terminal — they still need a manual send in the dashboard.

## Testing

- `cargo clippy --all-targets`: no warnings in touched files.
- `cargo test` (lit-payments): 120 passed.
- First live exercise will be the 2026-08-17 anchor tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Adversarial review fixes (2nd commit)

A Codex adversarial review flagged 6 issues; 4 were addressed here (the other 2 — duplicate internal FYI emails under multi-instance overlap, and the by-design past-window human hand-off — are accepted as low-risk/pre-existing):

1. **Finalize ≠ send**: `finalize_and_send` now explicitly POSTs `invoices/{id}/send` after finalize (separate idempotency keys). Finalization alone only emails the customer if the Stripe dashboard's "email finalized invoices" setting is on — otherwise the DB would say `sent` while the customer never received the invoice.
2. **Drained-buffer hold**: auto-send is also held when `consumed >= target_credit_cents` (`calc::hold_for_review`, unit-tested). Since `consumed = target + balance`, that reading means the payer balance went zero/positive mid-cycle and the overage figure is unreliable — previously this exact case was logged as "verify before the invoice is sent" but would have been auto-sent anyway. The review email explains the hold.
3. **Durable finalize marker**: new `finalized_at` column, written after Stripe confirms finalize+send and before the FYI email. A crash between them now resumes at the email step instead of replaying Stripe calls (whose idempotency keys expire after ~24h).
4. **Stricter missed-cycle guard**: the previous period's row must be in a resolved status (`draft`/`sent`/`paid`/`manual`), not merely exist — an `error`/`pending` prior cycle now blocks auto-billing the next one.

Note on the migration-flips-in-flight-rows concern: verified in prod that the only existing rows are terminal (`manual`, `draft`), so the flag flip resumes nothing retroactively.
