### PR TITLE
fix(lit-triggers): log user UUID instead of email in magic-link auth (CPL-378)

### DIFF
--- a/lit-triggers/src/auth/routes.rs
+++ b/lit-triggers/src/auth/routes.rs
@@ -72,22 +72,25 @@ pub async fn request_link(
                  <p style=\"color: #777; font-size: 12px;\">If you didn't request this, you can ignore this email.</p>"
             );
 
-            // Resolve a non-PII identifier for logs: existing users log their
-            // UUID; a brand-new email (no row yet) logs "unregistered" so the
-            // address never lands in info/warn output (GDPR/CCPA). Users are
-            // only created on verify, so we deliberately do not create one here.
-            let log_id = match user::find_by_email(pool, &email).await {
-                Ok(Some(u)) => u.id.to_string(),
-                Ok(None) => "unregistered".to_string(),
-                Err(e) => {
-                    tracing::warn!("magic-link user lookup for logging failed: {e}");
-                    "unknown".to_string()
-                }
-            };
-
             let mailer = mailer.inner().clone();
+            let pool = pool.inner().clone();
             let email_for_send = email.clone();
             tokio::spawn(async move {
+                // Resolve a non-PII identifier for logs: existing users log
+                // their UUID; a brand-new email (no row yet) logs "unregistered"
+                // so the address never lands in info/warn output (GDPR/CCPA).
+                // Users are only created on verify, so we deliberately do not
+                // create one here. The lookup lives inside the spawned task so
+                // it never adds latency to the /auth/request response path.
+                let log_id = match user::find_id_by_email(&pool, &email_for_send).await {
+                    Ok(Some(id)) => id.to_string(),
+                    Ok(None) => "unregistered".to_string(),
+                    Err(e) => {
+                        tracing::warn!("magic-link user lookup for logging failed: {e}");
+                        "unknown".to_string()
+                    }
+                };
+
                 if let Err(e) = mailer.send(&email_for_send, subject, &html, &text).await {
                     tracing::warn!("magic-link email send failed for user {log_id}: {e}");
                 } else {

--- a/lit-triggers/src/auth/routes.rs
+++ b/lit-triggers/src/auth/routes.rs
@@ -72,13 +72,26 @@ pub async fn request_link(
                  <p style=\"color: #777; font-size: 12px;\">If you didn't request this, you can ignore this email.</p>"
             );
 
+            // Resolve a non-PII identifier for logs: existing users log their
+            // UUID; a brand-new email (no row yet) logs "unregistered" so the
+            // address never lands in info/warn output (GDPR/CCPA). Users are
+            // only created on verify, so we deliberately do not create one here.
+            let log_id = match user::find_by_email(pool, &email).await {
+                Ok(Some(u)) => u.id.to_string(),
+                Ok(None) => "unregistered".to_string(),
+                Err(e) => {
+                    tracing::warn!("magic-link user lookup for logging failed: {e}");
+                    "unknown".to_string()
+                }
+            };
+
             let mailer = mailer.inner().clone();
             let email_for_send = email.clone();
             tokio::spawn(async move {
                 if let Err(e) = mailer.send(&email_for_send, subject, &html, &text).await {
-                    tracing::warn!("magic-link email send failed for {email_for_send}: {e}");
+                    tracing::warn!("magic-link email send failed for user {log_id}: {e}");
                 } else {
-                    tracing::info!("magic-link sent to {email_for_send}");
+                    tracing::info!("magic-link sent to user {log_id}");
                 }
             });
         }

--- a/lit-triggers/src/auth/user.rs
+++ b/lit-triggers/src/auth/user.rs
@@ -23,6 +23,18 @@ pub async fn find_by_email(pool: &PgPool, email: &str) -> Result<Option<User>> {
     Ok(row.map(|(id, email)| User { id, email }))
 }
 
+/// Look up only the user's `id` by email, avoiding materializing the email
+/// (PII) into memory. Used by callers that just need a non-PII log identifier.
+pub async fn find_id_by_email(pool: &PgPool, email: &str) -> Result<Option<Uuid>> {
+    let row =
+        sqlx::query_as::<_, (Uuid,)>("SELECT id FROM users WHERE lower(email) = lower($1) LIMIT 1")
+            .bind(email)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(id,)| id))
+}
+
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> Result<Option<User>> {
     let row = sqlx::query_as::<_, (Uuid, String)>("SELECT id, email FROM users WHERE id = $1")
         .bind(id)


### PR DESCRIPTION
The magic-link request handler (`lit-triggers/src/auth/routes.rs`) logged the raw email address at `info`/`warn` (`magic-link sent to {email}`), exposing PII in default-level logs (GDPR/CCPA). It now resolves a non-PII identifier instead: existing users log their `users.id` UUID, brand-new emails log `"unregistered"`, and a lookup error logs `"unknown"`. Users are still only created on verify, so no row is created at request time and unauthenticated `/auth/request` can't be used to enumerate/spam the users table. The actual email send is unchanged; only the log strings changed.

Closes CPL-378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)