### PR TITLE
fix(ci): pin staging Phala CLI to 1.1.19

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install Phala CLI
-        run: npm install -g phala
+        run: npm install -g phala@1.1.19
       - name: Set deployment target
         id: set
         env:
@@ -401,7 +401,7 @@ jobs:
           node-version: "20"
 
       - name: Install Phala CLI
-        run: npm install -g phala
+        run: npm install -g phala@1.1.19
 
       - name: Deploy to Phala Cloud
         env:
@@ -575,7 +575,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install Phala CLI
-        run: npm install -g phala
+        run: npm install -g phala@1.1.19
       - name: Stop the old instance — only if the domain has moved OFF it
         # Guard against stranding the public domain: resolve the live domain's
         # CNAME and refuse to stop OLD if the domain still points at OLD's gateway
@@ -644,7 +644,7 @@ jobs:
           node-version: "20"
       - name: Install Phala CLI + AWS CLI
         run: |
-          npm install -g phala
+          npm install -g phala@1.1.19
           # AWS CLI v2 via the official installer (no Python dependency). The old
           # `pip install --user awscli` fails on the runner's externally-managed
           # Python (PEP 668: "externally-managed-environment"). Guarded so a


### PR DESCRIPTION
The staging deploy installs the Phala CLI unpinned, so the run on 2026-07-31 picked up the newly-published `phala@1.1.20` and failed at "Deploy to Phala Cloud" with `KMS slug or id is required for decentralized KMS`. 1.1.20 changed how `phala deploy` resolves the env-encryption key for on-chain-KMS redeploys, routing this app down the decentralized-KMS path that needs `kms_info.slug`/`id` — which the cold ping-pong instance `chipotle-next-rep-sa6xj-rep-w4hdl` lacks. That same instance deployed cleanly under 1.1.19 on 07-21, so this pins all four `Install Phala CLI` sites in `deploy-staging.yml` to `1.1.19` to restore the working behavior. It also stops an unpinned upgrade from silently changing deploy behavior again; the prod and manual Phala workflows are intentionally left unpinned in this PR since they use a different `phala api`-based KMS flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)