### PR TITLE
revert(ci): restore strict TLS now that Phala fixed its gateway cert

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -63,23 +63,7 @@ jobs:
           K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-smoke
           K6_ACCOUNTS_FILE: ${{ steps.accounts-file.outputs.path || env.K6_ACCOUNTS_FILE }}
           K6_ENV: ${{ inputs.env }}
-        run: |
-          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
-          # endpoint is frequently expired/self-signed (it's Phala-managed, not
-          # our certbot cert), so k6's strict TLS verification fails outright
-          # ("x509: certificate has expired") and trips the post-cutover
-          # rollback. Skip TLS verification for the Phala direct URL only; a
-          # non-phala.network public domain keeps strict TLS. Box integrity is
-          # proven separately by verify-attestation, so Phala's transport cert
-          # is not the boundary here. (Same rationale as wait-for-api-restart
-          # PR #611 and verify-attestation PR #612.)
-          #
-          # Match on the extracted hostname (strip scheme, path/query, and port),
-          # not the whole URL, so a ".phala.network" substring in a path/query
-          # can't flip a non-Phala host into insecure mode.
-          HOST="${BASE_URL#*://}"; HOST="${HOST%%/*}"; HOST="${HOST%%:*}"
-          case "$HOST" in *.phala.network) export K6_INSECURE_SKIP_TLS_VERIFY=true ;; esac
-          k6 run k6/smoke.spec.ts
+        run: k6 run k6/smoke.spec.ts
 
       # gVisor (any-language runner) is off by default (CPL-359) and only
       # guaranteed on in the test/next staging environment, so gate the
@@ -91,13 +75,7 @@ jobs:
           K6_CORRELATION_ID: k6-${{ github.run_id }}-${{ github.run_attempt }}-gvisor-smoke
           K6_ACCOUNTS_FILE: ${{ steps.accounts-file.outputs.path || env.K6_ACCOUNTS_FILE }}
           K6_ENV: ${{ inputs.env }}
-        run: |
-          # Skip TLS verification only for the Phala-managed direct URL (see the
-          # smoke.spec.ts step above for the rationale); the public domain keeps
-          # strict TLS.
-          HOST="${BASE_URL#*://}"; HOST="${HOST%%/*}"; HOST="${HOST%%:*}"
-          case "$HOST" in *.phala.network) export K6_INSECURE_SKIP_TLS_VERIFY=true ;; esac
-          k6 run k6/gvisor-smoke.spec.ts
+        run: k6 run k6/gvisor-smoke.spec.ts
 
       - name: Clean up accounts file
         if: ${{ always() && steps.accounts-file.outputs.path }}

--- a/.github/workflows/openapi-spec-check.yml
+++ b/.github/workflows/openapi-spec-check.yml
@@ -46,30 +46,7 @@ jobs:
       - name: Generate litApiServer from deployed OpenAPI spec
         run: |
           npm install -g @grafana/openapi-to-k6
-          SPEC_URL="${{ inputs.api_root_url }}/openapi.json"
-
-          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
-          # endpoint is frequently expired/self-signed (it's Phala-managed, not
-          # our certbot cert). openapi-to-k6 fetches the spec via Node's fetch,
-          # which can't relax TLS per-host, so pre-download the spec ourselves
-          # with curl -k for the Phala direct URL only and feed the local file
-          # to the generator. A non-phala.network public domain keeps strict TLS.
-          # Box integrity is proven separately by verify-attestation, so trust of
-          # Phala's transport cert is not the boundary here. (Same rationale as
-          # wait-for-api-restart PR #611 and verify-attestation PR #612.)
-          #
-          # Match on the extracted hostname (strip scheme, path/query, and port),
-          # not the whole URL, so a ".phala.network" substring in a path/query
-          # can't flip a non-Phala host into -k.
-          HOST="${SPEC_URL#*://}"   # strip scheme
-          HOST="${HOST%%/*}"        # strip path/query
-          HOST="${HOST%%:*}"        # strip port
-          INSECURE=""
-          case "$HOST" in *.phala.network) INSECURE="-k" ;; esac
-
-          SPEC_FILE="${{ runner.temp }}/openapi.json"
-          curl -sf $INSECURE "$SPEC_URL" -o "$SPEC_FILE"
-          openapi-to-k6 --verbose "$SPEC_FILE" "${{ runner.temp }}/k6-generated"
+          openapi-to-k6 --verbose "${{ inputs.api_root_url }}/openapi.json" "${{ runner.temp }}/k6-generated"
 
       - name: Compare with committed litApiServer.ts
         run: |

--- a/.github/workflows/verify-attestation.yml
+++ b/.github/workflows/verify-attestation.yml
@@ -53,27 +53,8 @@ jobs:
           ATTESTATION_URL="${{ inputs.base_url }}"
           TMP_DIR=$(mktemp -d /tmp/verify-remote-XXXXXX)
 
-          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
-          # endpoint is frequently expired/self-signed (it's Phala-managed, not
-          # our certbot cert), which makes `curl -sf` fail before we ever fetch
-          # the attestation. Skip TLS verification for the Phala direct URL only;
-          # a non-phala.network public domain keeps strict TLS. This is safe here
-          # because the fetched attestation quote is itself the integrity
-          # boundary — the dstack-verifier cryptographically validates it below,
-          # so trust of Phala's transport gateway cert is irrelevant. (Same
-          # rationale as wait-for-api-restart, PR #611.)
-          #
-          # Match on the extracted hostname (strip scheme, path/query, and port)
-          # rather than the whole URL, so a ".phala.network" substring in a path
-          # or query can't flip a non-Phala host into -k.
-          HOST="${ATTESTATION_URL#*://}"   # strip scheme
-          HOST="${HOST%%/*}"               # strip path/query
-          HOST="${HOST%%:*}"               # strip port
-          INSECURE=""
-          case "$HOST" in *.phala.network) INSECURE="-k" ;; esac
-
           echo "Fetching attestation from $ATTESTATION_URL/attestation..."
-          curl -sf $INSECURE "$ATTESTATION_URL/attestation" > "$TMP_DIR/attestation.json" || {
+          curl -sf "$ATTESTATION_URL/attestation" > "$TMP_DIR/attestation.json" || {
             echo "::error::Failed to fetch $ATTESTATION_URL/attestation"
             rm -rf "$TMP_DIR"
             exit 1

--- a/.github/workflows/wait-for-api-restart.yml
+++ b/.github/workflows/wait-for-api-restart.yml
@@ -120,15 +120,6 @@ jobs:
           TIMEOUT="${{ inputs.timeout }}"
           VERSION_URL="${BASE_URL}/version"
 
-          # Phala's auto-issued TLS cert for the raw *-8000.*.phala.network CVM
-          # endpoint is frequently expired/self-signed (it's Phala-managed, not
-          # our certbot cert). We're only reading a version string here, and the
-          # box's integrity is proven separately by verify-attestation, so skip
-          # TLS verification for the Phala direct URL. The public domain
-          # (confirm-cutover) is NOT a phala.network host, so it keeps strict TLS.
-          INSECURE=""
-          case "$VERSION_URL" in *.phala.network*) INSECURE="-k" ;; esac
-
           # The API's commit_version is produced by git_version!() which runs
           # git describe --always at compile time. Reproduce the same output
           # here so we can compare directly.
@@ -145,7 +136,7 @@ jobs:
           deadline=$(( $(date +%s) + TIMEOUT ))
 
           while true; do
-            CURRENT_VERSION=$(curl -sf $INSECURE "$VERSION_URL" 2>/dev/null | jq -r '.commit_version // empty' 2>/dev/null || true)
+            CURRENT_VERSION=$(curl -sf "$VERSION_URL" 2>/dev/null | jq -r '.commit_version // empty' 2>/dev/null || true)
             case "$EXPECTED_VERSION" in "$CURRENT_VERSION"*) PREFIX_MATCH=1 ;; *) PREFIX_MATCH=0 ;; esac
             case "$CURRENT_VERSION" in "$EXPECTED_VERSION"*) REVERSE_MATCH=1 ;; *) REVERSE_MATCH=0 ;; esac
             if [ -n "$CURRENT_VERSION" ] && { [ "$PREFIX_MATCH" = 1 ] || [ "$REVERSE_MATCH" = 1 ]; }; then
@@ -167,13 +158,8 @@ jobs:
           TIMEOUT="${{ inputs.timeout }}"
           deadline=$(( $(date +%s) + TIMEOUT ))
 
-          # Same rationale as the version poll: skip TLS verification only for
-          # the Phala-managed direct URL, keep it strict for the public domain.
-          INSECURE=""
-          case "$HEALTH_URL" in *.phala.network*) INSECURE="-k" ;; esac
-
           echo "Confirming $HEALTH_URL is healthy..."
-          until curl -sf $INSECURE "$HEALTH_URL" > /dev/null; do
+          until curl -sf "$HEALTH_URL" > /dev/null; do
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "::error::Health check failed within timeout"
               exit 1


### PR DESCRIPTION
Phala has corrected the expired/self-signed gateway cert on the raw `*-8000.*.phala.network` CVM endpoint, so the temporary TLS-skip workarounds added in #611, #612, and #613 are no longer needed. This removes them and restores strict TLS verification everywhere: drops `-k` from the `curl`s in `wait-for-api-restart.yml` (version poll + health check) and `verify-attestation.yml` (attestation fetch), drops `K6_INSECURE_SKIP_TLS_VERIFY` from both steps in `k6-smoke.yml`, and restores the direct `openapi-to-k6` fetch in `openapi-spec-check.yml`. Each file is back to its exact pre-workaround state. The unrelated ruint 1.20.0 security bump that was bundled into #612 is deliberately left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)