### PR TITLE
feat(billing): label Stripe charges with action CID + request-id

### DIFF
--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -41,11 +41,9 @@ impl Client {
                 &self.api_key,
                 seconds,
                 // Derived CID of the action — always set on the billed execution
-                // path (both HTTP handlers derive it before charging; raw code is
-                // hashed the same way registered actions are). The empty-string
-                // filter only guards the builder's default, mirroring the
-                // is_empty() handling in execute_js_inner.
-                Some(self.ipfs_id.as_str()).filter(|s| !s.is_empty()),
+                // path (raw code is hashed the same way registered actions are).
+                // `charge` normalizes an empty CID away, so no filtering here.
+                Some(self.ipfs_id.as_str()),
                 self.request_id.as_deref(),
                 stripe,
             )

--- a/lit-api-server/src/actions/client/execution.rs
+++ b/lit-api-server/src/actions/client/execution.rs
@@ -37,12 +37,23 @@ impl Client {
                 return Ok(());
             }
             tracing::debug!(seconds, "execution::flush_unbilled_seconds: charging");
-            crate::stripe::charge_lit_action_time(&self.api_key, seconds, stripe)
-                .await
-                .map_err(|e| {
-                    warn!("Failed to bill remaining {seconds} seconds at end of action: {e}");
-                    anyhow!("Billing failed for {seconds} seconds of execution: {e}")
-                })?;
+            crate::stripe::charge_lit_action_time(
+                &self.api_key,
+                seconds,
+                // Derived CID of the action — always set on the billed execution
+                // path (both HTTP handlers derive it before charging; raw code is
+                // hashed the same way registered actions are). The empty-string
+                // filter only guards the builder's default, mirroring the
+                // is_empty() handling in execute_js_inner.
+                Some(self.ipfs_id.as_str()).filter(|s| !s.is_empty()),
+                self.request_id.as_deref(),
+                stripe,
+            )
+            .await
+            .map_err(|e| {
+                warn!("Failed to bill remaining {seconds} seconds at end of action: {e}");
+                anyhow!("Billing failed for {seconds} seconds of execution: {e}")
+            })?;
             self.state.unbilled_seconds = 0;
         }
         Ok(())

--- a/lit-api-server/src/actions/client/handle_ops.rs
+++ b/lit-api-server/src/actions/client/handle_ops.rs
@@ -180,6 +180,11 @@ impl Client {
                         match crate::stripe::charge_lit_action_time(
                             &self.api_key,
                             self.state.unbilled_seconds,
+                            // Derived CID of the action — always set on the billed
+                            // execution path. The empty-string filter only guards
+                            // the builder's default (see execution.rs).
+                            Some(self.ipfs_id.as_str()).filter(|s| !s.is_empty()),
+                            self.request_id.as_deref(),
                             stripe,
                         )
                         .await

--- a/lit-api-server/src/actions/client/handle_ops.rs
+++ b/lit-api-server/src/actions/client/handle_ops.rs
@@ -181,9 +181,9 @@ impl Client {
                             &self.api_key,
                             self.state.unbilled_seconds,
                             // Derived CID of the action — always set on the billed
-                            // execution path. The empty-string filter only guards
-                            // the builder's default (see execution.rs).
-                            Some(self.ipfs_id.as_str()).filter(|s| !s.is_empty()),
+                            // execution path; `charge` normalizes an empty CID
+                            // away (see execution.rs).
+                            Some(self.ipfs_id.as_str()),
                             self.request_id.as_deref(),
                             stripe,
                         )

--- a/lit-api-server/src/core/v1/guards/billing.rs
+++ b/lit-api-server/src/core/v1/guards/billing.rs
@@ -201,9 +201,17 @@ impl Fairing for ManagementBillingFairing {
         let Some(stripe) = state.as_ref() else {
             return;
         };
+        // The request's X-Request-Id, recorded as `metadata[request_id]` on the
+        // Stripe transaction so config-change charges correlate to the request.
+        // `RequestSpan`'s FromRequest is Infallible, so this always succeeds.
+        let request_id = request
+            .guard::<crate::observability::fairing::RequestSpan>()
+            .await
+            .succeeded()
+            .map(|span| span.request_id);
         // resolve/customer/balance are warm in cache from the guard, so this is
         // a fast local decrement plus a spawned (fire-and-forget) Stripe POST.
-        if let Err(e) = stripe::charge_management(key, stripe).await {
+        if let Err(e) = stripe::charge_management(key, request_id.as_deref(), stripe).await {
             // The operation already completed; never fail the response over
             // settlement. Surfaced via the billing settlement metrics/logs.
             tracing::error!("management charge settlement failed (operation completed): {e}");

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -827,6 +827,48 @@ pub async fn check_credit(
 /// network error cannot produce duplicate balance transactions.
 ///
 /// Returns `Err` only if the *cached* balance would go positive (insufficient credits).
+///
+/// The Stripe "Reason" (`description`) and CID metadata for a charge, along with
+/// the normalized CID. Only Lit Action charges carry a CID: an empty CID, or one
+/// passed with any other `reason`, is dropped so a stray argument can never
+/// mislabel a charge as a Lit Action. Pure so it can be unit-tested.
+fn charge_label<'a>(reason: BillingReason, ipfs_id: Option<&'a str>) -> (String, Option<&'a str>) {
+    let cid = match reason {
+        BillingReason::LitAction => ipfs_id.filter(|s| !s.is_empty()),
+        _ => None,
+    };
+    let description = match cid {
+        Some(id) => format!("Lit Action {id}"),
+        None => reason.description().to_string(),
+    };
+    (description, cid)
+}
+
+/// Build the Stripe balance-transaction form parameters. `ipfs_id` and
+/// `request_id` are attached as metadata only when present. Pure so the exact
+/// param set (and the conditional metadata) can be unit-tested.
+fn charge_params<'a>(
+    cost_str: &'a str,
+    description: &'a str,
+    reason: BillingReason,
+    ipfs_id: Option<&'a str>,
+    request_id: Option<&'a str>,
+) -> Vec<(&'a str, &'a str)> {
+    let mut params = vec![
+        ("amount", cost_str),
+        ("currency", "usd"),
+        ("description", description),
+        ("metadata[reason]", reason.as_str()),
+    ];
+    if let Some(id) = ipfs_id {
+        params.push(("metadata[ipfs_id]", id));
+    }
+    if let Some(rid) = request_id {
+        params.push(("metadata[request_id]", rid));
+    }
+    params
+}
+
 async fn charge(
     api_key: &str,
     cost_cents: i64,
@@ -899,17 +941,12 @@ async fn charge(
     let cid = customer_id.clone();
     let wallet_for_metric = wallet.clone();
     let idempotency_key = uuid::Uuid::new_v4().to_string();
-    // Owned copies of the Stripe `description` ("Reason" in the dashboard) and
-    // the metadata values, moved into the fire-and-forget task below. Lit Action
-    // charges label the Reason with the action's IPFS CID; everything else falls
-    // back to the reason's static description ("Configuration change", etc.).
-    let description = match ipfs_id {
-        Some(id) => format!("Lit Action {id}"),
-        None => reason.description().to_string(),
-    };
+    // The dashboard "Reason" and normalized CID metadata (Lit Action charges
+    // only — see `charge_label`), owned so they can move into the fire-and-forget
+    // task below. `request_id` groups the several balance transactions one
+    // request emits: a Lit Action's per-second flushes share a request-id.
+    let (description, ipfs_id) = charge_label(reason, ipfs_id);
     let ipfs_id = ipfs_id.map(str::to_owned);
-    // Groups the (possibly several) balance transactions a single request emits:
-    // one Lit Action execution flushes per-second charges under one request-id.
     let request_id = request_id.map(str::to_owned);
     tokio::spawn(async move {
         let cost_str = cost_cents.to_string();
@@ -925,18 +962,13 @@ async fn charge(
             if !delay.is_zero() {
                 tokio::time::sleep(delay).await;
             }
-            let mut params: Vec<(&str, &str)> = vec![
-                ("amount", cost_str.as_str()),
-                ("currency", "usd"),
-                ("description", description.as_str()),
-                ("metadata[reason]", reason.as_str()),
-            ];
-            if let Some(id) = ipfs_id.as_deref() {
-                params.push(("metadata[ipfs_id]", id));
-            }
-            if let Some(rid) = request_id.as_deref() {
-                params.push(("metadata[request_id]", rid));
-            }
+            let params = charge_params(
+                cost_str.as_str(),
+                description.as_str(),
+                reason,
+                ipfs_id.as_deref(),
+                request_id.as_deref(),
+            );
             match state
                 .client
                 .post_with_idempotency(
@@ -1270,6 +1302,78 @@ mod tests {
             BillingReason::Management.description(),
             BillingReason::LitAction.description()
         );
+    }
+
+    #[test]
+    fn charge_label_uses_cid_only_for_lit_action() {
+        // Lit Action + real CID → CID becomes the Reason and the metadata.
+        let (desc, cid) = charge_label(BillingReason::LitAction, Some("QmABC123"));
+        assert_eq!(desc, "Lit Action QmABC123");
+        assert_eq!(cid, Some("QmABC123"));
+
+        // Empty CID is dropped: fall back to the static Lit Action label, no meta.
+        let (desc, cid) = charge_label(BillingReason::LitAction, Some(""));
+        assert_eq!(desc, "Lit Action execution");
+        assert_eq!(cid, None);
+
+        // Missing CID on a Lit Action charge → static label, no metadata.
+        let (desc, cid) = charge_label(BillingReason::LitAction, None);
+        assert_eq!(desc, "Lit Action execution");
+        assert_eq!(cid, None);
+
+        // A CID passed with a non–Lit-Action reason must NOT mislabel the charge
+        // or leak into metadata — it is dropped entirely.
+        let (desc, cid) = charge_label(BillingReason::Management, Some("QmABC123"));
+        assert_eq!(desc, "Configuration change");
+        assert_eq!(cid, None);
+
+        let (desc, cid) = charge_label(BillingReason::Management, None);
+        assert_eq!(desc, "Configuration change");
+        assert_eq!(cid, None);
+    }
+
+    #[test]
+    fn charge_params_include_metadata_only_when_present() {
+        // Base params are always present, in order; reason code is always set.
+        let params = charge_params(
+            "10",
+            "Configuration change",
+            BillingReason::Management,
+            None,
+            None,
+        );
+        assert_eq!(
+            params,
+            vec![
+                ("amount", "10"),
+                ("currency", "usd"),
+                ("description", "Configuration change"),
+                ("metadata[reason]", "management"),
+            ]
+        );
+
+        // request_id is included when provided (grouping key for a request's
+        // several charges); ipfs_id is included when provided.
+        let params = charge_params(
+            "5",
+            "Lit Action QmABC123",
+            BillingReason::LitAction,
+            Some("QmABC123"),
+            Some("req-42"),
+        );
+        assert!(params.contains(&("metadata[ipfs_id]", "QmABC123")));
+        assert!(params.contains(&("metadata[request_id]", "req-42")));
+
+        // request_id without a CID is still attached.
+        let params = charge_params(
+            "5",
+            "Lit Action execution",
+            BillingReason::LitAction,
+            None,
+            Some("req-7"),
+        );
+        assert!(params.contains(&("metadata[request_id]", "req-7")));
+        assert!(!params.iter().any(|(k, _)| *k == "metadata[ipfs_id]"));
     }
 
     #[test]

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -113,10 +113,15 @@ impl BillingReason {
     }
 
     /// Human-readable description sent as the Stripe balance transaction
-    /// `description`, so the charge type is legible in the Stripe dashboard.
+    /// `description` (the "Reason" field in the Stripe dashboard), so the charge
+    /// type is legible there.
+    ///
+    /// This is the fallback label. Lit Action charges override it with the
+    /// action's IPFS CID (`Lit Action {cid}`) when one is available — see
+    /// [`charge`].
     pub fn description(self) -> &'static str {
         match self {
-            BillingReason::Management => "Management API call",
+            BillingReason::Management => "Configuration change",
             BillingReason::LitAction => "Lit Action execution",
         }
     }
@@ -826,6 +831,8 @@ async fn charge(
     api_key: &str,
     cost_cents: i64,
     reason: BillingReason,
+    ipfs_id: Option<&str>,
+    request_id: Option<&str>,
     state: &StripeState,
 ) -> std::result::Result<(), BillingError> {
     tracing::debug!(cost_cents, "stripe::charge: starting");
@@ -892,6 +899,18 @@ async fn charge(
     let cid = customer_id.clone();
     let wallet_for_metric = wallet.clone();
     let idempotency_key = uuid::Uuid::new_v4().to_string();
+    // Owned copies of the Stripe `description` ("Reason" in the dashboard) and
+    // the metadata values, moved into the fire-and-forget task below. Lit Action
+    // charges label the Reason with the action's IPFS CID; everything else falls
+    // back to the reason's static description ("Configuration change", etc.).
+    let description = match ipfs_id {
+        Some(id) => format!("Lit Action {id}"),
+        None => reason.description().to_string(),
+    };
+    let ipfs_id = ipfs_id.map(str::to_owned);
+    // Groups the (possibly several) balance transactions a single request emits:
+    // one Lit Action execution flushes per-second charges under one request-id.
+    let request_id = request_id.map(str::to_owned);
     tokio::spawn(async move {
         let cost_str = cost_cents.to_string();
         let delays = [
@@ -906,16 +925,23 @@ async fn charge(
             if !delay.is_zero() {
                 tokio::time::sleep(delay).await;
             }
+            let mut params: Vec<(&str, &str)> = vec![
+                ("amount", cost_str.as_str()),
+                ("currency", "usd"),
+                ("description", description.as_str()),
+                ("metadata[reason]", reason.as_str()),
+            ];
+            if let Some(id) = ipfs_id.as_deref() {
+                params.push(("metadata[ipfs_id]", id));
+            }
+            if let Some(rid) = request_id.as_deref() {
+                params.push(("metadata[request_id]", rid));
+            }
             match state
                 .client
                 .post_with_idempotency(
                     &format!("customers/{cid}/balance_transactions"),
-                    &[
-                        ("amount", cost_str.as_str()),
-                        ("currency", "usd"),
-                        ("description", reason.description()),
-                        ("metadata[reason]", reason.as_str()),
-                    ],
+                    &params,
                     &idempotency_key,
                 )
                 .await
@@ -950,15 +976,21 @@ async fn charge(
     Ok(())
 }
 
-/// Charge $0.01 for a management API call.
+/// Charge $0.01 for a management (configuration-change) API call.
+///
+/// `request_id` is the request's `X-Request-Id`, recorded as
+/// `metadata[request_id]` on the Stripe transaction for later correlation.
 pub async fn charge_management(
     api_key: &str,
+    request_id: Option<&str>,
     state: &StripeState,
 ) -> std::result::Result<(), BillingError> {
     charge(
         api_key,
         COST_MANAGEMENT_CENTS,
         BillingReason::Management,
+        None,
+        request_id,
         state,
     )
     .await
@@ -966,9 +998,17 @@ pub async fn charge_management(
 
 /// Charge for `seconds` of Lit Action execution time.
 /// Returns `Ok(())` if the charge succeeds, `Err` if insufficient credits.
+///
+/// `ipfs_id` is the executing action's IPFS CID; it becomes the Stripe
+/// transaction `description` (`Lit Action {cid}` — the "Reason" field) and
+/// `metadata[ipfs_id]`. `request_id` is the request's `X-Request-Id`, recorded
+/// as `metadata[request_id]` so the several per-second flushes of one execution
+/// can be grouped after the fact.
 pub async fn charge_lit_action_time(
     api_key: &str,
     seconds: u64,
+    ipfs_id: Option<&str>,
+    request_id: Option<&str>,
     state: &StripeState,
 ) -> Result<()> {
     tracing::debug!(seconds, "stripe::charge_lit_action_time: starting");
@@ -980,9 +1020,16 @@ pub async fn charge_lit_action_time(
     if cost == 0 {
         return Ok(());
     }
-    charge(api_key, cost, BillingReason::LitAction, state)
-        .await
-        .map_err(anyhow::Error::new)
+    charge(
+        api_key,
+        cost,
+        BillingReason::LitAction,
+        ipfs_id,
+        request_id,
+        state,
+    )
+    .await
+    .map_err(anyhow::Error::new)
 }
 
 /// Grant the configured starter credits to a newly created customer.
@@ -1208,11 +1255,12 @@ mod tests {
 
     #[test]
     fn billing_reason_descriptions_distinguish_charge_type() {
-        // Sent as the Stripe balance transaction `description`; must differ per
-        // reason so the charge type is legible in the Stripe dashboard.
+        // Fallback `description` (the "Reason" field in the Stripe dashboard).
+        // Lit Action charges override it with `Lit Action {cid}` when a CID is
+        // available; this is the label used when none is.
         assert_eq!(
             BillingReason::Management.description(),
-            "Management API call"
+            "Configuration change"
         );
         assert_eq!(
             BillingReason::LitAction.description(),

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -832,7 +832,7 @@ pub async fn check_credit(
 /// the normalized CID. Only Lit Action charges carry a CID: an empty CID, or one
 /// passed with any other `reason`, is dropped so a stray argument can never
 /// mislabel a charge as a Lit Action. Pure so it can be unit-tested.
-fn charge_label<'a>(reason: BillingReason, ipfs_id: Option<&'a str>) -> (String, Option<&'a str>) {
+fn charge_label(reason: BillingReason, ipfs_id: Option<&str>) -> (String, Option<&str>) {
     let cid = match reason {
         BillingReason::LitAction => ipfs_id.filter(|s| !s.is_empty()),
         _ => None,


### PR DESCRIPTION
Populates the Stripe balance-transaction "Reason" (the `description` field) with the executing Lit Action's IPFS CID (`Lit Action {cid}`), and relabels management/config charges from "Management API call" to "Configuration change". Both charge types now also carry `metadata[request_id]` (the request's X-Request-Id) and Lit Action charges carry `metadata[ipfs_id]`, so the several per-second billing flushes of a single execution can be grouped after the fact. The CID is the same authorization-grade hash derived for every execution (raw code included), so the label is always present on the billed path; the empty-string filter is purely defensive against the builder default. Threaded the two new args through `charge`, `charge_lit_action_time`, and `charge_management`, and updated the description unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)