### PR TITLE
fix(stripe): idempotency key on topup credit to close TOCTOU double-credit (CPL-370)

### DIFF
--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -1071,6 +1071,11 @@ pub async fn create_payment_intent(
 /// 3. Marks the PaymentIntent as credited (`metadata[credited]=true`) **before** creating
 ///    the balance transaction, so a crash or retry after this point is safe (the second call
 ///    will be rejected by check 1).
+/// 4. Posts the balance transaction with a stable idempotency key
+///    (`topup-credit-{pi_id}`). The check-then-set in step 3 spans two Stripe round-trips
+///    and is not atomic, so N concurrent callers can all pass check 1 before any writes
+///    the metadata; the shared idempotency key ensures Stripe still records the credit
+///    exactly once, closing that TOCTOU double-credit window.
 pub async fn confirm_payment_and_credit(
     payment_intent_id: &str,
     wallet_address: &str,
@@ -1133,15 +1138,21 @@ pub async fn confirm_payment_and_credit(
         .await?;
 
     let credit = (-amount).to_string(); // negative = credit to customer
+    // Stable idempotency key derived from the PaymentIntent so that N concurrent
+    // confirm_payment calls racing past the metadata.credited check-then-set above
+    // still produce exactly one balance transaction (Stripe deduplicates keys for
+    // 24h). This closes the TOCTOU window between the check and the credit POST.
+    let idempotency_key = format!("topup-credit-{payment_intent_id}");
     state
         .client
-        .post(
+        .post_with_idempotency(
             &format!("customers/{customer_id}/balance_transactions"),
             &[
                 ("amount", credit.as_str()),
                 ("currency", "usd"),
                 ("description", &format!("Top-up via {payment_intent_id}")),
             ],
+            &idempotency_key,
         )
         .await?;
 

--- a/lit-api-server/src/stripe.rs
+++ b/lit-api-server/src/stripe.rs
@@ -1062,6 +1062,17 @@ pub async fn create_payment_intent(
     Ok((client_secret, pi_id))
 }
 
+/// Stripe idempotency key for the top-up balance transaction of a PaymentIntent.
+///
+/// The key is a pure function of the PaymentIntent ID: every caller that races to
+/// credit the same intent computes the identical key, and Stripe collapses those
+/// requests into a single balance transaction (dedup window: 24h). Kept as a
+/// standalone, deterministic helper so the format is unit-testable and cannot drift
+/// silently — a regression here would re-open the double-credit window (CPL-370).
+fn topup_credit_idempotency_key(payment_intent_id: &str) -> String {
+    format!("topup-credit-{payment_intent_id}")
+}
+
 /// Verify a PaymentIntent succeeded and credit the customer's account.
 ///
 /// Replay protection:
@@ -1072,10 +1083,11 @@ pub async fn create_payment_intent(
 ///    the balance transaction, so a crash or retry after this point is safe (the second call
 ///    will be rejected by check 1).
 /// 4. Posts the balance transaction with a stable idempotency key
-///    (`topup-credit-{pi_id}`). The check-then-set in step 3 spans two Stripe round-trips
-///    and is not atomic, so N concurrent callers can all pass check 1 before any writes
-///    the metadata; the shared idempotency key ensures Stripe still records the credit
-///    exactly once, closing that TOCTOU double-credit window.
+///    (`topup-credit-{payment_intent_id}`, see [`topup_credit_idempotency_key`]). The
+///    check-then-set in step 3 spans two Stripe round-trips and is not atomic, so N
+///    concurrent callers can all pass check 1 before any writes the metadata; the shared
+///    idempotency key ensures Stripe still records the credit exactly once, closing that
+///    TOCTOU double-credit window.
 pub async fn confirm_payment_and_credit(
     payment_intent_id: &str,
     wallet_address: &str,
@@ -1142,7 +1154,7 @@ pub async fn confirm_payment_and_credit(
     // confirm_payment calls racing past the metadata.credited check-then-set above
     // still produce exactly one balance transaction (Stripe deduplicates keys for
     // 24h). This closes the TOCTOU window between the check and the credit POST.
-    let idempotency_key = format!("topup-credit-{payment_intent_id}");
+    let idempotency_key = topup_credit_idempotency_key(payment_intent_id);
     state
         .client
         .post_with_idempotency(
@@ -1256,6 +1268,38 @@ mod tests {
         let raw = "test-api-key";
         let hash_hex = format!("0x{:064x}", api_key_hash(raw));
         assert_eq!(cache_key(raw), cache_key(&hash_hex));
+    }
+
+    // ── Top-up credit idempotency key (CPL-370) ──────────────────────────────
+
+    #[test]
+    fn topup_key_has_expected_format() {
+        // The format is the load-bearing contract with Stripe: it must stay
+        // `topup-credit-<pi_id>` verbatim or the dedup guarantee silently breaks.
+        assert_eq!(
+            topup_credit_idempotency_key("pi_3AbCdEf12345"),
+            "topup-credit-pi_3AbCdEf12345"
+        );
+    }
+
+    #[test]
+    fn topup_key_is_deterministic_per_intent() {
+        // Same intent → same key, so concurrent confirm_payment callers collapse
+        // to a single Stripe balance transaction.
+        assert_eq!(
+            topup_credit_idempotency_key("pi_same"),
+            topup_credit_idempotency_key("pi_same")
+        );
+    }
+
+    #[test]
+    fn topup_key_differs_across_intents() {
+        // Distinct intents must never share a key, or a legitimate second top-up
+        // would be silently deduped away.
+        assert_ne!(
+            topup_credit_idempotency_key("pi_one"),
+            topup_credit_idempotency_key("pi_two")
+        );
     }
 
     // ── Balance cache merge logic ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes [CPL-370](https://linear.app/litprotocol/issue/CPL-370): a TOCTOU race in `confirm_payment_and_credit` (`lit-api-server/src/stripe.rs`) let N parallel `POST /core/v1/billing/confirm_payment` calls with the same succeeded `payment_intent_id` each credit real money (up to N× credit). The `metadata.credited` replay guard is a check-then-set spanning two Stripe round-trips, so concurrent callers can all pass the check before any writes the metadata, and the credit POST carried no idempotency key.

This switches the balance-transaction POST to `post_with_idempotency` using a stable key `topup-credit-{pi_id}`; Stripe deduplicates same-key requests for 24h, so racing callers collapse to exactly one credit (mirroring the pattern `charge()` already uses). The function doc comment gains a step 4 explaining the guarantee.

Verified with `cargo +1.91 check` and `cargo +1.91 fmt` on `lit-api-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)