### PR TITLE
fix(litkey): partial-row reconciler guards LITKEY double-credit (CPL-375)

### DIFF
--- a/lit-payments/migrations/20260805000001_litkey_partial_credit.sql
+++ b/lit-payments/migrations/20260805000001_litkey_partial_credit.sql
@@ -1,0 +1,38 @@
+-- CPL-375: close the LITKEY double-credit window after a crash.
+--
+-- Before this change `handle_confirmed_litkey_payment` wrote the Stripe
+-- balance_transaction FIRST and inserted the `litkey_payments` row LAST.
+-- A crash between those two steps left the credit at Stripe with no DB
+-- record; because Stripe drops a given Idempotency-Key after ~24h, a
+-- re-claim more than a day later re-issued the credit and double-credited
+-- the user.
+--
+-- The fix inserts the row BEFORE the Stripe call as the idempotency guard,
+-- then fills in `stripe_balance_transaction_id` once the credit lands. That
+-- makes a `credited` row legal in a "partial" state (credit intended, Stripe
+-- id not yet recorded), which the original status-fields CHECK forbade.
+-- A background reconciler (mirroring the auto_topup one) completes any
+-- partial row within Stripe's idempotency window using the same
+-- `litkey:{chain}:{tx}:{log_index}` key, so the retry dedupes instead of
+-- double-crediting.
+--
+-- This migration relaxes the credited branch of the CHECK to drop the
+-- `stripe_balance_transaction_id IS NOT NULL` requirement, and adds a
+-- partial index the reconciler uses to find rows still awaiting their
+-- balance_transactions write.
+
+ALTER TABLE litkey_payments
+    DROP CONSTRAINT litkey_payments_status_fields_check;
+
+ALTER TABLE litkey_payments
+    ADD CONSTRAINT litkey_payments_status_fields_check CHECK (
+        (status = 'credited' AND usd_wei_per_litkey IS NOT NULL AND cents_credited > 0 AND stripe_customer_id IS NOT NULL)
+        OR (status <> 'credited' AND stripe_balance_transaction_id IS NULL)
+    );
+
+-- Reconciler lookup: credited rows whose balance_transactions write has not
+-- landed yet (crash or Stripe error between INSERT and the credit). Partial
+-- so the index stays trivially small under normal operation.
+CREATE INDEX litkey_payments_pending_balance_tx_idx
+    ON litkey_payments (credited_at)
+    WHERE status = 'credited' AND stripe_balance_transaction_id IS NULL;

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -265,6 +265,148 @@ pub async fn insert_payment(pool: &PgPool, payment: &NewLitkeyPayment) -> Result
     Ok(inserted.is_some())
 }
 
+/// Fill in the Stripe `balance_transaction` id on a previously-inserted
+/// credited row, promoting it from "partial" to complete. Keyed by the
+/// on-chain `(chain_id, tx_hash, log_index)` identity so both the live claim
+/// path and the reconciler converge on the same row (CPL-375).
+pub async fn mark_payment_credited(
+    pool: &PgPool,
+    log: &PaymentLog,
+    stripe_balance_transaction_id: &str,
+) -> Result<()> {
+    sqlx::query(
+        "UPDATE litkey_payments
+            SET stripe_balance_transaction_id = $1
+          WHERE chain_id = $2 AND tx_hash = $3 AND log_index = $4",
+    )
+    .bind(stripe_balance_transaction_id)
+    .bind(log.chain_id)
+    .bind(format!("{:#x}", log.tx_hash))
+    .bind(log.log_index as i64)
+    .execute(pool)
+    .await
+    .context("marking litkey payment credited")?;
+    Ok(())
+}
+
+/// A `credited` `litkey_payments` row whose Stripe `balance_transaction`
+/// write never landed (crash or Stripe error between INSERT and the credit).
+/// Carries everything the reconciler needs to replay the credit with the
+/// original idempotency key.
+#[derive(Clone, Debug)]
+pub struct PartialLitkeyCredit {
+    pub log: PaymentLog,
+    pub usd_wei_per_litkey: String,
+    pub discount_basis_points: i64,
+    pub cents_credited: i64,
+    pub stripe_customer_id: String,
+    pub credited_at: time::OffsetDateTime,
+}
+
+impl PartialLitkeyCredit {
+    /// The stable Stripe Idempotency-Key for this credit. Reusing it is what
+    /// makes the reconciler retry safe: if the original credit landed, Stripe
+    /// dedupes; if it did not, Stripe credits fresh — never both.
+    pub fn idempotency_key(&self) -> String {
+        self.log.idempotency_key()
+    }
+
+    /// Stripe balance delta (negative cents credit the customer), matching
+    /// [`classify_litkey_payment`].
+    pub fn amount_cents(&self) -> i64 {
+        -self.cents_credited
+    }
+
+    pub fn description(&self) -> String {
+        litkey_payment_description(
+            &self.log,
+            &self.usd_wei_per_litkey,
+            self.discount_basis_points,
+        )
+    }
+}
+
+/// List every credited row still awaiting its `balance_transactions` write
+/// (`stripe_balance_transaction_id IS NULL`), oldest first. The reconciler
+/// age-gates each one before replaying the Stripe credit.
+pub async fn list_partial_litkey_credits(pool: &PgPool) -> Result<Vec<PartialLitkeyCredit>> {
+    let rows = sqlx::query_as::<
+        _,
+        (
+            i64,
+            String,
+            String,
+            i64,
+            i64,
+            String,
+            String,
+            String,
+            Option<String>,
+            i64,
+            i64,
+            Option<String>,
+            time::OffsetDateTime,
+        ),
+    >(
+        "SELECT chain_id, gateway_address, tx_hash, log_index, block_number,
+                wallet_address, payer_address, litkey_amount_wei::text,
+                usd_wei_per_litkey::text, discount_basis_points, cents_credited,
+                stripe_customer_id, credited_at
+           FROM litkey_payments
+          WHERE status = 'credited' AND stripe_balance_transaction_id IS NULL
+          ORDER BY credited_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .context("listing partial litkey credits")?;
+
+    rows.into_iter()
+        .map(|r| {
+            let (
+                chain_id,
+                gateway_address,
+                tx_hash,
+                log_index,
+                block_number,
+                wallet_address,
+                payer_address,
+                litkey_amount_wei,
+                usd_wei_per_litkey,
+                discount_basis_points,
+                cents_credited,
+                stripe_customer_id,
+                credited_at,
+            ) = r;
+            let log = PaymentLog {
+                chain_id,
+                gateway_address: gateway_address
+                    .parse()
+                    .context("partial credit gateway_address")?,
+                wallet: wallet_address.parse().context("partial credit wallet")?,
+                payer: payer_address.parse().context("partial credit payer")?,
+                amount_wei: litkey_amount_wei
+                    .parse()
+                    .context("partial credit litkey_amount_wei")?,
+                tx_hash: tx_hash.parse().context("partial credit tx_hash")?,
+                log_index: log_index as u64,
+                block_number: block_number as u64,
+            };
+            Ok(PartialLitkeyCredit {
+                log,
+                // A `credited` row always has a rate and a customer (enforced
+                // by `litkey_payments_status_fields_check`), so these are
+                // never NULL in practice; default defensively rather than
+                // panic if the invariant is ever violated.
+                usd_wei_per_litkey: usd_wei_per_litkey.unwrap_or_default(),
+                discount_basis_points,
+                cents_credited,
+                stripe_customer_id: stripe_customer_id.unwrap_or_default(),
+                credited_at,
+            })
+        })
+        .collect()
+}
+
 #[derive(Debug, Serialize)]
 pub struct LitkeyPaymentConfigResponse {
     pub chain_id: i64,
@@ -695,8 +837,22 @@ pub async fn handle_confirmed_litkey_payment(
             customer::find_by_wallet(stripe, &log.wallet_address()).await?
         }
     };
-    let mut decision =
-        classify_litkey_payment(log, rate.as_ref(), discount_basis_points, customer_id)?;
+    let decision = classify_litkey_payment(log, rate.as_ref(), discount_basis_points, customer_id)?;
+
+    // CPL-375: insert the row BEFORE the Stripe credit so the DB record is
+    // the idempotency guard, not an afterthought. For a credited payment the
+    // row lands "partial" (`stripe_balance_transaction_id` NULL) until the
+    // credit is confirmed; a crash after the Stripe call can no longer strand
+    // a credit with no DB record, so a re-claim past Stripe's ~24h
+    // idempotency-key TTL short-circuits on `payment_exists` instead of
+    // double-crediting. The `litkey_reconciler` completes any partial row
+    // (retrying with the same idempotency key, which dedupes at Stripe).
+    let inserted = insert_payment(pool, &decision.payment).await?;
+    if !inserted {
+        // A concurrent claim of the same event already recorded it (ON
+        // CONFLICT DO NOTHING). That claim owns the credit; nothing to do.
+        return Ok(());
+    }
 
     if let Some(credit) = &decision.stripe_credit {
         let balance_transaction_id = balance::write_transaction(
@@ -707,10 +863,9 @@ pub async fn handle_confirmed_litkey_payment(
             Some(&credit.idempotency_key),
         )
         .await?;
-        decision.payment.stripe_balance_transaction_id = Some(balance_transaction_id);
+        mark_payment_credited(pool, log, &balance_transaction_id).await?;
     }
 
-    insert_payment(pool, &decision.payment).await?;
     Ok(())
 }
 
@@ -729,6 +884,43 @@ mod tests {
             payment_idempotency_key(8453, tx_hash, 7),
             "litkey:8453:0x1111111111111111111111111111111111111111111111111111111111111111:7"
         );
+    }
+
+    // CPL-375: the reconciler must replay the EXACT Stripe call the live claim
+    // path issued — same idempotency key (so Stripe dedupes), same amount, same
+    // description. A partial row reconstructed by the reconciler is derived from
+    // the same fields `classify_litkey_payment` persisted, so the derived credit
+    // parameters must round-trip identically.
+    #[test]
+    fn partial_credit_replays_the_same_stripe_call_as_the_live_path() {
+        let log = sample_payment_log();
+        let discount_bps = 2_000;
+        let decision = classify_litkey_payment(
+            &log,
+            Some(&fresh_rate()),
+            discount_bps,
+            Some("cus_123".to_string()),
+        )
+        .unwrap();
+        let credit = decision
+            .stripe_credit
+            .expect("a customer with a live rate should credit");
+
+        // Rebuild the partial the reconciler would read back from the row.
+        let partial = PartialLitkeyCredit {
+            log: log.clone(),
+            usd_wei_per_litkey: decision.payment.usd_wei_per_litkey.clone().unwrap(),
+            discount_basis_points: decision.payment.discount_basis_points,
+            cents_credited: decision.payment.cents_credited,
+            stripe_customer_id: decision.payment.stripe_customer_id.clone().unwrap(),
+            credited_at: time::OffsetDateTime::UNIX_EPOCH,
+        };
+
+        assert_eq!(partial.idempotency_key(), credit.idempotency_key);
+        assert_eq!(partial.idempotency_key(), log.idempotency_key());
+        assert_eq!(partial.amount_cents(), credit.amount_cents);
+        assert_eq!(partial.description(), credit.description);
+        assert_eq!(partial.stripe_customer_id, credit.customer_id);
     }
 
     #[test]

--- a/lit-payments/src/chain.rs
+++ b/lit-payments/src/chain.rs
@@ -269,6 +269,13 @@ pub async fn insert_payment(pool: &PgPool, payment: &NewLitkeyPayment) -> Result
 /// credited row, promoting it from "partial" to complete. Keyed by the
 /// on-chain `(chain_id, tx_hash, log_index)` identity so both the live claim
 /// path and the reconciler converge on the same row (CPL-375).
+///
+/// Guarded on `stripe_balance_transaction_id IS NULL` so completion is
+/// write-once: once a row records a balance transaction, a later caller (the
+/// live path and reconciler can race on the same row) cannot clobber that id
+/// with a different one — a duplicate credit would then stay visible rather
+/// than being papered over. Affecting zero rows is therefore the normal
+/// idempotent outcome, not an error, so we don't assert a row count.
 pub async fn mark_payment_credited(
     pool: &PgPool,
     log: &PaymentLog,
@@ -277,7 +284,8 @@ pub async fn mark_payment_credited(
     sqlx::query(
         "UPDATE litkey_payments
             SET stripe_balance_transaction_id = $1
-          WHERE chain_id = $2 AND tx_hash = $3 AND log_index = $4",
+          WHERE chain_id = $2 AND tx_hash = $3 AND log_index = $4
+            AND stripe_balance_transaction_id IS NULL",
     )
     .bind(stripe_balance_transaction_id)
     .bind(log.chain_id)
@@ -289,10 +297,17 @@ pub async fn mark_payment_credited(
     Ok(())
 }
 
+/// Stripe drops a given Idempotency-Key after ~24h. Past this age the stable
+/// `litkey:{chain}:{tx}:{log_index}` key can no longer be trusted to dedupe,
+/// so replaying a partial credit risks double-crediting. Both the background
+/// reconciler and the synchronous claim path refuse to auto-complete a
+/// partial older than this; such rows are surfaced for manual repair.
+pub const PARTIAL_CREDIT_IDEMPOTENCY_WINDOW_HOURS: i64 = 23;
+
 /// A `credited` `litkey_payments` row whose Stripe `balance_transaction`
 /// write never landed (crash or Stripe error between INSERT and the credit).
-/// Carries everything the reconciler needs to replay the credit with the
-/// original idempotency key.
+/// Carries everything needed to replay the credit with the original
+/// idempotency key.
 #[derive(Clone, Debug)]
 pub struct PartialLitkeyCredit {
     pub log: PaymentLog,
@@ -305,8 +320,8 @@ pub struct PartialLitkeyCredit {
 
 impl PartialLitkeyCredit {
     /// The stable Stripe Idempotency-Key for this credit. Reusing it is what
-    /// makes the reconciler retry safe: if the original credit landed, Stripe
-    /// dedupes; if it did not, Stripe credits fresh — never both.
+    /// makes a replay safe: if the original credit landed, Stripe dedupes; if
+    /// it did not, Stripe credits fresh — never both.
     pub fn idempotency_key(&self) -> String {
         self.log.idempotency_key()
     }
@@ -324,87 +339,150 @@ impl PartialLitkeyCredit {
             self.discount_basis_points,
         )
     }
+
+    /// True once the partial is too old for its idempotency key to be trusted
+    /// to dedupe — replaying past this point risks a double credit, so callers
+    /// must refuse and leave the row for manual repair. See
+    /// [`PARTIAL_CREDIT_IDEMPOTENCY_WINDOW_HOURS`].
+    pub fn past_idempotency_window(&self, now: time::OffsetDateTime) -> bool {
+        (now - self.credited_at).whole_hours() >= PARTIAL_CREDIT_IDEMPOTENCY_WINDOW_HOURS
+    }
+}
+
+/// Column tuple shared by the partial-credit queries. The rate/customer
+/// columns read as `Option` because they are nullable in the schema, though a
+/// `credited` row always has both (enforced by the status-fields CHECK); a
+/// violated invariant then degrades to a default instead of panicking.
+type PartialCreditRow = (
+    i64,
+    String,
+    String,
+    i64,
+    i64,
+    String,
+    String,
+    String,
+    Option<String>,
+    i64,
+    i64,
+    Option<String>,
+    time::OffsetDateTime,
+);
+
+const PARTIAL_CREDIT_COLUMNS: &str = "chain_id, gateway_address, tx_hash, log_index, block_number, \
+     wallet_address, payer_address, litkey_amount_wei::text, \
+     usd_wei_per_litkey::text, discount_basis_points, cents_credited, \
+     stripe_customer_id, credited_at";
+
+fn partial_credit_from_row(r: PartialCreditRow) -> Result<PartialLitkeyCredit> {
+    let (
+        chain_id,
+        gateway_address,
+        tx_hash,
+        log_index,
+        block_number,
+        wallet_address,
+        payer_address,
+        litkey_amount_wei,
+        usd_wei_per_litkey,
+        discount_basis_points,
+        cents_credited,
+        stripe_customer_id,
+        credited_at,
+    ) = r;
+    let log = PaymentLog {
+        chain_id,
+        gateway_address: gateway_address
+            .parse()
+            .context("partial credit gateway_address")?,
+        wallet: wallet_address.parse().context("partial credit wallet")?,
+        payer: payer_address.parse().context("partial credit payer")?,
+        amount_wei: litkey_amount_wei
+            .parse()
+            .context("partial credit litkey_amount_wei")?,
+        tx_hash: tx_hash.parse().context("partial credit tx_hash")?,
+        log_index: log_index as u64,
+        block_number: block_number as u64,
+    };
+    Ok(PartialLitkeyCredit {
+        log,
+        // A `credited` row always has a rate and a customer (enforced by
+        // `litkey_payments_status_fields_check`); default defensively rather
+        // than panic if that invariant is ever violated.
+        usd_wei_per_litkey: usd_wei_per_litkey.unwrap_or_default(),
+        discount_basis_points,
+        cents_credited,
+        stripe_customer_id: stripe_customer_id.unwrap_or_default(),
+        credited_at,
+    })
 }
 
 /// List every credited row still awaiting its `balance_transactions` write
 /// (`stripe_balance_transaction_id IS NULL`), oldest first. The reconciler
 /// age-gates each one before replaying the Stripe credit.
 pub async fn list_partial_litkey_credits(pool: &PgPool) -> Result<Vec<PartialLitkeyCredit>> {
-    let rows = sqlx::query_as::<
-        _,
-        (
-            i64,
-            String,
-            String,
-            i64,
-            i64,
-            String,
-            String,
-            String,
-            Option<String>,
-            i64,
-            i64,
-            Option<String>,
-            time::OffsetDateTime,
-        ),
-    >(
-        "SELECT chain_id, gateway_address, tx_hash, log_index, block_number,
-                wallet_address, payer_address, litkey_amount_wei::text,
-                usd_wei_per_litkey::text, discount_basis_points, cents_credited,
-                stripe_customer_id, credited_at
+    let query = format!(
+        "SELECT {PARTIAL_CREDIT_COLUMNS}
            FROM litkey_payments
           WHERE status = 'credited' AND stripe_balance_transaction_id IS NULL
-          ORDER BY credited_at ASC",
-    )
-    .fetch_all(pool)
-    .await
-    .context("listing partial litkey credits")?;
+          ORDER BY credited_at ASC"
+    );
+    let rows = sqlx::query_as::<_, PartialCreditRow>(&query)
+        .fetch_all(pool)
+        .await
+        .context("listing partial litkey credits")?;
+    rows.into_iter().map(partial_credit_from_row).collect()
+}
 
-    rows.into_iter()
-        .map(|r| {
-            let (
-                chain_id,
-                gateway_address,
-                tx_hash,
-                log_index,
-                block_number,
-                wallet_address,
-                payer_address,
-                litkey_amount_wei,
-                usd_wei_per_litkey,
-                discount_basis_points,
-                cents_credited,
-                stripe_customer_id,
-                credited_at,
-            ) = r;
-            let log = PaymentLog {
-                chain_id,
-                gateway_address: gateway_address
-                    .parse()
-                    .context("partial credit gateway_address")?,
-                wallet: wallet_address.parse().context("partial credit wallet")?,
-                payer: payer_address.parse().context("partial credit payer")?,
-                amount_wei: litkey_amount_wei
-                    .parse()
-                    .context("partial credit litkey_amount_wei")?,
-                tx_hash: tx_hash.parse().context("partial credit tx_hash")?,
-                log_index: log_index as u64,
-                block_number: block_number as u64,
-            };
-            Ok(PartialLitkeyCredit {
-                log,
-                // A `credited` row always has a rate and a customer (enforced
-                // by `litkey_payments_status_fields_check`), so these are
-                // never NULL in practice; default defensively rather than
-                // panic if the invariant is ever violated.
-                usd_wei_per_litkey: usd_wei_per_litkey.unwrap_or_default(),
-                discount_basis_points,
-                cents_credited,
-                stripe_customer_id: stripe_customer_id.unwrap_or_default(),
-                credited_at,
-            })
-        })
-        .collect()
+/// Fetch the most recent partial credit for a `(tx_hash, wallet)`, if any.
+/// Used by the claim path to finish a credit synchronously on re-claim
+/// instead of waiting for the background reconciler. Matches the chain and
+/// wallet scoping of [`lookup_payment_status`].
+pub async fn find_partial_litkey_credit(
+    pool: &PgPool,
+    tx_hash: &str,
+    wallet: &str,
+) -> Result<Option<PartialLitkeyCredit>> {
+    let query = format!(
+        "SELECT {PARTIAL_CREDIT_COLUMNS}
+           FROM litkey_payments
+          WHERE chain_id = $1 AND tx_hash = $2 AND wallet_address = $3
+            AND status = 'credited' AND stripe_balance_transaction_id IS NULL
+          ORDER BY credited_at DESC
+          LIMIT 1"
+    );
+    let row = sqlx::query_as::<_, PartialCreditRow>(&query)
+        .bind(BASE_CHAIN_ID)
+        .bind(tx_hash)
+        .bind(wallet)
+        .fetch_optional(pool)
+        .await
+        .context("finding partial litkey credit")?;
+    row.map(partial_credit_from_row).transpose()
+}
+
+/// Replay the Stripe credit for a partial row and record the balance
+/// transaction id (write-once via [`mark_payment_credited`]). Shared by the
+/// reconciler and the synchronous claim path. Reuses the original idempotency
+/// key, so it dedupes if the credit already landed. Callers must enforce
+/// their own age policy first (see
+/// [`PartialLitkeyCredit::past_idempotency_window`]); this issues the Stripe
+/// call unconditionally.
+pub async fn complete_partial_litkey_credit(
+    stripe: &StripeClient,
+    pool: &PgPool,
+    partial: &PartialLitkeyCredit,
+) -> Result<()> {
+    let balance_transaction_id = balance::write_transaction(
+        stripe,
+        &partial.stripe_customer_id,
+        partial.amount_cents(),
+        &partial.description(),
+        Some(&partial.idempotency_key()),
+    )
+    .await?;
+    mark_payment_credited(pool, &partial.log, &balance_transaction_id).await?;
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]
@@ -766,6 +844,22 @@ async fn claim_litkey_payment_tx(
     wallet: &str,
     discount_basis_points: i64,
 ) -> Result<LitkeyPaymentStatusResponse> {
+    // A partial credit (row inserted, Stripe write interrupted — CPL-375) is a
+    // `credited` row that `lookup_payment_status` would report as done even
+    // though the balance_transactions write never landed. On re-claim, finish
+    // it synchronously (reusing the original idempotency key, so it dedupes if
+    // the credit actually landed) rather than waiting for the background
+    // reconciler tick, so the response reflects a truly-landed credit. Past
+    // the idempotency window a replay could double-credit, so we leave those
+    // for the reconciler to surface for manual repair and just report status.
+    if let Some(partial) = find_partial_litkey_credit(pool, tx_hash, wallet).await? {
+        if !partial.past_idempotency_window(time::OffsetDateTime::now_utc()) {
+            complete_partial_litkey_credit(stripe, pool, &partial).await?;
+        }
+        return Ok(payment_status_response_from_row(
+            lookup_payment_status(pool, tx_hash, wallet).await?,
+        ));
+    }
     if let Some(row) = lookup_payment_status(pool, tx_hash, wallet).await? {
         return Ok(payment_status_response_from_row(Some(row)));
     }
@@ -921,6 +1015,35 @@ mod tests {
         assert_eq!(partial.amount_cents(), credit.amount_cents);
         assert_eq!(partial.description(), credit.description);
         assert_eq!(partial.stripe_customer_id, credit.customer_id);
+    }
+
+    // CPL-375: both the reconciler and the synchronous claim path must refuse
+    // to replay a credit once the Stripe idempotency key can no longer dedupe,
+    // and must still replay just inside the window.
+    #[test]
+    fn partial_credit_idempotency_window_gate() {
+        let make = |credited_at| PartialLitkeyCredit {
+            log: sample_payment_log(),
+            usd_wei_per_litkey: "1000000000000000000".to_string(),
+            discount_basis_points: 2_000,
+            cents_credited: 125,
+            stripe_customer_id: "cus_123".to_string(),
+            credited_at,
+        };
+        let now = time::OffsetDateTime::UNIX_EPOCH + time::Duration::days(30);
+
+        assert!(
+            !make(now - time::Duration::hours(22)).past_idempotency_window(now),
+            "22h old is still inside the window"
+        );
+        assert!(
+            make(now - time::Duration::hours(23)).past_idempotency_window(now),
+            "23h old is at the window edge and must be refused"
+        );
+        assert!(
+            make(now - time::Duration::hours(48)).past_idempotency_window(now),
+            "well past the window must be refused"
+        );
     }
 
     #[test]

--- a/lit-payments/src/lib.rs
+++ b/lit-payments/src/lib.rs
@@ -12,6 +12,9 @@ pub mod db;
 pub mod enterprise;
 pub mod gas_funder;
 pub mod internal;
+pub mod litkey_reconciler;
+#[cfg(test)]
+mod litkey_reconciler_tests;
 pub mod mail;
 pub mod portal;
 pub mod rate;

--- a/lit-payments/src/litkey_reconciler.rs
+++ b/lit-payments/src/litkey_reconciler.rs
@@ -1,0 +1,134 @@
+//! LITKEY partial-credit reconciler (CPL-375).
+//!
+//! `chain::handle_confirmed_litkey_payment` inserts the `litkey_payments`
+//! row BEFORE it writes the Stripe `balance_transaction`, then fills in
+//! `stripe_balance_transaction_id` once the credit lands. A crash or Stripe
+//! error between those two steps leaves a "partial" credited row: the DB
+//! knows the credit is owed but the balance_transactions write never
+//! completed.
+//!
+//! This reconciler sweeps those partials every `RECONCILER_INTERVAL_SECS`
+//! and replays the Stripe credit using the SAME
+//! `litkey:{chain}:{tx}:{log_index}` idempotency key the live path used.
+//! Because the key is stable:
+//!   - if the original credit DID land (crash after Stripe, before UPDATE),
+//!     Stripe dedupes and returns the existing balance_transaction;
+//!   - if it did NOT (crash/error before Stripe), Stripe credits fresh.
+//!
+//! Either way the customer is credited exactly once.
+//!
+//! Two age gates bound the work, mirroring the auto_topup reconciler:
+//!   - `MIN_PARTIAL_AGE_SECS`: a fresh partial is almost certainly the live
+//!     claim still in-flight; skip it to avoid a pointless (though
+//!     idempotency-safe) race on the balance_transactions write.
+//!   - `MAX_PARTIAL_RETRY_AGE_HOURS`: past Stripe's ~24h Idempotency-Key TTL
+//!     the key no longer dedupes, so replaying it would risk the very
+//!     double-credit this whole change exists to prevent. Older rows are
+//!     logged loudly for manual repair and skipped.
+
+use std::time::Duration;
+
+use ::time::OffsetDateTime;
+use lit_billing_core::{StripeClient, balance};
+use sqlx::PgPool;
+use tokio::time as tokio_time;
+
+use crate::chain::{self, PartialLitkeyCredit};
+use crate::config::Config;
+
+/// A partial younger than this is overwhelmingly likely to be the live claim
+/// path's own in-flight balance_transactions write, not a real orphan.
+/// Retrying it would race the claim; the shared idempotency key keeps that
+/// race safe but it is wasteful and noisy. Mirrors the auto_topup floor.
+const MIN_PARTIAL_AGE_SECS: i64 = 60;
+
+/// Past this age the Stripe Idempotency-Key (~24h TTL) can no longer be
+/// trusted to dedupe, so replaying the credit risks double-crediting. Rows
+/// older than this are surfaced via an error log for manual repair and
+/// skipped. Mirrors the auto_topup / sca_resume 23h cap.
+const MAX_PARTIAL_RETRY_AGE_HOURS: i64 = 23;
+
+/// Spawn the reconciler. Returns immediately; the loop runs in the
+/// background for the lifetime of the process. The first tick fires
+/// immediately so a process restart repairs any partial left by the crash
+/// that triggered the restart.
+pub fn spawn(config: Config, stripe: StripeClient, pool: PgPool) {
+    let interval_secs = config.reconciler_interval_secs.max(10) as u64;
+    tracing::info!("litkey partial-credit reconciler: interval = {interval_secs}s");
+    tokio::spawn(async move {
+        let mut ticker = tokio_time::interval(Duration::from_secs(interval_secs));
+        loop {
+            ticker.tick().await;
+            if let Err(e) = run_once(&stripe, &pool).await {
+                tracing::warn!("litkey reconciler tick failed: {e:?}");
+            }
+        }
+    });
+}
+
+/// One sweep over the partial credited rows. Public for tests; the
+/// production scheduler in [`spawn`] is the only other caller.
+pub async fn run_once(stripe: &StripeClient, pool: &PgPool) -> anyhow::Result<()> {
+    let partials = chain::list_partial_litkey_credits(pool).await?;
+    if partials.is_empty() {
+        return Ok(());
+    }
+    let now = OffsetDateTime::now_utc();
+    for partial in partials {
+        if let Err(e) = repair_partial(stripe, pool, &partial, now).await {
+            tracing::warn!(
+                tx_hash = %format!("{:#x}", partial.log.tx_hash),
+                log_index = partial.log.log_index,
+                "litkey reconciler: repair failed, will retry next tick: {e:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn repair_partial(
+    stripe: &StripeClient,
+    pool: &PgPool,
+    partial: &PartialLitkeyCredit,
+    now: OffsetDateTime,
+) -> anyhow::Result<()> {
+    let tx_hash = format!("{:#x}", partial.log.tx_hash);
+    let log_index = partial.log.log_index;
+    let age = now - partial.credited_at;
+
+    // Too fresh: the live claim is probably still finishing its own credit.
+    if age.whole_seconds() < MIN_PARTIAL_AGE_SECS {
+        return Ok(());
+    }
+
+    // Too old: the idempotency key can no longer dedupe. Replaying would risk
+    // a double-credit — exactly what this change prevents. Flag for a human.
+    if age.whole_hours() >= MAX_PARTIAL_RETRY_AGE_HOURS {
+        tracing::error!(
+            tx_hash = %tx_hash,
+            log_index,
+            customer_id = %partial.stripe_customer_id,
+            age_hours = age.whole_hours(),
+            "litkey reconciler: partial credit older than Stripe idempotency window; \
+             manual repair needed (skipping to avoid double-credit risk)"
+        );
+        return Ok(());
+    }
+
+    tracing::warn!(
+        tx_hash = %tx_hash,
+        log_index,
+        customer_id = %partial.stripe_customer_id,
+        "litkey reconciler: completing partial credit"
+    );
+    let balance_transaction_id = balance::write_transaction(
+        stripe,
+        &partial.stripe_customer_id,
+        partial.amount_cents(),
+        &partial.description(),
+        Some(&partial.idempotency_key()),
+    )
+    .await?;
+    chain::mark_payment_credited(pool, &partial.log, &balance_transaction_id).await?;
+    Ok(())
+}

--- a/lit-payments/src/litkey_reconciler.rs
+++ b/lit-payments/src/litkey_reconciler.rs
@@ -29,7 +29,7 @@
 use std::time::Duration;
 
 use ::time::OffsetDateTime;
-use lit_billing_core::{StripeClient, balance};
+use lit_billing_core::StripeClient;
 use sqlx::PgPool;
 use tokio::time as tokio_time;
 
@@ -40,13 +40,11 @@ use crate::config::Config;
 /// path's own in-flight balance_transactions write, not a real orphan.
 /// Retrying it would race the claim; the shared idempotency key keeps that
 /// race safe but it is wasteful and noisy. Mirrors the auto_topup floor.
+///
+/// The claim path completes fresh partials synchronously (no min-age gate),
+/// so this only defers the *background* sweep; a true crash mid-flow still
+/// recovers within one tick if the user never re-claims.
 const MIN_PARTIAL_AGE_SECS: i64 = 60;
-
-/// Past this age the Stripe Idempotency-Key (~24h TTL) can no longer be
-/// trusted to dedupe, so replaying the credit risks double-crediting. Rows
-/// older than this are surfaced via an error log for manual repair and
-/// skipped. Mirrors the auto_topup / sca_resume 23h cap.
-const MAX_PARTIAL_RETRY_AGE_HOURS: i64 = 23;
 
 /// Spawn the reconciler. Returns immediately; the loop runs in the
 /// background for the lifetime of the process. The first tick fires
@@ -103,7 +101,7 @@ async fn repair_partial(
 
     // Too old: the idempotency key can no longer dedupe. Replaying would risk
     // a double-credit — exactly what this change prevents. Flag for a human.
-    if age.whole_hours() >= MAX_PARTIAL_RETRY_AGE_HOURS {
+    if partial.past_idempotency_window(now) {
         tracing::error!(
             tx_hash = %tx_hash,
             log_index,
@@ -121,14 +119,6 @@ async fn repair_partial(
         customer_id = %partial.stripe_customer_id,
         "litkey reconciler: completing partial credit"
     );
-    let balance_transaction_id = balance::write_transaction(
-        stripe,
-        &partial.stripe_customer_id,
-        partial.amount_cents(),
-        &partial.description(),
-        Some(&partial.idempotency_key()),
-    )
-    .await?;
-    chain::mark_payment_credited(pool, &partial.log, &balance_transaction_id).await?;
+    chain::complete_partial_litkey_credit(stripe, pool, partial).await?;
     Ok(())
 }

--- a/lit-payments/src/litkey_reconciler_tests.rs
+++ b/lit-payments/src/litkey_reconciler_tests.rs
@@ -123,6 +123,50 @@ async fn reconciler_completes_partial_credit() {
 
 #[tokio::test]
 #[serial_test::serial]
+async fn claim_path_completes_partial_credit_synchronously() {
+    // The synchronous claim-path primitives: find the partial for a
+    // (tx_hash, wallet) and complete it inline. A fresh partial (no min-age
+    // gate) must still complete.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key).unwrap();
+    let cust =
+        crate::billing::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+
+    let tx_hash = "0x4444444444444444444444444444444444444444444444444444444444444444";
+    seed_partial(&pool, &cust, tx_hash, 4, Duration::seconds(1)).await;
+
+    let partial = super::chain::find_partial_litkey_credit(&pool, tx_hash, TEST_WALLET)
+        .await
+        .unwrap()
+        .expect("a partial credit should be found for the tx/wallet");
+    super::chain::complete_partial_litkey_credit(&stripe, &pool, &partial)
+        .await
+        .expect("complete partial");
+
+    assert!(
+        balance_tx_id(&pool, tx_hash).await.is_some(),
+        "synchronous completion should fill in the balance_tx id"
+    );
+    // Once completed the row is no longer a partial.
+    assert!(
+        super::chain::find_partial_litkey_credit(&pool, tx_hash, TEST_WALLET)
+            .await
+            .unwrap()
+            .is_none(),
+        "completed row must not be returned as a partial"
+    );
+
+    sqlx::query("DELETE FROM litkey_payments WHERE tx_hash = $1")
+        .bind(tx_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
 async fn reconciler_skips_fresh_partial() {
     // A partial younger than MIN_PARTIAL_AGE_SECS is the live claim still
     // in-flight; the reconciler must leave it alone.

--- a/lit-payments/src/litkey_reconciler_tests.rs
+++ b/lit-payments/src/litkey_reconciler_tests.rs
@@ -1,0 +1,185 @@
+//! Integration tests for the LITKEY partial-credit reconciler (CPL-375).
+//!
+//! Each test seeds a `litkey_payments` row in the "partial" state a real
+//! claim would leave after a crash between the INSERT and the Stripe
+//! `balance_transactions` write (`status='credited'`,
+//! `stripe_balance_transaction_id IS NULL`), then drives `run_once` and
+//! asserts the age-gated outcome.
+//!
+//! Gated on `DATABASE_URL` + a Stripe test key; the happy-path test issues a
+//! real `balance_transactions` write against a test customer. Tests return
+//! early (skip) when either is absent, matching the auto_topup reconciler
+//! tests.
+
+use lit_billing_core::StripeClient;
+use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
+
+const TEST_WALLET: &str = "0x9090909090909090909090909090909090909090";
+const TEST_PAYER: &str = "0x000000000000000000000000000000000000dead";
+const GATEWAY: &str = super::chain::DEFAULT_GATEWAY_ADDRESS;
+
+fn stripe_key() -> Option<String> {
+    std::env::var("STRIPE_SECRET_KEY").ok().filter(|k| {
+        !k.trim().is_empty() && (k.starts_with("rk_test_") || k.starts_with("sk_test_"))
+    })
+}
+
+fn db_url() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty())
+}
+
+/// Insert a partial credited row (`stripe_balance_transaction_id` NULL) for
+/// a distinct `tx_hash`, back-dating `credited_at` by `age`. Returns the
+/// tx_hash used.
+async fn seed_partial(
+    pool: &PgPool,
+    customer_id: &str,
+    tx_hash: &str,
+    log_index: i64,
+    age: Duration,
+) {
+    sqlx::query("DELETE FROM litkey_payments WHERE tx_hash = $1")
+        .bind(tx_hash)
+        .execute(pool)
+        .await
+        .unwrap();
+    let credited_at = OffsetDateTime::now_utc() - age;
+    sqlx::query(
+        "INSERT INTO litkey_payments (
+            chain_id, gateway_address, tx_hash, log_index, block_number,
+            wallet_address, payer_address, litkey_amount_wei, usd_wei_per_litkey,
+            discount_basis_points, cents_credited, status, stripe_customer_id,
+            stripe_balance_transaction_id, credited_at
+         ) VALUES (
+            $1, $2, $3, $4, $5,
+            $6, $7, $8::numeric, $9::numeric,
+            $10, $11, 'credited', $12,
+            NULL, $13
+         )",
+    )
+    .bind(super::chain::BASE_CHAIN_ID)
+    .bind(GATEWAY)
+    .bind(tx_hash)
+    .bind(log_index)
+    .bind(1_000_000i64)
+    .bind(TEST_WALLET)
+    .bind(TEST_PAYER)
+    .bind("1000000000000000000")
+    .bind("1000000000000000000")
+    .bind(2_000i64)
+    .bind(125i64)
+    .bind(customer_id)
+    .bind(credited_at)
+    .execute(pool)
+    .await
+    .expect("seed partial litkey_payments row");
+}
+
+async fn balance_tx_id(pool: &PgPool, tx_hash: &str) -> Option<String> {
+    let row: (Option<String>,) = sqlx::query_as(
+        "SELECT stripe_balance_transaction_id FROM litkey_payments WHERE tx_hash = $1",
+    )
+    .bind(tx_hash)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    row.0
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_completes_partial_credit() {
+    // Crash after INSERT, before the balance_transactions write. The
+    // reconciler must replay the credit and fill in the balance_tx id.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key).unwrap();
+    let cust =
+        crate::billing::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+
+    let tx_hash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    seed_partial(&pool, &cust, tx_hash, 1, Duration::minutes(5)).await;
+    assert!(balance_tx_id(&pool, tx_hash).await.is_none());
+
+    super::litkey_reconciler::run_once(&stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    assert!(
+        balance_tx_id(&pool, tx_hash).await.is_some(),
+        "partial credit should be completed with a balance_tx id"
+    );
+
+    sqlx::query("DELETE FROM litkey_payments WHERE tx_hash = $1")
+        .bind(tx_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_skips_fresh_partial() {
+    // A partial younger than MIN_PARTIAL_AGE_SECS is the live claim still
+    // in-flight; the reconciler must leave it alone.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key).unwrap();
+    let cust =
+        crate::billing::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+
+    let tx_hash = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    seed_partial(&pool, &cust, tx_hash, 2, Duration::seconds(1)).await;
+
+    super::litkey_reconciler::run_once(&stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    assert!(
+        balance_tx_id(&pool, tx_hash).await.is_none(),
+        "a fresh partial must not be touched by the reconciler"
+    );
+
+    sqlx::query("DELETE FROM litkey_payments WHERE tx_hash = $1")
+        .bind(tx_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reconciler_skips_partial_past_idempotency_window() {
+    // Past ~24h the Stripe idempotency key no longer dedupes, so the
+    // reconciler must NOT replay (it would risk a double-credit) — it logs
+    // for manual repair and leaves the row partial.
+    let Some(key) = stripe_key() else { return };
+    let Some(url) = db_url() else { return };
+    let stripe = StripeClient::new(key).unwrap();
+    let cust =
+        crate::billing::setup_intent_tests::ensure_unique_customer(&stripe, TEST_WALLET).await;
+    let pool = PgPool::connect(&url).await.unwrap();
+
+    let tx_hash = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    seed_partial(&pool, &cust, tx_hash, 3, Duration::hours(24)).await;
+
+    super::litkey_reconciler::run_once(&stripe, &pool)
+        .await
+        .expect("reconcile");
+
+    assert!(
+        balance_tx_id(&pool, tx_hash).await.is_none(),
+        "a partial past the idempotency window must be left for manual repair"
+    );
+
+    sqlx::query("DELETE FROM litkey_payments WHERE tx_hash = $1")
+        .bind(tx_hash)
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/lit-payments/src/main.rs
+++ b/lit-payments/src/main.rs
@@ -47,6 +47,9 @@ async fn rocket() -> _ {
     rate::spawn_rate_poller(pool.clone());
     let per_customer_mutex = PerCustomerMutex::new();
     lit_payments::auto_topup::reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
+    // CPL-375: complete any LITKEY credit whose Stripe balance_transaction
+    // write was interrupted between the row INSERT and the credit landing.
+    lit_payments::litkey_reconciler::spawn(cfg.clone(), stripe.clone(), pool.clone());
     // Enterprise committed-use billing: monthly draft invoice + buffer regrant.
     // See plans/enterprise-committed-billing.md.
     lit_payments::enterprise::spawn(cfg.clone(), stripe.clone(), pool.clone(), mailer.clone());


### PR DESCRIPTION
`handle_confirmed_litkey_payment` wrote the Stripe credit before inserting the `litkey_payments` row, so a crash in between left a credit at Stripe with no DB record — and because Stripe drops an Idempotency-Key after ~24h, a re-claim past that window re-credited the user. This now inserts the row **first** as the idempotency guard (credited rows may be "partial" with a NULL `stripe_balance_transaction_id`) and fills the id in after the credit lands, backed by a new background reconciler (`litkey_reconciler`) that completes partial rows within a 23h gate by replaying the **same** idempotency key (dedupes if it landed, credits if it didn't; older rows are logged for manual repair). A migration relaxes the `litkey_payments` status-fields CHECK to permit the partial state and adds a partial index for the reconciler. Covered by a unit test locking that the reconciler replays the identical Stripe call as the live path, plus DB+Stripe-gated integration tests for the complete / skip-fresh / skip-past-window cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)