### PR TITLE
test(k6): skip gVisor smoke when the runner is disabled by contract

### DIFF
--- a/k6/gvisor-smoke.spec.ts
+++ b/k6/gvisor-smoke.spec.ts
@@ -10,6 +10,8 @@
  *
  * Use: k6 run gvisor-smoke.spec.ts
  */
+import { check } from "k6";
+import type { Response } from "k6/http";
 import { checkAndLog, warnOnHttpFailures, assertOk } from "./helpers.ts";
 import { LitApiServerClient } from "./litApiServer.ts";
 import { PRECREATED_ACCOUNTS } from "./setup.ts";
@@ -44,6 +46,28 @@ export interface GvisorSmokeSetupData {
   usageApiKey: string;
 }
 
+/**
+ * Returns the "runner disabled" message if this `/lit_binary_action` response
+ * is the gVisor gate rejecting the call, or null otherwise.
+ *
+ * The runner is gated by three fail-closed axes (build feature, `LIT_GVISOR_ENABLED`
+ * env, and the on-chain `GVISOR_RUNNER_ENABLED` contract setting). When it's off —
+ * most importantly when an operator flips the contract setting off network-wide
+ * without a redeploy — the gate rejects with 503 and a body whose `message` starts
+ * with "The gVisor any-language runner is disabled". A CPU-overload 503 carries a
+ * different message and is deliberately NOT matched, so it still fails the smoke.
+ */
+function gvisorDisabledReason(response: Response | undefined): string | null {
+  if ((response?.status ?? 0) !== 503) return null;
+  let message = "";
+  try {
+    message = JSON.parse(response!.body as string).message ?? "";
+  } catch {
+    return null;
+  }
+  return message.includes("gVisor any-language runner is disabled") ? message : null;
+}
+
 export function setup(): GvisorSmokeSetupData {
   if (PRECREATED_ACCOUNTS.length === 0) {
     throw new Error(
@@ -67,6 +91,21 @@ export default function (data: GvisorSmokeSetupData) {
     { bundle: BUNDLE_BASE64, js_params: { name: "chipotle" } },
     usageKeyHeaders,
   );
+
+  // If gVisor is disabled — e.g. the on-chain GVISOR_RUNNER_ENABLED contract
+  // setting is off — the runner isn't available to smoke, so skip instead of
+  // failing. The contract can flip the runner off network-wide without a
+  // redeploy; this smoke must not go red when it does. Record a passing check
+  // so the `checks: rate==1` threshold still holds on the skip path.
+  const disabledReason = gvisorDisabledReason(res.response);
+  if (disabledReason) {
+    console.warn(`gvisor-smoke: skipping — gVisor runner disabled | ${disabledReason}`);
+    check(null, {
+      "gVisor runner enabled (smoke skipped when disabled)": () => true,
+    });
+    return;
+  }
+
   if (!assertOk("litBinaryAction", "POST /lit_binary_action", res)) return;
 
   checkAndLog(res.response, {


### PR DESCRIPTION
The gVisor k6 smoke test previously went red whenever the runner was unavailable, but the runner is gated by three fail-closed axes — including the on-chain `GVISOR_RUNNER_ENABLED` contract setting that an operator can flip off network-wide without a redeploy. This makes `gvisor-smoke.spec.ts` detect the gate's distinct 503 (message starting with "The gVisor any-language runner is disabled") and skip gracefully — recording a passing check so the `checks: rate==1` and `http_reqs: count>=1` thresholds still hold — instead of failing. A CPU-overload 503 carries a different message and is deliberately not matched, so genuine failures still fail the smoke. Validated with `k6 archive gvisor-smoke.spec.ts` (exit 0); no route changes, so the generated client is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)