### PR TITLE
fix(ci): skip TLS verify for Phala direct URL in k6-smoke + openapi-spec-check

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -63,7 +63,23 @@ jobs:
           K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-smoke
           K6_ACCOUNTS_FILE: ${{ steps.accounts-file.outputs.path || env.K6_ACCOUNTS_FILE }}
           K6_ENV: ${{ inputs.env }}
-        run: k6 run k6/smoke.spec.ts
+        run: |
+          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
+          # endpoint is frequently expired/self-signed (it's Phala-managed, not
+          # our certbot cert), so k6's strict TLS verification fails outright
+          # ("x509: certificate has expired") and trips the post-cutover
+          # rollback. Skip TLS verification for the Phala direct URL only; a
+          # non-phala.network public domain keeps strict TLS. Box integrity is
+          # proven separately by verify-attestation, so Phala's transport cert
+          # is not the boundary here. (Same rationale as wait-for-api-restart
+          # PR #611 and verify-attestation PR #612.)
+          #
+          # Match on the extracted hostname (strip scheme, path/query, and port),
+          # not the whole URL, so a ".phala.network" substring in a path/query
+          # can't flip a non-Phala host into insecure mode.
+          HOST="${BASE_URL#*://}"; HOST="${HOST%%/*}"; HOST="${HOST%%:*}"
+          case "$HOST" in *.phala.network) export K6_INSECURE_SKIP_TLS_VERIFY=true ;; esac
+          k6 run k6/smoke.spec.ts
 
       # gVisor (any-language runner) is off by default (CPL-359) and only
       # guaranteed on in the test/next staging environment, so gate the
@@ -75,7 +91,13 @@ jobs:
           K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-gvisor-smoke
           K6_ACCOUNTS_FILE: ${{ steps.accounts-file.outputs.path || env.K6_ACCOUNTS_FILE }}
           K6_ENV: ${{ inputs.env }}
-        run: k6 run k6/gvisor-smoke.spec.ts
+        run: |
+          # Skip TLS verification only for the Phala-managed direct URL (see the
+          # smoke.spec.ts step above for the rationale); the public domain keeps
+          # strict TLS.
+          HOST="${BASE_URL#*://}"; HOST="${HOST%%/*}"; HOST="${HOST%%:*}"
+          case "$HOST" in *.phala.network) export K6_INSECURE_SKIP_TLS_VERIFY=true ;; esac
+          k6 run k6/gvisor-smoke.spec.ts
 
       - name: Clean up accounts file
         if: ${{ always() && steps.accounts-file.outputs.path }}

--- a/.github/workflows/openapi-spec-check.yml
+++ b/.github/workflows/openapi-spec-check.yml
@@ -46,7 +46,30 @@ jobs:
       - name: Generate litApiServer from deployed OpenAPI spec
         run: |
           npm install -g @grafana/openapi-to-k6
-          openapi-to-k6 --verbose "${{ inputs.api_root_url }}/openapi.json" "${{ runner.temp }}/k6-generated"
+          SPEC_URL="${{ inputs.api_root_url }}/openapi.json"
+
+          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
+          # endpoint is frequently expired/self-signed (it's Phala-managed, not
+          # our certbot cert). openapi-to-k6 fetches the spec via Node's fetch,
+          # which can't relax TLS per-host, so pre-download the spec ourselves
+          # with curl -k for the Phala direct URL only and feed the local file
+          # to the generator. A non-phala.network public domain keeps strict TLS.
+          # Box integrity is proven separately by verify-attestation, so trust of
+          # Phala's transport cert is not the boundary here. (Same rationale as
+          # wait-for-api-restart PR #611 and verify-attestation PR #612.)
+          #
+          # Match on the extracted hostname (strip scheme, path/query, and port),
+          # not the whole URL, so a ".phala.network" substring in a path/query
+          # can't flip a non-Phala host into -k.
+          HOST="${SPEC_URL#*://}"   # strip scheme
+          HOST="${HOST%%/*}"        # strip path/query
+          HOST="${HOST%%:*}"        # strip port
+          INSECURE=""
+          case "$HOST" in *.phala.network) INSECURE="-k" ;; esac
+
+          SPEC_FILE="${{ runner.temp }}/openapi.json"
+          curl -sf $INSECURE "$SPEC_URL" -o "$SPEC_FILE"
+          openapi-to-k6 --verbose "$SPEC_FILE" "${{ runner.temp }}/k6-generated"
 
       - name: Compare with committed litApiServer.ts
         run: |


### PR DESCRIPTION
Deploy Staging's `k6-smoke` and `openapi-spec-check` jobs both hit the raw `*-8000.*.phala.network` CVM endpoint, whose Phala-managed gateway cert is frequently expired/self-signed (it had expired 2026-07-22 by run 30858845859), so k6's strict TLS check failed with `x509: certificate has expired` and tripped the post-cutover rollback, while `openapi-to-k6` saw the same failure as a generic `fetch failed` and produced no file. This skips TLS verification for `*.phala.network` direct URLs only — `K6_INSECURE_SKIP_TLS_VERIFY=true` in both k6-smoke steps, and a `curl -k` pre-download of `openapi.json` fed to the generator (since openapi-to-k6 uses Node fetch and can't relax TLS per-host) — matching the fix already applied to `wait-for-api-restart` (#611) and `verify-attestation` (#612). Matching is done on the extracted hostname suffix so a `.phala.network` substring in a path/query can't flip a public domain into insecure mode, and the public `litprotocol.com` domain keeps strict TLS. This is safe because box integrity is proven separately by `verify-attestation`, so Phala's transport cert was never the trust boundary here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)